### PR TITLE
Updated as per compliance check #92

### DIFF
--- a/ShopEG/With buyer-app-preprod-v2.ondc.org/Group A/Flow 1/full_catalog_on_search.json
+++ b/ShopEG/With buyer-app-preprod-v2.ondc.org/Group A/Flow 1/full_catalog_on_search.json
@@ -7,7487 +7,21 @@
         "core_version": "1.2.0",
         "bap_id": "buyer-app-preprod-v2.ondc.org",
         "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
-        "transaction_id": "c74f20b5-0b27-476a-b059-75680c3cf40a",
-        "message_id": "fcba7f68-554f-4e8c-ad58-a13298392081",
-        "timestamp": "2023-10-27T16:00:20.865Z",
+        "transaction_id": "4e4731c5-6dbd-4700-9b22-c71e885c89a6",
+        "message_id": "56016590-44b4-4a0a-bbfe-4e34f12a27ce",
+        "timestamp": "2023-11-10T12:00:06.880Z",
         "ttl": "PT30S",
         "bpp_uri": "https://dev-api.shopeg.in/ondc/bpp",
         "bpp_id": "dev-api.shopeg.in"
     },
     "message": {
         "catalog": {
-            "bpp/fulfillments": [
-                {
-                    "id": "1",
-                    "type": "Delivery"
-                }
-            ],
-            "bpp/descriptor": {
-                "name": "ShopEG",
-                "symbol": "https://shopeg.in/i/eg.png",
-                "short_desc": "ShopEG",
-                "long_desc": "ShopEG: Online Angadi",
-                "code": "EG",
-                "images": [
-                    "https://shopeg.in/i/eg.png"
-                ]
-            },
             "bpp/providers": [
-                {
-                    "id": "7d5U7O4owr8Pzzw5hiiY",
-                    "time": {
-                        "label": "enable",
-                        "timestamp": "2023-10-27T16:00:20.865Z"
-                    },
-                    "ttl": "P1D",
-                    "descriptor": {
-                        "symbol": "https://firebasestorage.googleapis.com/v0/b/shopeg-dev.appspot.com/o/shopImages%2FSXGJLw4JFjTDTNxEG48PaThdmMG3%2F2023-08-16%2016%3A23%3A39.947237.jpg?alt=media&token=9638fab3-3217-4147-adc1-431ea1854bb9",
-                        "images": [
-                            "https://firebasestorage.googleapis.com/v0/b/shopeg-dev.appspot.com/o/shopImages%2FSXGJLw4JFjTDTNxEG48PaThdmMG3%2F2023-08-16%2016%3A23%3A39.947237.jpg?alt=media&token=9638fab3-3217-4147-adc1-431ea1854bb9"
-                        ],
-                        "name": "M shop sunkadakatte",
-                        "short_desc": "Rghyg"
-                    },
-                    "locations": [
-                        {
-                            "schedule": {
-                                "times": [
-                                    "0800"
-                                ],
-                                "holidays": [],
-                                "frequency": "PT15H"
-                            },
-                            "address": {
-                                "door": "tigig",
-                                "country": "India",
-                                "city": "Bengaluru",
-                                "street": "gxtd",
-                                "area_code": "560056",
-                                "name": "M shop sunkadakatte",
-                                "locality": "ugjbib",
-                                "state": "Karnataka",
-                                "building": "tigig"
-                            },
-                            "id": "6906",
-                            "gps": "12.967755240367376,77.4978847127529",
-                            "time": {
-                                "range": {
-                                    "start": "0800",
-                                    "end": "2300"
-                                },
-                                "days": "1,2,3,4,5,6,7",
-                                "schedule": {
-                                    "holidays": []
-                                },
-                                "label": "enable",
-                                "timestamp": "2023-10-27T16:00:20.865Z"
-                            },
-                            "circle": {
-                                "gps": "12.967755240367376,77.4978847127529",
-                                "radius": {
-                                    "unit": "km",
-                                    "value": "5"
-                                }
-                            }
-                        }
-                    ],
-                    "items": [
-                        {
-                            "@ondc/org/statutory_reqs_packaged_commodities": {
-                                "net_quantity_or_measure_of_commodity_in_pkg": "6",
-                                "date_of_import": "08/2023",
-                                "imported_product_country_of_origin": "yyhhh",
-                                "manufacturer_or_packer_name": "ysys"
-                            },
-                            "@ondc/org/seller_pickup_return": true,
-                            "@ondc/org/contact_details_consumer_care": "hsjwjwj7",
-                            "descriptor": {
-                                "symbol": "https://firebasestorage.googleapis.com/v0/b/shopeg-dev.appspot.com/o/shopImages%2FSXGJLw4JFjTDTNxEG48PaThdmMG3%2Fimg_1692618564183.jpg?alt=media&token=649115ab-975f-461e-b0fc-ca02567545e7",
-                                "images": [
-                                    "https://firebasestorage.googleapis.com/v0/b/shopeg-dev.appspot.com/o/shopImages%2FSXGJLw4JFjTDTNxEG48PaThdmMG3%2Fimg_1692618564183.jpg?alt=media&token=649115ab-975f-461e-b0fc-ca02567545e7"
-                                ],
-                                "name": "new twdff",
-                                "short_desc": "dhzhz",
-                                "long_desc": "ndnnd"
-                            },
-                            "tax_rate": "5",
-                            "location_id": "6906",
-                            "@ondc/org/available_on_cod": false,
-                            "L2_category": "Gourmet & World Foods",
-                            "category_id": "Gourmet & World Foods",
-                            "price": {
-                                "currency": "INR",
-                                "maximum_value": "125",
-                                "value": "124"
-                            },
-                            "id": "77388829-504a-412d-b2d2-22cccc061062",
-                            "@ondc/org/cancellable": true,
-                            "@ondc/org/returnable": true,
-                            "quantity": {
-                                "available": {
-                                    "count": "123"
-                                },
-                                "maximum": {
-                                    "count": "2"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "Kg",
-                                        "value": "23"
-                                    }
-                                }
-                            },
-                            "@ondc/org/time_to_ship": "PT1H",
-                            "hsn_code": "1234",
-                            "tags": [],
-                            "@ondc/org/return_window": "P14D",
-                            "@ondc/org/statutory_reqs_prepackaged_food": {
-                                "ingredients_info": "uujuuwjwj",
-                                "brand_owner_FSSAI_license_no": "1234",
-                                "net_quantity": "12",
-                                "additives_info": "ysywyw",
-                                "manufacturer_or_packer_address": "hshwhw",
-                                "other_premises": "gsysywy"
-                            },
-                            "@ondc/org/mandatory_reqs_veggies_fruits": {
-                                "net_quantity": "568"
-                            },
-                            "tax_type": "gst",
-                            "domain": "Grocery",
-                            "time": {
-                                "label": "enable",
-                                "timestamp": "2023-10-05T06:53:33.029Z"
-                            },
-                            "fulfillment_id": "1"
-                        },
-                        {
-                            "@ondc/org/statutory_reqs_packaged_commodities": {
-                                "common_or_generic_name_of_commodity": "Utensils & Cookware",
-                                "net_quantity_or_measure_of_commodity_in_pkg": "250 ml (Set of 3)",
-                                "imported_product_country_of_origin": "ARG",
-                                "description": "Saaj Maxx Pet Plastic Premium Container - Pink, 250 ml (Set of 3)",
-                                "manufacturer_or_packer_name": "Saaj Products, Janavi Polyplast, Survey No 366/3, Plot No 14, Premier Industrial Estate, Kachigam, Daman",
-                                "manufacturer_or_packer_address": "Saaj Products, Janavi Polyplast, Survey No 366/3, Plot No 14, Premier Industrial Estate, Kachigam, Daman",
-                                "month_year_of_manufacture_packing_import": ""
-                            },
-                            "@ondc/org/seller_pickup_return": true,
-                            "@ondc/org/contact_details_consumer_care": "dhjj68",
-                            "descriptor": {
-                                "symbol": "https://datalabs.siva3.io/image/Eunimart_groceries_40162322_4-saaj-maxx-pet-plastic-premium-container-pink.jpg",
-                                "images": [
-                                    "https://datalabs.siva3.io/image/Eunimart_groceries_40162322_4-saaj-maxx-pet-plastic-premium-container-pink.jpg",
-                                    "https://datalabs.siva3.io/image/Eunimart_groceries_40162322-2_1-saaj-maxx-pet-plastic-premium-container-pink.jpg"
-                                ],
-                                "name": "gggg Maxx Pet Plastic Premium",
-                                "short_desc": "These containers are made from high-quality PET material. These products ensure safety, hygiene and quality for you and your family. Do not use hot water to wash these. These storage containers are airtight, BPA Free, freezer-safe and are unbreakable. The high-quality lid is made from virgin plastic material and food-grade masterbatch. These are suitable for storing pickles, dry fruits and cookies. The glass-like transparency helps in spotting things easily and labelling is not required for the food kept inside and trendy design enhance your kitchen decor. You can store wet, dry food, snacks and Namkin in these.",
-                                "long_desc": "These containers are made from high-quality PET material. These products ensure safety, hygiene and quality for you and your family. Do not use hot water to wash these. These storage containers are airtight, BPA Free, freezer-safe and are unbreakable. The high-quality lid is made from virgin plastic material and food-grade masterbatch. These are suitable for storing pickles, dry fruits and cookies. The glass-like transparency helps in spotting things easily and labelling is not required for the food kept inside and trendy design enhance your kitchen decor. You can store wet, dry food, snacks and Namkin in these."
-                            },
-                            "tax_rate": "28",
-                            "location_id": "6906",
-                            "@ondc/org/available_on_cod": false,
-                            "L2_category": "Kitchen Accessories",
-                            "category_id": "Kitchen Accessories",
-                            "price": {
-                                "currency": "INR",
-                                "maximum_value": "109",
-                                "value": "109"
-                            },
-                            "id": "0576abd5-60af-46d7-9bbd-2617a906b731",
-                            "@ondc/org/cancellable": true,
-                            "@ondc/org/returnable": true,
-                            "quantity": {
-                                "available": {
-                                    "count": "21"
-                                },
-                                "maximum": {
-                                    "count": "3"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "l",
-                                        "value": "12"
-                                    }
-                                }
-                            },
-                            "@ondc/org/time_to_ship": "PT1H",
-                            "hsn_code": "1234",
-                            "tags": [],
-                            "@ondc/org/return_window": "P14D",
-                            "@ondc/org/statutory_reqs_prepackaged_food": {
-                                "importer_FSSAI_license_no": null,
-                                "nutritional_info": null,
-                                "other_FSSAI_license_no": null,
-                                "imported_product_country_of_origin": null,
-                                "brand_owner_FSSAI_license_no": null,
-                                "additives_info": null
-                            },
-                            "tax_type": "gst",
-                            "domain": "Grocery",
-                            "time": {
-                                "label": "enable",
-                                "timestamp": "2023-10-05T06:53:33.029Z"
-                            },
-                            "fulfillment_id": "1"
-                        },
-                        {
-                            "@ondc/org/statutory_reqs_packaged_commodities": {
-                                "common_or_generic_name_of_commodity": "Spices & Masala",
-                                "net_quantity_or_measure_of_commodity_in_pkg": "100 g",
-                                "imported_product_country_of_origin": "IND",
-                                "description": "Everest Chhole Masala, 100 g Carton",
-                                "manufacturer_or_packer_name": "S.Everest Food Products Pvt. Ltd.",
-                                "manufacturer_or_packer_address": "S.Everest Food Products Pvt. Ltd.",
-                                "month_year_of_manufacture_packing_import": ""
-                            },
-                            "@ondc/org/seller_pickup_return": true,
-                            "@ondc/org/contact_details_consumer_care": "tttty56",
-                            "descriptor": {
-                                "symbol": "https://www.bigbasket.com/media/uploads/p/xxl/268078_3-everest-chhole-masala.jpg",
-                                "images": [
-                                    "https://www.bigbasket.com/media/uploads/p/xxl/268078_3-everest-chhole-masala.jpg",
-                                    "https://www.bigbasket.com/media/uploads/p/xxl/268078-2_2-everest-chhole-masala.jpg",
-                                    "https://www.bigbasket.com/media/uploads/p/xxl/268078-3_1-everest-chhole-masala.jpg"
-                                ],
-                                "name": "Everest Chhole Masala, 100 g Carton",
-                                "short_desc": "Everest presents their authentic range of masalas that are blended with a wide variety of handpicked and selected spices that bring a whole new flavour and meaning to your dishes. Rake up your favourite recipes and cuisines by adding this magical blend of Everest masalas.",
-                                "long_desc": "Everest presents their authentic range of masalas that are blended with a wide variety of handpicked and selected spices that bring a whole new flavour and meaning to your dishes. Rake up your favourite recipes and cuisines by adding this magical blend of Everest masalas."
-                            },
-                            "tax_rate": "18",
-                            "location_id": "6906",
-                            "@ondc/org/available_on_cod": false,
-                            "L2_category": "Masala & Seasoning",
-                            "category_id": "Masala & Seasoning",
-                            "price": {
-                                "currency": "INR",
-                                "maximum_value": "78",
-                                "value": "78"
-                            },
-                            "id": "46cd927c-2d98-435d-9935-d5e41f50fd30",
-                            "@ondc/org/cancellable": true,
-                            "@ondc/org/returnable": true,
-                            "quantity": {
-                                "available": {
-                                    "count": "1"
-                                },
-                                "maximum": {
-                                    "count": "1"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "Kg",
-                                        "value": "23"
-                                    }
-                                }
-                            },
-                            "@ondc/org/time_to_ship": "PT1H",
-                            "hsn_code": "123456",
-                            "tags": [],
-                            "@ondc/org/return_window": "P14D",
-                            "@ondc/org/statutory_reqs_prepackaged_food": {
-                                "importer_FSSAI_license_no": null,
-                                "nutritional_info": null,
-                                "other_FSSAI_license_no": null,
-                                "imported_product_country_of_origin": null,
-                                "brand_owner_FSSAI_license_no": "123456",
-                                "additives_info": null
-                            },
-                            "tax_type": "gst",
-                            "domain": "Grocery",
-                            "time": {
-                                "label": "enable",
-                                "timestamp": "2023-10-05T06:53:33.029Z"
-                            },
-                            "fulfillment_id": "1"
-                        },
-                        {
-                            "@ondc/org/statutory_reqs_packaged_commodities": {
-                                "common_or_generic_name_of_commodity": "Sauces, Spreads & Dips",
-                                "net_quantity_or_measure_of_commodity_in_pkg": "500 ml Bottle",
-                                "imported_product_country_of_origin": "ARM",
-                                "description": "Disano Apple Cider Vinegar With Mother, 500 ml Bottle",
-                                "manufacturer_or_packer_name": "The unali co-op marketing-cum-processing society ltd (under the guidance punjab agriculture university & punjab state council for science & technology) 5 km talwara milestone, near mukerien hydel power house no. 1 G. T road talwar, distt. Hoshiarpur, punjab 144216",
-                                "manufacturer_or_packer_address": "The unali co-op marketing-cum-processing society ltd (under the guidance punjab agriculture university & punjab state council for science & technology) 5 km talwara milestone, near mukerien hydel power house no. 1 G. T road talwar, distt. Hoshiarpur, punjab 144216",
-                                "month_year_of_manufacture_packing_import": ""
-                            },
-                            "@ondc/org/seller_pickup_return": true,
-                            "@ondc/org/contact_details_consumer_care": "bhxhx67",
-                            "descriptor": {
-                                "symbol": "https://datalabs.siva3.io/image/Eunimart_groceries_40159677_2-disano-apple-cider-vinegar-with-mother-vinegar.jpg",
-                                "images": [
-                                    "https://datalabs.siva3.io/image/Eunimart_groceries_40159677_2-disano-apple-cider-vinegar-with-mother-vinegar.jpg",
-                                    "https://datalabs.siva3.io/image/Eunimart_groceries_40159677-2_2-disano-apple-cider-vinegar-with-mother-vinegar.jpg",
-                                    "https://datalabs.siva3.io/image/Eunimart_groceries_40159677-3_2-disano-apple-cider-vinegar-with-mother-vinegar.jpg"
-                                ],
-                                "name": "orange pple Cider Vinegar With",
-                                "short_desc": "Apple Cider Vinegar is naturally brewed from the delicious Himalayan apples & contains strands of Mother: as proof of unfiltered vinegar. Apple Cider Vinegar comes with tons of health benefits. It improves your gut system by adding good bacteria and thus improves your digestion. It also helps a great in weight loss. Quantity: 500 ml (Bottle) Store in cool, dry & dark place.",
-                                "long_desc": "Apple Cider Vinegar is naturally brewed from the delicious Himalayan apples & contains strands of Mother: as proof of unfiltered vinegar. Apple Cider Vinegar comes with tons of health benefits. It improves your gut system by adding good bacteria and thus improves your digestion. It also helps a great in weight loss. Quantity: 500 ml (Bottle) Store in cool, dry & dark place."
-                            },
-                            "tax_rate": "18",
-                            "location_id": "6906",
-                            "@ondc/org/available_on_cod": false,
-                            "L2_category": "Gourmet & World Foods",
-                            "category_id": "Gourmet & World Foods",
-                            "price": {
-                                "currency": "INR",
-                                "maximum_value": "183",
-                                "value": "183"
-                            },
-                            "id": "4bd9e1f2-1eae-4322-bb59-9f584dab8f74",
-                            "@ondc/org/cancellable": true,
-                            "@ondc/org/returnable": true,
-                            "quantity": {
-                                "available": {
-                                    "count": "21"
-                                },
-                                "maximum": {
-                                    "count": "1"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "Kg",
-                                        "value": "12"
-                                    }
-                                }
-                            },
-                            "@ondc/org/time_to_ship": "PT1H",
-                            "hsn_code": "123",
-                            "tags": [],
-                            "@ondc/org/return_window": "P14D",
-                            "@ondc/org/statutory_reqs_prepackaged_food": {
-                                "importer_FSSAI_license_no": null,
-                                "nutritional_info": null,
-                                "other_FSSAI_license_no": null,
-                                "imported_product_country_of_origin": null,
-                                "brand_owner_FSSAI_license_no": "464343",
-                                "additives_info": null
-                            },
-                            "tax_type": "gst",
-                            "domain": "Grocery",
-                            "time": {
-                                "label": "enable",
-                                "timestamp": "2023-10-05T06:53:33.029Z"
-                            },
-                            "fulfillment_id": "1"
-                        },
-                        {
-                            "@ondc/org/cancellable": true,
-                            "@ondc/org/returnable": true,
-                            "quantity": {
-                                "available": {
-                                    "count": "23"
-                                },
-                                "maximum": {
-                                    "count": "23"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "Kg",
-                                        "value": "12"
-                                    }
-                                }
-                            },
-                            "@ondc/org/statutory_reqs_packaged_commodities": {
-                                "net_quantity_or_measure_of_commodity_in_pkg": "12 Kg",
-                                "imported_product_country_of_origin": "IND",
-                                "manufacturer_or_packer_name": "gggggg"
-                            },
-                            "@ondc/org/seller_pickup_return": true,
-                            "@ondc/org/contact_details_consumer_care": "vvvvv",
-                            "@ondc/org/time_to_ship": "PT1H",
-                            "descriptor": {
-                                "symbol": "https://firebasestorage.googleapis.com/v0/b/shopeg-dev.appspot.com/o/shopImages%2FSXGJLw4JFjTDTNxEG48PaThdmMG3%2Fimg_1693531774828.jpg?alt=media&token=c4d3d056-f51b-424e-90d5-ed3915edf192",
-                                "images": [
-                                    "https://firebasestorage.googleapis.com/v0/b/shopeg-dev.appspot.com/o/shopImages%2FSXGJLw4JFjTDTNxEG48PaThdmMG3%2Fimg_1693531774828.jpg?alt=media&token=c4d3d056-f51b-424e-90d5-ed3915edf192"
-                                ],
-                                "name": "yduddu",
-                                "short_desc": "cucufu",
-                                "long_desc": "cucufuufifi"
-                            },
-                            "hsn_code": "1234",
-                            "tax_rate": "28",
-                            "location_id": "6906",
-                            "tags": [],
-                            "@ondc/org/return_window": "P14D",
-                            "@ondc/org/available_on_cod": false,
-                            "L2_category": "Feminine Care",
-                            "category_id": "Feminine Care",
-                            "tax_type": "gst",
-                            "price": {
-                                "currency": "INR",
-                                "maximum_value": "12",
-                                "value": "12"
-                            },
-                            "domain": "Beauty & Personal Care",
-                            "id": "8f288b54-dbc2-43f3-8e51-19fbdb41af8f",
-                            "time": {
-                                "label": "enable",
-                                "timestamp": "2023-10-05T06:53:33.029Z"
-                            },
-                            "fulfillment_id": "1"
-                        },
-                        {
-                            "@ondc/org/cancellable": true,
-                            "@ondc/org/returnable": true,
-                            "quantity": {
-                                "available": {
-                                    "count": "12"
-                                },
-                                "maximum": {
-                                    "count": "1"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "Kg",
-                                        "value": "12"
-                                    }
-                                }
-                            },
-                            "@ondc/org/statutory_reqs_packaged_commodities": {
-                                "net_quantity_or_measure_of_commodity_in_pkg": "12 Kg",
-                                "imported_product_country_of_origin": "IND",
-                                "manufacturer_or_packer_name": "jxjjcjcjc"
-                            },
-                            "@ondc/org/seller_pickup_return": true,
-                            "@ondc/org/contact_details_consumer_care": "nxnxnn",
-                            "@ondc/org/time_to_ship": "PT1H",
-                            "descriptor": {
-                                "symbol": "https://firebasestorage.googleapis.com/v0/b/shopeg-dev.appspot.com/o/shopImages%2FSXGJLw4JFjTDTNxEG48PaThdmMG3%2Fimg_1693531530329.jpg?alt=media&token=6fe5be7b-221a-45fa-9db4-e51f8b723280",
-                                "images": [
-                                    "https://firebasestorage.googleapis.com/v0/b/shopeg-dev.appspot.com/o/shopImages%2FSXGJLw4JFjTDTNxEG48PaThdmMG3%2Fimg_1693531530329.jpg?alt=media&token=6fe5be7b-221a-45fa-9db4-e51f8b723280"
-                                ],
-                                "name": "jxjxjx",
-                                "short_desc": "ghhj",
-                                "long_desc": "ghhjj"
-                            },
-                            "hsn_code": "1234",
-                            "tax_rate": "28",
-                            "location_id": "6906",
-                            "tags": [],
-                            "@ondc/org/return_window": "P14D",
-                            "@ondc/org/available_on_cod": false,
-                            "L2_category": "Feminine Care",
-                            "category_id": "Feminine Care",
-                            "tax_type": "gst",
-                            "price": {
-                                "currency": "INR",
-                                "maximum_value": "23",
-                                "value": "23"
-                            },
-                            "domain": "Beauty & Personal Care",
-                            "id": "9d6bf99b-28e7-4607-af77-fa634305ea30",
-                            "time": {
-                                "label": "enable",
-                                "timestamp": "2023-10-05T06:53:33.029Z"
-                            },
-                            "fulfillment_id": "1"
-                        },
-                        {
-                            "@ondc/org/statutory_reqs_packaged_commodities": {
-                                "common_or_generic_name_of_commodity": "Detergents & Dishwash",
-                                "net_quantity_or_measure_of_commodity_in_pkg": "12 Nos",
-                                "imported_product_country_of_origin": "India",
-                                "description": "Surf Excel Detergent - Liquid, Matic, Top Load, 2 L Pouch",
-                                "manufacturer_or_packer_name": "Hindustan Unilever Limited, Unilever House, B D Sawant Marg, Chakala, Anderi E, Mumbai - 400099",
-                                "manufacturer_or_packer_address": "Hindustan Unilever Limited, Unilever House, B D Sawant Marg, Chakala, Anderi E, Mumbai - 400099",
-                                "month_year_of_manufacture_packing_import": ""
-                            },
-                            "@ondc/org/seller_pickup_return": true,
-                            "@ondc/org/contact_details_consumer_care": "bxjxjxkx",
-                            "descriptor": {
-                                "symbol": "https://datalabs.siva3.io/image/Eunimart_groceries_40130609_3-surf-excel-detergent-liquid-matic-top-load.jpg",
-                                "images": [
-                                    "https://datalabs.siva3.io/image/Eunimart_groceries_40130609_3-surf-excel-detergent-liquid-matic-top-load.jpg",
-                                    "https://datalabs.siva3.io/image/Eunimart_groceries_40130609-2_2-surf-excel-detergent-liquid-matic-top-load.jpg",
-                                    "https://datalabs.siva3.io/image/Eunimart_groceries_40130609-3_2-surf-excel-detergent-liquid-matic-top-load.jpg"
-                                ],
-                                "name": "Surf Excel Detergent - Liquid, Matic, Top Load, 2 L Pouch",
-                                "short_desc": "Presenting Surf Excel Matic Top Load Liquid Detergent - a revolutionary liquid detergent for Top Load washing machines. Being liquid, it is best suited for washing machines and ensures a superior laundry experience. Surf Excel Matic Top Load Liquid Detergent is specially made for your Top Load washing machine and gives you tough stain removal in machines. Surf Excel Matic Top Load Liquid Detergent is effective in the high-water level environment (40 liters) of your Top Load washing machines and dissolves completely ensuring it leaves no residue in your machine or your clothes. Surf Excel Matic Top Load Liquid Detergent is one of its kind detergent liquids whose cleaning action and the superior fragrance is much sought after. Surf Excel Matic liquid with a powerful cleaning technology penetrates stains faster and removes tough stains in machines itself. Try Surf Excel Matic Top Load Liquid Detergent for your Top Load machine for a superior cleaning experience.\r\n\r\nThis Surf Matic Top Load Liquid Detergent Pouch 2 lt pack is a refill pack and the liquid in the pouch needs to be poured into an empty 1ltr Surf Matic Liquid Detergent Bottle. You can use the scrubber cap (of the bottle) to measure a cap-full of the liquid for 1 load and 1.5 cups for heavily soiled loads, in your Top Load Washing machine.\r\n\r\nNew Surf Excel Matic liquid top load washing detergent gives you 100% stain removal in washing machines. Faster stain removal in machines new Surf Excel Matic liquid detergent with a powerful cleaning technology penetrates stains faster and removes tough stains in machines itself. It dissolves quickly in a high water level environment of washing machines, reaches stains effortlessly and leaves no residue on clothes or on machines. It is designed to produce foam as per washing machine type that ensures no clogging and choking of pipes and reduces scaling issues. The superior fragrance ensures that your clothes not only look fresh but also smell fresh. Colour care, removes tough stains in machines but retains original colour of the fabric.",
-                                "long_desc": "Presenting Surf Excel Matic Top Load Liquid Detergent - a revolutionary liquid detergent for Top Load washing machines. Being liquid, it is best suited for washing machines and ensures a superior laundry experience. Surf Excel Matic Top Load Liquid Detergent is specially made for your Top Load washing machine and gives you tough stain removal in machines. Surf Excel Matic Top Load Liquid Detergent is effective in the high-water level environment (40 liters) of your Top Load washing machines and dissolves completely ensuring it leaves no residue in your machine or your clothes. Surf Excel Matic Top Load Liquid Detergent is one of its kind detergent liquids whose cleaning action and the superior fragrance is much sought after. Surf Excel Matic liquid with a powerful cleaning technology penetrates stains faster and removes tough stains in machines itself. Try Surf Excel Matic Top Load Liquid Detergent for your Top Load machine for a superior cleaning experience.\r\n\r\nThis Surf Matic Top Load Liquid Detergent Pouch 2 lt pack is a refill pack and the liquid in the pouch needs to be poured into an empty 1ltr Surf Matic Liquid Detergent Bottle. You can use the scrubber cap (of the bottle) to measure a cap-full of the liquid for 1 load and 1.5 cups for heavily soiled loads, in your Top Load Washing machine.\r\n\r\nNew Surf Excel Matic liquid top load washing detergent gives you 100% stain removal in washing machines. Faster stain removal in machines new Surf Excel Matic liquid detergent with a powerful cleaning technology penetrates stains faster and removes tough stains in machines itself. It dissolves quickly in a high water level environment of washing machines, reaches stains effortlessly and leaves no residue on clothes or on machines. It is designed to produce foam as per washing machine type that ensures no clogging and choking of pipes and reduces scaling issues. The superior fragrance ensures that your clothes not only look fresh but also smell fresh. Colour care, removes tough stains in machines but retains original colour of the fabric."
-                            },
-                            "tax_rate": "5",
-                            "location_id": "6906",
-                            "@ondc/org/available_on_cod": false,
-                            "L2_category": "Cleaning & Household",
-                            "category_id": "Cleaning & Household",
-                            "price": {
-                                "currency": "INR",
-                                "maximum_value": "371",
-                                "value": "371"
-                            },
-                            "id": "d13b0351-a054-4149-9a14-3fabfff74e75",
-                            "@ondc/org/cancellable": true,
-                            "@ondc/org/returnable": true,
-                            "quantity": {
-                                "available": {
-                                    "count": "2"
-                                },
-                                "maximum": {
-                                    "count": "2"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "Nos",
-                                        "value": "12"
-                                    }
-                                }
-                            },
-                            "@ondc/org/time_to_ship": "PT1H",
-                            "hsn_code": "1234",
-                            "tags": [],
-                            "@ondc/org/return_window": "P14D",
-                            "@ondc/org/statutory_reqs_prepackaged_food": {
-                                "importer_FSSAI_license_no": null,
-                                "nutritional_info": null,
-                                "other_FSSAI_license_no": null,
-                                "imported_product_country_of_origin": null,
-                                "brand_owner_FSSAI_license_no": null,
-                                "additives_info": null
-                            },
-                            "tax_type": "gst",
-                            "domain": "Grocery",
-                            "time": {
-                                "label": "enable",
-                                "timestamp": "2023-10-05T06:53:33.029Z"
-                            },
-                            "fulfillment_id": "1"
-                        },
-                        {
-                            "@ondc/org/cancellable": true,
-                            "@ondc/org/returnable": true,
-                            "quantity": {
-                                "available": {
-                                    "count": "3"
-                                },
-                                "maximum": {
-                                    "count": "3"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "Kg",
-                                        "value": "23"
-                                    }
-                                }
-                            },
-                            "@ondc/org/statutory_reqs_packaged_commodities": {
-                                "net_quantity_or_measure_of_commodity_in_pkg": "23 Kg",
-                                "imported_product_country_of_origin": "IND",
-                                "manufacturer_or_packer_name": "ifif"
-                            },
-                            "@ondc/org/seller_pickup_return": true,
-                            "@ondc/org/contact_details_consumer_care": "jdjxjxj",
-                            "@ondc/org/time_to_ship": "PT1H",
-                            "descriptor": {
-                                "symbol": "https://firebasestorage.googleapis.com/v0/b/shopeg-dev.appspot.com/o/shopImages%2FSXGJLw4JFjTDTNxEG48PaThdmMG3%2Fimg_1693977777658.jpg?alt=media&token=fa4ebc23-b57d-463f-afe6-5a8c1e583028",
-                                "images": [
-                                    "https://firebasestorage.googleapis.com/v0/b/shopeg-dev.appspot.com/o/shopImages%2FSXGJLw4JFjTDTNxEG48PaThdmMG3%2Fimg_1693977777658.jpg?alt=media&token=fa4ebc23-b57d-463f-afe6-5a8c1e583028"
-                                ],
-                                "name": "shsh",
-                                "short_desc": "jjxjjxcjc",
-                                "long_desc": "jjxjjxcjc"
-                            },
-                            "hsn_code": "1234",
-                            "location_id": "6906",
-                            "tax_rate": "5",
-                            "tags": [],
-                            "@ondc/org/return_window": "P14D",
-                            "@ondc/org/available_on_cod": false,
-                            "L2_category": "Feminine Care",
-                            "category_id": "Feminine Care",
-                            "tax_type": "gst",
-                            "price": {
-                                "currency": "INR",
-                                "maximum_value": "235",
-                                "value": "235"
-                            },
-                            "domain": "Beauty & Personal Care",
-                            "id": "938056d4-2a7a-41c1-a803-d45d00e9c0b3",
-                            "time": {
-                                "label": "enable",
-                                "timestamp": "2023-10-05T06:53:33.029Z"
-                            },
-                            "fulfillment_id": "1"
-                        },
-                        {
-                            "@ondc/org/cancellable": true,
-                            "@ondc/org/returnable": true,
-                            "quantity": {
-                                "available": {
-                                    "count": "23"
-                                },
-                                "maximum": {
-                                    "count": "23"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "g",
-                                        "value": "12"
-                                    }
-                                }
-                            },
-                            "@ondc/org/statutory_reqs_packaged_commodities": {
-                                "net_quantity_or_measure_of_commodity_in_pkg": "12 g",
-                                "imported_product_country_of_origin": "IND",
-                                "manufacturer_or_packer_name": "hxjxj"
-                            },
-                            "@ondc/org/seller_pickup_return": true,
-                            "@ondc/org/contact_details_consumer_care": "bncjx",
-                            "@ondc/org/time_to_ship": "PT1H",
-                            "descriptor": {
-                                "symbol": "https://firebasestorage.googleapis.com/v0/b/shopeg-dev.appspot.com/o/shopImages%2FSXGJLw4JFjTDTNxEG48PaThdmMG3%2Fimg_1693830258023.jpg?alt=media&token=f5b8858e-8ea4-4cd5-8b00-7058668aeec7",
-                                "images": [
-                                    "https://firebasestorage.googleapis.com/v0/b/shopeg-dev.appspot.com/o/shopImages%2FSXGJLw4JFjTDTNxEG48PaThdmMG3%2Fimg_1693830258023.jpg?alt=media&token=f5b8858e-8ea4-4cd5-8b00-7058668aeec7"
-                                ],
-                                "name": "jxdjd",
-                                "short_desc": "jxidid",
-                                "long_desc": "jxididjzj"
-                            },
-                            "hsn_code": "1000",
-                            "location_id": "6906",
-                            "tax_rate": "5",
-                            "tags": [],
-                            "@ondc/org/return_window": "P14D",
-                            "@ondc/org/available_on_cod": false,
-                            "L2_category": "Beauty & Hygiene",
-                            "category_id": "Beauty & Hygiene",
-                            "tax_type": "gst",
-                            "price": {
-                                "currency": "INR",
-                                "maximum_value": "123",
-                                "value": "123"
-                            },
-                            "domain": "Grocery",
-                            "id": "6cab3870-bd75-44f0-9b8e-c6b3daf0ce19",
-                            "time": {
-                                "label": "enable",
-                                "timestamp": "2023-10-05T06:53:33.029Z"
-                            },
-                            "fulfillment_id": "1"
-                        },
-                        {
-                            "@ondc/org/statutory_reqs_packaged_commodities": {
-                                "net_quantity_or_measure_of_commodity_in_pkg": "52 Kg",
-                                "imported_product_country_of_origin": "IND",
-                                "manufacturer_or_packer_name": "ccvbb"
-                            },
-                            "@ondc/org/seller_pickup_return": true,
-                            "@ondc/org/contact_details_consumer_care": "ddffgf",
-                            "descriptor": {
-                                "symbol": "https://firebasestorage.googleapis.com/v0/b/shopeg-dev.appspot.com/o/shopImages%2FSXGJLw4JFjTDTNxEG48PaThdmMG3%2Fimg_1694770700242.jpg?alt=media&token=28d06baf-92f7-44c4-b6d2-5150c219e715",
-                                "images": [
-                                    "https://firebasestorage.googleapis.com/v0/b/shopeg-dev.appspot.com/o/shopImages%2FSXGJLw4JFjTDTNxEG48PaThdmMG3%2Fimg_1694770700242.jpg?alt=media&token=28d06baf-92f7-44c4-b6d2-5150c219e715"
-                                ],
-                                "name": "mspice",
-                                "short_desc": "gf",
-                                "long_desc": "gf"
-                            },
-                            "location_id": "6906",
-                            "tax_rate": "18",
-                            "@ondc/org/available_on_cod": false,
-                            "L2_category": "Masala & Seasoning",
-                            "category_id": "Masala & Seasoning",
-                            "price": {
-                                "currency": "INR",
-                                "maximum_value": "23",
-                                "value": "23"
-                            },
-                            "id": "caa64df2-56db-4786-b6c4-1081d124aacf",
-                            "@ondc/org/cancellable": true,
-                            "@ondc/org/returnable": true,
-                            "quantity": {
-                                "available": {
-                                    "count": "23"
-                                },
-                                "maximum": {
-                                    "count": "23"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "Kg",
-                                        "value": "52"
-                                    }
-                                }
-                            },
-                            "@ondc/org/time_to_ship": "PT1H",
-                            "hsn_code": "1234",
-                            "tags": [],
-                            "@ondc/org/return_window": "P14D",
-                            "@ondc/org/statutory_reqs_prepackaged_food": {
-                                "importer_FSSAI_license_no": null,
-                                "nutritional_info": null,
-                                "other_importer_address": null,
-                                "importer_fssai_logo": null,
-                                "importer_address": null,
-                                "other_importer_name": null,
-                                "brand_owner_FSSAI_license_no": "12556666",
-                                "net_quantity": null,
-                                "additives_info": null,
-                                "other_premises": null,
-                                "importer_name": null,
-                                "brand_owner_address": null,
-                                "brand_owner_fssai_logo": null,
-                                "ingredients_info": null,
-                                "other_FSSAI_license_no": null,
-                                "brand_owner_name": null,
-                                "imported_product_country_of_origin": null,
-                                "manufacturer_or_packer_name": null,
-                                "manufacturer_or_packer_address": null
-                            },
-                            "tax_type": "gst",
-                            "domain": "Grocery",
-                            "time": {
-                                "label": "enable",
-                                "timestamp": "2023-10-05T06:53:33.029Z"
-                            },
-                            "fulfillment_id": "1"
-                        },
-                        {
-                            "@ondc/org/statutory_reqs_packaged_commodities": {
-                                "common_or_generic_name_of_commodity": "Bath & Hand Wash",
-                                "net_quantity_or_measure_of_commodity_in_pkg": "100 g",
-                                "imported_product_country_of_origin": "ATG",
-                                "description": "Mysore Sandal Centennial Soap, 100 g",
-                                "manufacturer_or_packer_name": "Karnataka Soaps & Detergents LTD #27, Industrial Suburd, P.B No. 5531, Bangalore-Pune Highway, Rajajinagar, Bangallore-560055",
-                                "manufacturer_or_packer_address": "Karnataka Soaps & Detergents LTD #27, Industrial Suburd, P.B No. 5531, Bangalore-Pune Highway, Rajajinagar, Bangallore-560055",
-                                "month_year_of_manufacture_packing_import": ""
-                            },
-                            "@ondc/org/seller_pickup_return": true,
-                            "@ondc/org/contact_details_consumer_care": "yxhddyud77",
-                            "descriptor": {
-                                "symbol": "https://datalabs.siva3.io/image/Eunimart_groceries_40063491_2-mysore-sandal-bathing-soap-centennial.jpg",
-                                "images": [
-                                    "https://datalabs.siva3.io/image/Eunimart_groceries_40063491_2-mysore-sandal-bathing-soap-centennial.jpg"
-                                ],
-                                "name": "Mysore Sandal Centennial Soap, 100 g",
-                                "short_desc": "Unchanging and matchless with a fragrance that rejuvenates the mind,body and soul. It is a legacy created by you which celebrates 100 years of purity",
-                                "long_desc": "Unchanging and matchless with a fragrance that rejuvenates the mind,body and soul. It is a legacy created by you which celebrates 100 years of purity"
-                            },
-                            "location_id": "6906",
-                            "tax_rate": "18",
-                            "@ondc/org/available_on_cod": false,
-                            "L2_category": "Beauty & Hygiene",
-                            "category_id": "Beauty & Hygiene",
-                            "price": {
-                                "currency": "INR",
-                                "maximum_value": "100",
-                                "value": "100"
-                            },
-                            "id": "a671e629-25a0-4bc1-a3dd-c5d2e73397b7",
-                            "@ondc/org/cancellable": true,
-                            "@ondc/org/returnable": true,
-                            "quantity": {
-                                "available": {
-                                    "count": "257"
-                                },
-                                "maximum": {
-                                    "count": "23"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "ml",
-                                        "value": "12"
-                                    }
-                                }
-                            },
-                            "@ondc/org/time_to_ship": "PT1H",
-                            "hsn_code": "1234",
-                            "tags": [],
-                            "@ondc/org/return_window": "P14D",
-                            "@ondc/org/statutory_reqs_prepackaged_food": {
-                                "importer_FSSAI_license_no": null,
-                                "nutritional_info": null,
-                                "other_importer_address": null,
-                                "importer_fssai_logo": null,
-                                "importer_address": null,
-                                "other_importer_name": null,
-                                "brand_owner_FSSAI_license_no": null,
-                                "net_quantity": null,
-                                "additives_info": null,
-                                "other_premises": null,
-                                "importer_name": null,
-                                "brand_owner_address": null,
-                                "brand_owner_fssai_logo": null,
-                                "ingredients_info": null,
-                                "other_FSSAI_license_no": null,
-                                "brand_owner_name": null,
-                                "imported_product_country_of_origin": null,
-                                "manufacturer_or_packer_name": null,
-                                "manufacturer_or_packer_address": null
-                            },
-                            "tax_type": "gst",
-                            "domain": "Grocery",
-                            "time": {
-                                "label": "enable",
-                                "timestamp": "2023-10-05T06:53:33.029Z"
-                            },
-                            "fulfillment_id": "1"
-                        },
-                        {
-                            "@ondc/org/statutory_reqs_packaged_commodities": {
-                                "net_quantity_or_measure_of_commodity_in_pkg": "12 Kg",
-                                "imported_product_country_of_origin": "IND",
-                                "manufacturer_or_packer_name": "yfihojj"
-                            },
-                            "@ondc/org/seller_pickup_return": true,
-                            "@ondc/org/contact_details_consumer_care": "hjvjv",
-                            "descriptor": {
-                                "symbol": "https://firebasestorage.googleapis.com/v0/b/shopeg-dev.appspot.com/o/shopImages%2FSXGJLw4JFjTDTNxEG48PaThdmMG3%2Fimg_1693050853101.jpg?alt=media&token=6435f30f-8f1f-4a53-b5f3-79d1fa9edce6",
-                                "images": [
-                                    "https://firebasestorage.googleapis.com/v0/b/shopeg-dev.appspot.com/o/shopImages%2FSXGJLw4JFjTDTNxEG48PaThdmMG3%2Fimg_1693050853101.jpg?alt=media&token=6435f30f-8f1f-4a53-b5f3-79d1fa9edce6"
-                                ],
-                                "name": "test product 1",
-                                "short_desc": "nxjxjjx",
-                                "long_desc": "nxjxjjxhxjxjxjx"
-                            },
-                            "location_id": "6906",
-                            "tax_rate": "18",
-                            "@ondc/org/available_on_cod": false,
-                            "L2_category": "Bath & Body",
-                            "category_id": "Bath & Body",
-                            "price": {
-                                "currency": "INR",
-                                "maximum_value": "123",
-                                "value": "12"
-                            },
-                            "id": "5313a701-8076-41ab-88cc-9b8aa4b1c35e",
-                            "@ondc/org/cancellable": true,
-                            "@ondc/org/returnable": true,
-                            "quantity": {
-                                "available": {
-                                    "count": "3"
-                                },
-                                "maximum": {
-                                    "count": "1"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "Kg",
-                                        "value": "12"
-                                    }
-                                }
-                            },
-                            "@ondc/org/time_to_ship": "PT1H",
-                            "hsn_code": "1000",
-                            "tags": [],
-                            "@ondc/org/return_window": "P14D",
-                            "@ondc/org/statutory_reqs_prepackaged_food": {
-                                "importer_FSSAI_license_no": null,
-                                "nutritional_info": null,
-                                "other_importer_address": null,
-                                "importer_fssai_logo": null,
-                                "importer_address": null,
-                                "other_importer_name": null,
-                                "brand_owner_FSSAI_license_no": "123456789",
-                                "net_quantity": null,
-                                "additives_info": null,
-                                "other_premises": null,
-                                "importer_name": null,
-                                "brand_owner_address": null,
-                                "brand_owner_fssai_logo": null,
-                                "ingredients_info": null,
-                                "other_FSSAI_license_no": null,
-                                "brand_owner_name": null,
-                                "imported_product_country_of_origin": null,
-                                "manufacturer_or_packer_name": null,
-                                "manufacturer_or_packer_address": null
-                            },
-                            "tax_type": "gst",
-                            "domain": "Beauty & Personal Care",
-                            "time": {
-                                "label": "enable",
-                                "timestamp": "2023-10-05T06:53:33.029Z"
-                            },
-                            "fulfillment_id": "1"
-                        },
-                        {
-                            "@ondc/org/statutory_reqs_packaged_commodities": {
-                                "common_or_generic_name_of_commodity": "Bath & Hand Wash",
-                                "net_quantity_or_measure_of_commodity_in_pkg": "12 Kg",
-                                "imported_product_country_of_origin": "India",
-                                "description": "Mysore Sandal Centennial Soap, 100 g",
-                                "manufacturer_or_packer_name": "Karnataka Soaps & Detergents LTD #27, Industrial Suburd, P.B No. 5531, Bangalore-Pune Highway, Rajajinagar, Bangallore-560055",
-                                "manufacturer_or_packer_address": "Karnataka Soaps & Detergents LTD #27, Industrial Suburd, P.B No. 5531, Bangalore-Pune Highway, Rajajinagar, Bangallore-560055",
-                                "month_year_of_manufacture_packing_import": ""
-                            },
-                            "@ondc/org/seller_pickup_return": true,
-                            "@ondc/org/contact_details_consumer_care": "nnnn",
-                            "descriptor": {
-                                "symbol": "https://datalabs.siva3.io/image/Eunimart_groceries_40063491_2-mysore-sandal-bathing-soap-centennial.jpg",
-                                "images": [
-                                    "https://datalabs.siva3.io/image/Eunimart_groceries_40063491_2-mysore-sandal-bathing-soap-centennial.jpg"
-                                ],
-                                "name": "Mysore Sandal Centennial Soap, 100 g",
-                                "short_desc": "Unchanging and matchless with a fragrance that rejuvenates the mind,body and soul. It is a legacy created by you which celebrates 100 years of purity",
-                                "long_desc": "Unchanging and matchless with a fragrance that rejuvenates the mind,body and soul. It is a legacy created by you which celebrates 100 years of purity"
-                            },
-                            "location_id": "6906",
-                            "tax_rate": "18",
-                            "@ondc/org/available_on_cod": false,
-                            "L2_category": "Beauty & Hygiene",
-                            "category_id": "Beauty & Hygiene",
-                            "price": {
-                                "currency": "INR",
-                                "maximum_value": "100",
-                                "value": "3"
-                            },
-                            "id": "3e28b6d7-a25b-42e6-82fe-6336fa83b04c",
-                            "@ondc/org/cancellable": true,
-                            "@ondc/org/returnable": true,
-                            "quantity": {
-                                "available": {
-                                    "count": "2"
-                                },
-                                "maximum": {
-                                    "count": "2"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "Kg",
-                                        "value": "12"
-                                    }
-                                }
-                            },
-                            "@ondc/org/time_to_ship": "PT1H",
-                            "hsn_code": "1000",
-                            "tags": [],
-                            "@ondc/org/return_window": "P14D",
-                            "@ondc/org/statutory_reqs_prepackaged_food": {
-                                "importer_FSSAI_license_no": null,
-                                "nutritional_info": null,
-                                "other_importer_address": null,
-                                "importer_fssai_logo": null,
-                                "importer_address": null,
-                                "other_importer_name": null,
-                                "brand_owner_FSSAI_license_no": null,
-                                "net_quantity": null,
-                                "additives_info": null,
-                                "other_premises": null,
-                                "importer_name": null,
-                                "brand_owner_address": null,
-                                "brand_owner_fssai_logo": null,
-                                "ingredients_info": null,
-                                "other_FSSAI_license_no": null,
-                                "brand_owner_name": null,
-                                "imported_product_country_of_origin": null,
-                                "manufacturer_or_packer_name": null,
-                                "manufacturer_or_packer_address": null
-                            },
-                            "tax_type": "gst",
-                            "domain": "Grocery",
-                            "time": {
-                                "label": "enable",
-                                "timestamp": "2023-10-05T06:53:33.029Z"
-                            },
-                            "fulfillment_id": "1"
-                        },
-                        {
-                            "@ondc/org/cancellable": true,
-                            "@ondc/org/returnable": true,
-                            "quantity": {
-                                "available": {
-                                    "count": "4"
-                                },
-                                "maximum": {
-                                    "count": "2"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "ml",
-                                        "value": "12"
-                                    }
-                                }
-                            },
-                            "@ondc/org/statutory_reqs_packaged_commodities": {
-                                "net_quantity_or_measure_of_commodity_in_pkg": "12 ml",
-                                "imported_product_country_of_origin": "IND",
-                                "manufacturer_or_packer_name": "jxjcjjv"
-                            },
-                            "@ondc/org/seller_pickup_return": true,
-                            "@ondc/org/contact_details_consumer_care": "bsbdjx",
-                            "@ondc/org/time_to_ship": "PT1H",
-                            "descriptor": {
-                                "symbol": "https://firebasestorage.googleapis.com/v0/b/shopeg-dev.appspot.com/o/shopImages%2FSXGJLw4JFjTDTNxEG48PaThdmMG3%2Fimg_1693532308753.jpg?alt=media&token=302605d1-dfd0-4259-ba91-45830acfd6fd",
-                                "images": [
-                                    "https://firebasestorage.googleapis.com/v0/b/shopeg-dev.appspot.com/o/shopImages%2FSXGJLw4JFjTDTNxEG48PaThdmMG3%2Fimg_1693532308753.jpg?alt=media&token=302605d1-dfd0-4259-ba91-45830acfd6fd"
-                                ],
-                                "name": "nxnx",
-                                "short_desc": "jfjjc",
-                                "long_desc": "jfjjc"
-                            },
-                            "hsn_code": "1234",
-                            "location_id": "6906",
-                            "tax_rate": "18",
-                            "tags": [],
-                            "@ondc/org/return_window": "P14D",
-                            "@ondc/org/available_on_cod": false,
-                            "L2_category": "Fragrance",
-                            "category_id": "Fragrance",
-                            "tax_type": "gst",
-                            "price": {
-                                "currency": "INR",
-                                "maximum_value": "23",
-                                "value": "22"
-                            },
-                            "domain": "Beauty & Personal Care",
-                            "id": "4aa50aff-e8bf-43d3-a3e1-c37c40043452",
-                            "time": {
-                                "label": "enable",
-                                "timestamp": "2023-10-05T06:53:33.029Z"
-                            },
-                            "fulfillment_id": "1"
-                        },
-                        {
-                            "@ondc/org/statutory_reqs_packaged_commodities": {
-                                "net_quantity_or_measure_of_commodity_in_pkg": "12 Kg",
-                                "imported_product_country_of_origin": "IND",
-                                "manufacturer_or_packer_name": "jcjcjcxj"
-                            },
-                            "@ondc/org/seller_pickup_return": true,
-                            "@ondc/org/contact_details_consumer_care": "nxjxxjxjxj",
-                            "descriptor": {
-                                "symbol": "https://firebasestorage.googleapis.com/v0/b/shopeg-dev.appspot.com/o/shopImages%2FSXGJLw4JFjTDTNxEG48PaThdmMG3%2Fimg_1694600526877.jpg?alt=media&token=e4e68cb0-cac9-4135-bba6-c1d1701c9dd1",
-                                "images": [
-                                    "https://firebasestorage.googleapis.com/v0/b/shopeg-dev.appspot.com/o/shopImages%2FSXGJLw4JFjTDTNxEG48PaThdmMG3%2Fimg_1694600526877.jpg?alt=media&token=e4e68cb0-cac9-4135-bba6-c1d1701c9dd1"
-                                ],
-                                "name": "new 3",
-                                "short_desc": "jdjkdkf",
-                                "long_desc": "jdjkdkfjj"
-                            },
-                            "location_id": "6906",
-                            "tax_rate": "28",
-                            "@ondc/org/available_on_cod": false,
-                            "L2_category": "Foodgrains",
-                            "category_id": "Foodgrains",
-                            "price": {
-                                "currency": "INR",
-                                "maximum_value": "235",
-                                "value": "235"
-                            },
-                            "id": "850543cc-fbe8-428c-bbbf-c6ed21453ba6",
-                            "@ondc/org/cancellable": true,
-                            "@ondc/org/returnable": true,
-                            "quantity": {
-                                "available": {
-                                    "count": "23"
-                                },
-                                "maximum": {
-                                    "count": "23"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "Kg",
-                                        "value": "12"
-                                    }
-                                }
-                            },
-                            "@ondc/org/time_to_ship": "PT1H",
-                            "hsn_code": "1234",
-                            "tags": [],
-                            "@ondc/org/return_window": "P14D",
-                            "@ondc/org/statutory_reqs_prepackaged_food": {
-                                "importer_FSSAI_license_no": null,
-                                "nutritional_info": null,
-                                "other_importer_address": null,
-                                "importer_fssai_logo": null,
-                                "importer_address": null,
-                                "other_importer_name": null,
-                                "brand_owner_FSSAI_license_no": "123456",
-                                "net_quantity": null,
-                                "additives_info": null,
-                                "other_premises": null,
-                                "importer_name": null,
-                                "brand_owner_address": null,
-                                "brand_owner_fssai_logo": null,
-                                "ingredients_info": null,
-                                "other_FSSAI_license_no": null,
-                                "brand_owner_name": null,
-                                "imported_product_country_of_origin": null,
-                                "manufacturer_or_packer_name": null,
-                                "manufacturer_or_packer_address": null
-                            },
-                            "tax_type": "gst",
-                            "domain": "Grocery",
-                            "time": {
-                                "label": "enable",
-                                "timestamp": "2023-10-05T06:53:33.029Z"
-                            },
-                            "fulfillment_id": "1"
-                        },
-                        {
-                            "@ondc/org/statutory_reqs_packaged_commodities": {
-                                "common_or_generic_name_of_commodity": "Feminine Hygiene",
-                                "net_quantity_or_measure_of_commodity_in_pkg": "1288 g",
-                                "imported_product_country_of_origin": "India",
-                                "description": "Whisper Ultra Soft Air Fresh Sanitary Pads - With Wider & Longer Back, XL, 50 pcs",
-                                "manufacturer_or_packer_name": "Procter & Gamble Home Products Private Limited, Plot No. 1, Industrial Area, Village Katha, Baddi, Dist Solan, H. P. - 173205",
-                                "multiple_products_name_number_or_qty": "hdhdjdd",
-                                "manufacturer_or_packer_address": "Procter & Gamble Home Products Private Limited, Plot No. 1, Industrial Area, Village Katha, Baddi, Dist Solan, H. P. - 173205",
-                                "month_year_of_manufacture_packing_import": "09/2023"
-                            },
-                            "@ondc/org/seller_pickup_return": true,
-                            "@ondc/org/contact_details_consumer_care": "vzhzhx",
-                            "descriptor": {
-                                "symbol": "https://datalabs.siva3.io/image/Eunimart_groceries_40111912_13-whisper-ultra-soft-air-fresh-sanitary-pads-with-wider-longer-back-xl.jpg",
-                                "images": [
-                                    "https://datalabs.siva3.io/image/Eunimart_groceries_40111912_13-whisper-ultra-soft-air-fresh-sanitary-pads-with-wider-longer-back-xl.jpg",
-                                    "https://datalabs.siva3.io/image/Eunimart_groceries_40111912-2_12-whisper-ultra-soft-air-fresh-sanitary-pads-with-wider-longer-back-xl.jpg",
-                                    "https://datalabs.siva3.io/image/Eunimart_groceries_40111912-3_2-whisper-ultra-soft-air-fresh-sanitary-pads-with-wider-longer-back-xl.jpg"
-                                ],
-                                "name": "Whisper Ultra Soft Air Fresh Sanitary Pads - With Wider & Longer Back, XL, 50 pcs",
-                                "short_desc": "Whisper Ultra Softs Air Fresh provides airy fresh feel for an irritation free periods. They have 500 air fresh pores that allow air to pass through while absorbing wetness. Now you can say Goodbye to the 'icky, sticky' feeling during your periods!",
-                                "long_desc": "Whisper Ultra Softs Air Fresh provides airy fresh feel for an irritation free periods. They have 500 air fresh pores that allow air to pass through while absorbing wetness. Now you can say Goodbye to the 'icky, sticky' feeling during your periods!"
-                            },
-                            "location_id": "6906",
-                            "tax_rate": "18",
-                            "@ondc/org/available_on_cod": false,
-                            "L2_category": "Beauty & Hygiene",
-                            "category_id": "Beauty & Hygiene",
-                            "price": {
-                                "currency": "INR",
-                                "maximum_value": "468.75",
-                                "value": "468.75"
-                            },
-                            "id": "875d315e-5402-4335-8368-ad636f6394d1",
-                            "@ondc/org/cancellable": true,
-                            "@ondc/org/returnable": true,
-                            "quantity": {
-                                "available": {
-                                    "count": "3"
-                                },
-                                "maximum": {
-                                    "count": "3"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "g",
-                                        "value": "1288"
-                                    }
-                                }
-                            },
-                            "@ondc/org/time_to_ship": "PT1H",
-                            "hsn_code": "13345",
-                            "tags": [],
-                            "@ondc/org/return_window": "P14D",
-                            "@ondc/org/statutory_reqs_prepackaged_food": {
-                                "importer_FSSAI_license_no": null,
-                                "nutritional_info": null,
-                                "other_FSSAI_license_no": null,
-                                "imported_product_country_of_origin": null,
-                                "brand_owner_FSSAI_license_no": null,
-                                "additives_info": null
-                            },
-                            "tax_type": "gst",
-                            "domain": "Grocery",
-                            "time": {
-                                "label": "enable",
-                                "timestamp": "2023-10-05T06:53:33.029Z"
-                            },
-                            "fulfillment_id": "1"
-                        },
-                        {
-                            "@ondc/org/cancellable": true,
-                            "@ondc/org/returnable": true,
-                            "quantity": {
-                                "available": {
-                                    "count": "3"
-                                },
-                                "maximum": {
-                                    "count": "3"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "ml",
-                                        "value": "21"
-                                    }
-                                }
-                            },
-                            "@ondc/org/statutory_reqs_packaged_commodities": {
-                                "common_or_generic_name_of_commodity": "ysysy",
-                                "net_quantity_or_measure_of_commodity_in_pkg": "21 ml",
-                                "imported_product_country_of_origin": "IND",
-                                "manufacturer_or_packer_name": "usus",
-                                "multiple_products_name_number_or_qty": "6",
-                                "manufacturer_or_packer_address": "hsys",
-                                "month_year_of_manufacture_packing_import": "09/2023"
-                            },
-                            "@ondc/org/seller_pickup_return": true,
-                            "@ondc/org/contact_details_consumer_care": "bshhssh",
-                            "@ondc/org/time_to_ship": "PT1H",
-                            "descriptor": {
-                                "symbol": "https://firebasestorage.googleapis.com/v0/b/shopeg-dev.appspot.com/o/shopImages%2FSXGJLw4JFjTDTNxEG48PaThdmMG3%2Fimg_1695816552671.jpg?alt=media&token=862c618e-7154-4df7-8b1e-fceaf09b7d72",
-                                "images": [
-                                    "https://firebasestorage.googleapis.com/v0/b/shopeg-dev.appspot.com/o/shopImages%2FSXGJLw4JFjTDTNxEG48PaThdmMG3%2Fimg_1695816552671.jpg?alt=media&token=862c618e-7154-4df7-8b1e-fceaf09b7d72"
-                                ],
-                                "name": "jjjjk",
-                                "short_desc": "hdudu",
-                                "long_desc": "hdududydydy"
-                            },
-                            "hsn_code": "1234",
-                            "location_id": "6906",
-                            "tax_rate": "18",
-                            "tags": [],
-                            "@ondc/org/return_window": "P14D",
-                            "@ondc/org/available_on_cod": false,
-                            "L2_category": "Beauty & Hygiene",
-                            "category_id": "Beauty & Hygiene",
-                            "tax_type": "gst",
-                            "price": {
-                                "currency": "INR",
-                                "maximum_value": "1234",
-                                "value": "1234"
-                            },
-                            "domain": "Grocery",
-                            "id": "4ed69a9d-b4cd-4912-b944-8b052dff29b5",
-                            "time": {
-                                "label": "enable",
-                                "timestamp": "2023-10-05T06:53:33.029Z"
-                            },
-                            "fulfillment_id": "1"
-                        },
-                        {
-                            "@ondc/org/statutory_reqs_packaged_commodities": {
-                                "common_or_generic_name_of_commodity": "hzhzh",
-                                "net_quantity_or_measure_of_commodity_in_pkg": "12 Kg",
-                                "imported_product_country_of_origin": "IND",
-                                "manufacturer_or_packer_name": "hzhzhx",
-                                "multiple_products_name_number_or_qty": "hzhz",
-                                "manufacturer_or_packer_address": "hxhxjxhx",
-                                "month_year_of_manufacture_packing_import": "10/2023"
-                            },
-                            "@ondc/org/seller_pickup_return": true,
-                            "@ondc/org/contact_details_consumer_care": "vbbjxjxjx",
-                            "descriptor": {
-                                "symbol": "https://firebasestorage.googleapis.com/v0/b/shopeg-dev.appspot.com/o/shopImages%2FSXGJLw4JFjTDTNxEG48PaThdmMG3%2Fimg_1696400460619.jpg?alt=media&token=87ee069d-1dea-4a11-9082-35b7eebba84a",
-                                "images": [
-                                    "https://firebasestorage.googleapis.com/v0/b/shopeg-dev.appspot.com/o/shopImages%2FSXGJLw4JFjTDTNxEG48PaThdmMG3%2Fimg_1696400460619.jpg?alt=media&token=87ee069d-1dea-4a11-9082-35b7eebba84a"
-                                ],
-                                "name": "new item1",
-                                "short_desc": "nxnxn",
-                                "long_desc": "nxnxn"
-                            },
-                            "location_id": "6906",
-                            "tax_rate": "18",
-                            "@ondc/org/available_on_cod": false,
-                            "L2_category": "Gourmet & World Foods",
-                            "category_id": "Gourmet & World Foods",
-                            "price": {
-                                "currency": "INR",
-                                "maximum_value": "250",
-                                "value": "250"
-                            },
-                            "id": "57257df1-699e-4910-8c44-1ec088a86d21",
-                            "@ondc/org/cancellable": true,
-                            "@ondc/org/returnable": true,
-                            "quantity": {
-                                "available": {
-                                    "count": "3"
-                                },
-                                "maximum": {
-                                    "count": "3"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "Kg",
-                                        "value": "12"
-                                    }
-                                }
-                            },
-                            "@ondc/org/time_to_ship": "PT1H",
-                            "hsn_code": "1234",
-                            "tags": [
-                                {
-                                    "code": "veg_nonveg",
-                                    "list": [
-                                        {
-                                            "code": "veg",
-                                            "value": "yes"
-                                        }
-                                    ]
-                                }
-                            ],
-                            "@ondc/org/return_window": "P14D",
-                            "@ondc/org/statutory_reqs_prepackaged_food": {
-                                "importer_FSSAI_license_no": "6135656535",
-                                "nutritional_info": "hxjx",
-                                "other_importer_address": "hxhxxj",
-                                "importer_address": "hsud",
-                                "other_importer_name": "bxbx",
-                                "brand_owner_FSSAI_license_no": "123456",
-                                "net_quantity": "12",
-                                "additives_info": "hxhx",
-                                "other_premises": "jdjd",
-                                "importer_name": "hzhz",
-                                "brand_owner_address": "hxjjxjxd",
-                                "ingredients_info": "bzbx",
-                                "other_FSSAI_license_no": "64656",
-                                "brand_owner_name": "jxjxj",
-                                "imported_product_country_of_origin": "IND",
-                                "manufacturer_or_packer_name": "hxhxhx",
-                                "manufacturer_or_packer_address": "hxhxhx"
-                            },
-                            "@ondc/org/mandatory_reqs_veggies_fruits": {
-                                "net_quantity": "12"
-                            },
-                            "tax_type": "gst",
-                            "domain": "Grocery",
-                            "time": {
-                                "label": "enable",
-                                "timestamp": "2023-10-05T06:53:33.029Z"
-                            },
-                            "fulfillment_id": "1"
-                        },
-                        {
-                            "@ondc/org/statutory_reqs_packaged_commodities": {
-                                "common_or_generic_name_of_commodity": "udud",
-                                "net_quantity_or_measure_of_commodity_in_pkg": "12 Kg",
-                                "imported_product_country_of_origin": "IND",
-                                "manufacturer_or_packer_name": "uxd",
-                                "multiple_products_name_number_or_qty": "hzhz",
-                                "manufacturer_or_packer_address": "udud",
-                                "month_year_of_manufacture_packing_import": "10/2023"
-                            },
-                            "@ondc/org/seller_pickup_return": true,
-                            "@ondc/org/contact_details_consumer_care": "jxjx",
-                            "descriptor": {
-                                "symbol": "https://firebasestorage.googleapis.com/v0/b/shopeg-dev.appspot.com/o/shopImages%2FSXGJLw4JFjTDTNxEG48PaThdmMG3%2Fimg_1696486026461.jpg?alt=media&token=131d2582-eb17-4c76-8275-da6231aeec90",
-                                "images": [
-                                    "https://firebasestorage.googleapis.com/v0/b/shopeg-dev.appspot.com/o/shopImages%2FSXGJLw4JFjTDTNxEG48PaThdmMG3%2Fimg_1696486026461.jpg?alt=media&token=131d2582-eb17-4c76-8275-da6231aeec90"
-                                ],
-                                "name": "bru1",
-                                "short_desc": "bxnxjx",
-                                "long_desc": "bxnxjxjxjx"
-                            },
-                            "location_id": "6906",
-                            "tax_rate": "18",
-                            "@ondc/org/available_on_cod": false,
-                            "L2_category": "Beverages",
-                            "category_id": "Beverages",
-                            "price": {
-                                "currency": "INR",
-                                "maximum_value": "123",
-                                "value": "123"
-                            },
-                            "id": "ea17c0cb-dc08-4849-8a28-edb4aaac9854",
-                            "@ondc/org/cancellable": true,
-                            "@ondc/org/returnable": true,
-                            "quantity": {
-                                "available": {
-                                    "count": "3"
-                                },
-                                "maximum": {
-                                    "count": "3"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "Kg",
-                                        "value": "12"
-                                    }
-                                }
-                            },
-                            "@ondc/org/time_to_ship": "PT1H",
-                            "hsn_code": "12345",
-                            "tags": [
-                                {
-                                    "code": "veg_nonveg",
-                                    "list": [
-                                        {
-                                            "code": "veg",
-                                            "value": "yes"
-                                        }
-                                    ]
-                                }
-                            ],
-                            "@ondc/org/return_window": "P14D",
-                            "@ondc/org/statutory_reqs_prepackaged_food": {
-                                "importer_FSSAI_license_no": "123456",
-                                "nutritional_info": "hzh",
-                                "other_importer_address": "hxhx",
-                                "importer_address": "hxh",
-                                "other_importer_name": "hzhz",
-                                "brand_owner_FSSAI_license_no": "12346456",
-                                "net_quantity": "66",
-                                "additives_info": "hxhx",
-                                "other_premises": "uzud",
-                                "importer_name": "gsgs",
-                                "brand_owner_address": "yzux",
-                                "ingredients_info": "jxj",
-                                "other_FSSAI_license_no": "28586868",
-                                "brand_owner_name": "hzhx",
-                                "imported_product_country_of_origin": "AFG",
-                                "manufacturer_or_packer_name": "usuz",
-                                "manufacturer_or_packer_address": "usus"
-                            },
-                            "tax_type": "gst",
-                            "domain": "Grocery",
-                            "time": {
-                                "label": "enable",
-                                "timestamp": "2023-10-05T06:53:33.029Z"
-                            },
-                            "fulfillment_id": "1"
-                        },
-                        {
-                            "@ondc/org/cancellable": true,
-                            "@ondc/org/returnable": true,
-                            "quantity": {
-                                "available": {
-                                    "count": "1"
-                                },
-                                "maximum": {
-                                    "count": "1"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "g",
-                                        "value": "12"
-                                    }
-                                }
-                            },
-                            "@ondc/org/statutory_reqs_packaged_commodities": {
-                                "net_quantity_or_measure_of_commodity_in_pkg": "12 g",
-                                "imported_product_country_of_origin": "IND",
-                                "manufacturer_or_packer_name": "gxyxy"
-                            },
-                            "@ondc/org/contact_details_consumer_care": "bcbc",
-                            "@ondc/org/seller_pickup_return": true,
-                            "@ondc/org/time_to_ship": "PT1H",
-                            "descriptor": {
-                                "symbol": "https://firebasestorage.googleapis.com/v0/b/shopeg-dev.appspot.com/o/shopImages%2FSXGJLw4JFjTDTNxEG48PaThdmMG3%2Fimg_1694596785144.jpg?alt=media&token=c3a8caa4-a33e-47d7-ad77-89f3a7a4cf6a",
-                                "images": [
-                                    "https://firebasestorage.googleapis.com/v0/b/shopeg-dev.appspot.com/o/shopImages%2FSXGJLw4JFjTDTNxEG48PaThdmMG3%2Fimg_1694596785144.jpg?alt=media&token=c3a8caa4-a33e-47d7-ad77-89f3a7a4cf6a"
-                                ],
-                                "name": "b nxjxxkxllxlzzllzzllzlxlx",
-                                "short_desc": "ucuxuc",
-                                "long_desc": "ucuxucduduud"
-                            },
-                            "hsn_code": "1234",
-                            "location_id": "6906",
-                            "tax_rate": "28",
-                            "tags": [],
-                            "@ondc/org/return_window": "P14D",
-                            "@ondc/org/available_on_cod": false,
-                            "L2_category": "Cleaning & Household",
-                            "category_id": "Cleaning & Household",
-                            "tax_type": "gst",
-                            "price": {
-                                "currency": "INR",
-                                "maximum_value": "125",
-                                "value": "12"
-                            },
-                            "domain": "Grocery",
-                            "id": "8fcbadfb-3916-42ad-91ba-164b6af8112a",
-                            "time": {
-                                "label": "enable",
-                                "timestamp": "2023-10-05T06:53:33.029Z"
-                            },
-                            "fulfillment_id": "1"
-                        },
-                        {
-                            "@ondc/org/statutory_reqs_packaged_commodities": {
-                                "common_or_generic_name_of_commodity": "Bath & Hand Wash",
-                                "net_quantity_or_measure_of_commodity_in_pkg": "50 g",
-                                "imported_product_country_of_origin": "ARM",
-                                "description": "Ponds Talc Natural - Sandal Radiance, 50 g Bottle",
-                                "manufacturer_or_packer_name": "Hindustan Unilever Limited, Unilever House, B D Sawant Marg, Chakala, Anderi E, Mumbai - 400099",
-                                "manufacturer_or_packer_address": "Hindustan Unilever Limited, Unilever House, B D Sawant Marg, Chakala, Anderi E, Mumbai - 400099",
-                                "month_year_of_manufacture_packing_import": ""
-                            },
-                            "@ondc/org/seller_pickup_return": true,
-                            "@ondc/org/contact_details_consumer_care": "hxhdhd677",
-                            "descriptor": {
-                                "symbol": "https://www.bigbasket.com/media/uploads/p/l/40019034_5-ponds-talc-natural-sandal-radiance.jpg",
-                                "images": [
-                                    "https://www.bigbasket.com/media/uploads/p/l/40019034_5-ponds-talc-natural-sandal-radiance.jpg",
-                                    "https://www.bigbasket.com/media/uploads/p/l/40019034-2_1-ponds-talc-natural-sandal-radiance.jpg",
-                                    "https://www.bigbasket.com/media/uploads/p/l/40019034-3_1-ponds-talc-natural-sandal-radiance.jpg"
-                                ],
-                                "name": "Ponds Talc Natural - Sandal Radiance, 50 g Bottle",
-                                "short_desc": "Mesmerize everyone with your subtle fragrance when you use Ponds Sandal Talcum Powder. This powder, with Its essential sandalwood aroma is designed to keep feeling soothed and fresh for a long time. Its silky texture is easy to apply and is highly effective. This powder keeps you feeling dry and clean even during sultry days of the summer season and its sandalwood fragrance will protect you against body odors. The powder is multipurpose as it also comes with Sun Protection formula. You can use this powder to protect your skin against harmful effects of UV rays. It also helps to conserve and restore the natural glow of your skin. Buy the Ponds Sandal Talcum Powder now!",
-                                "long_desc": "Mesmerize everyone with your subtle fragrance when you use Ponds Sandal Talcum Powder. This powder, with Its essential sandalwood aroma is designed to keep feeling soothed and fresh for a long time. Its silky texture is easy to apply and is highly effective. This powder keeps you feeling dry and clean even during sultry days of the summer season and its sandalwood fragrance will protect you against body odors. The powder is multipurpose as it also comes with Sun Protection formula. You can use this powder to protect your skin against harmful effects of UV rays. It also helps to conserve and restore the natural glow of your skin. Buy the Ponds Sandal Talcum Powder now!"
-                            },
-                            "tax_rate": "5",
-                            "location_id": "6906",
-                            "@ondc/org/available_on_cod": false,
-                            "L2_category": "Beauty & Hygiene",
-                            "category_id": "Beauty & Hygiene",
-                            "price": {
-                                "currency": "INR",
-                                "maximum_value": "72",
-                                "value": "72"
-                            },
-                            "id": "77220bcd-3d0d-4441-b242-c7691d703a98",
-                            "@ondc/org/cancellable": true,
-                            "@ondc/org/returnable": true,
-                            "quantity": {
-                                "available": {
-                                    "count": "4"
-                                },
-                                "maximum": {
-                                    "count": "4"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "ml",
-                                        "value": "156"
-                                    }
-                                }
-                            },
-                            "@ondc/org/time_to_ship": "PT1H",
-                            "hsn_code": "123456",
-                            "tags": [],
-                            "@ondc/org/return_window": "P14D",
-                            "@ondc/org/statutory_reqs_prepackaged_food": {
-                                "importer_FSSAI_license_no": null,
-                                "nutritional_info": null,
-                                "other_importer_address": null,
-                                "importer_fssai_logo": null,
-                                "importer_address": null,
-                                "other_importer_name": null,
-                                "brand_owner_FSSAI_license_no": null,
-                                "net_quantity": null,
-                                "additives_info": null,
-                                "other_premises": null,
-                                "importer_name": null,
-                                "brand_owner_address": null,
-                                "brand_owner_fssai_logo": null,
-                                "ingredients_info": null,
-                                "other_FSSAI_license_no": null,
-                                "brand_owner_name": null,
-                                "imported_product_country_of_origin": null,
-                                "manufacturer_or_packer_name": null,
-                                "manufacturer_or_packer_address": null
-                            },
-                            "tax_type": "gst",
-                            "domain": "Grocery",
-                            "time": {
-                                "label": "enable",
-                                "timestamp": "2023-10-05T06:53:33.029Z"
-                            },
-                            "fulfillment_id": "1"
-                        },
-                        {
-                            "@ondc/org/cancellable": true,
-                            "@ondc/org/returnable": true,
-                            "quantity": {
-                                "available": {
-                                    "count": "5"
-                                },
-                                "maximum": {
-                                    "count": "2"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "ml",
-                                        "value": "12"
-                                    }
-                                }
-                            },
-                            "@ondc/org/statutory_reqs_packaged_commodities": {
-                                "net_quantity_or_measure_of_commodity_in_pkg": "12 ml",
-                                "imported_product_country_of_origin": "IND",
-                                "manufacturer_or_packer_name": "jxjcjjv"
-                            },
-                            "@ondc/org/seller_pickup_return": true,
-                            "@ondc/org/contact_details_consumer_care": "bsbdjx",
-                            "@ondc/org/time_to_ship": "PT1H",
-                            "descriptor": {
-                                "symbol": "https://firebasestorage.googleapis.com/v0/b/shopeg-dev.appspot.com/o/shopImages%2FSXGJLw4JFjTDTNxEG48PaThdmMG3%2Fimg_1693532308753.jpg?alt=media&token=302605d1-dfd0-4259-ba91-45830acfd6fd",
-                                "images": [
-                                    "https://firebasestorage.googleapis.com/v0/b/shopeg-dev.appspot.com/o/shopImages%2FSXGJLw4JFjTDTNxEG48PaThdmMG3%2Fimg_1693532308753.jpg?alt=media&token=302605d1-dfd0-4259-ba91-45830acfd6fd"
-                                ],
-                                "name": "nxnx",
-                                "short_desc": "jfjjc",
-                                "long_desc": "jfjjc"
-                            },
-                            "hsn_code": "1234",
-                            "location_id": "6906",
-                            "tax_rate": "18",
-                            "tags": [],
-                            "@ondc/org/return_window": "P14D",
-                            "@ondc/org/available_on_cod": false,
-                            "L2_category": "Fragrance",
-                            "category_id": "Fragrance",
-                            "tax_type": "gst",
-                            "price": {
-                                "currency": "INR",
-                                "maximum_value": "23",
-                                "value": "23"
-                            },
-                            "domain": "Beauty & Personal Care",
-                            "id": "ad5224b3-1f8c-4d52-873a-67bd2f4fc8b9",
-                            "time": {
-                                "label": "enable",
-                                "timestamp": "2023-10-05T06:53:33.029Z"
-                            },
-                            "fulfillment_id": "1"
-                        },
-                        {
-                            "@ondc/org/cancellable": true,
-                            "@ondc/org/returnable": true,
-                            "quantity": {
-                                "available": {
-                                    "count": "22"
-                                },
-                                "maximum": {
-                                    "count": "23"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "Kg",
-                                        "value": "12"
-                                    }
-                                }
-                            },
-                            "@ondc/org/statutory_reqs_packaged_commodities": {
-                                "net_quantity_or_measure_of_commodity_in_pkg": "12 Kg",
-                                "imported_product_country_of_origin": "IND",
-                                "manufacturer_or_packer_name": "hxjxj"
-                            },
-                            "@ondc/org/seller_pickup_return": true,
-                            "@ondc/org/contact_details_consumer_care": "xnxxn",
-                            "@ondc/org/time_to_ship": "PT1H",
-                            "descriptor": {
-                                "symbol": "https://firebasestorage.googleapis.com/v0/b/shopeg-dev.appspot.com/o/shopImages%2FSXGJLw4JFjTDTNxEG48PaThdmMG3%2Fimg_1693758157307.jpg?alt=media&token=49f5fa6e-d42c-48e5-ae7d-c6c9c45ce58e",
-                                "images": [
-                                    "https://firebasestorage.googleapis.com/v0/b/shopeg-dev.appspot.com/o/shopImages%2FSXGJLw4JFjTDTNxEG48PaThdmMG3%2Fimg_1693758157307.jpg?alt=media&token=49f5fa6e-d42c-48e5-ae7d-c6c9c45ce58e"
-                                ],
-                                "name": "test 03",
-                                "short_desc": "hxxjjxf",
-                                "long_desc": "hxxjjxf"
-                            },
-                            "hsn_code": "1234",
-                            "location_id": "6906",
-                            "tax_rate": "5",
-                            "tags": [],
-                            "@ondc/org/return_window": "P14D",
-                            "@ondc/org/available_on_cod": false,
-                            "L2_category": "Fragrance",
-                            "category_id": "Fragrance",
-                            "tax_type": "gst",
-                            "price": {
-                                "currency": "INR",
-                                "maximum_value": "123",
-                                "value": "123"
-                            },
-                            "domain": "Beauty & Personal Care",
-                            "id": "23edf965-375d-4e08-949e-d555cdab7a94",
-                            "time": {
-                                "label": "enable",
-                                "timestamp": "2023-10-05T06:53:33.029Z"
-                            },
-                            "fulfillment_id": "1"
-                        },
-                        {
-                            "@ondc/org/cancellable": true,
-                            "@ondc/org/returnable": true,
-                            "quantity": {
-                                "available": {
-                                    "count": "4"
-                                },
-                                "maximum": {
-                                    "count": "3"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "ml",
-                                        "value": "25"
-                                    }
-                                }
-                            },
-                            "@ondc/org/statutory_reqs_packaged_commodities": {
-                                "net_quantity_or_measure_of_commodity_in_pkg": "25 ml",
-                                "imported_product_country_of_origin": "IND",
-                                "manufacturer_or_packer_name": "hijggjj"
-                            },
-                            "@ondc/org/seller_pickup_return": true,
-                            "@ondc/org/contact_details_consumer_care": "bbhjmnb",
-                            "@ondc/org/time_to_ship": "PT1H",
-                            "descriptor": {
-                                "symbol": "https://firebasestorage.googleapis.com/v0/b/shopeg-dev.appspot.com/o/shopImages%2FSXGJLw4JFjTDTNxEG48PaThdmMG3%2Fimg_1693977906327.jpg?alt=media&token=c0d186b2-522e-44eb-984f-f639d39e140f",
-                                "images": [
-                                    "https://firebasestorage.googleapis.com/v0/b/shopeg-dev.appspot.com/o/shopImages%2FSXGJLw4JFjTDTNxEG48PaThdmMG3%2Fimg_1693977906327.jpg?alt=media&token=c0d186b2-522e-44eb-984f-f639d39e140f"
-                                ],
-                                "name": "Fan",
-                                "short_desc": "jfjfjf",
-                                "long_desc": "jfjfjf"
-                            },
-                            "hsn_code": "1234",
-                            "location_id": "6906",
-                            "tax_rate": "18",
-                            "tags": [],
-                            "@ondc/org/return_window": "P14D",
-                            "@ondc/org/available_on_cod": false,
-                            "L2_category": "Feminine Care",
-                            "category_id": "Feminine Care",
-                            "tax_type": "gst",
-                            "price": {
-                                "currency": "INR",
-                                "maximum_value": "2356",
-                                "value": "2350"
-                            },
-                            "domain": "Beauty & Personal Care",
-                            "id": "a62f711b-7dfa-4b8b-8192-5d3d7f2786d4",
-                            "time": {
-                                "label": "enable",
-                                "timestamp": "2023-10-05T06:53:33.029Z"
-                            },
-                            "fulfillment_id": "1"
-                        },
-                        {
-                            "@ondc/org/cancellable": true,
-                            "@ondc/org/returnable": true,
-                            "quantity": {
-                                "available": {
-                                    "count": "23"
-                                },
-                                "maximum": {
-                                    "count": "13"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "l",
-                                        "value": "12"
-                                    }
-                                }
-                            },
-                            "@ondc/org/statutory_reqs_packaged_commodities": {
-                                "net_quantity_or_measure_of_commodity_in_pkg": "12 l",
-                                "imported_product_country_of_origin": "IND",
-                                "manufacturer_or_packer_name": "ydydyd"
-                            },
-                            "@ondc/org/seller_pickup_return": true,
-                            "@ondc/org/contact_details_consumer_care": "gxyxuuxuf",
-                            "@ondc/org/time_to_ship": "PT1H",
-                            "descriptor": {
-                                "symbol": "https://firebasestorage.googleapis.com/v0/b/shopeg-dev.appspot.com/o/shopImages%2FSXGJLw4JFjTDTNxEG48PaThdmMG3%2Fimg_1693758441819.jpg?alt=media&token=031f645b-3aaf-4728-9620-2212848d33aa",
-                                "images": [
-                                    "https://firebasestorage.googleapis.com/v0/b/shopeg-dev.appspot.com/o/shopImages%2FSXGJLw4JFjTDTNxEG48PaThdmMG3%2Fimg_1693758441819.jpg?alt=media&token=031f645b-3aaf-4728-9620-2212848d33aa"
-                                ],
-                                "name": "tetd56",
-                                "short_desc": "icicduxix",
-                                "long_desc": "icicduxix"
-                            },
-                            "hsn_code": "12345",
-                            "location_id": "6906",
-                            "tax_rate": "5",
-                            "tags": [],
-                            "@ondc/org/return_window": "P14D",
-                            "@ondc/org/available_on_cod": false,
-                            "L2_category": "Beauty & Hygiene",
-                            "category_id": "Beauty & Hygiene",
-                            "tax_type": "gst",
-                            "price": {
-                                "currency": "INR",
-                                "maximum_value": "23",
-                                "value": "23"
-                            },
-                            "domain": "Grocery",
-                            "id": "28680280-7ce8-4cb5-995b-1e379542269e",
-                            "time": {
-                                "label": "enable",
-                                "timestamp": "2023-10-05T06:53:33.029Z"
-                            },
-                            "fulfillment_id": "1"
-                        },
-                        {
-                            "@ondc/org/statutory_reqs_packaged_commodities": {
-                                "net_quantity_or_measure_of_commodity_in_pkg": "23",
-                                "date_of_import": "08/2023",
-                                "imported_product_country_of_origin": "hhss",
-                                "manufacturer_or_packer_name": "gwhewh"
-                            },
-                            "@ondc/org/seller_pickup_return": true,
-                            "@ondc/org/contact_details_consumer_care": "hsjjw6mj",
-                            "descriptor": {
-                                "symbol": "https://firebasestorage.googleapis.com/v0/b/shopeg-dev.appspot.com/o/shopImages%2FSXGJLw4JFjTDTNxEG48PaThdmMG3%2Fimg_1692618393065.jpg?alt=media&token=9af40f28-f739-4011-a3ba-73fd051de1ab",
-                                "images": [
-                                    "https://firebasestorage.googleapis.com/v0/b/shopeg-dev.appspot.com/o/shopImages%2FSXGJLw4JFjTDTNxEG48PaThdmMG3%2Fimg_1692618393065.jpg?alt=media&token=9af40f28-f739-4011-a3ba-73fd051de1ab"
-                                ],
-                                "name": "newttt",
-                                "short_desc": "tyu",
-                                "long_desc": "hhhy"
-                            },
-                            "tax_rate": "5",
-                            "location_id": "6906",
-                            "@ondc/org/available_on_cod": false,
-                            "L2_category": "Gourmet & World Foods",
-                            "category_id": "Gourmet & World Foods",
-                            "price": {
-                                "currency": "INR",
-                                "maximum_value": "653",
-                                "value": "123"
-                            },
-                            "id": "8b5528af-44cb-48a9-b3e2-e72cd4778410",
-                            "@ondc/org/cancellable": true,
-                            "@ondc/org/returnable": true,
-                            "quantity": {
-                                "available": {
-                                    "count": "152"
-                                },
-                                "maximum": {
-                                    "count": "3"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "ml",
-                                        "value": "23"
-                                    }
-                                }
-                            },
-                            "@ondc/org/time_to_ship": "PT1H",
-                            "hsn_code": "1234",
-                            "tags": [],
-                            "@ondc/org/return_window": "P14D",
-                            "@ondc/org/statutory_reqs_prepackaged_food": {
-                                "ingredients_info": "hdjsj",
-                                "brand_owner_FSSAI_license_no": "123456",
-                                "net_quantity": "896",
-                                "additives_info": "hhjjjj",
-                                "manufacturer_or_packer_address": "gshhssj",
-                                "other_premises": "yjjj"
-                            },
-                            "@ondc/org/mandatory_reqs_veggies_fruits": {
-                                "net_quantity": "45"
-                            },
-                            "tax_type": "gst",
-                            "domain": "Grocery",
-                            "time": {
-                                "label": "enable",
-                                "timestamp": "2023-10-05T06:53:33.029Z"
-                            },
-                            "fulfillment_id": "1"
-                        },
-                        {
-                            "@ondc/org/statutory_reqs_packaged_commodities": {
-                                "net_quantity_or_measure_of_commodity_in_pkg": "23",
-                                "date_of_import": "08/2023",
-                                "imported_product_country_of_origin": "idisis",
-                                "manufacturer_or_packer_name": "cccc"
-                            },
-                            "@ondc/org/seller_pickup_return": true,
-                            "@ondc/org/contact_details_consumer_care": "jcjcjcjcj",
-                            "descriptor": {
-                                "symbol": "https://firebasestorage.googleapis.com/v0/b/shopeg-dev.appspot.com/o/shopImages%2FSXGJLw4JFjTDTNxEG48PaThdmMG3%2Fimg_1692619195003.jpg?alt=media&token=0cee2657-7965-487b-8b60-842a272f5199",
-                                "images": [
-                                    "https://firebasestorage.googleapis.com/v0/b/shopeg-dev.appspot.com/o/shopImages%2FSXGJLw4JFjTDTNxEG48PaThdmMG3%2Fimg_1692619195003.jpg?alt=media&token=0cee2657-7965-487b-8b60-842a272f5199"
-                                ],
-                                "name": "ndndjdj",
-                                "short_desc": "hucucyc",
-                                "long_desc": "ydydyd"
-                            },
-                            "tax_rate": "18",
-                            "location_id": "6906",
-                            "@ondc/org/available_on_cod": false,
-                            "L2_category": "Beauty & Hygiene",
-                            "category_id": "Beauty & Hygiene",
-                            "price": {
-                                "currency": "INR",
-                                "maximum_value": "258",
-                                "value": "235"
-                            },
-                            "id": "eee13934-bfac-4333-91db-07203e44506b",
-                            "@ondc/org/cancellable": true,
-                            "@ondc/org/returnable": true,
-                            "quantity": {
-                                "available": {
-                                    "count": "235"
-                                },
-                                "maximum": {
-                                    "count": "25"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "ml",
-                                        "value": "123"
-                                    }
-                                }
-                            },
-                            "@ondc/org/time_to_ship": "PT1H",
-                            "hsn_code": "1234",
-                            "tags": [],
-                            "@ondc/org/return_window": "P14D",
-                            "@ondc/org/statutory_reqs_prepackaged_food": {
-                                "ingredients_info": "ud7d7",
-                                "net_quantity": "256",
-                                "additives_info": "7d7d77",
-                                "manufacturer_or_packer_address": "udud7df7f7",
-                                "other_premises": "udududu"
-                            },
-                            "@ondc/org/mandatory_reqs_veggies_fruits": {
-                                "net_quantity": "4567"
-                            },
-                            "tax_type": "gst",
-                            "domain": "Grocery",
-                            "time": {
-                                "label": "enable",
-                                "timestamp": "2023-10-05T06:53:33.029Z"
-                            },
-                            "fulfillment_id": "1"
-                        },
-                        {
-                            "@ondc/org/statutory_reqs_packaged_commodities": {
-                                "common_or_generic_name_of_commodity": "Spices & Masala",
-                                "net_quantity_or_measure_of_commodity_in_pkg": "200 g",
-                                "imported_product_country_of_origin": "IND",
-                                "description": "Everest Masala - Chhole, 200 g Jar",
-                                "manufacturer_or_packer_name": "4/B,L.B.S Marg, Vikhroli(W), Mumbai-400083,Maharastra",
-                                "manufacturer_or_packer_address": "4/B,L.B.S Marg, Vikhroli(W), Mumbai-400083,Maharastra",
-                                "month_year_of_manufacture_packing_import": ""
-                            },
-                            "@ondc/org/seller_pickup_return": true,
-                            "@ondc/org/contact_details_consumer_care": "hshxhxhx78",
-                            "descriptor": {
-                                "symbol": "https://datalabs.siva3.io/image/Eunimart_groceries_40129026_4-everest-masala-chhole.jpg",
-                                "images": [
-                                    "https://datalabs.siva3.io/image/Eunimart_groceries_40129026_4-everest-masala-chhole.jpg",
-                                    "https://datalabs.siva3.io/image/Eunimart_groceries_40129026-2_4-everest-masala-chhole.jpg",
-                                    "https://datalabs.siva3.io/image/Eunimart_groceries_40129026-3_4-everest-masala-chhole.jpg"
-                                ],
-                                "name": "Everest Masala - Chhole, 200 g Jar",
-                                "short_desc": "Everest presents their authentic range of masalas that are blended with a wide variety of handpicked and selected spices that bring a whole new flavour and meaning to your dishes. Rake up your favourite recipes and cuisines by adding this magical blend of Everest masalas.",
-                                "long_desc": "Everest presents their authentic range of masalas that are blended with a wide variety of handpicked and selected spices that bring a whole new flavour and meaning to your dishes. Rake up your favourite recipes and cuisines by adding this magical blend of Everest masalas."
-                            },
-                            "tax_rate": "5",
-                            "location_id": "6906",
-                            "@ondc/org/available_on_cod": false,
-                            "L2_category": "Masala & Seasoning",
-                            "category_id": "Masala & Seasoning",
-                            "price": {
-                                "currency": "INR",
-                                "maximum_value": "162",
-                                "value": "162"
-                            },
-                            "id": "1ad2632a-b9c8-467c-aefa-c3f7d2f6c28f",
-                            "@ondc/org/cancellable": true,
-                            "@ondc/org/returnable": true,
-                            "quantity": {
-                                "available": {
-                                    "count": "23"
-                                },
-                                "maximum": {
-                                    "count": "2"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "Kg",
-                                        "value": "23"
-                                    }
-                                }
-                            },
-                            "@ondc/org/time_to_ship": "PT1H",
-                            "hsn_code": "2333",
-                            "tags": [],
-                            "@ondc/org/return_window": "P14D",
-                            "@ondc/org/statutory_reqs_prepackaged_food": {
-                                "importer_FSSAI_license_no": null,
-                                "nutritional_info": null,
-                                "other_FSSAI_license_no": null,
-                                "imported_product_country_of_origin": null,
-                                "brand_owner_FSSAI_license_no": "123456",
-                                "additives_info": null
-                            },
-                            "tax_type": "gst",
-                            "domain": "Grocery",
-                            "time": {
-                                "label": "enable",
-                                "timestamp": "2023-10-05T06:53:33.029Z"
-                            },
-                            "fulfillment_id": "1"
-                        },
-                        {
-                            "@ondc/org/cancellable": true,
-                            "@ondc/org/returnable": true,
-                            "quantity": {
-                                "available": {
-                                    "count": "1"
-                                },
-                                "maximum": {
-                                    "count": "1"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "Kg",
-                                        "value": "12"
-                                    }
-                                }
-                            },
-                            "@ondc/org/statutory_reqs_packaged_commodities": {
-                                "net_quantity_or_measure_of_commodity_in_pkg": "12 Kg",
-                                "imported_product_country_of_origin": "IND",
-                                "manufacturer_or_packer_name": "jdjdjdi"
-                            },
-                            "@ondc/org/seller_pickup_return": true,
-                            "@ondc/org/contact_details_consumer_care": "dhhxxj",
-                            "@ondc/org/time_to_ship": "PT1H",
-                            "descriptor": {
-                                "symbol": "https://firebasestorage.googleapis.com/v0/b/shopeg-dev.appspot.com/o/shopImages%2FSXGJLw4JFjTDTNxEG48PaThdmMG3%2Fimg_1694671609438.jpg?alt=media&token=12e85458-e366-4c85-9a83-91da3dd4cf2e",
-                                "images": [
-                                    "https://firebasestorage.googleapis.com/v0/b/shopeg-dev.appspot.com/o/shopImages%2FSXGJLw4JFjTDTNxEG48PaThdmMG3%2Fimg_1694671609438.jpg?alt=media&token=12e85458-e366-4c85-9a83-91da3dd4cf2e"
-                                ],
-                                "name": "mfeminine care",
-                                "short_desc": "jfjx",
-                                "long_desc": "jfjxjcjxj"
-                            },
-                            "hsn_code": "1234",
-                            "location_id": "6906",
-                            "tax_rate": "18",
-                            "tags": [],
-                            "@ondc/org/return_window": "P14D",
-                            "@ondc/org/available_on_cod": false,
-                            "L2_category": "Feminine Care",
-                            "category_id": "Feminine Care",
-                            "tax_type": "gst",
-                            "price": {
-                                "currency": "INR",
-                                "maximum_value": "125",
-                                "value": "125"
-                            },
-                            "domain": "Beauty & Personal Care",
-                            "id": "d278c1b2-c891-427b-b9c8-5f80387cbfc5",
-                            "time": {
-                                "label": "enable",
-                                "timestamp": "2023-10-05T06:53:33.029Z"
-                            },
-                            "fulfillment_id": "1"
-                        },
-                        {
-                            "@ondc/org/statutory_reqs_packaged_commodities": {
-                                "net_quantity_or_measure_of_commodity_in_pkg": "12 Kg",
-                                "imported_product_country_of_origin": "IND",
-                                "manufacturer_or_packer_name": "bbxjxjx"
-                            },
-                            "@ondc/org/seller_pickup_return": true,
-                            "@ondc/org/contact_details_consumer_care": "cjfuf",
-                            "descriptor": {
-                                "symbol": "https://firebasestorage.googleapis.com/v0/b/shopeg-dev.appspot.com/o/shopImages%2FSXGJLw4JFjTDTNxEG48PaThdmMG3%2Fimg_1694611628047.jpg?alt=media&token=7aff566f-adec-4fcf-ad47-495102c4f20f",
-                                "images": [
-                                    "https://firebasestorage.googleapis.com/v0/b/shopeg-dev.appspot.com/o/shopImages%2FSXGJLw4JFjTDTNxEG48PaThdmMG3%2Fimg_1694611628047.jpg?alt=media&token=7aff566f-adec-4fcf-ad47-495102c4f20f"
-                                ],
-                                "name": "vishu1",
-                                "short_desc": "hfjfuf",
-                                "long_desc": "hfjfufhcjxj"
-                            },
-                            "location_id": "6906",
-                            "tax_rate": "18",
-                            "@ondc/org/available_on_cod": false,
-                            "L2_category": "Oil & Ghee",
-                            "category_id": "Oil & Ghee",
-                            "price": {
-                                "currency": "INR",
-                                "maximum_value": "125",
-                                "value": "125"
-                            },
-                            "id": "9e9cd408-93d7-4e6d-b3d5-1920ef8252db",
-                            "@ondc/org/cancellable": true,
-                            "@ondc/org/returnable": true,
-                            "quantity": {
-                                "available": {
-                                    "count": "23"
-                                },
-                                "maximum": {
-                                    "count": "23"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "Kg",
-                                        "value": "12"
-                                    }
-                                }
-                            },
-                            "@ondc/org/time_to_ship": "PT1H",
-                            "hsn_code": "12345",
-                            "tags": [],
-                            "@ondc/org/return_window": "P14D",
-                            "@ondc/org/statutory_reqs_prepackaged_food": {
-                                "importer_FSSAI_license_no": null,
-                                "nutritional_info": null,
-                                "other_importer_address": null,
-                                "importer_fssai_logo": null,
-                                "importer_address": null,
-                                "other_importer_name": null,
-                                "brand_owner_FSSAI_license_no": "936663",
-                                "net_quantity": null,
-                                "additives_info": null,
-                                "other_premises": null,
-                                "importer_name": null,
-                                "brand_owner_address": null,
-                                "brand_owner_fssai_logo": null,
-                                "ingredients_info": null,
-                                "other_FSSAI_license_no": null,
-                                "brand_owner_name": null,
-                                "imported_product_country_of_origin": null,
-                                "manufacturer_or_packer_name": null,
-                                "manufacturer_or_packer_address": null
-                            },
-                            "tax_type": "gst",
-                            "domain": "Grocery",
-                            "time": {
-                                "label": "enable",
-                                "timestamp": "2023-10-05T06:53:33.029Z"
-                            },
-                            "fulfillment_id": "1"
-                        },
-                        {
-                            "@ondc/org/cancellable": true,
-                            "@ondc/org/returnable": true,
-                            "quantity": {
-                                "available": {
-                                    "count": "4"
-                                },
-                                "maximum": {
-                                    "count": "3"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "ml",
-                                        "value": "16"
-                                    }
-                                }
-                            },
-                            "@ondc/org/statutory_reqs_packaged_commodities": {
-                                "net_quantity_or_measure_of_commodity_in_pkg": "16 ml",
-                                "imported_product_country_of_origin": "IND",
-                                "manufacturer_or_packer_name": "gjcjxjxj"
-                            },
-                            "@ondc/org/seller_pickup_return": true,
-                            "@ondc/org/contact_details_consumer_care": "ncncnxjxd",
-                            "@ondc/org/time_to_ship": "PT1H",
-                            "descriptor": {
-                                "symbol": "https://firebasestorage.googleapis.com/v0/b/shopeg-dev.appspot.com/o/shopImages%2FSXGJLw4JFjTDTNxEG48PaThdmMG3%2Fimg_1694535440663.jpg?alt=media&token=c0886f58-1ada-4272-9383-efd22e91dbb1",
-                                "images": [
-                                    "https://firebasestorage.googleapis.com/v0/b/shopeg-dev.appspot.com/o/shopImages%2FSXGJLw4JFjTDTNxEG48PaThdmMG3%2Fimg_1694535440663.jpg?alt=media&token=c0886f58-1ada-4272-9383-efd22e91dbb1"
-                                ],
-                                "name": "hhhhhhhmadhu",
-                                "short_desc": "jcjx",
-                                "long_desc": "jcjx"
-                            },
-                            "hsn_code": "1234",
-                            "location_id": "6906",
-                            "tax_rate": "5",
-                            "tags": [],
-                            "@ondc/org/return_window": "P14D",
-                            "@ondc/org/available_on_cod": false,
-                            "L2_category": "Fragrance",
-                            "category_id": "Fragrance",
-                            "tax_type": "gst",
-                            "price": {
-                                "currency": "INR",
-                                "maximum_value": "123",
-                                "value": "123"
-                            },
-                            "domain": "Beauty & Personal Care",
-                            "id": "b765f098-6469-4638-ae2c-e961e3b89ca8",
-                            "time": {
-                                "label": "enable",
-                                "timestamp": "2023-10-05T06:53:33.029Z"
-                            },
-                            "fulfillment_id": "1"
-                        },
-                        {
-                            "@ondc/org/cancellable": true,
-                            "@ondc/org/returnable": true,
-                            "quantity": {
-                                "available": {
-                                    "count": "4"
-                                },
-                                "maximum": {
-                                    "count": "0"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "Kg",
-                                        "value": "68"
-                                    }
-                                }
-                            },
-                            "@ondc/org/statutory_reqs_packaged_commodities": {
-                                "net_quantity_or_measure_of_commodity_in_pkg": "68 Kg",
-                                "imported_product_country_of_origin": "IND",
-                                "manufacturer_or_packer_name": "hfjgug"
-                            },
-                            "@ondc/org/seller_pickup_return": true,
-                            "@ondc/org/contact_details_consumer_care": "jfjtt",
-                            "@ondc/org/time_to_ship": "PT1H",
-                            "descriptor": {
-                                "symbol": "https://firebasestorage.googleapis.com/v0/b/shopeg-dev.appspot.com/o/shopImages%2FSXGJLw4JFjTDTNxEG48PaThdmMG3%2Fimg_1694598516361.jpg?alt=media&token=667982da-f296-4d60-91be-734c3a59e018",
-                                "images": [
-                                    "https://firebasestorage.googleapis.com/v0/b/shopeg-dev.appspot.com/o/shopImages%2FSXGJLw4JFjTDTNxEG48PaThdmMG3%2Fimg_1694598516361.jpg?alt=media&token=667982da-f296-4d60-91be-734c3a59e018"
-                                ],
-                                "name": "new2",
-                                "short_desc": "jxjxjd",
-                                "long_desc": "jxjxjdjdjxjd"
-                            },
-                            "hsn_code": "1234",
-                            "location_id": "6906",
-                            "tax_rate": "18",
-                            "tags": [],
-                            "@ondc/org/return_window": "P14D",
-                            "@ondc/org/available_on_cod": false,
-                            "L2_category": "Feminine Care",
-                            "category_id": "Feminine Care",
-                            "tax_type": "gst",
-                            "price": {
-                                "currency": "INR",
-                                "maximum_value": "365",
-                                "value": "365"
-                            },
-                            "domain": "Beauty & Personal Care",
-                            "id": "6995dd54-97fd-4f71-8404-1588876a5be7",
-                            "time": {
-                                "label": "enable",
-                                "timestamp": "2023-10-05T06:53:33.029Z"
-                            },
-                            "fulfillment_id": "1"
-                        },
-                        {
-                            "@ondc/org/statutory_reqs_packaged_commodities": {
-                                "common_or_generic_name_of_commodity": "Pooja Supplies",
-                                "net_quantity_or_measure_of_commodity_in_pkg": "20 pcs",
-                                "imported_product_country_of_origin": "AUS",
-                                "description": "Mysore Sandal Dhoop - Cones, 20 pcs Carton",
-                                "manufacturer_or_packer_name": "Karnataka Soaps & Detergents LTD #27, Industrial Suburd, P.B No. 5531, Bangalore-Pune Highway, Rajajinagar, Bangallore-560055",
-                                "manufacturer_or_packer_address": "Karnataka Soaps & Detergents LTD #27, Industrial Suburd, P.B No. 5531, Bangalore-Pune Highway, Rajajinagar, Bangallore-560055",
-                                "month_year_of_manufacture_packing_import": ""
-                            },
-                            "@ondc/org/seller_pickup_return": true,
-                            "@ondc/org/contact_details_consumer_care": "ghjkk67",
-                            "descriptor": {
-                                "symbol": "https://www.bigbasket.com/media/uploads/p/l/40020190_1-mysore-sandal-dhoop-cones.jpg",
-                                "images": [
-                                    "https://www.bigbasket.com/media/uploads/p/l/40020190_1-mysore-sandal-dhoop-cones.jpg"
-                                ],
-                                "name": "Tumkur Sandal Dhoop  Cones 20 ",
-                                "short_desc": "KS&DL the house of world famous Mysore Sandal soap brings to you the tradition of Offering Prayers with divine fragrance of natural Sandalwood, Lightup Mysore Sandal Dhoop for pleasant, Calm, Soothing, holistic experience of your Prayer.\r\n",
-                                "long_desc": "KS&DL the house of world famous Mysore Sandal soap brings to you the tradition of Offering Prayers with divine fragrance of natural Sandalwood, Lightup Mysore Sandal Dhoop for pleasant, Calm, Soothing, holistic experience of your Prayer.\r\n"
-                            },
-                            "tax_rate": "5",
-                            "location_id": "6906",
-                            "@ondc/org/available_on_cod": false,
-                            "L2_category": "Cleaning & Household",
-                            "category_id": "Cleaning & Household",
-                            "price": {
-                                "currency": "INR",
-                                "maximum_value": "30",
-                                "value": "30"
-                            },
-                            "id": "8b44680b-e616-4672-b6fe-b89c7e5a4117",
-                            "@ondc/org/cancellable": true,
-                            "@ondc/org/returnable": true,
-                            "quantity": {
-                                "available": {
-                                    "count": "22"
-                                },
-                                "maximum": {
-                                    "count": "22"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "l",
-                                        "value": "12"
-                                    }
-                                }
-                            },
-                            "@ondc/org/time_to_ship": "PT1H",
-                            "hsn_code": "125",
-                            "tags": [],
-                            "@ondc/org/return_window": "P14D",
-                            "@ondc/org/statutory_reqs_prepackaged_food": {
-                                "importer_FSSAI_license_no": null,
-                                "nutritional_info": null,
-                                "other_FSSAI_license_no": null,
-                                "imported_product_country_of_origin": null,
-                                "brand_owner_FSSAI_license_no": null,
-                                "additives_info": null
-                            },
-                            "tax_type": "gst",
-                            "domain": "Grocery",
-                            "time": {
-                                "label": "enable",
-                                "timestamp": "2023-10-05T06:53:33.029Z"
-                            },
-                            "fulfillment_id": "1"
-                        },
-                        {
-                            "@ondc/org/cancellable": true,
-                            "@ondc/org/returnable": true,
-                            "quantity": {
-                                "available": {
-                                    "count": "2"
-                                },
-                                "maximum": {
-                                    "count": "2"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "Kg",
-                                        "value": "23"
-                                    }
-                                }
-                            },
-                            "@ondc/org/statutory_reqs_packaged_commodities": {
-                                "net_quantity_or_measure_of_commodity_in_pkg": "23 Kg",
-                                "imported_product_country_of_origin": "IND",
-                                "manufacturer_or_packer_name": "ggg"
-                            },
-                            "@ondc/org/seller_pickup_return": true,
-                            "@ondc/org/contact_details_consumer_care": "cafs",
-                            "@ondc/org/time_to_ship": "PT1H",
-                            "descriptor": {
-                                "symbol": "https://firebasestorage.googleapis.com/v0/b/shopeg-dev.appspot.com/o/shopImages%2FSXGJLw4JFjTDTNxEG48PaThdmMG3%2Fimg_1693201172954.jpg?alt=media&token=21e3b3ba-cb7b-4085-9045-57580f6f3f9d",
-                                "images": [
-                                    "https://firebasestorage.googleapis.com/v0/b/shopeg-dev.appspot.com/o/shopImages%2FSXGJLw4JFjTDTNxEG48PaThdmMG3%2Fimg_1693201172954.jpg?alt=media&token=21e3b3ba-cb7b-4085-9045-57580f6f3f9d"
-                                ],
-                                "name": "ttt",
-                                "short_desc": "dggg",
-                                "long_desc": "dgggfhjju"
-                            },
-                            "hsn_code": "8552",
-                            "tax_rate": "18",
-                            "location_id": "6906",
-                            "tags": [],
-                            "@ondc/org/return_window": "P14D",
-                            "@ondc/org/available_on_cod": false,
-                            "L2_category": "Beauty & Hygiene",
-                            "category_id": "Beauty & Hygiene",
-                            "tax_type": "gst",
-                            "price": {
-                                "currency": "INR",
-                                "maximum_value": "123",
-                                "value": "12"
-                            },
-                            "domain": "Grocery",
-                            "id": "b73d8ae3-af7d-416a-b693-24f4709fe0a1",
-                            "time": {
-                                "label": "enable",
-                                "timestamp": "2023-10-05T06:53:33.029Z"
-                            },
-                            "fulfillment_id": "1"
-                        },
-                        {
-                            "@ondc/org/cancellable": true,
-                            "@ondc/org/returnable": true,
-                            "quantity": {
-                                "available": {
-                                    "count": "23"
-                                },
-                                "maximum": {
-                                    "count": "23"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "Kg",
-                                        "value": "12"
-                                    }
-                                }
-                            },
-                            "@ondc/org/statutory_reqs_packaged_commodities": {
-                                "net_quantity_or_measure_of_commodity_in_pkg": "12 Kg",
-                                "imported_product_country_of_origin": "IND",
-                                "manufacturer_or_packer_name": "gggggg"
-                            },
-                            "@ondc/org/seller_pickup_return": true,
-                            "@ondc/org/contact_details_consumer_care": "vvvvv",
-                            "@ondc/org/time_to_ship": "PT1H",
-                            "descriptor": {
-                                "symbol": "https://firebasestorage.googleapis.com/v0/b/shopeg-dev.appspot.com/o/shopImages%2FSXGJLw4JFjTDTNxEG48PaThdmMG3%2Fimg_1693531774828.jpg?alt=media&token=c4d3d056-f51b-424e-90d5-ed3915edf192",
-                                "images": [
-                                    "https://firebasestorage.googleapis.com/v0/b/shopeg-dev.appspot.com/o/shopImages%2FSXGJLw4JFjTDTNxEG48PaThdmMG3%2Fimg_1693531774828.jpg?alt=media&token=c4d3d056-f51b-424e-90d5-ed3915edf192"
-                                ],
-                                "name": "yduddu",
-                                "short_desc": "cucufu",
-                                "long_desc": "cucufuufifi"
-                            },
-                            "hsn_code": "1234",
-                            "tax_rate": "28",
-                            "location_id": "6906",
-                            "tags": [],
-                            "@ondc/org/return_window": "P14D",
-                            "@ondc/org/available_on_cod": false,
-                            "L2_category": "Feminine Care",
-                            "category_id": "Feminine Care",
-                            "tax_type": "gst",
-                            "price": {
-                                "currency": "INR",
-                                "maximum_value": "12",
-                                "value": "12"
-                            },
-                            "domain": "Beauty & Personal Care",
-                            "id": "e920df2a-0162-4e0f-b476-08e8954ba117",
-                            "time": {
-                                "label": "enable",
-                                "timestamp": "2023-10-05T06:53:33.029Z"
-                            },
-                            "fulfillment_id": "1"
-                        },
-                        {
-                            "@ondc/org/cancellable": true,
-                            "@ondc/org/returnable": true,
-                            "quantity": {
-                                "available": {
-                                    "count": "12"
-                                },
-                                "maximum": {
-                                    "count": "1"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "Kg",
-                                        "value": "12"
-                                    }
-                                }
-                            },
-                            "@ondc/org/statutory_reqs_packaged_commodities": {
-                                "net_quantity_or_measure_of_commodity_in_pkg": "12 Kg",
-                                "imported_product_country_of_origin": "IND",
-                                "manufacturer_or_packer_name": "jxjjcjcjc"
-                            },
-                            "@ondc/org/seller_pickup_return": true,
-                            "@ondc/org/contact_details_consumer_care": "nxnxnn",
-                            "@ondc/org/time_to_ship": "PT1H",
-                            "descriptor": {
-                                "symbol": "https://firebasestorage.googleapis.com/v0/b/shopeg-dev.appspot.com/o/shopImages%2FSXGJLw4JFjTDTNxEG48PaThdmMG3%2Fimg_1693531530329.jpg?alt=media&token=6fe5be7b-221a-45fa-9db4-e51f8b723280",
-                                "images": [
-                                    "https://firebasestorage.googleapis.com/v0/b/shopeg-dev.appspot.com/o/shopImages%2FSXGJLw4JFjTDTNxEG48PaThdmMG3%2Fimg_1693531530329.jpg?alt=media&token=6fe5be7b-221a-45fa-9db4-e51f8b723280"
-                                ],
-                                "name": "jxjxjx",
-                                "short_desc": "ghhj",
-                                "long_desc": "ghhjj"
-                            },
-                            "hsn_code": "1234",
-                            "tax_rate": "28",
-                            "location_id": "6906",
-                            "tags": [],
-                            "@ondc/org/return_window": "P14D",
-                            "@ondc/org/available_on_cod": false,
-                            "L2_category": "Feminine Care",
-                            "category_id": "Feminine Care",
-                            "tax_type": "gst",
-                            "price": {
-                                "currency": "INR",
-                                "maximum_value": "23",
-                                "value": "23"
-                            },
-                            "domain": "Beauty & Personal Care",
-                            "id": "03384e45-d27c-4b69-ac11-e6630ed75b3d",
-                            "time": {
-                                "label": "enable",
-                                "timestamp": "2023-10-05T06:53:33.029Z"
-                            },
-                            "fulfillment_id": "1"
-                        },
-                        {
-                            "@ondc/org/statutory_reqs_packaged_commodities": {
-                                "common_or_generic_name_of_commodity": "Spices & Masala",
-                                "net_quantity_or_measure_of_commodity_in_pkg": "50 g",
-                                "imported_product_country_of_origin": "ATG",
-                                "description": "Everest Chaat Masala, 50 g Carton",
-                                "manufacturer_or_packer_name": "S.Everest Food Products Pvt. Ltd.",
-                                "manufacturer_or_packer_address": "S.Everest Food Products Pvt. Ltd.",
-                                "month_year_of_manufacture_packing_import": ""
-                            },
-                            "@ondc/org/seller_pickup_return": true,
-                            "@ondc/org/contact_details_consumer_care": "2333fghu66",
-                            "descriptor": {
-                                "symbol": "https://www.bigbasket.com/media/uploads/p/xxl/268002_3-everest-chaat-masala.jpg",
-                                "images": [
-                                    "https://www.bigbasket.com/media/uploads/p/xxl/268002_3-everest-chaat-masala.jpg"
-                                ],
-                                "name": "Everest Chaat Masala, 50 g Carton",
-                                "short_desc": "Everest Dry Mango Powder is a spice derived by grinding dried mango pieces. It retains the spicy and acidic taste of unripe mangoes.\r\n",
-                                "long_desc": "Everest Dry Mango Powder is a spice derived by grinding dried mango pieces. It retains the spicy and acidic taste of unripe mangoes.\r\n"
-                            },
-                            "tax_rate": "18",
-                            "location_id": "6906",
-                            "@ondc/org/available_on_cod": false,
-                            "L2_category": "Masala & Seasoning",
-                            "category_id": "Masala & Seasoning",
-                            "price": {
-                                "currency": "INR",
-                                "maximum_value": "39",
-                                "value": "39"
-                            },
-                            "id": "dc1f61f2-1d83-4b13-bc74-4f20e975dc3e",
-                            "@ondc/org/cancellable": true,
-                            "@ondc/org/returnable": true,
-                            "quantity": {
-                                "available": {
-                                    "count": "2"
-                                },
-                                "maximum": {
-                                    "count": "20"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "Kg",
-                                        "value": "21"
-                                    }
-                                }
-                            },
-                            "@ondc/org/time_to_ship": "PT1H",
-                            "hsn_code": "12345",
-                            "tags": [],
-                            "@ondc/org/return_window": "P14D",
-                            "@ondc/org/statutory_reqs_prepackaged_food": {
-                                "importer_FSSAI_license_no": null,
-                                "nutritional_info": null,
-                                "other_FSSAI_license_no": null,
-                                "imported_product_country_of_origin": null,
-                                "brand_owner_FSSAI_license_no": "123456",
-                                "additives_info": null
-                            },
-                            "tax_type": "gst",
-                            "domain": "Grocery",
-                            "time": {
-                                "label": "enable",
-                                "timestamp": "2023-10-05T06:53:33.029Z"
-                            },
-                            "fulfillment_id": "1"
-                        },
-                        {
-                            "@ondc/org/cancellable": true,
-                            "@ondc/org/returnable": true,
-                            "quantity": {
-                                "available": {
-                                    "count": "1"
-                                },
-                                "maximum": {
-                                    "count": "1"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "Kg",
-                                        "value": "12"
-                                    }
-                                }
-                            },
-                            "@ondc/org/statutory_reqs_packaged_commodities": {
-                                "net_quantity_or_measure_of_commodity_in_pkg": "12 Kg",
-                                "imported_product_country_of_origin": "IND",
-                                "manufacturer_or_packer_name": "tdtdyyf"
-                            },
-                            "@ondc/org/seller_pickup_return": true,
-                            "@ondc/org/contact_details_consumer_care": "gxghxyx223",
-                            "@ondc/org/time_to_ship": "PT1H",
-                            "descriptor": {
-                                "symbol": "https://firebasestorage.googleapis.com/v0/b/shopeg-dev.appspot.com/o/shopImages%2FSXGJLw4JFjTDTNxEG48PaThdmMG3%2Fimg_1693313585549.jpg?alt=media&token=d5e7355a-0bf6-46a4-9303-1da4c28a4c47",
-                                "images": [
-                                    "https://firebasestorage.googleapis.com/v0/b/shopeg-dev.appspot.com/o/shopImages%2FSXGJLw4JFjTDTNxEG48PaThdmMG3%2Fimg_1693313585549.jpg?alt=media&token=d5e7355a-0bf6-46a4-9303-1da4c28a4c47",
-                                    "https://firebasestorage.googleapis.com/v0/b/shopeg-dev.appspot.com/o/shopImages%2FSXGJLw4JFjTDTNxEG48PaThdmMG3%2Fimg_1693313595382.jpg?alt=media&token=8da869ca-85b3-459d-9632-a53cd0ad9277"
-                                ],
-                                "name": "ghhh",
-                                "short_desc": "ggg",
-                                "long_desc": "ggg"
-                            },
-                            "hsn_code": "1000",
-                            "tax_rate": "18",
-                            "location_id": "6906",
-                            "tags": [],
-                            "@ondc/org/return_window": "P14D",
-                            "@ondc/org/available_on_cod": false,
-                            "L2_category": "Cleaning & Household",
-                            "category_id": "Cleaning & Household",
-                            "tax_type": "gst",
-                            "price": {
-                                "currency": "INR",
-                                "maximum_value": "235",
-                                "value": "235"
-                            },
-                            "domain": "Grocery",
-                            "id": "2d3e10b3-6924-419e-a661-92e5ca13d982",
-                            "time": {
-                                "label": "enable",
-                                "timestamp": "2023-10-05T06:53:33.029Z"
-                            },
-                            "fulfillment_id": "1"
-                        },
-                        {
-                            "@ondc/org/statutory_reqs_packaged_commodities": {
-                                "common_or_generic_name_of_commodity": "jdudu",
-                                "net_quantity_or_measure_of_commodity_in_pkg": "12 Kg",
-                                "imported_product_country_of_origin": "IND",
-                                "manufacturer_or_packer_name": "dfffhdud",
-                                "multiple_products_name_number_or_qty": "ududdu",
-                                "manufacturer_or_packer_address": "udu",
-                                "month_year_of_manufacture_packing_import": "09/2023"
-                            },
-                            "@ondc/org/seller_pickup_return": true,
-                            "@ondc/org/contact_details_consumer_care": "hxjxxj",
-                            "descriptor": {
-                                "symbol": "https://firebasestorage.googleapis.com/v0/b/shopeg-dev.appspot.com/o/shopImages%2FSXGJLw4JFjTDTNxEG48PaThdmMG3%2Fimg_1695819230772.jpg?alt=media&token=da1db9a8-8bf7-4d5e-8524-18d193f55d3c",
-                                "images": [
-                                    "https://firebasestorage.googleapis.com/v0/b/shopeg-dev.appspot.com/o/shopImages%2FSXGJLw4JFjTDTNxEG48PaThdmMG3%2Fimg_1695819230772.jpg?alt=media&token=da1db9a8-8bf7-4d5e-8524-18d193f55d3c"
-                                ],
-                                "name": "pppppp",
-                                "short_desc": "hxhxj",
-                                "long_desc": "hxhxjhdhxdh"
-                            },
-                            "location_id": "6906",
-                            "tax_rate": "18",
-                            "@ondc/org/available_on_cod": false,
-                            "L2_category": "Beauty & Hygiene",
-                            "category_id": "Beauty & Hygiene",
-                            "price": {
-                                "currency": "INR",
-                                "maximum_value": "123",
-                                "value": "123"
-                            },
-                            "id": "81ceaae1-972b-4bd9-b32d-1080904002a6",
-                            "@ondc/org/cancellable": true,
-                            "@ondc/org/returnable": true,
-                            "quantity": {
-                                "available": {
-                                    "count": "3"
-                                },
-                                "maximum": {
-                                    "count": "3"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "Kg",
-                                        "value": "12"
-                                    }
-                                }
-                            },
-                            "@ondc/org/time_to_ship": "PT1H",
-                            "hsn_code": "123456",
-                            "tags": [],
-                            "@ondc/org/return_window": "P14D",
-                            "@ondc/org/mandatory_reqs_veggies_fruits": {
-                                "net_quantity": "12"
-                            },
-                            "tax_type": "gst",
-                            "domain": "Grocery",
-                            "time": {
-                                "label": "enable",
-                                "timestamp": "2023-10-05T06:53:33.029Z"
-                            },
-                            "fulfillment_id": "1"
-                        },
-                        {
-                            "@ondc/org/cancellable": true,
-                            "@ondc/org/returnable": true,
-                            "quantity": {
-                                "available": {
-                                    "count": "3"
-                                },
-                                "maximum": {
-                                    "count": "3"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "Kg",
-                                        "value": "12"
-                                    }
-                                }
-                            },
-                            "@ondc/org/statutory_reqs_packaged_commodities": {
-                                "common_or_generic_name_of_commodity": "Coffee",
-                                "net_quantity_or_measure_of_commodity_in_pkg": "12 Kg",
-                                "imported_product_country_of_origin": "India",
-                                "manufacturer_or_packer_name": "Hindustan Unilever Limited, Unilever House, B D Sawant Marg, Chakala, Anderi E, Mumbai - 400099",
-                                "multiple_products_name_number_or_qty": "45",
-                                "manufacturer_or_packer_address": "Hindustan Unilever Limited, Unilever House, B D Sawant Marg, Chakala, Anderi E, Mumbai - 400099"
-                            },
-                            "@ondc/org/seller_pickup_return": true,
-                            "@ondc/org/contact_details_consumer_care": "3uue",
-                            "@ondc/org/time_to_ship": "PT12H",
-                            "descriptor": {
-                                "symbol": "https://www.bigbasket.com/media/uploads/p/xxl/266584_22-bru-instant-coffee.jpg",
-                                "images": [
-                                    "https://www.bigbasket.com/media/uploads/p/xxl/266584_22-bru-instant-coffee.jpg",
-                                    "https://datalabs.siva3.io/image/Eunimart_groceries_266531-2_13-bru-instant-coffee.jpg",
-                                    "https://datalabs.siva3.io/image/Eunimart_groceries_266531-3_13-bru-instant-coffee.jpg"
-                                ],
-                                "name": "BRU Instant Coffee, 50 g",
-                                "short_desc": "BRU Instant Coffee was launched in 1968 and was Indias first coffee-chicory mix instant coffee. It is the perfect mix of 70% coffee and 30% chicory and is made from a fine blend of the choicest plantation and Robusta beans. These coffee beans are first roasted to perfection, then the new and enhanced process ensures that the fresh coffee aroma is preserved so that you get a rich coffee taste beyond compare. Bru Instant coffee can be used to make an aromatic cup of hot coffee as well as a refreshing glass of cold coffee. With Bru Instant, you can now discover a great coffee experience with your loved ones.\r\nABOUT BRU\r\nA part of Hindustan Unilever Ltd. , BRU Coffee is Indias largest and favourite coffee brand that offers a wide variety of coffee products. Since 1968, BRU has been a pioneer in bringing the authentic taste of coffee to Indian consumers. The best coffee beans are selected from across innumerable coffee trails and are freshly roasted, to serve a great cup of rich, irresistible coffee. BRU has four distinct offerings - BRU Instant and BRU Gold in Instant coffee, BRU Green Label and BRU Select in Filter coffee. BRU-ed with love and blended with passion, BRU Coffee celebrates authenticity in coffee and relationships.",
-                                "long_desc": "BRU Instant Coffee was launched in 1968 and was Indias first coffee-chicory mix instant coffee. It is the perfect mix of 70% coffee and 30% chicory and is made from a fine blend of the choicest plantation and Robusta beans. These coffee beans are first roasted to perfection, then the new and enhanced process ensures that the fresh coffee aroma is preserved so that you get a rich coffee taste beyond compare. Bru Instant coffee can be used to make an aromatic cup of hot coffee as well as a refreshing glass of cold coffee. With Bru Instant, you can now discover a great coffee experience with your loved ones.\r\nABOUT BRU\r\nA part of Hindustan Unilever Ltd. , BRU Coffee is Indias largest and favourite coffee brand that offers a wide variety of coffee products. Since 1968, BRU has been a pioneer in bringing the authentic taste of coffee to Indian consumers. The best coffee beans are selected from across innumerable coffee trails and are freshly roasted, to serve a great cup of rich, irresistible coffee. BRU has four distinct offerings - BRU Instant and BRU Gold in Instant coffee, BRU Green Label and BRU Select in Filter coffee. BRU-ed with love and blended with passion, BRU Coffee celebrates authenticity in coffee and relationships."
-                            },
-                            "hsn_code": "12345",
-                            "location_id": "6906",
-                            "tax_rate": "5",
-                            "tags": [
-                                {
-                                    "code": "veg_nonveg",
-                                    "list": [
-                                        {
-                                            "code": "veg",
-                                            "value": "yes"
-                                        }
-                                    ]
-                                }
-                            ],
-                            "@ondc/org/return_window": "P14D",
-                            "@ondc/org/available_on_cod": true,
-                            "@ondc/org/statutory_reqs_prepackaged_food": {
-                                "importer_FSSAI_license_no": "98688",
-                                "nutritional_info": "vvbbbb",
-                                "other_importer_address": "hxyx",
-                                "importer_address": " nbx",
-                                "other_importer_name": "b b ",
-                                "brand_owner_FSSAI_license_no": "65688683",
-                                "net_quantity": "23",
-                                "additives_info": "hxhx",
-                                "other_premises": "hxhx",
-                                "importer_name": "fff",
-                                "brand_owner_address": "dff",
-                                "ingredients_info": "ccvvb",
-                                "other_FSSAI_license_no": "9868",
-                                "brand_owner_name": "BRU",
-                                "imported_product_country_of_origin": "IND",
-                                "manufacturer_or_packer_name": "jxjx",
-                                "manufacturer_or_packer_address": "uxud"
-                            },
-                            "L2_category": "Beverages",
-                            "category_id": "Beverages",
-                            "tax_type": "gst",
-                            "price": {
-                                "currency": "INR",
-                                "maximum_value": "97",
-                                "value": "97"
-                            },
-                            "domain": "Grocery",
-                            "id": "0238ed85-691a-4d95-a2b9-1249ca365c58",
-                            "time": {
-                                "label": "enable",
-                                "timestamp": "2023-10-05T07:35:23.834Z"
-                            },
-                            "fulfillment_id": "1"
-                        },
-                        {
-                            "@ondc/org/statutory_reqs_packaged_commodities": {
-                                "net_quantity_or_measure_of_commodity_in_pkg": "986",
-                                "date_of_import": "08/2023",
-                                "imported_product_country_of_origin": "gxjxjxj",
-                                "manufacturer_or_packer_name": "yxyyxydy"
-                            },
-                            "@ondc/org/seller_pickup_return": true,
-                            "@ondc/org/contact_details_consumer_care": "gjjkk678",
-                            "descriptor": {
-                                "symbol": "https://firebasestorage.googleapis.com/v0/b/shopeg-dev.appspot.com/o/shopImages%2FSXGJLw4JFjTDTNxEG48PaThdmMG3%2Fimg_1692599617312.jpg?alt=media&token=1b8bdd6e-774a-40a7-a022-36e8fe104b1b",
-                                "images": [
-                                    "https://firebasestorage.googleapis.com/v0/b/shopeg-dev.appspot.com/o/shopImages%2FSXGJLw4JFjTDTNxEG48PaThdmMG3%2Fimg_1692599617312.jpg?alt=media&token=1b8bdd6e-774a-40a7-a022-36e8fe104b1b"
-                                ],
-                                "name": "zfRzrs",
-                                "short_desc": "xrtx",
-                                "long_desc": "hxjxjxjx"
-                            },
-                            "tax_rate": "5",
-                            "location_id": "6906",
-                            "@ondc/org/available_on_cod": false,
-                            "L2_category": "Feminine Care",
-                            "category_id": "Feminine Care",
-                            "price": {
-                                "currency": "INR",
-                                "maximum_value": "235",
-                                "value": "12"
-                            },
-                            "id": "d358ca28-630d-4bfa-a847-c6d3e863abfc",
-                            "@ondc/org/cancellable": true,
-                            "@ondc/org/returnable": true,
-                            "quantity": {
-                                "available": {
-                                    "count": "235"
-                                },
-                                "maximum": {
-                                    "count": "25"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "Nos",
-                                        "value": "23"
-                                    }
-                                }
-                            },
-                            "@ondc/org/time_to_ship": "PT1H",
-                            "hsn_code": "1234",
-                            "tags": [],
-                            "@ondc/org/return_window": "P14D",
-                            "@ondc/org/statutory_reqs_prepackaged_food": {
-                                "ingredients_info": "yyuuu",
-                                "net_quantity": "236",
-                                "additives_info": "jjjko",
-                                "manufacturer_or_packer_address": "uxixiid",
-                                "other_premises": "gchcjcj"
-                            },
-                            "@ondc/org/mandatory_reqs_veggies_fruits": {
-                                "net_quantity": "569"
-                            },
-                            "tax_type": "gst",
-                            "domain": "Beauty & Personal Care",
-                            "time": {
-                                "label": "enable",
-                                "timestamp": "2023-10-05T06:53:33.029Z"
-                            },
-                            "fulfillment_id": "1"
-                        },
-                        {
-                            "@ondc/org/statutory_reqs_packaged_commodities": {
-                                "net_quantity_or_measure_of_commodity_in_pkg": "25",
-                                "date_of_import": "08/2023",
-                                "imported_product_country_of_origin": "jcucuc",
-                                "manufacturer_or_packer_name": "ghjhh"
-                            },
-                            "@ondc/org/seller_pickup_return": true,
-                            "@ondc/org/contact_details_consumer_care": "jxjxixi7",
-                            "descriptor": {
-                                "symbol": "https://firebasestorage.googleapis.com/v0/b/shopeg-dev.appspot.com/o/shopImages%2FSXGJLw4JFjTDTNxEG48PaThdmMG3%2Fimg_1692618772195.jpg?alt=media&token=149db8c4-24d2-435e-baf7-f88ab93cd4fc",
-                                "images": [
-                                    "https://firebasestorage.googleapis.com/v0/b/shopeg-dev.appspot.com/o/shopImages%2FSXGJLw4JFjTDTNxEG48PaThdmMG3%2Fimg_1692618772195.jpg?alt=media&token=149db8c4-24d2-435e-baf7-f88ab93cd4fc"
-                                ],
-                                "name": "floqqq",
-                                "short_desc": "hdhdhdh",
-                                "long_desc": "bdjdjd"
-                            },
-                            "tax_rate": "18",
-                            "location_id": "6906",
-                            "@ondc/org/available_on_cod": false,
-                            "L2_category": "Feminine Care",
-                            "category_id": "Feminine Care",
-                            "price": {
-                                "currency": "INR",
-                                "maximum_value": "154",
-                                "value": "124"
-                            },
-                            "id": "ca893f0b-7e77-4048-9f88-e488cb5a523d",
-                            "@ondc/org/cancellable": true,
-                            "@ondc/org/returnable": true,
-                            "quantity": {
-                                "available": {
-                                    "count": "2356"
-                                },
-                                "maximum": {
-                                    "count": "23"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "Kg",
-                                        "value": "23"
-                                    }
-                                }
-                            },
-                            "@ondc/org/time_to_ship": "PT1H",
-                            "hsn_code": "1234",
-                            "tags": [],
-                            "@ondc/org/return_window": "P14D",
-                            "@ondc/org/statutory_reqs_prepackaged_food": {
-                                "ingredients_info": "jcjcjc",
-                                "net_quantity": "125",
-                                "additives_info": "ncjcjcjjcfj",
-                                "manufacturer_or_packer_address": "jxjxjxj",
-                                "other_premises": "jdjdjdjd"
-                            },
-                            "@ondc/org/mandatory_reqs_veggies_fruits": {
-                                "net_quantity": "56789"
-                            },
-                            "tax_type": "gst",
-                            "domain": "Beauty & Personal Care",
-                            "time": {
-                                "label": "enable",
-                                "timestamp": "2023-10-05T06:53:33.029Z"
-                            },
-                            "fulfillment_id": "1"
-                        },
-                        {
-                            "@ondc/org/statutory_reqs_packaged_commodities": {
-                                "common_or_generic_name_of_commodity": "Spices & Masala",
-                                "net_quantity_or_measure_of_commodity_in_pkg": "50 g",
-                                "imported_product_country_of_origin": "IND",
-                                "description": "Keya Nawabi Meat Masala MC, 50 g",
-                                "manufacturer_or_packer_name": "Keya Foods International Pvt. Ltd, Thuravoor, 688532, Alleppey Dist., Kerala",
-                                "manufacturer_or_packer_address": "Keya Foods International Pvt. Ltd, Thuravoor, 688532, Alleppey Dist., Kerala",
-                                "month_year_of_manufacture_packing_import": ""
-                            },
-                            "@ondc/org/seller_pickup_return": true,
-                            "@ondc/org/contact_details_consumer_care": "jxjxxjxj",
-                            "descriptor": {
-                                "symbol": "https://datalabs.siva3.io/image/Eunimart_groceries_40223866_1-keya-nawabi-meat-masala-mc.jpg",
-                                "images": [
-                                    "https://datalabs.siva3.io/image/Eunimart_groceries_40223866_1-keya-nawabi-meat-masala-mc.jpg",
-                                    "https://datalabs.siva3.io/image/Eunimart_groceries_40223866-2_1-keya-nawabi-meat-masala-mc.jpg",
-                                    "https://datalabs.siva3.io/image/Eunimart_groceries_40223866-3_1-keya-nawabi-meat-masala-mc.jpg"
-                                ],
-                                "name": "Keya Nawabi Meat Masala MC, 50 g",
-                                "short_desc": "Keya Nawabi Meat Masala MC is a mix of aromatic and flavourful spices. It adds a unique flavour to your dishes. It's the most magical and extraordinary mix of spices that is used mostly in Indian cuisine. It is slightly spicy and has an earthy flavour to it. This masala pairs perfectly with any meat making it delightful. The cloves, cinnamon and peppercorns used in this mix are known to improve digestive complaints and immune functions. It is added to any chicken or even mutton curry which makes it highly delicious.",
-                                "long_desc": "Keya Nawabi Meat Masala MC is a mix of aromatic and flavourful spices. It adds a unique flavour to your dishes. It's the most magical and extraordinary mix of spices that is used mostly in Indian cuisine. It is slightly spicy and has an earthy flavour to it. This masala pairs perfectly with any meat making it delightful. The cloves, cinnamon and peppercorns used in this mix are known to improve digestive complaints and immune functions. It is added to any chicken or even mutton curry which makes it highly delicious."
-                            },
-                            "tax_rate": "5",
-                            "location_id": "6906",
-                            "@ondc/org/available_on_cod": false,
-                            "L2_category": "Masala & Seasoning",
-                            "category_id": "Masala & Seasoning",
-                            "price": {
-                                "currency": "INR",
-                                "maximum_value": "38",
-                                "value": "38"
-                            },
-                            "id": "b45f817e-6bea-4a62-8c4a-06ccb712f20f",
-                            "@ondc/org/cancellable": true,
-                            "@ondc/org/returnable": true,
-                            "quantity": {
-                                "available": {
-                                    "count": "123"
-                                },
-                                "maximum": {
-                                    "count": "2"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "Kg",
-                                        "value": "23"
-                                    }
-                                }
-                            },
-                            "@ondc/org/time_to_ship": "PT1H",
-                            "hsn_code": "1000",
-                            "tags": [],
-                            "@ondc/org/return_window": "P14D",
-                            "@ondc/org/statutory_reqs_prepackaged_food": {
-                                "importer_FSSAI_license_no": null,
-                                "nutritional_info": null,
-                                "other_FSSAI_license_no": null,
-                                "imported_product_country_of_origin": null,
-                                "brand_owner_FSSAI_license_no": "12345678",
-                                "additives_info": null
-                            },
-                            "tax_type": "gst",
-                            "domain": "Grocery",
-                            "time": {
-                                "label": "enable",
-                                "timestamp": "2023-10-05T06:53:33.029Z"
-                            },
-                            "fulfillment_id": "1"
-                        },
-                        {
-                            "@ondc/org/statutory_reqs_packaged_commodities": {
-                                "common_or_generic_name_of_commodity": "Feminine Hygiene",
-                                "net_quantity_or_measure_of_commodity_in_pkg": "50 pcs",
-                                "imported_product_country_of_origin": "ARM",
-                                "description": "Whisper Ultra Soft Air Fresh Sanitary Pads - With Wider & Longer Back, XL, 50 pcs",
-                                "manufacturer_or_packer_name": "Procter & Gamble Home Products Private Limited, Plot No. 1, Industrial Area, Village Katha, Baddi, Dist Solan, H. P. - 173205",
-                                "manufacturer_or_packer_address": "Procter & Gamble Home Products Private Limited, Plot No. 1, Industrial Area, Village Katha, Baddi, Dist Solan, H. P. - 173205",
-                                "month_year_of_manufacture_packing_import": ""
-                            },
-                            "@ondc/org/seller_pickup_return": true,
-                            "@ondc/org/contact_details_consumer_care": "shhss889",
-                            "descriptor": {
-                                "symbol": "https://datalabs.siva3.io/image/Eunimart_groceries_40111912_13-whisper-ultra-soft-air-fresh-sanitary-pads-with-wider-longer-back-xl.jpg",
-                                "images": [
-                                    "https://datalabs.siva3.io/image/Eunimart_groceries_40111912_13-whisper-ultra-soft-air-fresh-sanitary-pads-with-wider-longer-back-xl.jpg",
-                                    "https://datalabs.siva3.io/image/Eunimart_groceries_40111912-2_12-whisper-ultra-soft-air-fresh-sanitary-pads-with-wider-longer-back-xl.jpg",
-                                    "https://datalabs.siva3.io/image/Eunimart_groceries_40111912-3_2-whisper-ultra-soft-air-fresh-sanitary-pads-with-wider-longer-back-xl.jpg"
-                                ],
-                                "name": "Whisper Ultra Soft Air Fresh Sanitary Pads - With Wider & Longer Back, XL, 50 pcs",
-                                "short_desc": "Whisper Ultra Softs Air Fresh provides airy fresh feel for an irritation free periods. They have 500 air fresh pores that allow air to pass through while absorbing wetness. Now you can say Goodbye to the 'icky, sticky' feeling during your periods!",
-                                "long_desc": "Whisper Ultra Softs Air Fresh provides airy fresh feel for an irritation free periods. They have 500 air fresh pores that allow air to pass through while absorbing wetness. Now you can say Goodbye to the 'icky, sticky' feeling during your periods!"
-                            },
-                            "tax_rate": "28",
-                            "location_id": "6906",
-                            "@ondc/org/available_on_cod": false,
-                            "L2_category": "Beauty & Hygiene",
-                            "category_id": "Beauty & Hygiene",
-                            "price": {
-                                "currency": "INR",
-                                "maximum_value": "468.75",
-                                "value": "468.75"
-                            },
-                            "id": "59c61ea5-abf9-46c9-b8ab-b7c2934e6574",
-                            "@ondc/org/cancellable": true,
-                            "@ondc/org/returnable": true,
-                            "quantity": {
-                                "available": {
-                                    "count": "235"
-                                },
-                                "maximum": {
-                                    "count": "21"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "l",
-                                        "value": "125"
-                                    }
-                                }
-                            },
-                            "@ondc/org/time_to_ship": "PT1H",
-                            "hsn_code": "1234",
-                            "tags": [],
-                            "@ondc/org/return_window": "P14D",
-                            "@ondc/org/statutory_reqs_prepackaged_food": {
-                                "importer_FSSAI_license_no": null,
-                                "nutritional_info": null,
-                                "other_FSSAI_license_no": null,
-                                "imported_product_country_of_origin": null,
-                                "brand_owner_FSSAI_license_no": null,
-                                "additives_info": null
-                            },
-                            "tax_type": "gst",
-                            "domain": "Grocery",
-                            "time": {
-                                "label": "enable",
-                                "timestamp": "2023-10-05T06:53:33.029Z"
-                            },
-                            "fulfillment_id": "1"
-                        },
-                        {
-                            "@ondc/org/statutory_reqs_packaged_commodities": {
-                                "common_or_generic_name_of_commodity": "Detergents & Dishwash",
-                                "net_quantity_or_measure_of_commodity_in_pkg": "12 ml",
-                                "imported_product_country_of_origin": "India",
-                                "description": "Surf Excel Detergent Bar, 200 g Pack of 4",
-                                "manufacturer_or_packer_name": "Hindustan Unilever Limited, Unilever House, B D Sawant Marg, Chakala, Anderi E, Mumbai - 400099",
-                                "manufacturer_or_packer_address": "Hindustan Unilever Limited, Unilever House, B D Sawant Marg, Chakala, Anderi E, Mumbai - 400099",
-                                "month_year_of_manufacture_packing_import": ""
-                            },
-                            "@ondc/org/seller_pickup_return": true,
-                            "@ondc/org/contact_details_consumer_care": "vzhxxh",
-                            "descriptor": {
-                                "symbol": "https://datalabs.siva3.io/image/Eunimart_groceries_267011_12-surf-excel-detergent-bar.jpg",
-                                "images": [
-                                    "https://datalabs.siva3.io/image/Eunimart_groceries_267011_12-surf-excel-detergent-bar.jpg",
-                                    "https://datalabs.siva3.io/image/Eunimart_groceries_267011-2_3-surf-excel-detergent-bar.jpg",
-                                    "https://datalabs.siva3.io/image/Eunimart_groceries_267011-3_3-surf-excel-detergent-bar.jpg"
-                                ],
-                                "name": "Surf Excel Detergent Bar, 200 g Pack of 4",
-                                "short_desc": "Surf excel detergent bar is Indias most premium detergent bar and is developed with a unique patented technology. Surf excel bar combines the power of 4 products - vinegar, blue, bleach and lemon into just 1 product, thereby helping you fight and remove tough stains easily that help you save time, money and†’¬‚…¡  effort you put behind laundry. With just one product, Surf Excel Bar, you can easily remove tough stains like tea, coffee, turmeric, curry, ketchup and chocolate. Besides the 95g pack, Surf Excel Bar is also available across other convenient pack sizes such as 150g, 250g, 400g & 800g (4packs of 200g each). All you need to do is apply the bar on the tough stains, scrub a little and then wash the garment as usual and voila, you have spotless clean clothes. Unlike most popular based brands, the effort required when using Surf Excel Bar is far lesser and makes your laundry process a less tedious chore. It is gentle on both your clothes and your hands. Surf Excel Bar removes tough stain easily and works like your own personal stain eraser! So what are you waiting for? Try Surf Excel Bar and make your laundry experience a happy effortless one!\r\nFeatures and Benefits:\r\n‚ Indias most premium detergent bar‚ Youre personal Stain Eraser: Removes tough stains with ease.‚ Surf Excel Bar combines the cleaning benefits similar to that of vinegar, blue, bleach, and lemon.‚ Removes tough stains such as tea, coffee, turmeric, curry, ketchup and chocolate with just one product‚ Gentle on both your clothes and your hand‚ Makes your laundry easy",
-                                "long_desc": "Surf excel detergent bar is Indias most premium detergent bar and is developed with a unique patented technology. Surf excel bar combines the power of 4 products - vinegar, blue, bleach and lemon into just 1 product, thereby helping you fight and remove tough stains easily that help you save time, money and†’¬‚…¡  effort you put behind laundry. With just one product, Surf Excel Bar, you can easily remove tough stains like tea, coffee, turmeric, curry, ketchup and chocolate. Besides the 95g pack, Surf Excel Bar is also available across other convenient pack sizes such as 150g, 250g, 400g & 800g (4packs of 200g each). All you need to do is apply the bar on the tough stains, scrub a little and then wash the garment as usual and voila, you have spotless clean clothes. Unlike most popular based brands, the effort required when using Surf Excel Bar is far lesser and makes your laundry process a less tedious chore. It is gentle on both your clothes and your hands. Surf Excel Bar removes tough stain easily and works like your own personal stain eraser! So what are you waiting for? Try Surf Excel Bar and make your laundry experience a happy effortless one!\r\nFeatures and Benefits:\r\n‚ Indias most premium detergent bar‚ Youre personal Stain Eraser: Removes tough stains with ease.‚ Surf Excel Bar combines the cleaning benefits similar to that of vinegar, blue, bleach, and lemon.‚ Removes tough stains such as tea, coffee, turmeric, curry, ketchup and chocolate with just one product‚ Gentle on both your clothes and your hand‚ Makes your laundry easy"
-                            },
-                            "tax_rate": "18",
-                            "location_id": "6906",
-                            "@ondc/org/available_on_cod": false,
-                            "L2_category": "Cleaning & Household",
-                            "category_id": "Cleaning & Household",
-                            "price": {
-                                "currency": "INR",
-                                "maximum_value": "107",
-                                "value": "107"
-                            },
-                            "id": "cc0d1a9a-b731-4e4b-b9c2-f00b2688d2fd",
-                            "@ondc/org/cancellable": true,
-                            "@ondc/org/returnable": true,
-                            "quantity": {
-                                "available": {
-                                    "count": "2"
-                                },
-                                "maximum": {
-                                    "count": "2"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "ml",
-                                        "value": "12"
-                                    }
-                                }
-                            },
-                            "@ondc/org/time_to_ship": "PT1H",
-                            "hsn_code": "1000",
-                            "tags": [],
-                            "@ondc/org/return_window": "P14D",
-                            "@ondc/org/statutory_reqs_prepackaged_food": {
-                                "importer_FSSAI_license_no": null,
-                                "nutritional_info": null,
-                                "other_FSSAI_license_no": null,
-                                "imported_product_country_of_origin": null,
-                                "brand_owner_FSSAI_license_no": null,
-                                "additives_info": null
-                            },
-                            "tax_type": "gst",
-                            "domain": "Grocery",
-                            "time": {
-                                "label": "enable",
-                                "timestamp": "2023-10-05T06:53:33.029Z"
-                            },
-                            "fulfillment_id": "1"
-                        },
-                        {
-                            "@ondc/org/statutory_reqs_packaged_commodities": {
-                                "net_quantity_or_measure_of_commodity_in_pkg": "23",
-                                "imported_product_country_of_origin": "v v gig8hih",
-                                "manufacturer_or_packer_name": "tdhfjf"
-                            },
-                            "@ondc/org/seller_pickup_return": true,
-                            "@ondc/org/contact_details_consumer_care": "dyyffy7gxgx",
-                            "descriptor": {
-                                "symbol": "https://firebasestorage.googleapis.com/v0/b/shopeg-dev.appspot.com/o/shopImages%2FSXGJLw4JFjTDTNxEG48PaThdmMG3%2Fimg_1692598996513.jpg?alt=media&token=23d74ed7-4215-4d05-9745-afbe23028c71",
-                                "images": [
-                                    "https://firebasestorage.googleapis.com/v0/b/shopeg-dev.appspot.com/o/shopImages%2FSXGJLw4JFjTDTNxEG48PaThdmMG3%2Fimg_1692598996513.jpg?alt=media&token=23d74ed7-4215-4d05-9745-afbe23028c71"
-                                ],
-                                "name": "testbbn",
-                                "short_desc": "hdhjcjc",
-                                "long_desc": "hxjxkkx"
-                            },
-                            "location_id": "6906",
-                            "tax_rate": "5",
-                            "@ondc/org/available_on_cod": false,
-                            "L2_category": "Bath & Body",
-                            "category_id": "Bath & Body",
-                            "price": {
-                                "currency": "INR",
-                                "maximum_value": "253",
-                                "value": "2"
-                            },
-                            "id": "5f657ae3-75d3-4f66-9648-8b8ca44817d3",
-                            "@ondc/org/cancellable": true,
-                            "@ondc/org/returnable": true,
-                            "quantity": {
-                                "available": {
-                                    "count": "26"
-                                },
-                                "maximum": {
-                                    "count": "3"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "Nos",
-                                        "value": "23"
-                                    }
-                                }
-                            },
-                            "@ondc/org/time_to_ship": "PT1H",
-                            "hsn_code": "1234",
-                            "tags": [],
-                            "@ondc/org/return_window": "P14D",
-                            "@ondc/org/statutory_reqs_prepackaged_food": {
-                                "importer_FSSAI_license_no": null,
-                                "nutritional_info": null,
-                                "other_importer_address": null,
-                                "importer_fssai_logo": null,
-                                "importer_address": null,
-                                "other_importer_name": null,
-                                "brand_owner_FSSAI_license_no": null,
-                                "net_quantity": "253",
-                                "additives_info": "yxhfjcjc",
-                                "other_premises": "gxfufuf6",
-                                "importer_name": null,
-                                "brand_owner_address": null,
-                                "brand_owner_fssai_logo": null,
-                                "ingredients_info": "xyxvubjhuv",
-                                "other_FSSAI_license_no": null,
-                                "brand_owner_name": null,
-                                "imported_product_country_of_origin": null,
-                                "manufacturer_or_packer_name": null,
-                                "manufacturer_or_packer_address": "hvuhihihih"
-                            },
-                            "@ondc/org/mandatory_reqs_veggies_fruits": {
-                                "net_quantity": "78"
-                            },
-                            "tax_type": "gst",
-                            "domain": "Beauty & Personal Care",
-                            "time": {
-                                "label": "enable",
-                                "timestamp": "2023-10-05T06:53:33.029Z"
-                            },
-                            "fulfillment_id": "1"
-                        },
-                        {
-                            "@ondc/org/statutory_reqs_packaged_commodities": {
-                                "net_quantity_or_measure_of_commodity_in_pkg": "25 Kg",
-                                "imported_product_country_of_origin": "IND",
-                                "manufacturer_or_packer_name": "xgjxxj"
-                            },
-                            "@ondc/org/seller_pickup_return": true,
-                            "@ondc/org/contact_details_consumer_care": "xbxn",
-                            "descriptor": {
-                                "symbol": "https://firebasestorage.googleapis.com/v0/b/shopeg-dev.appspot.com/o/shopImages%2FSXGJLw4JFjTDTNxEG48PaThdmMG3%2Fimg_1694669427034.jpg?alt=media&token=a2c63482-409e-4489-84a7-ae96f9d3745a",
-                                "images": [
-                                    "https://firebasestorage.googleapis.com/v0/b/shopeg-dev.appspot.com/o/shopImages%2FSXGJLw4JFjTDTNxEG48PaThdmMG3%2Fimg_1694669427034.jpg?alt=media&token=a2c63482-409e-4489-84a7-ae96f9d3745a"
-                                ],
-                                "name": "Mflour",
-                                "short_desc": "hjsjsjs",
-                                "long_desc": "hjsjsjsbxnxjx"
-                            },
-                            "location_id": "6906",
-                            "tax_rate": "18",
-                            "@ondc/org/available_on_cod": false,
-                            "L2_category": "Foodgrains",
-                            "category_id": "Foodgrains",
-                            "price": {
-                                "currency": "INR",
-                                "maximum_value": "258",
-                                "value": "258"
-                            },
-                            "id": "746d88f4-1356-4487-860b-2046ae708321",
-                            "@ondc/org/cancellable": true,
-                            "@ondc/org/returnable": true,
-                            "quantity": {
-                                "available": {
-                                    "count": "2"
-                                },
-                                "maximum": {
-                                    "count": "2"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "Kg",
-                                        "value": "25"
-                                    }
-                                }
-                            },
-                            "@ondc/org/time_to_ship": "PT1H",
-                            "hsn_code": "123",
-                            "tags": [],
-                            "@ondc/org/return_window": "P14D",
-                            "@ondc/org/statutory_reqs_prepackaged_food": {
-                                "importer_FSSAI_license_no": null,
-                                "nutritional_info": null,
-                                "other_importer_address": null,
-                                "importer_fssai_logo": null,
-                                "importer_address": null,
-                                "other_importer_name": null,
-                                "brand_owner_FSSAI_license_no": "1237676",
-                                "net_quantity": null,
-                                "additives_info": null,
-                                "other_premises": null,
-                                "importer_name": null,
-                                "brand_owner_address": null,
-                                "brand_owner_fssai_logo": null,
-                                "ingredients_info": null,
-                                "other_FSSAI_license_no": null,
-                                "brand_owner_name": null,
-                                "imported_product_country_of_origin": null,
-                                "manufacturer_or_packer_name": null,
-                                "manufacturer_or_packer_address": null
-                            },
-                            "tax_type": "gst",
-                            "domain": "Grocery",
-                            "time": {
-                                "label": "enable",
-                                "timestamp": "2023-10-05T06:53:33.029Z"
-                            },
-                            "fulfillment_id": "1"
-                        },
-                        {
-                            "@ondc/org/cancellable": true,
-                            "@ondc/org/returnable": true,
-                            "quantity": {
-                                "available": {
-                                    "count": "23"
-                                },
-                                "maximum": {
-                                    "count": "23"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "Kg",
-                                        "value": "12"
-                                    }
-                                }
-                            },
-                            "@ondc/org/statutory_reqs_packaged_commodities": {
-                                "net_quantity_or_measure_of_commodity_in_pkg": "12 Kg",
-                                "imported_product_country_of_origin": "IND",
-                                "manufacturer_or_packer_name": "gggggg"
-                            },
-                            "@ondc/org/seller_pickup_return": true,
-                            "@ondc/org/contact_details_consumer_care": "vvvvv",
-                            "@ondc/org/time_to_ship": "PT1H",
-                            "descriptor": {
-                                "symbol": "https://firebasestorage.googleapis.com/v0/b/shopeg-dev.appspot.com/o/shopImages%2FSXGJLw4JFjTDTNxEG48PaThdmMG3%2Fimg_1693531774828.jpg?alt=media&token=c4d3d056-f51b-424e-90d5-ed3915edf192",
-                                "images": [
-                                    "https://firebasestorage.googleapis.com/v0/b/shopeg-dev.appspot.com/o/shopImages%2FSXGJLw4JFjTDTNxEG48PaThdmMG3%2Fimg_1693531774828.jpg?alt=media&token=c4d3d056-f51b-424e-90d5-ed3915edf192"
-                                ],
-                                "name": "yduddu",
-                                "short_desc": "cucufu",
-                                "long_desc": "cucufuufifi"
-                            },
-                            "hsn_code": "1234",
-                            "location_id": "6906",
-                            "tax_rate": "28",
-                            "tags": [],
-                            "@ondc/org/return_window": "P14D",
-                            "@ondc/org/available_on_cod": false,
-                            "L2_category": "Feminine Care",
-                            "category_id": "Feminine Care",
-                            "tax_type": "gst",
-                            "price": {
-                                "currency": "INR",
-                                "maximum_value": "123",
-                                "value": "12"
-                            },
-                            "domain": "Beauty & Personal Care",
-                            "id": "9e22b8ac-2778-4a34-a050-5613099ab22b",
-                            "time": {
-                                "label": "enable",
-                                "timestamp": "2023-10-05T06:53:33.029Z"
-                            },
-                            "fulfillment_id": "1"
-                        },
-                        {
-                            "@ondc/org/statutory_reqs_packaged_commodities": {
-                                "common_or_generic_name_of_commodity": "Baby Food & Formula",
-                                "net_quantity_or_measure_of_commodity_in_pkg": "2x300 g Multipack",
-                                "imported_product_country_of_origin": "IND",
-                                "description": "Nestle Cerelac - Wheat Rice Moong Dal Veg Kichdi (Stage 2 for 8 months & above), 2x300 g Multipack",
-                                "manufacturer_or_packer_name": "NESTLE INDIA LIMITED, 100/101, World Trade Centre, Barakhamba lane, NEW DELHI- 110001",
-                                "manufacturer_or_packer_address": "NESTLE INDIA LIMITED, 100/101, World Trade Centre, Barakhamba lane, NEW DELHI- 110001",
-                                "month_year_of_manufacture_packing_import": ""
-                            },
-                            "@ondc/org/seller_pickup_return": true,
-                            "@ondc/org/contact_details_consumer_care": "ghji78",
-                            "descriptor": {
-                                "symbol": "https://datalabs.siva3.io/image/Eunimart_groceries_201657_3-nestle-cerelac-wheat-rice-moong-dal-veg-kichdi-stage-2-for-8-months-above.jpg",
-                                "images": [
-                                    "https://datalabs.siva3.io/image/Eunimart_groceries_201657_3-nestle-cerelac-wheat-rice-moong-dal-veg-kichdi-stage-2-for-8-months-above.jpg"
-                                ],
-                                "name": "Nestle Cerelac - Wheat Rice Moong Dal Veg Kichdi (Stage 2 for 8 months & above), 2x300 g Multipack",
-                                "short_desc": "Nestle Cerelac Shishu Aahaar Wheat-Rice Moong Dal Veg Khichdi Stage 2 Cerelac Shishu Aahaar offers the combined benefit of cereals and pulses are a excellent source of vegetarian proteins. Cereals & pulse complement each other and their combination is regularly a part of traditional Indian diet.",
-                                "long_desc": "Nestle Cerelac Shishu Aahaar Wheat-Rice Moong Dal Veg Khichdi Stage 2 Cerelac Shishu Aahaar offers the combined benefit of cereals and pulses are a excellent source of vegetarian proteins. Cereals & pulse complement each other and their combination is regularly a part of traditional Indian diet."
-                            },
-                            "tax_rate": "18",
-                            "location_id": "6906",
-                            "@ondc/org/available_on_cod": false,
-                            "L2_category": "Gourmet & World Foods",
-                            "category_id": "Gourmet & World Foods",
-                            "price": {
-                                "currency": "INR",
-                                "maximum_value": "560",
-                                "value": "201"
-                            },
-                            "id": "6ec74266-403e-4d94-ac5f-2348c0410ee2",
-                            "@ondc/org/cancellable": true,
-                            "@ondc/org/returnable": true,
-                            "quantity": {
-                                "available": {
-                                    "count": "1"
-                                },
-                                "maximum": {
-                                    "count": "1"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "Kg",
-                                        "value": "23"
-                                    }
-                                }
-                            },
-                            "@ondc/org/time_to_ship": "PT1H",
-                            "hsn_code": "1000",
-                            "tags": [],
-                            "@ondc/org/return_window": "P14D",
-                            "@ondc/org/statutory_reqs_prepackaged_food": {
-                                "importer_FSSAI_license_no": null,
-                                "nutritional_info": null,
-                                "other_importer_address": null,
-                                "importer_fssai_logo": null,
-                                "importer_address": null,
-                                "other_importer_name": null,
-                                "brand_owner_FSSAI_license_no": "123456",
-                                "net_quantity": null,
-                                "additives_info": null,
-                                "other_premises": null,
-                                "importer_name": null,
-                                "brand_owner_address": null,
-                                "brand_owner_fssai_logo": null,
-                                "ingredients_info": null,
-                                "other_FSSAI_license_no": null,
-                                "brand_owner_name": null,
-                                "imported_product_country_of_origin": null,
-                                "manufacturer_or_packer_name": null,
-                                "manufacturer_or_packer_address": null
-                            },
-                            "tax_type": "gst",
-                            "domain": "Grocery",
-                            "time": {
-                                "label": "enable",
-                                "timestamp": "2023-10-05T06:53:33.029Z"
-                            },
-                            "fulfillment_id": "1"
-                        }
-                    ],
-                    "fulfillments": [
-                        {
-                            "contact": {
-                                "email": "ondc-support@shopeg.in"
-                            },
-                            "id": "1",
-                            "type": "Delivery"
-                        }
-                    ],
-                    "tags": [
-                        {
-                            "code": "serviceability",
-                            "list": [
-                                {
-                                    "code": "location",
-                                    "value": "6906"
-                                },
-                                {
-                                    "code": "category",
-                                    "value": "Gourmet & World Foods"
-                                },
-                                {
-                                    "code": "type",
-                                    "value": "10"
-                                },
-                                {
-                                    "code": "val",
-                                    "value": "5"
-                                },
-                                {
-                                    "code": "unit",
-                                    "value": "km"
-                                }
-                            ]
-                        },
-                        {
-                            "code": "serviceability",
-                            "list": [
-                                {
-                                    "code": "location",
-                                    "value": "6906"
-                                },
-                                {
-                                    "code": "category",
-                                    "value": "Kitchen Accessories"
-                                },
-                                {
-                                    "code": "type",
-                                    "value": "10"
-                                },
-                                {
-                                    "code": "val",
-                                    "value": "5"
-                                },
-                                {
-                                    "code": "unit",
-                                    "value": "km"
-                                }
-                            ]
-                        },
-                        {
-                            "code": "serviceability",
-                            "list": [
-                                {
-                                    "code": "location",
-                                    "value": "6906"
-                                },
-                                {
-                                    "code": "category",
-                                    "value": "Masala & Seasoning"
-                                },
-                                {
-                                    "code": "type",
-                                    "value": "10"
-                                },
-                                {
-                                    "code": "val",
-                                    "value": "5"
-                                },
-                                {
-                                    "code": "unit",
-                                    "value": "km"
-                                }
-                            ]
-                        },
-                        {
-                            "code": "serviceability",
-                            "list": [
-                                {
-                                    "code": "location",
-                                    "value": "6906"
-                                },
-                                {
-                                    "code": "category",
-                                    "value": "Feminine Care"
-                                },
-                                {
-                                    "code": "type",
-                                    "value": "10"
-                                },
-                                {
-                                    "code": "val",
-                                    "value": "5"
-                                },
-                                {
-                                    "code": "unit",
-                                    "value": "km"
-                                }
-                            ]
-                        },
-                        {
-                            "code": "serviceability",
-                            "list": [
-                                {
-                                    "code": "location",
-                                    "value": "6906"
-                                },
-                                {
-                                    "code": "category",
-                                    "value": "Cleaning & Household"
-                                },
-                                {
-                                    "code": "type",
-                                    "value": "10"
-                                },
-                                {
-                                    "code": "val",
-                                    "value": "5"
-                                },
-                                {
-                                    "code": "unit",
-                                    "value": "km"
-                                }
-                            ]
-                        },
-                        {
-                            "code": "serviceability",
-                            "list": [
-                                {
-                                    "code": "location",
-                                    "value": "6906"
-                                },
-                                {
-                                    "code": "category",
-                                    "value": "Beauty & Hygiene"
-                                },
-                                {
-                                    "code": "type",
-                                    "value": "10"
-                                },
-                                {
-                                    "code": "val",
-                                    "value": "5"
-                                },
-                                {
-                                    "code": "unit",
-                                    "value": "km"
-                                }
-                            ]
-                        },
-                        {
-                            "code": "serviceability",
-                            "list": [
-                                {
-                                    "code": "location",
-                                    "value": "6906"
-                                },
-                                {
-                                    "code": "category",
-                                    "value": "Fragrance"
-                                },
-                                {
-                                    "code": "type",
-                                    "value": "10"
-                                },
-                                {
-                                    "code": "val",
-                                    "value": "5"
-                                },
-                                {
-                                    "code": "unit",
-                                    "value": "km"
-                                }
-                            ]
-                        }
-                    ]
-                },
-                {
-                    "id": "cK4NBOIKU0Rf2M0Qv9qX",
-                    "time": {
-                        "label": "enable",
-                        "timestamp": "2023-10-27T16:00:20.865Z"
-                    },
-                    "ttl": "P1D",
-                    "descriptor": {
-                        "symbol": "https://firebasestorage.googleapis.com/v0/b/shopeg-dev.appspot.com/o/shopImages%2FWy4ujm1L2gZH18LCxz2FHu1J21Y2%2Fimg_1692371468430.jpg?alt=media&token=f69cc21c-2a59-46f5-a472-f2e8e2a47021",
-                        "name": "SLV grocery store",
-                        "images": [
-                            "https://firebasestorage.googleapis.com/v0/b/shopeg-dev.appspot.com/o/shopImages%2FWy4ujm1L2gZH18LCxz2FHu1J21Y2%2Fimg_1692371468430.jpg?alt=media&token=f69cc21c-2a59-46f5-a472-f2e8e2a47021"
-                        ]
-                    },
-                    "locations": [
-                        {
-                            "schedule": {
-                                "times": [
-                                    "0702",
-                                    "2300"
-                                ],
-                                "holidays": [],
-                                "frequency": "PT15H"
-                            },
-                            "address": {
-                                "door": "67, 2nd Cross Road, 2nd Cross Road",
-                                "country": "India",
-                                "city": "Bengaluru",
-                                "street": "Basaveshwara Nagar, Bengaluru",
-                                "area_code": "560079",
-                                "name": "SLV grocery store",
-                                "locality": "",
-                                "state": "KA",
-                                "building": "67, 2nd Cross Road, 2nd Cross Road"
-                            },
-                            "id": "6908",
-                            "gps": "13.000997251887071,77.53779746937829",
-                            "time": {
-                                "range": {
-                                    "start": "0702",
-                                    "end": "2300"
-                                },
-                                "days": "1,2,3,4,5,6,7",
-                                "schedule": {
-                                    "holidays": []
-                                },
-                                "label": "enable",
-                                "timestamp": "2023-10-27T16:00:20.865Z"
-                            },
-                            "circle": {
-                                "gps": "13.000997251887071,77.53779746937829",
-                                "radius": {
-                                    "unit": "km",
-                                    "value": "5.0"
-                                }
-                            }
-                        }
-                    ],
-                    "items": [
-                        {
-                            "@ondc/org/statutory_reqs_packaged_commodities": {
-                                "net_quantity_or_measure_of_commodity_in_pkg": "1",
-                                "date_of_import": "08/2023",
-                                "imported_product_country_of_origin": "ind",
-                                "manufacturer_or_packer_name": "dynamic manufacturing "
-                            },
-                            "@ondc/org/seller_pickup_return": false,
-                            "@ondc/org/contact_details_consumer_care": "Johndoe,John",
-                            "descriptor": {
-                                "symbol": "https://firebasestorage.googleapis.com/v0/b/shopeg-dev.appspot.com/o/shopImages%2FWy4ujm1L2gZH18LCxz2FHu1J21Y2%2Fimg_1692371468430.jpg?alt=media&token=f69cc21c-2a59-46f5-a472-f2e8e2a47021",
-                                "images": [
-                                    "https://firebasestorage.googleapis.com/v0/b/shopeg-dev.appspot.com/o/shopImages%2FWy4ujm1L2gZH18LCxz2FHu1J21Y2%2Fimg_1692371468430.jpg?alt=media&token=f69cc21c-2a59-46f5-a472-f2e8e2a47021"
-                                ],
-                                "name": "dynamic product",
-                                "short_desc": "dynamic",
-                                "long_desc": "shushsb"
-                            },
-                            "tax_rate": "5",
-                            "location_id": "6908",
-                            "@ondc/org/available_on_cod": false,
-                            "L2_category": "Foodgrains",
-                            "category_id": "Foodgrains",
-                            "price": {
-                                "currency": "INR",
-                                "maximum_value": "477",
-                                "value": "460"
-                            },
-                            "id": "58decf58-7ea2-4757-bef8-2f0890104d16",
-                            "@ondc/org/cancellable": false,
-                            "@ondc/org/returnable": false,
-                            "quantity": {
-                                "available": {
-                                    "count": "6"
-                                },
-                                "maximum": {
-                                    "count": "2"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "Nos",
-                                        "value": "1"
-                                    }
-                                }
-                            },
-                            "@ondc/org/time_to_ship": "P1D",
-                            "hsn_code": "1224",
-                            "tags": [],
-                            "@ondc/org/return_window": "P4H",
-                            "@ondc/org/statutory_reqs_prepackaged_food": {
-                                "ingredients_info": "",
-                                "brand_owner_FSSAI_license_no": "548494949497997",
-                                "net_quantity": "",
-                                "additives_info": "",
-                                "manufacturer_or_packer_address": "Bangalore 5600001",
-                                "other_premises": ""
-                            },
-                            "@ondc/org/mandatory_reqs_veggies_fruits": {
-                                "net_quantity": "1"
-                            },
-                            "tax_type": "gst",
-                            "domain": "Grocery",
-                            "time": {
-                                "label": "enable",
-                                "timestamp": "2023-08-31T19:07:43.584Z"
-                            },
-                            "fulfillment_id": "1"
-                        },
-                        {
-                            "@ondc/org/statutory_reqs_packaged_commodities": {
-                                "common_or_generic_name_of_commodity": "Coffee",
-                                "net_quantity_or_measure_of_commodity_in_pkg": "1 Nos",
-                                "imported_product_country_of_origin": "India",
-                                "manufacturer_or_packer_name": "Amrit Corp Ltd (Unit Amrit Food), Amrit Nagar, G.T. Road, Ghaziabad, U.P. - 201009 & 145/1, Ground Floor, Shahpur Jat, Delhi-110049",
-                                "multiple_products_name_number_or_qty": "jddj",
-                                "manufacturer_or_packer_address": "Amrit Corp Ltd (Unit Amrit Food), Amrit Nagar, G.T. Road, Ghaziabad, U.P. - 201009 & 145/1, Ground Floor, Shahpur Jat, Delhi-110049"
-                            },
-                            "@ondc/org/seller_pickup_return": true,
-                            "@ondc/org/contact_details_consumer_care": "nxnxnx",
-                            "descriptor": {
-                                "symbol": "https://www.bigbasket.com/media/uploads/p/l/40172087_6-sleepy-owl-cold-brew-coffee-classic.jpg",
-                                "images": [
-                                    "https://www.bigbasket.com/media/uploads/p/l/40172087_6-sleepy-owl-cold-brew-coffee-classic.jpg"
-                                ],
-                                "name": "Sleepy Owl Classic Iced Coffee - Made With Cold Brew, 200 ml Bottle",
-                                "short_desc": "Sleepy Owl Classic is a cold-brewed iced coffee made from the highest quality 100% Grade A coffee sourced straight from Chikmagalur. Made with just 8 grams of sugar and a little milk, Sleepy Owl Classic is the perfect functional beverage for all lovers of coffee. The bottles contain 200ml of iced coffee and are made with love at our production facility in Ghaziabad. Each bottle has a shelf life of 120 days, which is achieved without any preservatives due to a special production process we use. The bottles are capped with easy-to-pull pop-off caps and have an ambient shelf life meaning they can be stored in cold or warm temperatures. These ready-to-drink bottles are India's first and only bottled iced coffee drink that contains nothing except coffee, milk, and sugar. No preservatives, no stabilisers, no emulsifiers, and no chemicals. Our mission at Sleepy Owl Coffee is to make high-quality cold brew coffee products that you can consume with ease and convenience at home, at work or on the go without having to compromise on taste or health. The same formula applies to the bottles - just chill them, shake them, pop them open, and gulp them down!",
-                                "long_desc": "Sleepy Owl Classic is a cold-brewed iced coffee made from the highest quality 100% Grade A coffee sourced straight from Chikmagalur. Made with just 8 grams of sugar and a little milk, Sleepy Owl Classic is the perfect functional beverage for all lovers of coffee. The bottles contain 200ml of iced coffee and are made with love at our production facility in Ghaziabad. Each bottle has a shelf life of 120 days, which is achieved without any preservatives due to a special production process we use. The bottles are capped with easy-to-pull pop-off caps and have an ambient shelf life meaning they can be stored in cold or warm temperatures. These ready-to-drink bottles are India's first and only bottled iced coffee drink that contains nothing except coffee, milk, and sugar. No preservatives, no stabilisers, no emulsifiers, and no chemicals. Our mission at Sleepy Owl Coffee is to make high-quality cold brew coffee products that you can consume with ease and convenience at home, at work or on the go without having to compromise on taste or health. The same formula applies to the bottles - just chill them, shake them, pop them open, and gulp them down!"
-                            },
-                            "location_id": "6908",
-                            "tax_rate": "5",
-                            "@ondc/org/available_on_cod": true,
-                            "L2_category": "Beverages",
-                            "category_id": "Beverages",
-                            "price": {
-                                "currency": "INR",
-                                "maximum_value": "110",
-                                "value": "110"
-                            },
-                            "id": "f0aa0393-3a0a-434e-b63b-6ee364e4c886",
-                            "@ondc/org/cancellable": true,
-                            "@ondc/org/returnable": true,
-                            "quantity": {
-                                "available": {
-                                    "count": "3"
-                                },
-                                "maximum": {
-                                    "count": "3"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "Nos",
-                                        "value": "1"
-                                    }
-                                }
-                            },
-                            "@ondc/org/time_to_ship": "PT4H",
-                            "product_master_uuid": "89ebf116-3559-404c-9e04-5f76f884a6fd",
-                            "hsn_code": "124545",
-                            "tags": [
-                                {
-                                    "code": "veg_nonveg",
-                                    "list": [
-                                        {
-                                            "code": "veg",
-                                            "value": "yes"
-                                        }
-                                    ]
-                                }
-                            ],
-                            "@ondc/org/return_window": "P7D",
-                            "@ondc/org/statutory_reqs_prepackaged_food": {
-                                "importer_FSSAI_license_no": "54845",
-                                "nutritional_info": "djdjjf",
-                                "other_importer_address": "hdjdj",
-                                "importer_address": "djdjjd",
-                                "other_importer_name": "hdjdjd",
-                                "brand_owner_FSSAI_license_no": "64644",
-                                "net_quantity": "5555",
-                                "additives_info": "ejje",
-                                "other_premises": "dhdhd",
-                                "importer_name": "hdjfj",
-                                "brand_owner_address": "djjdjf",
-                                "ingredients_info": "jdjdjf",
-                                "other_FSSAI_license_no": "55956",
-                                "brand_owner_name": "Sleepy Owl",
-                                "imported_product_country_of_origin": "IND",
-                                "manufacturer_or_packer_name": "jdjd",
-                                "manufacturer_or_packer_address": "jdjdj"
-                            },
-                            "tax_type": "gst",
-                            "domain": "Grocery",
-                            "time": {
-                                "label": "enable",
-                                "timestamp": "2023-09-25T13:21:30.301Z"
-                            },
-                            "fulfillment_id": "1"
-                        },
-                        {
-                            "@ondc/org/statutory_reqs_packaged_commodities": {
-                                "net_quantity_or_measure_of_commodity_in_pkg": "26",
-                                "date_of_import": "08/2023",
-                                "imported_product_country_of_origin": "hddgdg",
-                                "manufacturer_or_packer_name": "shdhdhdhdh"
-                            },
-                            "@ondc/org/seller_pickup_return": false,
-                            "@ondc/org/contact_details_consumer_care": "dxfzgr",
-                            "descriptor": {
-                                "symbol": "https://firebasestorage.googleapis.com/v0/b/shopeg-dev.appspot.com/o/shopImages%2FWy4ujm1L2gZH18LCxz2FHu1J21Y2%2Fimg_1692597477984.jpg?alt=media&token=b257c319-e33d-45fd-8c30-be09846a09ba",
-                                "images": [
-                                    "https://firebasestorage.googleapis.com/v0/b/shopeg-dev.appspot.com/o/shopImages%2FWy4ujm1L2gZH18LCxz2FHu1J21Y2%2Fimg_1692597477984.jpg?alt=media&token=b257c319-e33d-45fd-8c30-be09846a09ba"
-                                ],
-                                "name": "jamun",
-                                "short_desc": "jj jxj",
-                                "long_desc": "jxhxjxcu"
-                            },
-                            "tax_rate": "5",
-                            "location_id": "6908",
-                            "@ondc/org/available_on_cod": true,
-                            "L2_category": "Gourmet & World Foods",
-                            "category_id": "Gourmet & World Foods",
-                            "price": {
-                                "currency": "INR",
-                                "maximum_value": "980",
-                                "value": "950"
-                            },
-                            "id": "acac835c-3573-4523-b49c-fa0511eb75fd",
-                            "@ondc/org/cancellable": true,
-                            "@ondc/org/returnable": true,
-                            "quantity": {
-                                "available": {
-                                    "count": "56"
-                                },
-                                "maximum": {
-                                    "count": "3"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "Kg",
-                                        "value": "23"
-                                    }
-                                }
-                            },
-                            "@ondc/org/time_to_ship": "P8H",
-                            "hsn_code": "1000",
-                            "tags": [],
-                            "@ondc/org/return_window": "P8H",
-                            "@ondc/org/statutory_reqs_prepackaged_food": {
-                                "ingredients_info": "rhdhdh",
-                                "brand_owner_FSSAI_license_no": "123456799",
-                                "net_quantity": "58",
-                                "additives_info": "hrhrh",
-                                "manufacturer_or_packer_address": "",
-                                "other_premises": "hcuvg"
-                            },
-                            "@ondc/org/mandatory_reqs_veggies_fruits": {
-                                "net_quantity": "45"
-                            },
-                            "tax_type": "gst",
-                            "domain": "Grocery",
-                            "time": {
-                                "label": "enable",
-                                "timestamp": "2023-08-21T05:58:04.616Z"
-                            },
-                            "fulfillment_id": "1"
-                        },
-                        {
-                            "@ondc/org/statutory_reqs_packaged_commodities": {
-                                "common_or_generic_name_of_commodity": "Spices & Masala",
-                                "net_quantity_or_measure_of_commodity_in_pkg": "1545 Nos",
-                                "imported_product_country_of_origin": "India",
-                                "manufacturer_or_packer_name": "S.Everest Food Products Pvt. Ltd.",
-                                "multiple_products_name_number_or_qty": "dhdh",
-                                "manufacturer_or_packer_address": "S.Everest Food Products Pvt. Ltd.",
-                                "month_year_of_manufacture_packing_import": "10/2023"
-                            },
-                            "@ondc/org/seller_pickup_return": true,
-                            "@ondc/org/contact_details_consumer_care": "hshdhd",
-                            "descriptor": {
-                                "symbol": "https://www.bigbasket.com/media/uploads/p/xxl/40059447_6-everest-kasuri-methi.jpg",
-                                "images": [
-                                    "https://www.bigbasket.com/media/uploads/p/xxl/40059447_6-everest-kasuri-methi.jpg"
-                                ],
-                                "name": "EVEREST KASURI METHI 25 G\r\n",
-                                "short_desc": "Sun-dried, pleasantly flavoured, Fenugreek leaves which is dried in hot air in controlled conditions, is a great taste enhancer. It adds flavour and texture to vegetables, pulses and lentils, parathas and chapattis.\r\n",
-                                "long_desc": "Sun-dried, pleasantly flavoured, Fenugreek leaves which is dried in hot air in controlled conditions, is a great taste enhancer. It adds flavour and texture to vegetables, pulses and lentils, parathas and chapattis.\r\n"
-                            },
-                            "location_id": "6908",
-                            "tax_rate": "5",
-                            "@ondc/org/available_on_cod": true,
-                            "L2_category": "Masala & Seasoning",
-                            "category_id": "Masala & Seasoning",
-                            "price": {
-                                "currency": "INR",
-                                "maximum_value": "23",
-                                "value": "23"
-                            },
-                            "id": "96eb055a-4956-412f-b78c-f5ab80043fdb",
-                            "@ondc/org/cancellable": true,
-                            "@ondc/org/returnable": true,
-                            "quantity": {
-                                "available": {
-                                    "count": "3"
-                                },
-                                "maximum": {
-                                    "count": "3"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "Nos",
-                                        "value": "1545"
-                                    }
-                                }
-                            },
-                            "@ondc/org/time_to_ship": "PT2H",
-                            "product_master_uuid": "6b45c17c-3950-4de7-b6bb-0e45bc737351",
-                            "hsn_code": "1554",
-                            "tags": [
-                                {
-                                    "code": "veg_nonveg",
-                                    "list": [
-                                        {
-                                            "code": "veg",
-                                            "value": "yes"
-                                        }
-                                    ]
-                                }
-                            ],
-                            "@ondc/org/return_window": "P7D",
-                            "@ondc/org/statutory_reqs_prepackaged_food": {
-                                "importer_FSSAI_license_no": "5255",
-                                "nutritional_info": "dhdh",
-                                "other_importer_address": "yrhf",
-                                "importer_address": "hehd",
-                                "other_importer_name": "hdhfh",
-                                "brand_owner_FSSAI_license_no": "545555",
-                                "net_quantity": "1545 Nos",
-                                "additives_info": "hdfh",
-                                "other_premises": "jdjf",
-                                "importer_name": "hehd",
-                                "brand_owner_address": "fhhffh",
-                                "ingredients_info": "hdhd",
-                                "other_FSSAI_license_no": "959555885",
-                                "brand_owner_name": "Everest",
-                                "imported_product_country_of_origin": "IND",
-                                "manufacturer_or_packer_name": "herh",
-                                "manufacturer_or_packer_address": "ruru"
-                            },
-                            "tax_type": "gst",
-                            "domain": "Grocery",
-                            "time": {
-                                "label": "enable",
-                                "timestamp": "2023-10-09T13:33:33.126Z"
-                            },
-                            "fulfillment_id": "1"
-                        },
-                        {
-                            "@ondc/org/cancellable": true,
-                            "@ondc/org/returnable": true,
-                            "quantity": {
-                                "available": {
-                                    "count": "3"
-                                },
-                                "maximum": {
-                                    "count": "3"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "Nos",
-                                        "value": "1"
-                                    }
-                                }
-                            },
-                            "@ondc/org/statutory_reqs_packaged_commodities": {
-                                "common_or_generic_name_of_commodity": "Utensils & Cookware",
-                                "net_quantity_or_measure_of_commodity_in_pkg": "1 Nos",
-                                "imported_product_country_of_origin": "India",
-                                "manufacturer_or_packer_name": "Neelam Appliances Ltd., Neelam House,Fafadia Industrial Estate, Waliv, Vasai, Dist. Palghar.Maharashtra-401208",
-                                "multiple_products_name_number_or_qty": "1",
-                                "manufacturer_or_packer_address": "Neelam Appliances Ltd., Neelam House,Fafadia Industrial Estate, Waliv, Vasai, Dist. Palghar.Maharashtra-401208",
-                                "month_year_of_manufacture_packing_import": "09/2023"
-                            },
-                            "@ondc/org/seller_pickup_return": true,
-                            "@ondc/org/contact_details_consumer_care": "sndndndn",
-                            "@ondc/org/time_to_ship": "PT4H",
-                            "descriptor": {
-                                "symbol": "https://www.bigbasket.com/media/uploads/p/l/40183413_10-bb-home-stainless-steel-deep-dabbastorage-container-no-12-plain.jpg?tr=w-1080,q=80",
-                                "images": [
-                                    "https://www.bigbasket.com/media/uploads/p/l/40183413_10-bb-home-stainless-steel-deep-dabbastorage-container-no-12-plain.jpg?tr=w-1080,q=80",
-                                    "https://www.bigbasket.com/media/uploads/p/l/40183413-2_11-bb-home-stainless-steel-deep-dabbastorage-container-no-12-plain.jpg?tr=w-1080,q=80",
-                                    "https://www.bigbasket.com/media/uploads/p/l/40183413-3_11-bb-home-stainless-steel-deep-dabbastorage-container-no-12-plain.jpg?tr=w-1080,q=80"
-                                ],
-                                "name": "BB Home Deep Dabba/Storage Container - No.12, Plain, Stainless Steel, Durable, 1.9 l (1 pc)",
-                                "short_desc": "BB Home Canister/Container Deep Dabba is a long cylindrical-shaped storage container, made of fine quality stainless steel that is durable and ideal for storing grains, snacks and other edibles. They are easy to clean and maintain. They add a great addition to your modular kitchen.",
-                                "long_desc": "BB Home Canister/Container Deep Dabba is a long cylindrical-shaped storage container, made of fine quality stainless steel that is durable and ideal for storing grains, snacks and other edibles. They are easy to clean and maintain. They add a great addition to your modular kitchen."
-                            },
-                            "product_master_uuid": "426cd36c-4c0d-4f2e-859d-5a819fc6e4f6",
-                            "hsn_code": "12345",
-                            "location_id": "6908",
-                            "tax_rate": "5",
-                            "tags": [],
-                            "@ondc/org/return_window": "P7D",
-                            "@ondc/org/available_on_cod": true,
-                            "L2_category": "Kitchen Accessories",
-                            "category_id": "Kitchen Accessories",
-                            "tax_type": "gst",
-                            "price": {
-                                "currency": "INR",
-                                "maximum_value": "299",
-                                "value": "299"
-                            },
-                            "domain": "Grocery",
-                            "id": "e278c2c9-3e50-4062-b73d-14976103ef81",
-                            "time": {
-                                "label": "enable",
-                                "timestamp": "2023-09-25T13:19:25.759Z"
-                            },
-                            "fulfillment_id": "1"
-                        }
-                    ],
-                    "fulfillments": [
-                        {
-                            "contact": {
-                                "email": "ondc-support@shopeg.in"
-                            },
-                            "id": "1",
-                            "type": "Delivery"
-                        }
-                    ],
-                    "tags": [
-                        {
-                            "code": "serviceability",
-                            "list": [
-                                {
-                                    "code": "location",
-                                    "value": "6908"
-                                },
-                                {
-                                    "code": "category",
-                                    "value": "Foodgrains"
-                                },
-                                {
-                                    "code": "type",
-                                    "value": "10"
-                                },
-                                {
-                                    "code": "val",
-                                    "value": "5.0"
-                                },
-                                {
-                                    "code": "unit",
-                                    "value": "km"
-                                }
-                            ]
-                        },
-                        {
-                            "code": "serviceability",
-                            "list": [
-                                {
-                                    "code": "location",
-                                    "value": "6908"
-                                },
-                                {
-                                    "code": "category",
-                                    "value": "Beverages"
-                                },
-                                {
-                                    "code": "type",
-                                    "value": "10"
-                                },
-                                {
-                                    "code": "val",
-                                    "value": "5.0"
-                                },
-                                {
-                                    "code": "unit",
-                                    "value": "km"
-                                }
-                            ]
-                        }
-                    ]
-                },
-                {
-                    "id": "aEPr6bTFeh6qQjtP7R9V",
-                    "time": {
-                        "label": "enable",
-                        "timestamp": "2023-10-27T16:00:20.865Z"
-                    },
-                    "ttl": "P1D",
-                    "descriptor": {
-                        "symbol": "https://firebasestorage.googleapis.com/v0/b/shopeg-dev.appspot.com/o/shopImages%2FP3rGcNdyeae5uhffGGOXuGWsgbJ2%2F2023-07-12%2011%3A28%3A12.662854.jpg?alt=media&token=a3d35cd6-59be-4386-a268-138b9400df73",
-                        "images": [
-                            "https://firebasestorage.googleapis.com/v0/b/shopeg-dev.appspot.com/o/shopImages%2FP3rGcNdyeae5uhffGGOXuGWsgbJ2%2F2023-07-12%2011%3A28%3A12.662854.jpg?alt=media&token=a3d35cd6-59be-4386-a268-138b9400df73"
-                        ],
-                        "name": "Vismaya shop",
-                        "short_desc": "Vismaya shop desc",
-                        "long_desc": "Vismaya shop desc"
-                    },
-                    "locations": [
-                        {
-                            "schedule": {
-                                "times": [
-                                    "0800"
-                                ],
-                                "holidays": [],
-                                "frequency": "PT15H"
-                            },
-                            "address": {
-                                "door": "Srigandada Kaval, ",
-                                "country": "India",
-                                "city": "Bengaluru",
-                                "street": "Annapurneshwari Nagar, Bengaluru",
-                                "area_code": "560091",
-                                "name": "Vismaya shop",
-                                "locality": "",
-                                "state": "Karnataka",
-                                "building": "Srigandada Kaval, "
-                            },
-                            "id": "6275",
-                            "gps": "13.001749,77.483685",
-                            "time": {
-                                "range": {
-                                    "start": "0800",
-                                    "end": "2310"
-                                },
-                                "days": "1,2,3,4,5,6,7",
-                                "schedule": {
-                                    "holidays": []
-                                },
-                                "label": "enable",
-                                "timestamp": "2023-10-27T16:00:20.865Z"
-                            },
-                            "circle": {
-                                "gps": "13.001749,77.483685",
-                                "radius": {
-                                    "unit": "km",
-                                    "value": "5"
-                                }
-                            }
-                        }
-                    ],
-                    "items": [
-                        {
-                            "@ondc/org/statutory_reqs_packaged_commodities": {
-                                "common_or_generic_name_of_commodity": "",
-                                "net_quantity_or_measure_of_commodity_in_pkg": "1 kg",
-                                "consumer_care_details": "",
-                                "imported_product_country_of_origin": "IND",
-                                "description": "AABBCCDDEEFF 1 KG",
-                                "manufacturer_or_packer_name": "General Mills India Pvt ltd",
-                                "multiple_products_name_number_or_qty": "1",
-                                "manufacturer_or_packer_address": "",
-                                "month_year_of_manufacture_packing_import": "",
-                                "contact_details_consumer_care": "1800-111-789"
-                            },
-                            "@ondc/org/seller_pickup_return": true,
-                            "@ondc/org/contact_details_consumer_care": "ondc-support@shopeg.in",
-                            "descriptor": {
-                                "symbol": "https://shopeg.in/i/eg.png",
-                                "images": [
-                                    "https://shopeg.in/i/eg.png"
-                                ],
-                                "name": "Product 34",
-                                "short_desc": "prdct shrt desc",
-                                "long_desc": ""
-                            },
-                            "location_id": "6275",
-                            "tax_rate": "5",
-                            "@ondc/org/available_on_cod": false,
-                            "L2_category": "Foodgrains",
-                            "category_id": "Foodgrains",
-                            "price": {
-                                "currency": "INR",
-                                "maximum_value": "7003",
-                                "maxium_value": "6666",
-                                "value": "6193"
-                            },
-                            "id": "daa796ff-435d-4d66-aa56-4289327915a9",
-                            "@ondc/org/cancellable": true,
-                            "@ondc/org/allergen_information": "",
-                            "@ondc/org/returnable": true,
-                            "quantity": {
-                                "available": {
-                                    "count": "2"
-                                },
-                                "maximum": {
-                                    "count": "2"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "",
-                                        "value": 0
-                                    }
-                                }
-                            },
-                            "@ondc/org/time_to_ship": "PT2H",
-                            "hsn_code": "1101",
-                            "@ondc/org/seller_return_pickup": false,
-                            "tags": [
-                                {
-                                    "code": "origin",
-                                    "list": [
-                                        {
-                                            "code": "country",
-                                            "value": "IND"
-                                        }
-                                    ]
-                                }
-                            ],
-                            "@ondc/org/return_window": "P7D",
-                            "@ondc/org/statutory_reqs_prepackaged_food": {
-                                "food_additive": "",
-                                "nutritional_information": "",
-                                "brand_owner_name": "",
-                                "consumer_care_details": "",
-                                "country_of_origin_for_imported_product": "",
-                                "brand_owner_FSSAI_license_no": "568565353582865",
-                                "list_of_ingredients": "",
-                                "storage_information": "",
-                                "other_premises": "hxhxhxhxh"
-                            },
-                            "tax_type": "gst",
-                            "domain": "Grocery",
-                            "time": {
-                                "label": "enable",
-                                "timestamp": "2023-10-10T05:42:27.530Z"
-                            },
-                            "fulfillment_id": "1"
-                        },
-                        {
-                            "@ondc/org/statutory_reqs_packaged_commodities": {
-                                "common_or_generic_name_of_commodity": "",
-                                "net_quantity_or_measure_of_commodity_in_pkg": "12",
-                                "consumer_care_details": "",
-                                "imported_product_country_of_origin": "cggjjj",
-                                "manufacturer_or_packer_name": "fggghh",
-                                "manufacturer_or_packer_address": "",
-                                "month_year_of_manufacture_packing_import": ""
-                            },
-                            "@ondc/org/seller_pickup_return": true,
-                            "@ondc/org/contact_details_consumer_care": "tdydyd",
-                            "descriptor": {
-                                "symbol": "https://firebasestorage.googleapis.com/v0/b/shopeg-dev.appspot.com/o/shopImages%2FP3rGcNdyeae5uhffGGOXuGWsgbJ2%2Fimg_1692251569257.jpg?alt=media&token=fd807cd1-9b98-41c2-bd52-97280afc1fd2",
-                                "images": [
-                                    "https://firebasestorage.googleapis.com/v0/b/shopeg-dev.appspot.com/o/shopImages%2FP3rGcNdyeae5uhffGGOXuGWsgbJ2%2Fimg_1692251569257.jpg?alt=media&token=fd807cd1-9b98-41c2-bd52-97280afc1fd2"
-                                ],
-                                "name": "tttt",
-                                "short_desc": "hxhx",
-                                "long_desc": ""
-                            },
-                            "tax_rate": "5",
-                            "location_id": "6275",
-                            "@ondc/org/available_on_cod": false,
-                            "L2_category": "Cleaning & Household",
-                            "category_id": "Cleaning & Household",
-                            "price": {
-                                "currency": "INR",
-                                "maximum_value": "125",
-                                "value": "13"
-                            },
-                            "id": "dd353ff1-49b4-455f-8297-d4e854380984",
-                            "@ondc/org/allergen_information": "",
-                            "@ondc/org/cancellable": true,
-                            "@ondc/org/returnable": true,
-                            "quantity": {
-                                "available": {
-                                    "count": "12"
-                                },
-                                "maximum": {
-                                    "count": "2"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "",
-                                        "value": 0
-                                    }
-                                }
-                            },
-                            "@ondc/org/time_to_ship": "PT2H",
-                            "@ondc/org/seller_return_pickup": false,
-                            "hsn_code": "123",
-                            "tags": [
-                                {
-                                    "code": "origin",
-                                    "list": [
-                                        {
-                                            "code": "country",
-                                            "value": "cggjjj"
-                                        }
-                                    ]
-                                }
-                            ],
-                            "@ondc/org/return_window": "P7D",
-                            "@ondc/org/statutory_reqs_prepackaged_food": {
-                                "food_additive": "",
-                                "nutritional_information": "",
-                                "brand_owner_name": "",
-                                "consumer_care_details": "",
-                                "country_of_origin_for_imported_product": "",
-                                "list_of_ingredients": "",
-                                "storage_information": "",
-                                "other_premises": null
-                            },
-                            "tax_type": "gst",
-                            "domain": "Grocery",
-                            "time": {
-                                "label": "enable",
-                                "timestamp": "2023-10-10T05:42:27.530Z"
-                            },
-                            "fulfillment_id": "1"
-                        },
-                        {
-                            "@ondc/org/statutory_reqs_packaged_commodities": {
-                                "common_or_generic_name_of_commodity": "",
-                                "net_quantity_or_measure_of_commodity_in_pkg": "12",
-                                "consumer_care_details": "",
-                                "imported_product_country_of_origin": "cggjjj",
-                                "manufacturer_or_packer_name": "fggghh",
-                                "manufacturer_or_packer_address": "",
-                                "month_year_of_manufacture_packing_import": ""
-                            },
-                            "@ondc/org/seller_pickup_return": true,
-                            "@ondc/org/contact_details_consumer_care": "tdydyd",
-                            "descriptor": {
-                                "symbol": "https://firebasestorage.googleapis.com/v0/b/shopeg-dev.appspot.com/o/shopImages%2FP3rGcNdyeae5uhffGGOXuGWsgbJ2%2Fimg_1692251569257.jpg?alt=media&token=fd807cd1-9b98-41c2-bd52-97280afc1fd2",
-                                "images": [
-                                    "https://firebasestorage.googleapis.com/v0/b/shopeg-dev.appspot.com/o/shopImages%2FP3rGcNdyeae5uhffGGOXuGWsgbJ2%2Fimg_1692251569257.jpg?alt=media&token=fd807cd1-9b98-41c2-bd52-97280afc1fd2"
-                                ],
-                                "name": "tttt",
-                                "short_desc": "hxhx",
-                                "long_desc": ""
-                            },
-                            "tax_rate": "5",
-                            "location_id": "6275",
-                            "@ondc/org/available_on_cod": false,
-                            "L2_category": "Cleaning & Household",
-                            "category_id": "Cleaning & Household",
-                            "price": {
-                                "currency": "INR",
-                                "maximum_value": "125",
-                                "value": "13"
-                            },
-                            "id": "3f684521-3f5d-4f44-bce4-9d6a694a4546",
-                            "@ondc/org/allergen_information": "",
-                            "@ondc/org/cancellable": true,
-                            "@ondc/org/returnable": true,
-                            "quantity": {
-                                "available": {
-                                    "count": "12"
-                                },
-                                "maximum": {
-                                    "count": "2"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "",
-                                        "value": 0
-                                    }
-                                }
-                            },
-                            "@ondc/org/time_to_ship": "PT2H",
-                            "@ondc/org/seller_return_pickup": false,
-                            "hsn_code": "123",
-                            "tags": [
-                                {
-                                    "code": "origin",
-                                    "list": [
-                                        {
-                                            "code": "country",
-                                            "value": "cggjjj"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "origin",
-                                    "list": [
-                                        {
-                                            "code": "country",
-                                            "value": "cggjjj"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "origin",
-                                    "list": [
-                                        {
-                                            "code": "country",
-                                            "value": "cggjjj"
-                                        }
-                                    ]
-                                }
-                            ],
-                            "@ondc/org/return_window": "P7D",
-                            "@ondc/org/statutory_reqs_prepackaged_food": {
-                                "food_additive": "",
-                                "nutritional_information": "",
-                                "brand_owner_name": "",
-                                "consumer_care_details": "",
-                                "country_of_origin_for_imported_product": "",
-                                "list_of_ingredients": "",
-                                "storage_information": "",
-                                "other_premises": null
-                            },
-                            "tax_type": "gst",
-                            "domain": "Grocery",
-                            "time": {
-                                "label": "enable",
-                                "timestamp": "2023-10-10T05:42:27.530Z"
-                            },
-                            "fulfillment_id": "1"
-                        },
-                        {
-                            "@ondc/org/statutory_reqs_packaged_commodities": {
-                                "common_or_generic_name_of_commodity": "",
-                                "net_quantity_or_measure_of_commodity_in_pkg": "12",
-                                "consumer_care_details": "",
-                                "imported_product_country_of_origin": "cggjjj",
-                                "manufacturer_or_packer_name": "fggghh",
-                                "manufacturer_or_packer_address": "",
-                                "month_year_of_manufacture_packing_import": ""
-                            },
-                            "@ondc/org/seller_pickup_return": true,
-                            "@ondc/org/contact_details_consumer_care": "tdydyd",
-                            "descriptor": {
-                                "symbol": "https://firebasestorage.googleapis.com/v0/b/shopeg-dev.appspot.com/o/shopImages%2FP3rGcNdyeae5uhffGGOXuGWsgbJ2%2Fimg_1692251569257.jpg?alt=media&token=fd807cd1-9b98-41c2-bd52-97280afc1fd2",
-                                "images": [
-                                    "https://firebasestorage.googleapis.com/v0/b/shopeg-dev.appspot.com/o/shopImages%2FP3rGcNdyeae5uhffGGOXuGWsgbJ2%2Fimg_1692251569257.jpg?alt=media&token=fd807cd1-9b98-41c2-bd52-97280afc1fd2"
-                                ],
-                                "name": "tttt",
-                                "short_desc": "hxhx",
-                                "long_desc": ""
-                            },
-                            "tax_rate": "5",
-                            "location_id": "6275",
-                            "@ondc/org/available_on_cod": false,
-                            "L2_category": "Cleaning & Household",
-                            "category_id": "Cleaning & Household",
-                            "price": {
-                                "currency": "INR",
-                                "maximum_value": "125",
-                                "value": "13"
-                            },
-                            "id": "780ee3ed-0fb4-4367-949b-960e06790ed8",
-                            "@ondc/org/allergen_information": "",
-                            "@ondc/org/cancellable": true,
-                            "@ondc/org/returnable": true,
-                            "quantity": {
-                                "available": {
-                                    "count": "12"
-                                },
-                                "maximum": {
-                                    "count": "2"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "",
-                                        "value": 0
-                                    }
-                                }
-                            },
-                            "@ondc/org/time_to_ship": "PT2H",
-                            "@ondc/org/seller_return_pickup": false,
-                            "hsn_code": "123",
-                            "tags": [
-                                {
-                                    "code": "origin",
-                                    "list": [
-                                        {
-                                            "code": "country",
-                                            "value": "cggjjj"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "origin",
-                                    "list": [
-                                        {
-                                            "code": "country",
-                                            "value": "cggjjj"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "origin",
-                                    "list": [
-                                        {
-                                            "code": "country",
-                                            "value": "cggjjj"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "origin",
-                                    "list": [
-                                        {
-                                            "code": "country",
-                                            "value": "cggjjj"
-                                        }
-                                    ]
-                                }
-                            ],
-                            "@ondc/org/return_window": "P7D",
-                            "@ondc/org/statutory_reqs_prepackaged_food": {
-                                "food_additive": "",
-                                "nutritional_information": "",
-                                "brand_owner_name": "",
-                                "consumer_care_details": "",
-                                "country_of_origin_for_imported_product": "",
-                                "list_of_ingredients": "",
-                                "storage_information": "",
-                                "other_premises": null
-                            },
-                            "tax_type": "gst",
-                            "domain": "Grocery",
-                            "time": {
-                                "label": "enable",
-                                "timestamp": "2023-10-10T05:42:27.530Z"
-                            },
-                            "fulfillment_id": "1"
-                        },
-                        {
-                            "@ondc/org/statutory_reqs_packaged_commodities": {
-                                "common_or_generic_name_of_commodity": "",
-                                "net_quantity_or_measure_of_commodity_in_pkg": "12",
-                                "consumer_care_details": "",
-                                "imported_product_country_of_origin": "hhxjxj",
-                                "manufacturer_or_packer_name": "fggg",
-                                "manufacturer_or_packer_address": "",
-                                "month_year_of_manufacture_packing_import": ""
-                            },
-                            "@ondc/org/seller_pickup_return": true,
-                            "@ondc/org/contact_details_consumer_care": "hdudu",
-                            "descriptor": {
-                                "symbol": "https://firebasestorage.googleapis.com/v0/b/shopeg-dev.appspot.com/o/shopImages%2FP3rGcNdyeae5uhffGGOXuGWsgbJ2%2Fimg_1692251938950.jpg?alt=media&token=7dfd7188-98d4-41ad-a0bc-a298d340d11e",
-                                "images": [
-                                    "https://firebasestorage.googleapis.com/v0/b/shopeg-dev.appspot.com/o/shopImages%2FP3rGcNdyeae5uhffGGOXuGWsgbJ2%2Fimg_1692251938950.jpg?alt=media&token=7dfd7188-98d4-41ad-a0bc-a298d340d11e"
-                                ],
-                                "name": "hdydh",
-                                "short_desc": "hchxjx",
-                                "long_desc": ""
-                            },
-                            "tax_rate": "0",
-                            "location_id": "6275",
-                            "@ondc/org/available_on_cod": false,
-                            "L2_category": "Bath & Body",
-                            "category_id": "Bath & Body",
-                            "price": {
-                                "currency": "INR",
-                                "maximum_value": "123",
-                                "value": "122"
-                            },
-                            "id": "148f41fa-9d1b-40a0-b6c8-8d9f0599dd92",
-                            "@ondc/org/allergen_information": "",
-                            "@ondc/org/cancellable": true,
-                            "@ondc/org/returnable": true,
-                            "quantity": {
-                                "available": {
-                                    "count": "125"
-                                },
-                                "maximum": {
-                                    "count": "2"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "",
-                                        "value": 0
-                                    }
-                                }
-                            },
-                            "@ondc/org/time_to_ship": "PT2H",
-                            "@ondc/org/seller_return_pickup": false,
-                            "hsn_code": "1234",
-                            "tags": [
-                                {
-                                    "code": "origin",
-                                    "list": [
-                                        {
-                                            "code": "country",
-                                            "value": "hhxjxj"
-                                        }
-                                    ]
-                                }
-                            ],
-                            "@ondc/org/return_window": "P7D",
-                            "@ondc/org/statutory_reqs_prepackaged_food": {
-                                "food_additive": "",
-                                "nutritional_information": "",
-                                "brand_owner_name": "",
-                                "consumer_care_details": "",
-                                "country_of_origin_for_imported_product": "",
-                                "list_of_ingredients": "",
-                                "storage_information": "",
-                                "other_premises": "jxjxj"
-                            },
-                            "tax_type": "gst",
-                            "domain": "Beauty & Personal Care",
-                            "time": {
-                                "label": "enable",
-                                "timestamp": "2023-10-10T05:42:27.530Z"
-                            },
-                            "fulfillment_id": "1"
-                        },
-                        {
-                            "@ondc/org/statutory_reqs_packaged_commodities": {
-                                "common_or_generic_name_of_commodity": "",
-                                "net_quantity_or_measure_of_commodity_in_pkg": "23",
-                                "consumer_care_details": "",
-                                "imported_product_country_of_origin": "hchc",
-                                "manufacturer_or_packer_name": "hfjf23",
-                                "manufacturer_or_packer_address": "",
-                                "month_year_of_manufacture_packing_import": ""
-                            },
-                            "@ondc/org/seller_pickup_return": true,
-                            "@ondc/org/contact_details_consumer_care": "hchc",
-                            "descriptor": {
-                                "symbol": "https://firebasestorage.googleapis.com/v0/b/shopeg-dev.appspot.com/o/shopImages%2FP3rGcNdyeae5uhffGGOXuGWsgbJ2%2Fimg_1692252279250.jpg?alt=media&token=e4a706d5-79ee-4e43-8c00-1a98189a193c",
-                                "images": [
-                                    "https://firebasestorage.googleapis.com/v0/b/shopeg-dev.appspot.com/o/shopImages%2FP3rGcNdyeae5uhffGGOXuGWsgbJ2%2Fimg_1692252279250.jpg?alt=media&token=e4a706d5-79ee-4e43-8c00-1a98189a193c"
-                                ],
-                                "name": "4tttt",
-                                "short_desc": "ufug",
-                                "long_desc": ""
-                            },
-                            "tax_rate": "18",
-                            "location_id": "6275",
-                            "@ondc/org/available_on_cod": false,
-                            "L2_category": "Feminine Care",
-                            "category_id": "Feminine Care",
-                            "price": {
-                                "currency": "INR",
-                                "maximum_value": "123",
-                                "value": "111"
-                            },
-                            "id": "18e15bce-1a0c-47a6-aee5-c0308d8b0452",
-                            "@ondc/org/allergen_information": "",
-                            "@ondc/org/cancellable": true,
-                            "@ondc/org/returnable": true,
-                            "quantity": {
-                                "available": {
-                                    "count": "12"
-                                },
-                                "maximum": {
-                                    "count": "2"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "",
-                                        "value": 0
-                                    }
-                                }
-                            },
-                            "@ondc/org/time_to_ship": "PT2H",
-                            "@ondc/org/seller_return_pickup": false,
-                            "hsn_code": "9868",
-                            "tags": [
-                                {
-                                    "code": "origin",
-                                    "list": [
-                                        {
-                                            "code": "country",
-                                            "value": "hchc"
-                                        }
-                                    ]
-                                }
-                            ],
-                            "@ondc/org/return_window": "P7D",
-                            "@ondc/org/statutory_reqs_prepackaged_food": {
-                                "food_additive": "",
-                                "nutritional_information": "",
-                                "brand_owner_name": "",
-                                "consumer_care_details": "",
-                                "country_of_origin_for_imported_product": "",
-                                "list_of_ingredients": "",
-                                "storage_information": "",
-                                "other_premises": null
-                            },
-                            "tax_type": "gst",
-                            "domain": "Beauty & Personal Care",
-                            "time": {
-                                "label": "enable",
-                                "timestamp": "2023-10-10T05:42:27.530Z"
-                            },
-                            "fulfillment_id": "1"
-                        },
-                        {
-                            "@ondc/org/statutory_reqs_packaged_commodities": {
-                                "common_or_generic_name_of_commodity": "",
-                                "net_quantity_or_measure_of_commodity_in_pkg": "2 kg",
-                                "consumer_care_details": "",
-                                "imported_product_country_of_origin": "ITC India Pvt ltd. 404, Powai, Mumbai- 400071",
-                                "description": "Atta",
-                                "manufacturer_or_packer_name": "ITC India Pvt ltd",
-                                "multiple_products_name_number_or_qty": "2",
-                                "manufacturer_or_packer_address": "",
-                                "month_year_of_manufacture_packing_import": "",
-                                "contact_details_consumer_care": "1800-100-123"
-                            },
-                            "@ondc/org/seller_pickup_return": true,
-                            "@ondc/org/contact_details_consumer_care": "ondc-support@shopeg.in",
-                            "descriptor": {
-                                "symbol": "https://shopeg.in/i/eg.png",
-                                "images": [
-                                    "https://shopeg.in/i/eg.png"
-                                ],
-                                "name": "Ashhhirvad 2 kg atta",
-                                "short_desc": "Ashhhirvad 2kg atta",
-                                "long_desc": ""
-                            },
-                            "location_id": "6275",
-                            "tax_rate": "5",
-                            "@ondc/org/available_on_cod": false,
-                            "L2_category": "Foodgrains",
-                            "category_id": "Foodgrains",
-                            "price": {
-                                "currency": "INR",
-                                "maximum_value": "151",
-                                "value": "140"
-                            },
-                            "id": "vismaya-asdf-4889-a7c4-772233",
-                            "@ondc/org/cancellable": true,
-                            "@ondc/org/allergen_information": "",
-                            "@ondc/org/returnable": true,
-                            "quantity": {
-                                "available": {
-                                    "count": "10"
-                                },
-                                "maximum": {
-                                    "count": "3"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "",
-                                        "value": 0
-                                    }
-                                }
-                            },
-                            "@ondc/org/time_to_ship": "PT2H",
-                            "hsn_code": "1000",
-                            "@ondc/org/seller_return_pickup": false,
-                            "fulfillment_id": "1",
-                            "tags": [
-                                {
-                                    "code": "origin",
-                                    "list": [
-                                        {
-                                            "code": "country",
-                                            "value": "ITC India Pvt ltd. 404, Powai, Mumbai- 400071"
-                                        }
-                                    ]
-                                }
-                            ],
-                            "@ondc/org/return_window": "P7D",
-                            "@ondc/org/statutory_reqs_prepackaged_food": {
-                                "food_additive": "",
-                                "nutritional_information": "",
-                                "brand_owner_name": "",
-                                "consumer_care_details": "",
-                                "country_of_origin_for_imported_product": "",
-                                "brand_owner_FSSAI_license_no": "235233",
-                                "list_of_ingredients": "",
-                                "storage_information": "",
-                                "other_premises": null
-                            },
-                            "tax_type": "gst",
-                            "domain": "Grocery",
-                            "time": {
-                                "label": "enable",
-                                "timestamp": "2023-10-10T05:42:27.530Z"
-                            }
-                        },
-                        {
-                            "@ondc/org/statutory_reqs_packaged_commodities": {
-                                "common_or_generic_name_of_commodity": "",
-                                "net_quantity_or_measure_of_commodity_in_pkg": "5 kg",
-                                "consumer_care_details": "",
-                                "imported_product_country_of_origin": "hjddjdjdididifi",
-                                "description": "Pest Control & Repellents",
-                                "manufacturer_or_packer_name": "najsjs ",
-                                "multiple_products_name_number_or_qty": "5",
-                                "manufacturer_or_packer_address": "",
-                                "month_year_of_manufacture_packing_import": "",
-                                "contact_details_consumer_care": "8105942133"
-                            },
-                            "@ondc/org/seller_pickup_return": true,
-                            "@ondc/org/contact_details_consumer_care": "ondc-support@shopeg.in",
-                            "descriptor": {
-                                "symbol": "https://shopeg.in/i/eg.png",
-                                "images": [
-                                    "https://shopeg.in/i/eg.png",
-                                    "/data/user/0/com.shopeg.dev/cache/scaled_ba3df09f-57fa-4fc9-bf0f-f6a549ff74f45204993428582776042.jpg"
-                                ],
-                                "name": "Test M",
-                                "short_desc": "jddjsjjskd",
-                                "long_desc": ""
-                            },
-                            "location_id": "6275",
-                            "tax_rate": "5",
-                            "@ondc/org/available_on_cod": false,
-                            "L2_category": "Cleaning & Household",
-                            "category_id": "Cleaning & Household",
-                            "price": {
-                                "currency": "INR",
-                                "maximum_value": "121",
-                                "value": "110"
-                            },
-                            "id": "fb0c1c56-6644-4543-b829-33c9185c5891",
-                            "@ondc/org/cancellable": true,
-                            "@ondc/org/allergen_information": "",
-                            "@ondc/org/returnable": true,
-                            "quantity": {
-                                "available": {
-                                    "count": "8"
-                                },
-                                "maximum": {
-                                    "count": "2"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "",
-                                        "value": 0
-                                    }
-                                }
-                            },
-                            "@ondc/org/time_to_ship": "PT2H",
-                            "hsn_code": "1000",
-                            "@ondc/org/seller_return_pickup": false,
-                            "tags": [
-                                {
-                                    "code": "origin",
-                                    "list": [
-                                        {
-                                            "code": "country",
-                                            "value": "hjddjdjdididifi"
-                                        }
-                                    ]
-                                }
-                            ],
-                            "@ondc/org/return_window": "P7D",
-                            "@ondc/org/statutory_reqs_prepackaged_food": {
-                                "food_additive": "",
-                                "nutritional_information": "",
-                                "brand_owner_name": "",
-                                "consumer_care_details": "",
-                                "country_of_origin_for_imported_product": "",
-                                "list_of_ingredients": "",
-                                "storage_information": "",
-                                "other_premises": null
-                            },
-                            "tax_type": "gst",
-                            "domain": "Grocery",
-                            "time": {
-                                "label": "enable",
-                                "timestamp": "2023-10-10T05:42:27.530Z"
-                            },
-                            "fulfillment_id": "1"
-                        },
-                        {
-                            "@ondc/org/statutory_reqs_packaged_commodities": {
-                                "common_or_generic_name_of_commodity": "",
-                                "net_quantity_or_measure_of_commodity_in_pkg": "12",
-                                "consumer_care_details": "",
-                                "imported_product_country_of_origin": "cggjjj",
-                                "manufacturer_or_packer_name": "fggghh",
-                                "manufacturer_or_packer_address": "",
-                                "month_year_of_manufacture_packing_import": ""
-                            },
-                            "@ondc/org/seller_pickup_return": true,
-                            "@ondc/org/contact_details_consumer_care": "tdydyd",
-                            "descriptor": {
-                                "symbol": "https://firebasestorage.googleapis.com/v0/b/shopeg-dev.appspot.com/o/shopImages%2FP3rGcNdyeae5uhffGGOXuGWsgbJ2%2Fimg_1692251569257.jpg?alt=media&token=fd807cd1-9b98-41c2-bd52-97280afc1fd2",
-                                "images": [
-                                    "https://firebasestorage.googleapis.com/v0/b/shopeg-dev.appspot.com/o/shopImages%2FP3rGcNdyeae5uhffGGOXuGWsgbJ2%2Fimg_1692251569257.jpg?alt=media&token=fd807cd1-9b98-41c2-bd52-97280afc1fd2"
-                                ],
-                                "name": "tttt",
-                                "short_desc": "hxhx",
-                                "long_desc": ""
-                            },
-                            "tax_rate": "5",
-                            "location_id": "6275",
-                            "@ondc/org/available_on_cod": false,
-                            "L2_category": "Cleaning & Household",
-                            "category_id": "Cleaning & Household",
-                            "price": {
-                                "currency": "INR",
-                                "maximum_value": "125",
-                                "value": "13"
-                            },
-                            "id": "2a90cdf4-9af8-4e05-b1e5-4f74eb73ef70",
-                            "@ondc/org/allergen_information": "",
-                            "@ondc/org/cancellable": true,
-                            "@ondc/org/returnable": true,
-                            "quantity": {
-                                "available": {
-                                    "count": "12"
-                                },
-                                "maximum": {
-                                    "count": "2"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "",
-                                        "value": 0
-                                    }
-                                }
-                            },
-                            "@ondc/org/time_to_ship": "PT2H",
-                            "@ondc/org/seller_return_pickup": false,
-                            "hsn_code": "123",
-                            "tags": [
-                                {
-                                    "code": "origin",
-                                    "list": [
-                                        {
-                                            "code": "country",
-                                            "value": "cggjjj"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "origin",
-                                    "list": [
-                                        {
-                                            "code": "country",
-                                            "value": "cggjjj"
-                                        }
-                                    ]
-                                }
-                            ],
-                            "@ondc/org/return_window": "P7D",
-                            "@ondc/org/statutory_reqs_prepackaged_food": {
-                                "food_additive": "",
-                                "nutritional_information": "",
-                                "brand_owner_name": "",
-                                "consumer_care_details": "",
-                                "country_of_origin_for_imported_product": "",
-                                "list_of_ingredients": "",
-                                "storage_information": "",
-                                "other_premises": null
-                            },
-                            "tax_type": "gst",
-                            "domain": "Grocery",
-                            "time": {
-                                "label": "enable",
-                                "timestamp": "2023-10-10T05:42:27.530Z"
-                            },
-                            "fulfillment_id": "1"
-                        },
-                        {
-                            "@ondc/org/statutory_reqs_packaged_commodities": {
-                                "common_or_generic_name_of_commodity": "",
-                                "net_quantity_or_measure_of_commodity_in_pkg": "140 g Pouch",
-                                "consumer_care_details": "",
-                                "imported_product_country_of_origin": "India",
-                                "description": "MAGGI 2-Min Masala Instant Noodles, 140 g Pouch",
-                                "manufacturer_or_packer_name": "NESTLE INDIA LIMITED, 100/101, World Trade Centre, Barakhamba lane, NEW DELHI- 110001",
-                                "manufacturer_or_packer_address": "",
-                                "month_year_of_manufacture_packing_import": ""
-                            },
-                            "@ondc/org/seller_pickup_return": true,
-                            "@ondc/org/contact_details_consumer_care": "zvhc",
-                            "descriptor": {
-                                "symbol": "https://www.bigbasket.com/media/uploads/p/l/266165_15-maggi-masala-2-minute-instant-noodles.jpg?tr=w-1080,q=80",
-                                "images": [
-                                    "https://www.bigbasket.com/media/uploads/p/l/266165_15-maggi-masala-2-minute-instant-noodles.jpg?tr=w-1080,q=80",
-                                    "https://www.bigbasket.com/media/uploads/p/l/266165-2_13-maggi-masala-2-minute-instant-noodles.jpg?tr=w-1080,q=80",
-                                    "https://www.bigbasket.com/media/uploads/p/l/266165-3_12-maggi-masala-2-minute-instant-noodles.jpg?tr=w-1080,q=80"
-                                ],
-                                "name": "MAGGI 2-Min Masala Instant Noodles, 140 g Pouch",
-                                "short_desc": "India's favourite Masala Noodles, Maggi 2-minute Noodles, now come with the goodness of Iron. Each portion (70g) of Maggi Masala Noodles provides you with 15% of your daily Iron requirement (*as per the Daily Dietary Allowances for an Adult Sedentary Male (ICMR 2010). Containing your favourite masala taste, Maggi noodles are made with the choicest quality spices. Make your bowl of Maggi even better by chopping up some vegetables, dropping in an egg or throwing in your favourite ingredients.",
-                                "long_desc": ""
-                            },
-                            "tax_rate": "5",
-                            "location_id": "6275",
-                            "@ondc/org/available_on_cod": false,
-                            "L2_category": "Gourmet & World Foods",
-                            "category_id": "Gourmet & World Foods",
-                            "price": {
-                                "currency": "INR",
-                                "maximum_value": "25.5",
-                                "value": "25.5"
-                            },
-                            "id": "19c0c96e-0d67-4e3d-a5ac-268e1b61cf7a",
-                            "@ondc/org/allergen_information": "",
-                            "@ondc/org/cancellable": true,
-                            "@ondc/org/returnable": true,
-                            "quantity": {
-                                "available": {
-                                    "count": "1"
-                                },
-                                "maximum": {
-                                    "count": "1"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "",
-                                        "value": 0
-                                    }
-                                }
-                            },
-                            "@ondc/org/time_to_ship": "PT2H",
-                            "@ondc/org/seller_return_pickup": false,
-                            "hsn_code": "1000",
-                            "tags": [
-                                {
-                                    "code": "origin",
-                                    "list": [
-                                        {
-                                            "code": "country",
-                                            "value": "India"
-                                        }
-                                    ]
-                                }
-                            ],
-                            "@ondc/org/return_window": "P7D",
-                            "@ondc/org/statutory_reqs_prepackaged_food": {
-                                "importer_FSSAI_license_no": null,
-                                "nutritional_info": null,
-                                "nutritional_information": "",
-                                "consumer_care_details": "",
-                                "brand_owner_FSSAI_license_no": "9898688383",
-                                "additives_info": null,
-                                "list_of_ingredients": "",
-                                "other_premises": "yfufugivi",
-                                "food_additive": "",
-                                "other_FSSAI_license_no": null,
-                                "brand_owner_name": "",
-                                "imported_product_country_of_origin": null,
-                                "country_of_origin_for_imported_product": "",
-                                "storage_information": ""
-                            },
-                            "tax_type": "gst",
-                            "domain": "Grocery",
-                            "time": {
-                                "label": "enable",
-                                "timestamp": "2023-10-10T05:42:27.530Z"
-                            },
-                            "fulfillment_id": "1"
-                        },
-                        {
-                            "storeOpenTillDate": "2023-08-30T22:00:00.315Z",
-                            "@ondc/org/statutory_reqs_packaged_commodities": {
-                                "common_or_generic_name_of_commodity": "",
-                                "net_quantity_or_measure_of_commodity_in_pkg": "10 kg",
-                                "consumer_care_details": "",
-                                "imported_product_country_of_origin": "ITC India Pvt ltd. 404, Powai, Mumbai- 400071",
-                                "description": "Atta",
-                                "manufacturer_or_packer_name": "ITC India Pvt ltd",
-                                "multiple_products_name_number_or_qty": "10",
-                                "manufacturer_or_packer_address": "",
-                                "month_year_of_manufacture_packing_import": "",
-                                "contact_details_consumer_care": "1800-100-123"
-                            },
-                            "@ondc/org/seller_pickup_return": true,
-                            "@ondc/org/contact_details_consumer_care": "ondc-support@shopeg.in",
-                            "descriptor": {
-                                "symbol": "https://shopeg.in/i/eg.png",
-                                "images": [
-                                    "https://shopeg.in/i/eg.png"
-                                ],
-                                "name": "Ashirvad 10 kg atta",
-                                "short_desc": "Ashirvad 10kg atta",
-                                "long_desc": ""
-                            },
-                            "location_id": "6275",
-                            "tax_rate": "18",
-                            "@ondc/org/available_on_cod": false,
-                            "L2_category": "Foodgrains",
-                            "category_id": "Foodgrains",
-                            "price": {
-                                "currency": "INR",
-                                "maximum_value": "711",
-                                "value": "700"
-                            },
-                            "id": "vismaya-shop-4889-a7c4-772233",
-                            "@ondc/org/cancellable": true,
-                            "@ondc/org/allergen_information": "",
-                            "@ondc/org/returnable": true,
-                            "quantity": {
-                                "available": {
-                                    "count": "10"
-                                },
-                                "maximum": {
-                                    "count": "3"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "",
-                                        "value": 0
-                                    }
-                                }
-                            },
-                            "@ondc/org/time_to_ship": "PT2H",
-                            "hsn_code": "1000",
-                            "@ondc/org/seller_return_pickup": false,
-                            "ttl": "P3D",
-                            "fulfillment_id": "1",
-                            "tags": [
-                                {
-                                    "code": "origin",
-                                    "list": [
-                                        {
-                                            "code": "country",
-                                            "value": "ITC India Pvt ltd. 404, Powai, Mumbai- 400071"
-                                        }
-                                    ]
-                                }
-                            ],
-                            "@ondc/org/return_window": "P7D",
-                            "@ondc/org/statutory_reqs_prepackaged_food": {
-                                "food_additive": "",
-                                "nutritional_information": "",
-                                "brand_owner_name": "",
-                                "consumer_care_details": "",
-                                "country_of_origin_for_imported_product": "",
-                                "brand_owner_FSSAI_license_no": "986868",
-                                "list_of_ingredients": "",
-                                "storage_information": "",
-                                "other_premises": null
-                            },
-                            "tax_type": "gst",
-                            "domain": "Grocery",
-                            "time": {
-                                "label": "enable",
-                                "time": "2023-08-04T12:25:23.097Z",
-                                "timestamp": "2023-10-10T05:42:27.530Z"
-                            }
-                        },
-                        {
-                            "@ondc/org/statutory_reqs_packaged_commodities": {
-                                "common_or_generic_name_of_commodity": "",
-                                "net_quantity_or_measure_of_commodity_in_pkg": "12 ft",
-                                "consumer_care_details": "",
-                                "imported_product_country_of_origin": "gdhxhhcchjjkk",
-                                "description": "Utensils & Cookware",
-                                "manufacturer_or_packer_name": "dfgyyy",
-                                "multiple_products_name_number_or_qty": "12",
-                                "manufacturer_or_packer_address": "",
-                                "month_year_of_manufacture_packing_import": "",
-                                "contact_details_consumer_care": "1234567891"
-                            },
-                            "@ondc/org/seller_pickup_return": true,
-                            "@ondc/org/contact_details_consumer_care": "ondc-support@shopeg.in",
-                            "descriptor": {
-                                "symbol": "/data/user/0/com.shopeg.dev/cache/scaled_6c89d408-b4b9-455e-b957-88cb69d9d76e4799441287814468614.jpg",
-                                "images": [
-                                    "/data/user/0/com.shopeg.dev/cache/scaled_6c89d408-b4b9-455e-b957-88cb69d9d76e4799441287814468614.jpg"
-                                ],
-                                "name": "test mango",
-                                "short_desc": "hduxu",
-                                "long_desc": ""
-                            },
-                            "location_id": "6275",
-                            "tax_rate": "28",
-                            "@ondc/org/available_on_cod": false,
-                            "L2_category": "Gourmet & World Foods",
-                            "category_id": "Gourmet & World Foods",
-                            "price": {
-                                "currency": "INR",
-                                "maximum_value": "151",
-                                "value": "106"
-                            },
-                            "id": "71a65777-6223-4d92-8596-c61f14e49363",
-                            "@ondc/org/cancellable": true,
-                            "@ondc/org/allergen_information": "",
-                            "@ondc/org/returnable": true,
-                            "quantity": {
-                                "available": {
-                                    "count": "3"
-                                },
-                                "maximum": {
-                                    "count": "2"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "",
-                                        "value": 0
-                                    }
-                                }
-                            },
-                            "@ondc/org/time_to_ship": "PT2H",
-                            "hsn_code": "1000",
-                            "@ondc/org/seller_return_pickup": false,
-                            "tags": [
-                                {
-                                    "code": "origin",
-                                    "list": [
-                                        {
-                                            "code": "country",
-                                            "value": "gdhxhhcchjjkk"
-                                        }
-                                    ]
-                                }
-                            ],
-                            "@ondc/org/return_window": "P7D",
-                            "@ondc/org/statutory_reqs_prepackaged_food": {
-                                "food_additive": "",
-                                "nutritional_information": "",
-                                "brand_owner_name": "",
-                                "consumer_care_details": "",
-                                "country_of_origin_for_imported_product": "",
-                                "brand_owner_FSSAI_license_no": "9909060990",
-                                "list_of_ingredients": "",
-                                "storage_information": "",
-                                "other_premises": null
-                            },
-                            "tax_type": "gst",
-                            "domain": "Grocery",
-                            "time": {
-                                "label": "enable",
-                                "timestamp": "2023-10-10T05:42:27.530Z"
-                            },
-                            "fulfillment_id": "1"
-                        },
-                        {
-                            "@ondc/org/statutory_reqs_packaged_commodities": {
-                                "common_or_generic_name_of_commodity": "",
-                                "net_quantity_or_measure_of_commodity_in_pkg": "2 pcs",
-                                "consumer_care_details": "",
-                                "imported_product_country_of_origin": "gggvvcghhhb6",
-                                "description": "xxfffgghhh",
-                                "manufacturer_or_packer_name": "dxxcvvhhhhhhj   ",
-                                "multiple_products_name_number_or_qty": "2",
-                                "manufacturer_or_packer_address": "",
-                                "month_year_of_manufacture_packing_import": "",
-                                "contact_details_consumer_care": "111112222999"
-                            },
-                            "@ondc/org/seller_pickup_return": true,
-                            "@ondc/org/contact_details_consumer_care": "ondc-support@shopeg.in",
-                            "descriptor": {
-                                "symbol": "/data/user/0/com.shopeg.dev/cache/scaled_a361afe2-ff0a-4b5a-9876-dbe0186376c83110379649159751450.jpg",
-                                "images": [
-                                    "/data/user/0/com.shopeg.dev/cache/scaled_a361afe2-ff0a-4b5a-9876-dbe0186376c83110379649159751450.jpg",
-                                    "/data/user/0/com.shopeg.dev/cache/scaled_7288b3b4-e65a-411b-a422-4882bc400734557644514661265758.jpg"
-                                ],
-                                "name": "eee1",
-                                "short_desc": "cccghjjjjjjjj",
-                                "long_desc": ""
-                            },
-                            "location_id": "6275",
-                            "tax_rate": "5",
-                            "@ondc/org/available_on_cod": false,
-                            "L2_category": "Cleaning & Household",
-                            "category_id": "Cleaning & Household",
-                            "price": {
-                                "currency": "INR",
-                                "maximum_value": "111",
-                                "value": "13"
-                            },
-                            "id": "02b5d0c4-c4eb-4986-80ec-8116be6c2a82",
-                            "@ondc/org/cancellable": true,
-                            "@ondc/org/allergen_information": "",
-                            "@ondc/org/returnable": true,
-                            "quantity": {
-                                "available": {
-                                    "count": "3"
-                                },
-                                "maximum": {
-                                    "count": "2"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "",
-                                        "value": 0
-                                    }
-                                }
-                            },
-                            "@ondc/org/time_to_ship": "PT2H",
-                            "hsn_code": "232312",
-                            "@ondc/org/seller_return_pickup": false,
-                            "tags": [
-                                {
-                                    "code": "origin",
-                                    "list": [
-                                        {
-                                            "code": "country",
-                                            "value": "gggvvcghhhb6"
-                                        }
-                                    ]
-                                }
-                            ],
-                            "@ondc/org/return_window": "P7D",
-                            "@ondc/org/statutory_reqs_prepackaged_food": {
-                                "food_additive": "",
-                                "nutritional_information": "",
-                                "brand_owner_name": "",
-                                "consumer_care_details": "",
-                                "country_of_origin_for_imported_product": "",
-                                "list_of_ingredients": "",
-                                "storage_information": "",
-                                "other_premises": null
-                            },
-                            "tax_type": "gst",
-                            "domain": "Grocery",
-                            "time": {
-                                "label": "enable",
-                                "time": "2023-08-04T12:25:23.097Z",
-                                "timestamp": "2023-10-10T05:42:27.530Z"
-                            },
-                            "fulfillment_id": "1"
-                        },
-                        {
-                            "@ondc/org/statutory_reqs_packaged_commodities": {
-                                "common_or_generic_name_of_commodity": "",
-                                "net_quantity_or_measure_of_commodity_in_pkg": "1 kg",
-                                "consumer_care_details": "",
-                                "imported_product_country_of_origin": "IND",
-                                "description": "AABBCCDDEEFF 1 KG",
-                                "manufacturer_or_packer_name": "General Mills India Pvt ltd",
-                                "multiple_products_name_number_or_qty": "1",
-                                "manufacturer_or_packer_address": "",
-                                "month_year_of_manufacture_packing_import": "",
-                                "contact_details_consumer_care": "1800-111-789"
-                            },
-                            "@ondc/org/seller_pickup_return": true,
-                            "@ondc/org/contact_details_consumer_care": "ondc-support@shopeg.in",
-                            "descriptor": {
-                                "symbol": "https://shopeg.in/i/eg.png",
-                                "images": [
-                                    "https://shopeg.in/i/eg.png"
-                                ],
-                                "name": "Product 179",
-                                "short_desc": "prdct shrt desc",
-                                "long_desc": ""
-                            },
-                            "location_id": "6275",
-                            "tax_rate": "5",
-                            "@ondc/org/available_on_cod": false,
-                            "L2_category": "Foodgrains",
-                            "category_id": "Foodgrains",
-                            "price": {
-                                "currency": "INR",
-                                "maximum_value": "8001",
-                                "maxium_value": "6666",
-                                "value": "5322"
-                            },
-                            "id": "3481b829-78d4-45be-b5f9-12bee9971b4f",
-                            "@ondc/org/cancellable": true,
-                            "@ondc/org/allergen_information": "",
-                            "@ondc/org/returnable": true,
-                            "quantity": {
-                                "available": {
-                                    "count": "2"
-                                },
-                                "maximum": {
-                                    "count": "2"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "",
-                                        "value": 0
-                                    }
-                                }
-                            },
-                            "@ondc/org/time_to_ship": "PT2H",
-                            "hsn_code": "1101",
-                            "@ondc/org/seller_return_pickup": false,
-                            "tags": [
-                                {
-                                    "code": "origin",
-                                    "list": [
-                                        {
-                                            "code": "country",
-                                            "value": "IND"
-                                        }
-                                    ]
-                                }
-                            ],
-                            "@ondc/org/return_window": "P7D",
-                            "@ondc/org/statutory_reqs_prepackaged_food": {
-                                "food_additive": "",
-                                "nutritional_information": "",
-                                "brand_owner_name": "",
-                                "consumer_care_details": "",
-                                "country_of_origin_for_imported_product": "",
-                                "brand_owner_FSSAI_license_no": "59358682936",
-                                "list_of_ingredients": "",
-                                "storage_information": "",
-                                "other_premises": null
-                            },
-                            "tax_type": "gst",
-                            "domain": "Grocery",
-                            "time": {
-                                "label": "enable",
-                                "timestamp": "2023-10-10T05:42:27.530Z"
-                            },
-                            "fulfillment_id": "1"
-                        },
-                        {
-                            "@ondc/org/statutory_reqs_packaged_commodities": {
-                                "common_or_generic_name_of_commodity": "",
-                                "net_quantity_or_measure_of_commodity_in_pkg": "1 kg",
-                                "consumer_care_details": "",
-                                "imported_product_country_of_origin": "IND",
-                                "description": "AABBCCDDEEFF 1 KG",
-                                "manufacturer_or_packer_name": "General Mills India Pvt ltd",
-                                "multiple_products_name_number_or_qty": "1",
-                                "manufacturer_or_packer_address": "",
-                                "month_year_of_manufacture_packing_import": "",
-                                "contact_details_consumer_care": "1800-111-789"
-                            },
-                            "@ondc/org/seller_pickup_return": true,
-                            "@ondc/org/contact_details_consumer_care": "ondc-support@shopeg.in",
-                            "descriptor": {
-                                "symbol": "https://shopeg.in/i/eg.png",
-                                "images": [
-                                    "https://shopeg.in/i/eg.png"
-                                ],
-                                "name": "Product 364",
-                                "short_desc": "prdct shrt desc",
-                                "long_desc": ""
-                            },
-                            "location_id": "6275",
-                            "tax_rate": "5",
-                            "@ondc/org/available_on_cod": false,
-                            "L2_category": "Foodgrains",
-                            "category_id": "Foodgrains",
-                            "price": {
-                                "currency": "INR",
-                                "maximum_value": "2001",
-                                "maxium_value": "6666",
-                                "value": "84"
-                            },
-                            "id": "e533b2be-cc9b-4cd2-9e4b-b11b7c92f2a5",
-                            "@ondc/org/cancellable": true,
-                            "@ondc/org/allergen_information": "",
-                            "@ondc/org/returnable": true,
-                            "quantity": {
-                                "available": {
-                                    "count": "2"
-                                },
-                                "maximum": {
-                                    "count": "2"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "",
-                                        "value": 0
-                                    }
-                                }
-                            },
-                            "@ondc/org/time_to_ship": "PT2H",
-                            "hsn_code": "1101",
-                            "@ondc/org/seller_return_pickup": false,
-                            "tags": [
-                                {
-                                    "code": "origin",
-                                    "list": [
-                                        {
-                                            "code": "country",
-                                            "value": "IND"
-                                        }
-                                    ]
-                                }
-                            ],
-                            "@ondc/org/return_window": "P7D",
-                            "@ondc/org/statutory_reqs_prepackaged_food": {
-                                "food_additive": "",
-                                "nutritional_information": "",
-                                "brand_owner_name": "",
-                                "consumer_care_details": "",
-                                "country_of_origin_for_imported_product": "",
-                                "brand_owner_FSSAI_license_no": "6568655666",
-                                "list_of_ingredients": "",
-                                "storage_information": "",
-                                "other_premises": null
-                            },
-                            "tax_type": "gst",
-                            "domain": "Grocery",
-                            "time": {
-                                "label": "enable",
-                                "timestamp": "2023-10-10T05:42:27.530Z"
-                            },
-                            "fulfillment_id": "1"
-                        },
-                        {
-                            "@ondc/org/statutory_reqs_packaged_commodities": {
-                                "common_or_generic_name_of_commodity": "",
-                                "net_quantity_or_measure_of_commodity_in_pkg": "1 kg",
-                                "consumer_care_details": "",
-                                "imported_product_country_of_origin": "IND",
-                                "description": "AABBCCDDEEFF 1 KG",
-                                "manufacturer_or_packer_name": "General Mills India Pvt ltd",
-                                "multiple_products_name_number_or_qty": "1",
-                                "manufacturer_or_packer_address": "",
-                                "month_year_of_manufacture_packing_import": "",
-                                "contact_details_consumer_care": "1800-111-789"
-                            },
-                            "@ondc/org/seller_pickup_return": true,
-                            "@ondc/org/contact_details_consumer_care": "ondc-support@shopeg.in",
-                            "descriptor": {
-                                "symbol": "https://shopeg.in/i/eg.png",
-                                "images": [
-                                    "https://shopeg.in/i/eg.png"
-                                ],
-                                "name": "Product 246",
-                                "short_desc": "prdct shrt desc",
-                                "long_desc": ""
-                            },
-                            "location_id": "6275",
-                            "tax_rate": "5",
-                            "@ondc/org/available_on_cod": false,
-                            "L2_category": "Foodgrains",
-                            "category_id": "Foodgrains",
-                            "price": {
-                                "currency": "INR",
-                                "maximum_value": "4001",
-                                "maxium_value": "6666",
-                                "value": "3224"
-                            },
-                            "id": "1cdbb21f-8285-42d5-a356-08dbd67279c4",
-                            "@ondc/org/cancellable": true,
-                            "@ondc/org/allergen_information": "",
-                            "@ondc/org/returnable": true,
-                            "quantity": {
-                                "available": {
-                                    "count": "2"
-                                },
-                                "maximum": {
-                                    "count": "2"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "",
-                                        "value": 0
-                                    }
-                                }
-                            },
-                            "@ondc/org/time_to_ship": "PT2H",
-                            "hsn_code": "1101",
-                            "@ondc/org/seller_return_pickup": false,
-                            "tags": [
-                                {
-                                    "code": "origin",
-                                    "list": [
-                                        {
-                                            "code": "country",
-                                            "value": "IND"
-                                        }
-                                    ]
-                                }
-                            ],
-                            "@ondc/org/return_window": "P7D",
-                            "@ondc/org/statutory_reqs_prepackaged_food": {
-                                "food_additive": "",
-                                "nutritional_information": "",
-                                "brand_owner_name": "",
-                                "consumer_care_details": "",
-                                "country_of_origin_for_imported_product": "",
-                                "brand_owner_FSSAI_license_no": "45535353",
-                                "list_of_ingredients": "",
-                                "storage_information": "",
-                                "other_premises": null
-                            },
-                            "tax_type": "gst",
-                            "domain": "Grocery",
-                            "time": {
-                                "label": "enable",
-                                "timestamp": "2023-10-10T05:42:27.530Z"
-                            },
-                            "fulfillment_id": "1"
-                        },
-                        {
-                            "@ondc/org/statutory_reqs_packaged_commodities": {
-                                "common_or_generic_name_of_commodity": "",
-                                "net_quantity_or_measure_of_commodity_in_pkg": "12",
-                                "consumer_care_details": "",
-                                "imported_product_country_of_origin": "hsh",
-                                "manufacturer_or_packer_name": "gdhx",
-                                "manufacturer_or_packer_address": "",
-                                "month_year_of_manufacture_packing_import": ""
-                            },
-                            "@ondc/org/seller_pickup_return": true,
-                            "@ondc/org/contact_details_consumer_care": "uxuxu",
-                            "descriptor": {
-                                "symbol": "https://firebasestorage.googleapis.com/v0/b/shopeg-dev.appspot.com/o/shopImages%2FP3rGcNdyeae5uhffGGOXuGWsgbJ2%2Fimg_1692251479994.jpg?alt=media&token=77d9fd0e-4049-40a6-aee2-da773d2b8b3d",
-                                "images": [
-                                    "https://firebasestorage.googleapis.com/v0/b/shopeg-dev.appspot.com/o/shopImages%2FP3rGcNdyeae5uhffGGOXuGWsgbJ2%2Fimg_1692251479994.jpg?alt=media&token=77d9fd0e-4049-40a6-aee2-da773d2b8b3d"
-                                ],
-                                "name": "rere",
-                                "short_desc": "hzhzh",
-                                "long_desc": ""
-                            },
-                            "tax_rate": "18",
-                            "location_id": "6275",
-                            "@ondc/org/available_on_cod": false,
-                            "L2_category": "Beauty & Hygiene",
-                            "category_id": "Beauty & Hygiene",
-                            "price": {
-                                "currency": "INR",
-                                "maximum_value": "123",
-                                "value": "12"
-                            },
-                            "id": "2c516c85-6c45-4304-9c9f-dbbf5e1dde64",
-                            "@ondc/org/allergen_information": "",
-                            "@ondc/org/cancellable": true,
-                            "@ondc/org/returnable": true,
-                            "quantity": {
-                                "available": {
-                                    "count": "6868"
-                                },
-                                "maximum": {
-                                    "count": "6"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "",
-                                        "value": 0
-                                    }
-                                }
-                            },
-                            "@ondc/org/time_to_ship": "PT2H",
-                            "@ondc/org/seller_return_pickup": false,
-                            "hsn_code": "2355",
-                            "tags": [
-                                {
-                                    "code": "origin",
-                                    "list": [
-                                        {
-                                            "code": "country",
-                                            "value": "hsh"
-                                        }
-                                    ]
-                                }
-                            ],
-                            "@ondc/org/return_window": "P7D",
-                            "@ondc/org/statutory_reqs_prepackaged_food": {
-                                "food_additive": "",
-                                "nutritional_information": "",
-                                "brand_owner_name": "",
-                                "consumer_care_details": "",
-                                "country_of_origin_for_imported_product": "",
-                                "list_of_ingredients": "",
-                                "storage_information": "",
-                                "other_premises": null
-                            },
-                            "tax_type": "gst",
-                            "domain": "Grocery",
-                            "time": {
-                                "label": "enable",
-                                "timestamp": "2023-10-10T05:42:27.530Z"
-                            },
-                            "fulfillment_id": "1"
-                        },
-                        {
-                            "@ondc/org/statutory_reqs_packaged_commodities": {
-                                "common_or_generic_name_of_commodity": "",
-                                "net_quantity_or_measure_of_commodity_in_pkg": "12",
-                                "consumer_care_details": "",
-                                "imported_product_country_of_origin": "cggjjj",
-                                "manufacturer_or_packer_name": "fggghh",
-                                "manufacturer_or_packer_address": "",
-                                "month_year_of_manufacture_packing_import": ""
-                            },
-                            "@ondc/org/seller_pickup_return": true,
-                            "@ondc/org/contact_details_consumer_care": "tdydyd",
-                            "descriptor": {
-                                "symbol": "https://firebasestorage.googleapis.com/v0/b/shopeg-dev.appspot.com/o/shopImages%2FP3rGcNdyeae5uhffGGOXuGWsgbJ2%2Fimg_1692251569257.jpg?alt=media&token=fd807cd1-9b98-41c2-bd52-97280afc1fd2",
-                                "images": [
-                                    "https://firebasestorage.googleapis.com/v0/b/shopeg-dev.appspot.com/o/shopImages%2FP3rGcNdyeae5uhffGGOXuGWsgbJ2%2Fimg_1692251569257.jpg?alt=media&token=fd807cd1-9b98-41c2-bd52-97280afc1fd2"
-                                ],
-                                "name": "tttt",
-                                "short_desc": "hxhx",
-                                "long_desc": ""
-                            },
-                            "tax_rate": "5",
-                            "location_id": "6275",
-                            "@ondc/org/available_on_cod": false,
-                            "L2_category": "Cleaning & Household",
-                            "category_id": "Cleaning & Household",
-                            "price": {
-                                "currency": "INR",
-                                "maximum_value": "125",
-                                "value": "13"
-                            },
-                            "id": "23f3d054-e41e-4afd-8890-c1f43b54f0df",
-                            "@ondc/org/allergen_information": "",
-                            "@ondc/org/cancellable": true,
-                            "@ondc/org/returnable": true,
-                            "quantity": {
-                                "available": {
-                                    "count": "12"
-                                },
-                                "maximum": {
-                                    "count": "2"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "",
-                                        "value": 0
-                                    }
-                                }
-                            },
-                            "@ondc/org/time_to_ship": "PT2H",
-                            "@ondc/org/seller_return_pickup": false,
-                            "hsn_code": "123",
-                            "tags": [
-                                {
-                                    "code": "origin",
-                                    "list": [
-                                        {
-                                            "code": "country",
-                                            "value": "cggjjj"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "origin",
-                                    "list": [
-                                        {
-                                            "code": "country",
-                                            "value": "cggjjj"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "origin",
-                                    "list": [
-                                        {
-                                            "code": "country",
-                                            "value": "cggjjj"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "origin",
-                                    "list": [
-                                        {
-                                            "code": "country",
-                                            "value": "cggjjj"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "origin",
-                                    "list": [
-                                        {
-                                            "code": "country",
-                                            "value": "cggjjj"
-                                        }
-                                    ]
-                                }
-                            ],
-                            "@ondc/org/return_window": "P7D",
-                            "@ondc/org/statutory_reqs_prepackaged_food": {
-                                "food_additive": "",
-                                "nutritional_information": "",
-                                "brand_owner_name": "",
-                                "consumer_care_details": "",
-                                "country_of_origin_for_imported_product": "",
-                                "list_of_ingredients": "",
-                                "storage_information": "",
-                                "other_premises": null
-                            },
-                            "tax_type": "gst",
-                            "domain": "Grocery",
-                            "time": {
-                                "label": "enable",
-                                "timestamp": "2023-10-10T05:42:27.530Z"
-                            },
-                            "fulfillment_id": "1"
-                        },
-                        {
-                            "@ondc/org/statutory_reqs_packaged_commodities": {
-                                "common_or_generic_name_of_commodity": "",
-                                "net_quantity_or_measure_of_commodity_in_pkg": "12",
-                                "consumer_care_details": "",
-                                "imported_product_country_of_origin": "cggjjj",
-                                "manufacturer_or_packer_name": "fggghh",
-                                "manufacturer_or_packer_address": "",
-                                "month_year_of_manufacture_packing_import": ""
-                            },
-                            "@ondc/org/seller_pickup_return": true,
-                            "@ondc/org/contact_details_consumer_care": "tdydyd",
-                            "descriptor": {
-                                "symbol": "https://firebasestorage.googleapis.com/v0/b/shopeg-dev.appspot.com/o/shopImages%2FP3rGcNdyeae5uhffGGOXuGWsgbJ2%2Fimg_1692251569257.jpg?alt=media&token=fd807cd1-9b98-41c2-bd52-97280afc1fd2",
-                                "images": [
-                                    "https://firebasestorage.googleapis.com/v0/b/shopeg-dev.appspot.com/o/shopImages%2FP3rGcNdyeae5uhffGGOXuGWsgbJ2%2Fimg_1692251569257.jpg?alt=media&token=fd807cd1-9b98-41c2-bd52-97280afc1fd2"
-                                ],
-                                "name": "tttt",
-                                "short_desc": "hxhx",
-                                "long_desc": ""
-                            },
-                            "tax_rate": "5",
-                            "location_id": "6275",
-                            "@ondc/org/available_on_cod": false,
-                            "L2_category": "Cleaning & Household",
-                            "category_id": "Cleaning & Household",
-                            "price": {
-                                "currency": "INR",
-                                "maximum_value": "125",
-                                "value": "13"
-                            },
-                            "id": "169824f5-70d4-4eca-a872-9d54b008d2d6",
-                            "@ondc/org/allergen_information": "",
-                            "@ondc/org/cancellable": true,
-                            "@ondc/org/returnable": true,
-                            "quantity": {
-                                "available": {
-                                    "count": "12"
-                                },
-                                "maximum": {
-                                    "count": "2"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "",
-                                        "value": 0
-                                    }
-                                }
-                            },
-                            "@ondc/org/time_to_ship": "PT2H",
-                            "@ondc/org/seller_return_pickup": false,
-                            "hsn_code": "123",
-                            "tags": [
-                                {
-                                    "code": "origin",
-                                    "list": [
-                                        {
-                                            "code": "country",
-                                            "value": "cggjjj"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "origin",
-                                    "list": [
-                                        {
-                                            "code": "country",
-                                            "value": "cggjjj"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "origin",
-                                    "list": [
-                                        {
-                                            "code": "country",
-                                            "value": "cggjjj"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "origin",
-                                    "list": [
-                                        {
-                                            "code": "country",
-                                            "value": "cggjjj"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "origin",
-                                    "list": [
-                                        {
-                                            "code": "country",
-                                            "value": "cggjjj"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "origin",
-                                    "list": [
-                                        {
-                                            "code": "country",
-                                            "value": "cggjjj"
-                                        }
-                                    ]
-                                }
-                            ],
-                            "@ondc/org/return_window": "P7D",
-                            "@ondc/org/statutory_reqs_prepackaged_food": {
-                                "food_additive": "",
-                                "nutritional_information": "",
-                                "brand_owner_name": "",
-                                "consumer_care_details": "",
-                                "country_of_origin_for_imported_product": "",
-                                "list_of_ingredients": "",
-                                "storage_information": "",
-                                "other_premises": null
-                            },
-                            "tax_type": "gst",
-                            "domain": "Grocery",
-                            "time": {
-                                "label": "enable",
-                                "timestamp": "2023-10-10T05:42:27.530Z"
-                            },
-                            "fulfillment_id": "1"
-                        },
-                        {
-                            "@ondc/org/statutory_reqs_packaged_commodities": {
-                                "common_or_generic_name_of_commodity": "",
-                                "net_quantity_or_measure_of_commodity_in_pkg": "12",
-                                "consumer_care_details": "",
-                                "imported_product_country_of_origin": "cggjjj",
-                                "manufacturer_or_packer_name": "fggghh",
-                                "manufacturer_or_packer_address": "",
-                                "month_year_of_manufacture_packing_import": ""
-                            },
-                            "@ondc/org/seller_pickup_return": true,
-                            "@ondc/org/contact_details_consumer_care": "tdydyd",
-                            "descriptor": {
-                                "symbol": "https://firebasestorage.googleapis.com/v0/b/shopeg-dev.appspot.com/o/shopImages%2FP3rGcNdyeae5uhffGGOXuGWsgbJ2%2Fimg_1692251569257.jpg?alt=media&token=fd807cd1-9b98-41c2-bd52-97280afc1fd2",
-                                "images": [
-                                    "https://firebasestorage.googleapis.com/v0/b/shopeg-dev.appspot.com/o/shopImages%2FP3rGcNdyeae5uhffGGOXuGWsgbJ2%2Fimg_1692251569257.jpg?alt=media&token=fd807cd1-9b98-41c2-bd52-97280afc1fd2"
-                                ],
-                                "name": "tttt",
-                                "short_desc": "hxhx",
-                                "long_desc": ""
-                            },
-                            "tax_rate": "5",
-                            "location_id": "6275",
-                            "@ondc/org/available_on_cod": false,
-                            "L2_category": "Cleaning & Household",
-                            "category_id": "Cleaning & Household",
-                            "price": {
-                                "currency": "INR",
-                                "maximum_value": "125",
-                                "value": "13"
-                            },
-                            "id": "dff253e1-238a-45bc-a0ca-7871a73725e7",
-                            "@ondc/org/allergen_information": "",
-                            "@ondc/org/cancellable": true,
-                            "@ondc/org/returnable": true,
-                            "quantity": {
-                                "available": {
-                                    "count": "12"
-                                },
-                                "maximum": {
-                                    "count": "2"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "",
-                                        "value": 0
-                                    }
-                                }
-                            },
-                            "@ondc/org/time_to_ship": "PT2H",
-                            "@ondc/org/seller_return_pickup": false,
-                            "hsn_code": "123",
-                            "tags": [
-                                {
-                                    "code": "origin",
-                                    "list": [
-                                        {
-                                            "code": "country",
-                                            "value": "cggjjj"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "origin",
-                                    "list": [
-                                        {
-                                            "code": "country",
-                                            "value": "cggjjj"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "origin",
-                                    "list": [
-                                        {
-                                            "code": "country",
-                                            "value": "cggjjj"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "origin",
-                                    "list": [
-                                        {
-                                            "code": "country",
-                                            "value": "cggjjj"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "origin",
-                                    "list": [
-                                        {
-                                            "code": "country",
-                                            "value": "cggjjj"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "origin",
-                                    "list": [
-                                        {
-                                            "code": "country",
-                                            "value": "cggjjj"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "origin",
-                                    "list": [
-                                        {
-                                            "code": "country",
-                                            "value": "cggjjj"
-                                        }
-                                    ]
-                                }
-                            ],
-                            "@ondc/org/return_window": "P7D",
-                            "@ondc/org/statutory_reqs_prepackaged_food": {
-                                "food_additive": "",
-                                "nutritional_information": "",
-                                "brand_owner_name": "",
-                                "consumer_care_details": "",
-                                "country_of_origin_for_imported_product": "",
-                                "list_of_ingredients": "",
-                                "storage_information": "",
-                                "other_premises": null
-                            },
-                            "tax_type": "gst",
-                            "domain": "Grocery",
-                            "time": {
-                                "label": "enable",
-                                "timestamp": "2023-10-10T05:42:27.530Z"
-                            },
-                            "fulfillment_id": "1"
-                        },
-                        {
-                            "@ondc/org/statutory_reqs_packaged_commodities": {
-                                "common_or_generic_name_of_commodity": "",
-                                "net_quantity_or_measure_of_commodity_in_pkg": "1 kg",
-                                "consumer_care_details": "",
-                                "imported_product_country_of_origin": "IND",
-                                "description": "AABBCCDDEEFF 1 KG",
-                                "manufacturer_or_packer_name": "General Mills India Pvt ltd",
-                                "multiple_products_name_number_or_qty": "1",
-                                "manufacturer_or_packer_address": "",
-                                "month_year_of_manufacture_packing_import": "",
-                                "contact_details_consumer_care": "1800-111-789"
-                            },
-                            "@ondc/org/seller_pickup_return": true,
-                            "@ondc/org/contact_details_consumer_care": "ondc-support@shopeg.in",
-                            "descriptor": {
-                                "symbol": "https://shopeg.in/i/eg.png",
-                                "images": [
-                                    "https://shopeg.in/i/eg.png"
-                                ],
-                                "name": "Product 179",
-                                "short_desc": "prdct shrt desc",
-                                "long_desc": ""
-                            },
-                            "location_id": "6275",
-                            "tax_rate": "5",
-                            "@ondc/org/available_on_cod": false,
-                            "L2_category": "Foodgrains",
-                            "category_id": "Foodgrains",
-                            "price": {
-                                "currency": "INR",
-                                "maximum_value": "8001",
-                                "maxium_value": "6666",
-                                "value": "5326"
-                            },
-                            "id": "5aeea39f-4fe6-42b0-8be9-6e0fb3b925f5",
-                            "@ondc/org/cancellable": true,
-                            "@ondc/org/allergen_information": "",
-                            "@ondc/org/returnable": true,
-                            "quantity": {
-                                "available": {
-                                    "count": "2"
-                                },
-                                "maximum": {
-                                    "count": "2"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "",
-                                        "value": 0
-                                    }
-                                }
-                            },
-                            "@ondc/org/time_to_ship": "PT2H",
-                            "hsn_code": "1101",
-                            "@ondc/org/seller_return_pickup": false,
-                            "tags": [
-                                {
-                                    "code": "origin",
-                                    "list": [
-                                        {
-                                            "code": "country",
-                                            "value": "IND"
-                                        }
-                                    ]
-                                }
-                            ],
-                            "@ondc/org/return_window": "P7D",
-                            "@ondc/org/statutory_reqs_prepackaged_food": {
-                                "food_additive": "",
-                                "nutritional_information": "",
-                                "brand_owner_name": "",
-                                "consumer_care_details": "",
-                                "country_of_origin_for_imported_product": "",
-                                "brand_owner_FSSAI_license_no": "355898556",
-                                "list_of_ingredients": "",
-                                "storage_information": "",
-                                "other_premises": null
-                            },
-                            "tax_type": "gst",
-                            "domain": "Grocery",
-                            "time": {
-                                "label": "enable",
-                                "timestamp": "2023-10-10T05:42:27.530Z"
-                            },
-                            "fulfillment_id": "1"
-                        },
-                        {
-                            "@ondc/org/statutory_reqs_packaged_commodities": {
-                                "common_or_generic_name_of_commodity": "",
-                                "net_quantity_or_measure_of_commodity_in_pkg": "1 kg",
-                                "consumer_care_details": "",
-                                "imported_product_country_of_origin": "IND",
-                                "description": "AABBCCDDEEFF 1 KG",
-                                "manufacturer_or_packer_name": "General Mills India Pvt ltd",
-                                "multiple_products_name_number_or_qty": "1",
-                                "manufacturer_or_packer_address": "",
-                                "month_year_of_manufacture_packing_import": "",
-                                "contact_details_consumer_care": "1800-111-789"
-                            },
-                            "@ondc/org/seller_pickup_return": true,
-                            "@ondc/org/contact_details_consumer_care": "ondc-support@shopeg.in",
-                            "descriptor": {
-                                "symbol": "https://shopeg.in/i/eg.png",
-                                "images": [
-                                    "https://shopeg.in/i/eg.png"
-                                ],
-                                "name": "Product 457",
-                                "short_desc": "prdct shrt desc",
-                                "long_desc": ""
-                            },
-                            "location_id": "6275",
-                            "tax_rate": "5",
-                            "@ondc/org/available_on_cod": false,
-                            "L2_category": "Foodgrains",
-                            "category_id": "Foodgrains",
-                            "price": {
-                                "currency": "INR",
-                                "maximum_value": "2351",
-                                "maxium_value": "6666",
-                                "value": "106"
-                            },
-                            "id": "2e8b80d2-4168-43f6-bbfd-e1e7b20129bf",
-                            "@ondc/org/cancellable": true,
-                            "@ondc/org/allergen_information": "",
-                            "@ondc/org/returnable": true,
-                            "quantity": {
-                                "available": {
-                                    "count": "2"
-                                },
-                                "maximum": {
-                                    "count": "2"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "",
-                                        "value": 0
-                                    }
-                                }
-                            },
-                            "@ondc/org/time_to_ship": "PT2H",
-                            "hsn_code": "1101",
-                            "@ondc/org/seller_return_pickup": false,
-                            "tags": [
-                                {
-                                    "code": "origin",
-                                    "list": [
-                                        {
-                                            "code": "country",
-                                            "value": "IND"
-                                        }
-                                    ]
-                                }
-                            ],
-                            "@ondc/org/return_window": "P7D",
-                            "@ondc/org/statutory_reqs_prepackaged_food": {
-                                "food_additive": "",
-                                "nutritional_information": "",
-                                "brand_owner_name": "",
-                                "consumer_care_details": "",
-                                "country_of_origin_for_imported_product": "",
-                                "brand_owner_FSSAI_license_no": "55359895",
-                                "list_of_ingredients": "",
-                                "storage_information": "",
-                                "other_premises": null
-                            },
-                            "tax_type": "gst",
-                            "domain": "Grocery",
-                            "time": {
-                                "label": "enable",
-                                "timestamp": "2023-10-10T05:42:27.530Z"
-                            },
-                            "fulfillment_id": "1"
-                        },
-                        {
-                            "@ondc/org/statutory_reqs_packaged_commodities": {
-                                "common_or_generic_name_of_commodity": "",
-                                "net_quantity_or_measure_of_commodity_in_pkg": "1 kg",
-                                "consumer_care_details": "",
-                                "imported_product_country_of_origin": "IND",
-                                "description": "TTTEEEOOOWWWQQQ 1 KG",
-                                "manufacturer_or_packer_name": "General Mills India Pvt ltd",
-                                "multiple_products_name_number_or_qty": "1",
-                                "manufacturer_or_packer_address": "",
-                                "month_year_of_manufacture_packing_import": "",
-                                "contact_details_consumer_care": "1800-111-789"
-                            },
-                            "@ondc/org/seller_pickup_return": true,
-                            "@ondc/org/contact_details_consumer_care": "ondc-support@shopeg.in",
-                            "descriptor": {
-                                "symbol": "https://shopeg.in/i/eg.png",
-                                "images": [
-                                    "https://shopeg.in/i/eg.png"
-                                ],
-                                "name": "TTTEEEOOOWWWQQQ PRODUCT 100 ml",
-                                "short_desc": "TTTEEEOOOWWWQQQ PRODUCT",
-                                "long_desc": ""
-                            },
-                            "location_id": "6275",
-                            "tax_rate": "28",
-                            "@ondc/org/available_on_cod": false,
-                            "L2_category": "Foodgrains",
-                            "category_id": "Foodgrains",
-                            "price": {
-                                "currency": "INR",
-                                "maximum_value": "91",
-                                "value": "53"
-                            },
-                            "id": "77788899-asb-4889-asd-asdasdsad",
-                            "@ondc/org/cancellable": true,
-                            "@ondc/org/allergen_information": "",
-                            "@ondc/org/returnable": true,
-                            "quantity": {
-                                "available": {
-                                    "count": "2"
-                                },
-                                "maximum": {
-                                    "count": "2"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "",
-                                        "value": 0
-                                    }
-                                }
-                            },
-                            "@ondc/org/time_to_ship": "PT2H",
-                            "@ondc/org/seller_return_pickup": false,
-                            "hsn_code": "7558585595",
-                            "fulfillment_id": "1",
-                            "tags": [
-                                {
-                                    "code": "origin",
-                                    "list": [
-                                        {
-                                            "code": "country",
-                                            "value": "IND"
-                                        }
-                                    ]
-                                }
-                            ],
-                            "@ondc/org/return_window": "P7D",
-                            "@ondc/org/statutory_reqs_prepackaged_food": {
-                                "food_additive": "",
-                                "nutritional_information": "",
-                                "brand_owner_name": "",
-                                "consumer_care_details": "",
-                                "country_of_origin_for_imported_product": "",
-                                "brand_owner_FSSAI_license_no": "865682485",
-                                "list_of_ingredients": "",
-                                "storage_information": "",
-                                "other_premises": null
-                            },
-                            "tax_type": "gst",
-                            "domain": "Grocery",
-                            "time": {
-                                "label": "enable",
-                                "timestamp": "2023-10-10T05:42:27.530Z"
-                            }
-                        },
-                        {
-                            "storeOpenTillDate": "2023-08-30T22:00:00.315Z",
-                            "@ondc/org/statutory_reqs_packaged_commodities": {
-                                "common_or_generic_name_of_commodity": "",
-                                "net_quantity_or_measure_of_commodity_in_pkg": "5 kg",
-                                "consumer_care_details": "",
-                                "imported_product_country_of_origin": "ITC India Pvt ltd. 404, Powai, Mumbai- 400071",
-                                "description": "Juices",
-                                "manufacturer_or_packer_name": "ITC India Pvt ltd",
-                                "multiple_products_name_number_or_qty": "5",
-                                "manufacturer_or_packer_address": "",
-                                "month_year_of_manufacture_packing_import": "",
-                                "contact_details_consumer_care": "1800-100-123"
-                            },
-                            "@ondc/org/seller_pickup_return": true,
-                            "@ondc/org/contact_details_consumer_care": "ondc-support@shopeg.in",
-                            "descriptor": {
-                                "symbol": "https://shopeg.in/i/eg.png",
-                                "images": [
-                                    "https://shopeg.in/i/eg.png"
-                                ],
-                                "name": "Ashirvad 20 kg atta",
-                                "short_desc": "Ashirvad 20kg atta",
-                                "long_desc": ""
-                            },
-                            "location_id": "6275",
-                            "tax_rate": "5",
-                            "@ondc/org/available_on_cod": false,
-                            "L2_category": "Gourmet & World Foods",
-                            "category_id": "Gourmet & World Foods",
-                            "price": {
-                                "currency": "INR",
-                                "maximum_value": "2001",
-                                "value": "2000"
-                            },
-                            "id": "vismaya-shop-2233-a7c4-112233",
-                            "@ondc/org/cancellable": true,
-                            "@ondc/org/allergen_information": "",
-                            "@ondc/org/returnable": true,
-                            "quantity": {
-                                "available": {
-                                    "count": "1"
-                                },
-                                "maximum": {
-                                    "count": "1"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "",
-                                        "value": 0
-                                    }
-                                }
-                            },
-                            "@ondc/org/time_to_ship": "PT2H",
-                            "hsn_code": "1000",
-                            "@ondc/org/seller_return_pickup": false,
-                            "ttl": "P3D",
-                            "fulfillment_id": "1",
-                            "tags": [
-                                {
-                                    "code": "origin",
-                                    "list": [
-                                        {
-                                            "code": "country",
-                                            "value": "ITC India Pvt ltd. 404, Powai, Mumbai- 400071"
-                                        }
-                                    ]
-                                }
-                            ],
-                            "@ondc/org/return_window": "P7D",
-                            "@ondc/org/statutory_reqs_prepackaged_food": {
-                                "food_additive": "",
-                                "nutritional_information": "",
-                                "brand_owner_name": "",
-                                "consumer_care_details": "",
-                                "country_of_origin_for_imported_product": "",
-                                "brand_owner_FSSAI_license_no": "24568383838",
-                                "list_of_ingredients": "",
-                                "storage_information": "",
-                                "other_premises": null
-                            },
-                            "tax_type": "gst",
-                            "domain": "Grocery",
-                            "time": {
-                                "label": "enable",
-                                "time": "2023-08-04T12:25:23.097Z",
-                                "timestamp": "2023-10-10T05:42:27.530Z"
-                            }
-                        },
-                        {
-                            "@ondc/org/statutory_reqs_packaged_commodities": {
-                                "common_or_generic_name_of_commodity": "",
-                                "net_quantity_or_measure_of_commodity_in_pkg": "65 mtr",
-                                "consumer_care_details": "",
-                                "imported_product_country_of_origin": "hdhxhxxhx",
-                                "description": "ccydydydyd",
-                                "manufacturer_or_packer_name": "6dd66ddd",
-                                "multiple_products_name_number_or_qty": "12",
-                                "manufacturer_or_packer_address": "",
-                                "month_year_of_manufacture_packing_import": "",
-                                "contact_details_consumer_care": "1234567891"
-                            },
-                            "@ondc/org/seller_pickup_return": true,
-                            "@ondc/org/contact_details_consumer_care": "ondc-support@shopeg.in",
-                            "descriptor": {
-                                "symbol": "/data/user/0/com.shopeg.dev/cache/scaled_5c78d04f-1a8a-480d-88a5-07b473b35f405008472597580969824.jpg",
-                                "images": [
-                                    "/data/user/0/com.shopeg.dev/cache/scaled_5c78d04f-1a8a-480d-88a5-07b473b35f405008472597580969824.jpg"
-                                ],
-                                "name": "test mk",
-                                "short_desc": "bhjjj9",
-                                "long_desc": ""
-                            },
-                            "location_id": "6275",
-                            "tax_rate": "5",
-                            "@ondc/org/available_on_cod": false,
-                            "L2_category": "Cleaning & Household",
-                            "category_id": "Cleaning & Household",
-                            "price": {
-                                "currency": "INR",
-                                "maximum_value": "61",
-                                "value": "3"
-                            },
-                            "id": "d06946c7-efa0-498f-bf13-f4b3369808cf",
-                            "@ondc/org/cancellable": true,
-                            "@ondc/org/allergen_information": "",
-                            "@ondc/org/returnable": true,
-                            "quantity": {
-                                "available": {
-                                    "count": "12"
-                                },
-                                "maximum": {
-                                    "count": "7"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "",
-                                        "value": 0
-                                    }
-                                }
-                            },
-                            "@ondc/org/time_to_ship": "PT2H",
-                            "hsn_code": "1234",
-                            "@ondc/org/seller_return_pickup": false,
-                            "tags": [
-                                {
-                                    "code": "origin",
-                                    "list": [
-                                        {
-                                            "code": "country",
-                                            "value": "hdhxhxxhx"
-                                        }
-                                    ]
-                                }
-                            ],
-                            "@ondc/org/return_window": "P7D",
-                            "@ondc/org/statutory_reqs_prepackaged_food": {
-                                "food_additive": "",
-                                "nutritional_information": "",
-                                "brand_owner_name": "",
-                                "consumer_care_details": "",
-                                "country_of_origin_for_imported_product": "",
-                                "list_of_ingredients": "",
-                                "storage_information": "",
-                                "other_premises": null
-                            },
-                            "tax_type": "gst",
-                            "domain": "Grocery",
-                            "time": {
-                                "label": "enable",
-                                "timestamp": "2023-10-10T05:42:27.530Z"
-                            },
-                            "fulfillment_id": "1"
-                        },
-                        {
-                            "@ondc/org/cancellable": true,
-                            "@ondc/org/returnable": true,
-                            "quantity": {
-                                "available": {
-                                    "count": "23"
-                                },
-                                "maximum": {
-                                    "count": "23"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "Kg",
-                                        "value": "12"
-                                    }
-                                }
-                            },
-                            "@ondc/org/statutory_reqs_packaged_commodities": {
-                                "net_quantity_or_measure_of_commodity_in_pkg": "12 Kg",
-                                "imported_product_country_of_origin": "IND",
-                                "manufacturer_or_packer_name": "gdgd"
-                            },
-                            "@ondc/org/seller_pickup_return": true,
-                            "@ondc/org/contact_details_consumer_care": "vdgx",
-                            "@ondc/org/time_to_ship": "PT2H",
-                            "descriptor": {
-                                "symbol": "https://firebasestorage.googleapis.com/v0/b/shopeg-dev.appspot.com/o/shopImages%2FP3rGcNdyeae5uhffGGOXuGWsgbJ2%2Fimg_1693284889085.jpg?alt=media&token=7631d171-306c-4af1-b457-3eb65f945131",
-                                "images": [
-                                    "https://firebasestorage.googleapis.com/v0/b/shopeg-dev.appspot.com/o/shopImages%2FP3rGcNdyeae5uhffGGOXuGWsgbJ2%2Fimg_1693284889085.jpg?alt=media&token=7631d171-306c-4af1-b457-3eb65f945131"
-                                ],
-                                "name": "hxjx",
-                                "short_desc": "jxjxjdududid",
-                                "long_desc": "jxjxjdududidhduf"
-                            },
-                            "hsn_code": "1000",
-                            "tax_rate": "18",
-                            "location_id": "6275",
-                            "tags": [],
-                            "@ondc/org/return_window": "P7D",
-                            "@ondc/org/available_on_cod": false,
-                            "L2_category": "Cleaning & Household",
-                            "category_id": "Cleaning & Household",
-                            "tax_type": "gst",
-                            "price": {
-                                "currency": "INR",
-                                "maximum_value": "123",
-                                "value": "123"
-                            },
-                            "domain": "Grocery",
-                            "id": "ac5f3b39-390e-47fb-985d-f2b3c7461afb",
-                            "time": {
-                                "label": "enable",
-                                "timestamp": "2023-10-10T05:42:27.530Z"
-                            },
-                            "fulfillment_id": "1"
-                        },
-                        {
-                            "@ondc/org/statutory_reqs_packaged_commodities": {
-                                "common_or_generic_name_of_commodity": "",
-                                "net_quantity_or_measure_of_commodity_in_pkg": "12",
-                                "consumer_care_details": "",
-                                "imported_product_country_of_origin": "hxhxh",
-                                "manufacturer_or_packer_name": "bxbx",
-                                "manufacturer_or_packer_address": "",
-                                "month_year_of_manufacture_packing_import": ""
-                            },
-                            "@ondc/org/seller_pickup_return": true,
-                            "@ondc/org/contact_details_consumer_care": "hnnx",
-                            "descriptor": {
-                                "symbol": "https://firebasestorage.googleapis.com/v0/b/shopeg-dev.appspot.com/o/shopImages%2FP3rGcNdyeae5uhffGGOXuGWsgbJ2%2Fimg_1692251320930.jpg?alt=media&token=4685d080-26e1-4d58-a565-6535535872c9",
-                                "images": [
-                                    "https://firebasestorage.googleapis.com/v0/b/shopeg-dev.appspot.com/o/shopImages%2FP3rGcNdyeae5uhffGGOXuGWsgbJ2%2Fimg_1692251320930.jpg?alt=media&token=4685d080-26e1-4d58-a565-6535535872c9"
-                                ],
-                                "name": "rtrt",
-                                "short_desc": "kgjgk",
-                                "long_desc": ""
-                            },
-                            "tax_rate": "5",
-                            "location_id": "6275",
-                            "@ondc/org/available_on_cod": false,
-                            "L2_category": "Gourmet & World Foods",
-                            "category_id": "Gourmet & World Foods",
-                            "price": {
-                                "currency": "INR",
-                                "maximum_value": "235",
-                                "value": "100"
-                            },
-                            "id": "caf04ddf-8b4c-4f40-931b-ff6cd492ffd3",
-                            "@ondc/org/allergen_information": "",
-                            "@ondc/org/cancellable": true,
-                            "@ondc/org/returnable": true,
-                            "quantity": {
-                                "available": {
-                                    "count": "135"
-                                },
-                                "maximum": {
-                                    "count": "2"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "",
-                                        "value": 0
-                                    }
-                                }
-                            },
-                            "@ondc/org/time_to_ship": "PT2H",
-                            "@ondc/org/seller_return_pickup": false,
-                            "hsn_code": "9868686",
-                            "tags": [
-                                {
-                                    "code": "origin",
-                                    "list": [
-                                        {
-                                            "code": "country",
-                                            "value": "hxhxh"
-                                        }
-                                    ]
-                                }
-                            ],
-                            "@ondc/org/return_window": "P7D",
-                            "@ondc/org/statutory_reqs_prepackaged_food": {
-                                "food_additive": "",
-                                "nutritional_information": "",
-                                "brand_owner_name": "",
-                                "consumer_care_details": "",
-                                "country_of_origin_for_imported_product": "",
-                                "brand_owner_FSSAI_license_no": "6453776656556",
-                                "list_of_ingredients": "",
-                                "storage_information": "",
-                                "other_premises": "yhzyz"
-                            },
-                            "tax_type": "gst",
-                            "domain": "Grocery",
-                            "time": {
-                                "label": "enable",
-                                "timestamp": "2023-10-10T05:42:27.530Z"
-                            },
-                            "fulfillment_id": "1"
-                        },
-                        {
-                            "@ondc/org/statutory_reqs_packaged_commodities": {
-                                "common_or_generic_name_of_commodity": "",
-                                "net_quantity_or_measure_of_commodity_in_pkg": "1 kg",
-                                "consumer_care_details": "",
-                                "imported_product_country_of_origin": "IND",
-                                "description": "AABBCCDDEEFF 1 KG",
-                                "manufacturer_or_packer_name": "General Mills India Pvt ltd",
-                                "multiple_products_name_number_or_qty": "1",
-                                "manufacturer_or_packer_address": "",
-                                "month_year_of_manufacture_packing_import": "",
-                                "contact_details_consumer_care": "1800-111-789"
-                            },
-                            "@ondc/org/seller_pickup_return": true,
-                            "@ondc/org/contact_details_consumer_care": "ondc-support@shopeg.in",
-                            "descriptor": {
-                                "symbol": "https://shopeg.in/i/eg.png",
-                                "images": [
-                                    "https://shopeg.in/i/eg.png"
-                                ],
-                                "name": "Product 675",
-                                "short_desc": "prdct shrt desc",
-                                "long_desc": ""
-                            },
-                            "location_id": "6275",
-                            "tax_rate": "5",
-                            "@ondc/org/available_on_cod": false,
-                            "L2_category": "Foodgrains",
-                            "category_id": "Foodgrains",
-                            "price": {
-                                "currency": "INR",
-                                "maximum_value": "5001",
-                                "maxium_value": "6666",
-                                "value": "4034"
-                            },
-                            "id": "96c6d5f9-dd1b-4e3c-b9c3-1be62d69d3be",
-                            "@ondc/org/cancellable": true,
-                            "@ondc/org/allergen_information": "",
-                            "@ondc/org/returnable": true,
-                            "quantity": {
-                                "available": {
-                                    "count": "2"
-                                },
-                                "maximum": {
-                                    "count": "2"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "",
-                                        "value": 0
-                                    }
-                                }
-                            },
-                            "@ondc/org/time_to_ship": "PT2H",
-                            "hsn_code": "1101",
-                            "@ondc/org/seller_return_pickup": false,
-                            "tags": [
-                                {
-                                    "code": "origin",
-                                    "list": [
-                                        {
-                                            "code": "country",
-                                            "value": "IND"
-                                        }
-                                    ]
-                                }
-                            ],
-                            "@ondc/org/return_window": "P7D",
-                            "@ondc/org/statutory_reqs_prepackaged_food": {
-                                "food_additive": "",
-                                "nutritional_information": "",
-                                "brand_owner_name": "",
-                                "consumer_care_details": "",
-                                "country_of_origin_for_imported_product": "",
-                                "brand_owner_FSSAI_license_no": "9595526669",
-                                "list_of_ingredients": "",
-                                "storage_information": "",
-                                "other_premises": null
-                            },
-                            "tax_type": "gst",
-                            "domain": "Grocery",
-                            "time": {
-                                "label": "enable",
-                                "timestamp": "2023-10-10T05:42:27.530Z"
-                            },
-                            "fulfillment_id": "1"
-                        },
-                        {
-                            "@ondc/org/statutory_reqs_packaged_commodities": {
-                                "common_or_generic_name_of_commodity": "",
-                                "net_quantity_or_measure_of_commodity_in_pkg": "1 kg",
-                                "consumer_care_details": "",
-                                "imported_product_country_of_origin": "IND",
-                                "description": "AABBCCDDEEFF 1 KG",
-                                "manufacturer_or_packer_name": "General Mills India Pvt ltd",
-                                "multiple_products_name_number_or_qty": "1",
-                                "manufacturer_or_packer_address": "",
-                                "month_year_of_manufacture_packing_import": "",
-                                "contact_details_consumer_care": "1800-111-789"
-                            },
-                            "@ondc/org/seller_pickup_return": true,
-                            "@ondc/org/contact_details_consumer_care": "ondc-support@shopeg.in",
-                            "descriptor": {
-                                "symbol": "https://shopeg.in/i/eg.png",
-                                "images": [
-                                    "https://shopeg.in/i/eg.png"
-                                ],
-                                "name": "Product 258",
-                                "short_desc": "prdct shrt desc",
-                                "long_desc": ""
-                            },
-                            "location_id": "6275",
-                            "tax_rate": "5",
-                            "@ondc/org/available_on_cod": false,
-                            "L2_category": "Foodgrains",
-                            "category_id": "Foodgrains",
-                            "price": {
-                                "currency": "INR",
-                                "maximum_value": "8001",
-                                "maxium_value": "6666",
-                                "value": "7115"
-                            },
-                            "id": "ea6208d5-ffbe-456b-8210-1f2d25fa9acd",
-                            "@ondc/org/cancellable": true,
-                            "@ondc/org/allergen_information": "",
-                            "@ondc/org/returnable": true,
-                            "quantity": {
-                                "available": {
-                                    "count": "2"
-                                },
-                                "maximum": {
-                                    "count": "2"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "",
-                                        "value": 0
-                                    }
-                                }
-                            },
-                            "@ondc/org/time_to_ship": "PT2H",
-                            "hsn_code": "1101",
-                            "@ondc/org/seller_return_pickup": false,
-                            "tags": [
-                                {
-                                    "code": "origin",
-                                    "list": [
-                                        {
-                                            "code": "country",
-                                            "value": "IND"
-                                        }
-                                    ]
-                                }
-                            ],
-                            "@ondc/org/return_window": "P7D",
-                            "@ondc/org/statutory_reqs_prepackaged_food": {
-                                "food_additive": "",
-                                "nutritional_information": "",
-                                "brand_owner_name": "",
-                                "consumer_care_details": "",
-                                "country_of_origin_for_imported_product": "",
-                                "brand_owner_FSSAI_license_no": "84535356865",
-                                "list_of_ingredients": "",
-                                "storage_information": "",
-                                "other_premises": null
-                            },
-                            "tax_type": "gst",
-                            "domain": "Grocery",
-                            "time": {
-                                "label": "enable",
-                                "timestamp": "2023-10-10T05:42:27.530Z"
-                            },
-                            "fulfillment_id": "1"
-                        },
-                        {
-                            "@ondc/org/statutory_reqs_packaged_commodities": {
-                                "common_or_generic_name_of_commodity": "",
-                                "net_quantity_or_measure_of_commodity_in_pkg": "1 kg",
-                                "consumer_care_details": "",
-                                "imported_product_country_of_origin": "IND",
-                                "description": "AABBCCDDEEFF 1 KG",
-                                "manufacturer_or_packer_name": "General Mills India Pvt ltd",
-                                "multiple_products_name_number_or_qty": "1",
-                                "manufacturer_or_packer_address": "",
-                                "month_year_of_manufacture_packing_import": "",
-                                "contact_details_consumer_care": "1800-111-789"
-                            },
-                            "@ondc/org/seller_pickup_return": true,
-                            "@ondc/org/contact_details_consumer_care": "ondc-support@shopeg.in",
-                            "descriptor": {
-                                "symbol": "https://shopeg.in/i/eg.png",
-                                "images": [
-                                    "https://shopeg.in/i/eg.png"
-                                ],
-                                "name": "Product 960",
-                                "short_desc": "prdct shrt desc",
-                                "long_desc": ""
-                            },
-                            "location_id": "6275",
-                            "tax_rate": "5",
-                            "@ondc/org/available_on_cod": false,
-                            "L2_category": "Foodgrains",
-                            "category_id": "Foodgrains",
-                            "price": {
-                                "currency": "INR",
-                                "maximum_value": "7001",
-                                "maxium_value": "6666",
-                                "value": "6187"
-                            },
-                            "id": "1daca331-df02-40bc-8bd9-870606324310",
-                            "@ondc/org/cancellable": true,
-                            "@ondc/org/allergen_information": "",
-                            "@ondc/org/returnable": true,
-                            "quantity": {
-                                "available": {
-                                    "count": "2"
-                                },
-                                "maximum": {
-                                    "count": "2"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "",
-                                        "value": 0
-                                    }
-                                }
-                            },
-                            "@ondc/org/time_to_ship": "PT2H",
-                            "hsn_code": "1101",
-                            "@ondc/org/seller_return_pickup": false,
-                            "tags": [
-                                {
-                                    "code": "origin",
-                                    "list": [
-                                        {
-                                            "code": "country",
-                                            "value": "IND"
-                                        }
-                                    ]
-                                }
-                            ],
-                            "@ondc/org/return_window": "P7D",
-                            "@ondc/org/statutory_reqs_prepackaged_food": {
-                                "food_additive": "",
-                                "nutritional_information": "",
-                                "brand_owner_name": "",
-                                "consumer_care_details": "",
-                                "country_of_origin_for_imported_product": "",
-                                "brand_owner_FSSAI_license_no": "1259855656566",
-                                "list_of_ingredients": "",
-                                "storage_information": "",
-                                "other_premises": null
-                            },
-                            "tax_type": "gst",
-                            "domain": "Grocery",
-                            "time": {
-                                "label": "enable",
-                                "timestamp": "2023-10-10T05:42:27.530Z"
-                            },
-                            "fulfillment_id": "1"
-                        },
-                        {
-                            "@ondc/org/statutory_reqs_packaged_commodities": {
-                                "common_or_generic_name_of_commodity": "",
-                                "net_quantity_or_measure_of_commodity_in_pkg": "65 mtr",
-                                "consumer_care_details": "",
-                                "imported_product_country_of_origin": "hdhxhxxhx",
-                                "description": "ccydydydyd",
-                                "manufacturer_or_packer_name": "6dd66ddd",
-                                "multiple_products_name_number_or_qty": "12",
-                                "manufacturer_or_packer_address": "",
-                                "month_year_of_manufacture_packing_import": "",
-                                "contact_details_consumer_care": "1234567891"
-                            },
-                            "@ondc/org/seller_pickup_return": true,
-                            "@ondc/org/contact_details_consumer_care": "ondc-support@shopeg.in",
-                            "descriptor": {
-                                "symbol": "/data/user/0/com.shopeg.dev/cache/scaled_5c78d04f-1a8a-480d-88a5-07b473b35f405008472597580969824.jpg",
-                                "images": [
-                                    "/data/user/0/com.shopeg.dev/cache/scaled_5c78d04f-1a8a-480d-88a5-07b473b35f405008472597580969824.jpg"
-                                ],
-                                "name": "test mk",
-                                "short_desc": "bhjjj9",
-                                "long_desc": ""
-                            },
-                            "location_id": "6275",
-                            "tax_rate": "5",
-                            "@ondc/org/available_on_cod": false,
-                            "L2_category": "Cleaning & Household",
-                            "category_id": "Cleaning & Household",
-                            "price": {
-                                "currency": "INR",
-                                "maximum_value": "91",
-                                "value": "3"
-                            },
-                            "id": "6ed59f98-1242-4043-bc98-8a2a1ab80e87",
-                            "@ondc/org/cancellable": true,
-                            "@ondc/org/allergen_information": "",
-                            "@ondc/org/returnable": true,
-                            "quantity": {
-                                "available": {
-                                    "count": "12"
-                                },
-                                "maximum": {
-                                    "count": "7"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "",
-                                        "value": 0
-                                    }
-                                }
-                            },
-                            "@ondc/org/time_to_ship": "PT2H",
-                            "hsn_code": "1234",
-                            "@ondc/org/seller_return_pickup": false,
-                            "tags": [
-                                {
-                                    "code": "origin",
-                                    "list": [
-                                        {
-                                            "code": "country",
-                                            "value": "hdhxhxxhx"
-                                        }
-                                    ]
-                                }
-                            ],
-                            "@ondc/org/return_window": "P7D",
-                            "@ondc/org/statutory_reqs_prepackaged_food": {
-                                "food_additive": "",
-                                "nutritional_information": "",
-                                "brand_owner_name": "",
-                                "consumer_care_details": "",
-                                "country_of_origin_for_imported_product": "",
-                                "list_of_ingredients": "",
-                                "storage_information": "",
-                                "other_premises": null
-                            },
-                            "tax_type": "gst",
-                            "domain": "Grocery",
-                            "time": {
-                                "label": "enable",
-                                "timestamp": "2023-10-10T05:42:27.530Z"
-                            },
-                            "fulfillment_id": "1"
-                        },
-                        {
-                            "@ondc/org/statutory_reqs_packaged_commodities": {
-                                "common_or_generic_name_of_commodity": "",
-                                "net_quantity_or_measure_of_commodity_in_pkg": "123",
-                                "consumer_care_details": "",
-                                "imported_product_country_of_origin": "ghxhxh",
-                                "manufacturer_or_packer_name": "hxhhzjddjd",
-                                "manufacturer_or_packer_address": "",
-                                "month_year_of_manufacture_packing_import": ""
-                            },
-                            "@ondc/org/contact_details_consumer_care": "7272727",
-                            "@ondc/org/seller_pickup_return": true,
-                            "descriptor": {
-                                "symbol": "https://firebasestorage.googleapis.com/v0/b/shopeg-dev.appspot.com/o/shopImages%2FP3rGcNdyeae5uhffGGOXuGWsgbJ2%2Fimg_1692162258235.jpg?alt=media&token=c493c40a-f591-4f56-b682-b62d48309554",
-                                "images": [
-                                    "https://firebasestorage.googleapis.com/v0/b/shopeg-dev.appspot.com/o/shopImages%2FP3rGcNdyeae5uhffGGOXuGWsgbJ2%2Fimg_1692162258235.jpg?alt=media&token=c493c40a-f591-4f56-b682-b62d48309554"
-                                ],
-                                "name": "hhhhh",
-                                "short_desc": "jdjxj",
-                                "long_desc": ""
-                            },
-                            "tax_rate": "28",
-                            "location_id": "6275",
-                            "@ondc/org/available_on_cod": false,
-                            "L2_category": "Foodgrains",
-                            "category_id": "Foodgrains",
-                            "price": {
-                                "currency": "INR",
-                                "maximum_value": "2611",
-                                "value": "223"
-                            },
-                            "id": "4cd2d1f9-0043-49cc-aaae-9f78794c8a78",
-                            "@ondc/org/allergen_information": "",
-                            "@ondc/org/cancellable": true,
-                            "@ondc/org/returnable": true,
-                            "quantity": {
-                                "available": {
-                                    "count": "68686"
-                                },
-                                "maximum": {
-                                    "count": "1"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "",
-                                        "value": 0
-                                    }
-                                }
-                            },
-                            "@ondc/org/time_to_ship": "PT2H",
-                            "@ondc/org/seller_return_pickup": false,
-                            "hsn_code": "67676466",
-                            "tags": [
-                                {
-                                    "code": "origin",
-                                    "list": [
-                                        {
-                                            "code": "country",
-                                            "value": "ghxhxh"
-                                        }
-                                    ]
-                                }
-                            ],
-                            "@ondc/org/return_window": "P7D",
-                            "@ondc/org/statutory_reqs_prepackaged_food": {
-                                "food_additive": "",
-                                "nutritional_information": "",
-                                "brand_owner_name": "",
-                                "consumer_care_details": "",
-                                "country_of_origin_for_imported_product": "",
-                                "brand_owner_FSSAI_license_no": "12434365",
-                                "list_of_ingredients": "",
-                                "storage_information": "",
-                                "other_premises": null
-                            },
-                            "tax_type": "gst",
-                            "domain": "Grocery",
-                            "time": {
-                                "label": "enable",
-                                "timestamp": "2023-10-10T05:42:27.530Z"
-                            },
-                            "fulfillment_id": "1"
-                        },
-                        {
-                            "@ondc/org/statutory_reqs_packaged_commodities": {
-                                "common_or_generic_name_of_commodity": "",
-                                "net_quantity_or_measure_of_commodity_in_pkg": "65 mtr",
-                                "consumer_care_details": "",
-                                "imported_product_country_of_origin": "hdhxhxxhx",
-                                "description": "ccydydydyd",
-                                "manufacturer_or_packer_name": "6dd66ddd",
-                                "multiple_products_name_number_or_qty": "12",
-                                "manufacturer_or_packer_address": "",
-                                "month_year_of_manufacture_packing_import": "",
-                                "contact_details_consumer_care": "1234567891"
-                            },
-                            "@ondc/org/seller_pickup_return": true,
-                            "@ondc/org/contact_details_consumer_care": "ondc-support@shopeg.in",
-                            "descriptor": {
-                                "symbol": "/data/user/0/com.shopeg.dev/cache/scaled_5c78d04f-1a8a-480d-88a5-07b473b35f405008472597580969824.jpg",
-                                "images": [
-                                    "/data/user/0/com.shopeg.dev/cache/scaled_5c78d04f-1a8a-480d-88a5-07b473b35f405008472597580969824.jpg"
-                                ],
-                                "name": "test mk",
-                                "short_desc": "bhjjj",
-                                "long_desc": ""
-                            },
-                            "location_id": "6275",
-                            "tax_rate": "5",
-                            "@ondc/org/available_on_cod": false,
-                            "L2_category": "Cleaning & Household",
-                            "category_id": "Cleaning & Household",
-                            "price": {
-                                "currency": "INR",
-                                "maximum_value": "81",
-                                "value": "3"
-                            },
-                            "id": "7958dad4-8454-40d4-97e4-cb2b3797a5e7",
-                            "@ondc/org/cancellable": true,
-                            "@ondc/org/allergen_information": "",
-                            "@ondc/org/returnable": true,
-                            "quantity": {
-                                "available": {
-                                    "count": "12"
-                                },
-                                "maximum": {
-                                    "count": "7"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "",
-                                        "value": 0
-                                    }
-                                }
-                            },
-                            "@ondc/org/time_to_ship": "PT2H",
-                            "hsn_code": "1234",
-                            "@ondc/org/seller_return_pickup": false,
-                            "tags": [
-                                {
-                                    "code": "origin",
-                                    "list": [
-                                        {
-                                            "code": "country",
-                                            "value": "hdhxhxxhx"
-                                        }
-                                    ]
-                                }
-                            ],
-                            "@ondc/org/return_window": "P7D",
-                            "@ondc/org/statutory_reqs_prepackaged_food": {
-                                "food_additive": "",
-                                "nutritional_information": "",
-                                "brand_owner_name": "",
-                                "consumer_care_details": "",
-                                "country_of_origin_for_imported_product": "",
-                                "list_of_ingredients": "",
-                                "storage_information": "",
-                                "other_premises": null
-                            },
-                            "tax_type": "gst",
-                            "domain": "Grocery",
-                            "time": {
-                                "label": "enable",
-                                "timestamp": "2023-10-10T05:42:27.530Z"
-                            },
-                            "fulfillment_id": "1"
-                        },
-                        {
-                            "@ondc/org/statutory_reqs_packaged_commodities": {
-                                "net_quantity_or_measure_of_commodity_in_pkg": "12",
-                                "date_of_import": "08/2023",
-                                "imported_product_country_of_origin": "hhdhdy",
-                                "manufacturer_or_packer_name": "jdjjd"
-                            },
-                            "@ondc/org/seller_pickup_return": true,
-                            "@ondc/org/contact_details_consumer_care": "gsgdg",
-                            "descriptor": {
-                                "symbol": "https://firebasestorage.googleapis.com/v0/b/shopeg-dev.appspot.com/o/shopImages%2FP3rGcNdyeae5uhffGGOXuGWsgbJ2%2Fimg_1692371079226.jpg?alt=media&token=3807aa13-18d2-4005-9346-5187002bed1a",
-                                "images": [
-                                    "https://firebasestorage.googleapis.com/v0/b/shopeg-dev.appspot.com/o/shopImages%2FP3rGcNdyeae5uhffGGOXuGWsgbJ2%2Fimg_1692371079226.jpg?alt=media&token=3807aa13-18d2-4005-9346-5187002bed1a"
-                                ],
-                                "name": "bzbzj",
-                                "short_desc": "jxjxixo",
-                                "long_desc": "hzhzjcujcjc"
-                            },
-                            "tax_rate": "18",
-                            "location_id": "6275",
-                            "@ondc/org/available_on_cod": false,
-                            "L2_category": "Fragrance",
-                            "category_id": "Fragrance",
-                            "price": {
-                                "currency": "INR",
-                                "maximum_value": "253",
-                                "value": "123"
-                            },
-                            "id": "4daf0ef6-520a-4622-aa74-5853fba91345",
-                            "@ondc/org/cancellable": true,
-                            "@ondc/org/returnable": true,
-                            "quantity": {
-                                "available": {
-                                    "count": "135"
-                                },
-                                "maximum": {
-                                    "count": "2"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "Kg",
-                                        "value": "23"
-                                    }
-                                }
-                            },
-                            "@ondc/org/time_to_ship": "PT2H",
-                            "hsn_code": "1234",
-                            "tags": [
-                                {
-                                    "code": "veg_nonveg",
-                                    "list": [
-                                        {
-                                            "code": "nonveg",
-                                            "value": "yes"
-                                        }
-                                    ]
-                                }
-                            ],
-                            "@ondc/org/return_window": "P7D",
-                            "@ondc/org/statutory_reqs_prepackaged_food": {
-                                "ingredients_info": "",
-                                "net_quantity": "",
-                                "additives_info": "",
-                                "manufacturer_or_packer_address": "",
-                                "other_premises": ""
-                            },
-                            "@ondc/org/mandatory_reqs_veggies_fruits": {
-                                "net_quantity": ""
-                            },
-                            "tax_type": "gst",
-                            "domain": "Beauty & Personal Care",
-                            "time": {
-                                "label": "enable",
-                                "timestamp": "2023-10-10T05:42:27.530Z"
-                            },
-                            "fulfillment_id": "1"
-                        },
-                        {
-                            "@ondc/org/statutory_reqs_packaged_commodities": {
-                                "common_or_generic_name_of_commodity": "",
-                                "net_quantity_or_measure_of_commodity_in_pkg": "2 pcs",
-                                "consumer_care_details": "",
-                                "imported_product_country_of_origin": "gggvvcghhhb6",
-                                "description": "xxfffgghhh",
-                                "manufacturer_or_packer_name": "dxxcvvhhhhhhj   ",
-                                "multiple_products_name_number_or_qty": "2",
-                                "manufacturer_or_packer_address": "",
-                                "month_year_of_manufacture_packing_import": "",
-                                "contact_details_consumer_care": "111112222999"
-                            },
-                            "@ondc/org/seller_pickup_return": true,
-                            "@ondc/org/contact_details_consumer_care": "ondc-support@shopeg.in",
-                            "descriptor": {
-                                "symbol": "/data/user/0/com.shopeg.dev/cache/scaled_a361afe2-ff0a-4b5a-9876-dbe0186376c83110379649159751450.jpg",
-                                "images": [
-                                    "/data/user/0/com.shopeg.dev/cache/scaled_a361afe2-ff0a-4b5a-9876-dbe0186376c83110379649159751450.jpg",
-                                    "/data/user/0/com.shopeg.dev/cache/scaled_7288b3b4-e65a-411b-a422-4882bc400734557644514661265758.jpg"
-                                ],
-                                "name": "eee1",
-                                "short_desc": "cccghjjjjjjjj",
-                                "long_desc": ""
-                            },
-                            "location_id": "6275",
-                            "tax_rate": "5",
-                            "@ondc/org/available_on_cod": false,
-                            "L2_category": "Gourmet & World Foods",
-                            "category_id": "Gourmet & World Foods",
-                            "price": {
-                                "currency": "INR",
-                                "maximum_value": "112",
-                                "value": "13"
-                            },
-                            "id": "39a70996-79cd-4de4-a3ce-077c10df2628",
-                            "@ondc/org/cancellable": true,
-                            "@ondc/org/allergen_information": "",
-                            "@ondc/org/returnable": true,
-                            "quantity": {
-                                "available": {
-                                    "count": "3"
-                                },
-                                "maximum": {
-                                    "count": "2"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "",
-                                        "value": 0
-                                    }
-                                }
-                            },
-                            "@ondc/org/time_to_ship": "PT2H",
-                            "hsn_code": "232312",
-                            "@ondc/org/seller_return_pickup": false,
-                            "tags": [
-                                {
-                                    "code": "origin",
-                                    "list": [
-                                        {
-                                            "code": "country",
-                                            "value": "gggvvcghhhb6"
-                                        }
-                                    ]
-                                }
-                            ],
-                            "@ondc/org/return_window": "P7D",
-                            "@ondc/org/statutory_reqs_prepackaged_food": {
-                                "food_additive": "",
-                                "nutritional_information": "",
-                                "brand_owner_name": "",
-                                "consumer_care_details": "",
-                                "country_of_origin_for_imported_product": "",
-                                "brand_owner_FSSAI_license_no": "986867765",
-                                "list_of_ingredients": "",
-                                "storage_information": "",
-                                "other_premises": null
-                            },
-                            "tax_type": "gst",
-                            "domain": "Grocery",
-                            "time": {
-                                "label": "enable",
-                                "time": "2023-08-04T12:25:23.097Z",
-                                "timestamp": "2023-10-10T05:42:27.530Z"
-                            },
-                            "fulfillment_id": "1"
-                        },
-                        {
-                            "@ondc/org/statutory_reqs_packaged_commodities": {
-                                "common_or_generic_name_of_commodity": "",
-                                "net_quantity_or_measure_of_commodity_in_pkg": "1 kg",
-                                "consumer_care_details": "",
-                                "imported_product_country_of_origin": "IND",
-                                "description": "AABBCCDDEEFF 1 KG",
-                                "manufacturer_or_packer_name": "General Mills India Pvt ltd",
-                                "multiple_products_name_number_or_qty": "1",
-                                "manufacturer_or_packer_address": "",
-                                "month_year_of_manufacture_packing_import": "",
-                                "contact_details_consumer_care": "1800-111-789"
-                            },
-                            "@ondc/org/seller_pickup_return": true,
-                            "@ondc/org/contact_details_consumer_care": "ondc-support@shopeg.in",
-                            "descriptor": {
-                                "symbol": "https://shopeg.in/i/eg.png",
-                                "images": [
-                                    "https://shopeg.in/i/eg.png"
-                                ],
-                                "name": "Product 839",
-                                "short_desc": "prdct shrt desc",
-                                "long_desc": ""
-                            },
-                            "location_id": "6275",
-                            "tax_rate": "5",
-                            "@ondc/org/available_on_cod": false,
-                            "L2_category": "Foodgrains",
-                            "category_id": "Foodgrains",
-                            "price": {
-                                "currency": "INR",
-                                "maximum_value": "461",
-                                "maxium_value": "6666",
-                                "value": "60"
-                            },
-                            "id": "3409efee-7809-4560-8e08-47964e04e4b4",
-                            "@ondc/org/cancellable": true,
-                            "@ondc/org/allergen_information": "",
-                            "@ondc/org/returnable": true,
-                            "quantity": {
-                                "available": {
-                                    "count": "2"
-                                },
-                                "maximum": {
-                                    "count": "2"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "",
-                                        "value": 0
-                                    }
-                                }
-                            },
-                            "@ondc/org/time_to_ship": "PT2H",
-                            "hsn_code": "1101",
-                            "@ondc/org/seller_return_pickup": false,
-                            "tags": [
-                                {
-                                    "code": "origin",
-                                    "list": [
-                                        {
-                                            "code": "country",
-                                            "value": "IND"
-                                        }
-                                    ]
-                                }
-                            ],
-                            "@ondc/org/return_window": "P7D",
-                            "@ondc/org/statutory_reqs_prepackaged_food": {
-                                "food_additive": "",
-                                "nutritional_information": "",
-                                "brand_owner_name": "",
-                                "consumer_care_details": "",
-                                "country_of_origin_for_imported_product": "",
-                                "brand_owner_FSSAI_license_no": "68683835353",
-                                "list_of_ingredients": "",
-                                "storage_information": "",
-                                "other_premises": null
-                            },
-                            "tax_type": "gst",
-                            "domain": "Grocery",
-                            "time": {
-                                "label": "enable",
-                                "timestamp": "2023-10-10T05:42:27.530Z"
-                            },
-                            "fulfillment_id": "1"
-                        },
-                        {
-                            "@ondc/org/statutory_reqs_packaged_commodities": {
-                                "common_or_generic_name_of_commodity": "",
-                                "net_quantity_or_measure_of_commodity_in_pkg": "1 kg",
-                                "consumer_care_details": "",
-                                "imported_product_country_of_origin": "IND",
-                                "description": "AABBCCDDEEFF 1 KG",
-                                "manufacturer_or_packer_name": "General Mills India Pvt ltd",
-                                "multiple_products_name_number_or_qty": "1",
-                                "manufacturer_or_packer_address": "",
-                                "month_year_of_manufacture_packing_import": "",
-                                "contact_details_consumer_care": "1800-111-789"
-                            },
-                            "@ondc/org/seller_pickup_return": true,
-                            "@ondc/org/contact_details_consumer_care": "ondc-support@shopeg.in",
-                            "descriptor": {
-                                "symbol": "https://shopeg.in/i/eg.png",
-                                "images": [
-                                    "https://shopeg.in/i/eg.png"
-                                ],
-                                "name": "Product 832",
-                                "short_desc": "prdct shrt desc",
-                                "long_desc": ""
-                            },
-                            "location_id": "6275",
-                            "tax_rate": "5",
-                            "@ondc/org/available_on_cod": false,
-                            "L2_category": "Foodgrains",
-                            "category_id": "Foodgrains",
-                            "price": {
-                                "currency": "INR",
-                                "maximum_value": "80001",
-                                "maxium_value": "6666",
-                                "value": "7005"
-                            },
-                            "id": "90144eb6-8446-409c-aa87-681b354c7045",
-                            "@ondc/org/cancellable": true,
-                            "@ondc/org/allergen_information": "",
-                            "@ondc/org/returnable": true,
-                            "quantity": {
-                                "available": {
-                                    "count": "2"
-                                },
-                                "maximum": {
-                                    "count": "2"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "",
-                                        "value": 0
-                                    }
-                                }
-                            },
-                            "@ondc/org/time_to_ship": "PT2H",
-                            "hsn_code": "1101",
-                            "@ondc/org/seller_return_pickup": false,
-                            "tags": [
-                                {
-                                    "code": "origin",
-                                    "list": [
-                                        {
-                                            "code": "country",
-                                            "value": "IND"
-                                        }
-                                    ]
-                                }
-                            ],
-                            "@ondc/org/return_window": "P7D",
-                            "@ondc/org/statutory_reqs_prepackaged_food": {
-                                "food_additive": "",
-                                "nutritional_information": "",
-                                "brand_owner_name": "",
-                                "consumer_care_details": "",
-                                "country_of_origin_for_imported_product": "",
-                                "brand_owner_FSSAI_license_no": "8666976767",
-                                "list_of_ingredients": "",
-                                "storage_information": "",
-                                "other_premises": null
-                            },
-                            "tax_type": "gst",
-                            "domain": "Grocery",
-                            "time": {
-                                "label": "enable",
-                                "timestamp": "2023-10-10T05:42:27.530Z"
-                            },
-                            "fulfillment_id": "1"
-                        }
-                    ],
-                    "fulfillments": [
-                        {
-                            "contact": {
-                                "email": "ondc-support@shopeg.in"
-                            },
-                            "id": "1",
-                            "type": "Delivery"
-                        }
-                    ],
-                    "tags": [
-                        {
-                            "code": "serviceability",
-                            "list": [
-                                {
-                                    "code": "location",
-                                    "value": "6275"
-                                },
-                                {
-                                    "code": "category",
-                                    "value": "Bath & Body"
-                                },
-                                {
-                                    "code": "type",
-                                    "value": "10"
-                                },
-                                {
-                                    "code": "val",
-                                    "value": "5"
-                                },
-                                {
-                                    "code": "unit",
-                                    "value": "km"
-                                }
-                            ]
-                        }
-                    ]
-                },
                 {
                     "id": "nynGrPkGHzKUiR64S3Mw",
                     "time": {
                         "label": "enable",
-                        "timestamp": "2023-10-27T16:00:20.865Z"
+                        "timestamp": "2023-11-10T12:00:06.880Z"
                     },
                     "ttl": "P1D",
                     "descriptor": {
@@ -7497,7 +31,7 @@
                         ],
                         "name": "Vijai ondc test shop",
                         "short_desc": "Ondc test shop ",
-                        "long_desc": "Test shop for ondc"
+                        "long_desc": "Ondc test shop "
                     },
                     "locations": [
                         {
@@ -7514,7 +48,7 @@
                                 "city": "Bengaluru",
                                 "street": "Bangalore ",
                                 "area_code": "560038",
-                                "name": "Vijai's ondc test shop",
+                                "name": "Vijai ondc test shop",
                                 "locality": "",
                                 "state": "Karnataka",
                                 "building": "Indira nagar"
@@ -7531,7 +65,7 @@
                                 },
                                 "days": "1,2,3,4,5,6,7",
                                 "label": "enable",
-                                "timestamp": "2023-10-27T16:00:20.865Z"
+                                "timestamp": "2023-11-10T12:00:06.880Z"
                             },
                             "circle": {
                                 "gps": "12.9749164,77.6366598",
@@ -7546,80 +80,375 @@
                         {
                             "@ondc/org/TAT": "P6D",
                             "@ondc/org/statutory_reqs_packaged_commodities": {
-                                "common_or_generic_name_of_commodity": "Bath & Hand Wash",
-                                "net_quantity_or_measure_of_commodity_in_pkg": "Combo (2 Items)",
-                                "imported_product_country_of_origin": "India",
-                                "description": "Yardley London English Rose Perfumed Talc 250 g + English Lavender Perfumed Talc 250 g, Combo (2 Items)",
-                                "manufacturer_or_packer_name": "Wipro Enterprises (P) Ltd., Doddakannelli, Sarjapur Road, Bengaluru - 560 035, India",
-                                "manufacturer_or_packer_address": "Wipro Enterprises (P) Ltd., Doddakannelli, Sarjapur Road, Bengaluru - 560 035, India",
+                                "common_or_generic_name_of_commodity": "Spices & Masala",
+                                "net_quantity_or_measure_of_commodity_in_pkg": "200 g",
+                                "imported_product_country_of_origin": "IND",
+                                "description": "Everest Masala - Chhole, 200 g Jar",
+                                "manufacturer_or_packer_name": "4/B,L.B.S Marg, Vikhroli(W), Mumbai-400083,Maharastra",
+                                "multiple_products_name_number_or_qty": "km",
+                                "manufacturer_or_packer_address": "4/B,L.B.S Marg, Vikhroli(W), Mumbai-400083,Maharastra",
                                 "month_year_of_manufacture_packing_import": ""
                             },
                             "@ondc/org/seller_pickup_return": true,
-                            "@ondc/org/contact_details_consumer_care": "",
+                            "@ondc/org/contact_details_consumer_care": "John Nov9,John@acme.com,9911991199",
                             "descriptor": {
-                                "symbol": "https://datalabs.siva3.io/image/Eunimart_groceries_208262_1-yardley-london-english-rose-perfumed-talc-250-g-english-lavender-perfumed-talc-250-g.jpg",
+                                "symbol": "https://datalabs.siva3.io/image/Eunimart_groceries_40129026_4-everest-masala-chhole.jpg",
                                 "images": [
-                                    "https://datalabs.siva3.io/image/Eunimart_groceries_208262_1-yardley-london-english-rose-perfumed-talc-250-g-english-lavender-perfumed-talc-250-g.jpg"
+                                    "https://datalabs.siva3.io/image/Eunimart_groceries_40129026_4-everest-masala-chhole.jpg",
+                                    "https://datalabs.siva3.io/image/Eunimart_groceries_40129026-2_4-everest-masala-chhole.jpg",
+                                    "https://datalabs.siva3.io/image/Eunimart_groceries_40129026-3_4-everest-masala-chhole.jpg"
                                 ],
-                                "name": "Yardley London English Rose Po",
-                                "short_desc": "With over 200 years' expertise, Yardley London selects only the finest ingredients to create its unforgettable fragrances. This is a fine, silky luxury talcum powder and will leave your skin feeling soft and subtly fragrant all day long. This luxurious rose scented talcum powder will keep you fresh, smooth, and scented throughout the day.\r\n\r\nIt takes the world's finest natural lavender oils and over 200 years' expertise to create Yardley English Lavender. This is a fine, silky luxury talcum powder and will leave your skin feeling soft and subtly fragrant all day. This luxurious talcum powder will keep you fresh, smooth, and scented throughout the day.",
-                                "long_desc": "With over 200 years' expertise, Yardley London selects only the finest ingredients to create its unforgettable fragrances. This is a fine, silky luxury talcum powder and will leave your skin feeling soft and subtly fragrant all day long. This luxurious rose scented talcum powder will keep you fresh, smooth, and scented throughout the day.\r\n\r\nIt takes the world's finest natural lavender oils and over 200 years' expertise to create Yardley English Lavender. This is a fine, silky luxury talcum powder and will leave your skin feeling soft and subtly fragrant all day. This luxurious talcum powder will keep you fresh, smooth, and scented throughout the day."
+                                "name": "Everest Masala - Chhole, 200 g Jar",
+                                "short_desc": "Everest presents their authentic range of masalas that are blended with a wide variety of handpicked and selected spices that bring a whole new flavour and meaning to your dishes. Rake up your favourite recipes and cuisines by adding this magical blend of Everest masalas.",
+                                "long_desc": "Everest presents their authentic range of masalas that are blended with a wide variety of handpicked and selected spices that bring a whole new flavour and meaning to your dishes. Rake up your favourite recipes and cuisines by adding this magical blend of Everest masalas."
                             },
+                            "tax_rate": "18",
                             "location_id": "6879",
                             "@ondc/org/available_on_cod": false,
-                            "L2_category": "Beauty & Hygiene",
-                            "category_id": "Beauty & Hygiene",
+                            "L2_category": "Masala & Seasoning",
+                            "category_id": "Masala & Seasoning",
                             "price": {
                                 "currency": "INR",
-                                "maximum_value": "370",
-                                "value": "370"
+                                "maximum_value": "162",
+                                "value": "162"
                             },
-                            "id": "f90307a0-3cd1-4146-9784-dd5e9fe8cf41",
+                            "id": "f52e7ea6-1f24-4c84-a783-7cf74da3300e",
                             "@ondc/org/cancellable": true,
                             "@ondc/org/returnable": true,
                             "quantity": {
                                 "available": {
-                                    "count": "1"
+                                    "count": "5"
                                 },
                                 "maximum": {
-                                    "count": "3"
+                                    "count": "2"
                                 },
                                 "unitized": {
                                     "measure": {
-                                        "value": ""
+                                        "unit": "g",
+                                        "value": "200"
                                     }
                                 }
                             },
                             "@ondc/org/time_to_ship": "P3D",
-                            "hsn_code": "",
-                            "tags": [],
+                            "hsn_code": "1234567",
+                            "tags": [
+                                {
+                                    "code": "veg_nonveg",
+                                    "list": [
+                                        {
+                                            "code": "veg",
+                                            "value": "yes"
+                                        }
+                                    ]
+                                }
+                            ],
                             "@ondc/org/return_window": "P14D",
                             "@ondc/org/statutory_reqs_prepackaged_food": {
-                                "importer_FSSAI_license_no": null,
-                                "nutritional_info": null,
-                                "other_importer_address": null,
+                                "importer_FSSAI_license_no": "686868",
+                                "nutritional_info": " bchhcc",
+                                "other_importer_address": "ufuf",
                                 "importer_fssai_logo": null,
-                                "importer_address": null,
-                                "other_importer_name": null,
-                                "brand_owner_FSSAI_license_no": null,
-                                "net_quantity": null,
-                                "additives_info": null,
-                                "other_premises": null,
-                                "importer_name": null,
-                                "brand_owner_address": null,
+                                "importer_address": "chcuuf",
+                                "other_importer_name": "fiif",
+                                "brand_owner_FSSAI_license_no": "123456789",
+                                "net_quantity": "5335",
+                                "additives_info": "xhch",
+                                "other_premises": "hxhxxh",
+                                "importer_name": "hcucuf",
+                                "brand_owner_address": "ch",
                                 "brand_owner_fssai_logo": null,
-                                "ingredients_info": null,
-                                "other_FSSAI_license_no": null,
-                                "brand_owner_name": "Yardley London",
-                                "imported_product_country_of_origin": null,
-                                "manufacturer_or_packer_name": null,
-                                "manufacturer_or_packer_address": null
+                                "ingredients_info": "ccv",
+                                "other_FSSAI_license_no": "6886",
+                                "brand_owner_name": "xhc",
+                                "imported_product_country_of_origin": "IND",
+                                "manufacturer_or_packer_name": "chcj",
+                                "manufacturer_or_packer_address": "chch"
                             },
                             "tax_type": "gst",
                             "domain": "Grocery",
                             "time": {
                                 "label": "enable",
                                 "timestamp": "2023-10-18T08:49:13.972Z"
+                            },
+                            "fulfillment_id": "1"
+                        },
+                        {
+                            "@ondc/org/statutory_reqs_packaged_commodities": {
+                                "common_or_generic_name_of_commodity": "Ready To Cook & Eat",
+                                "net_quantity_or_measure_of_commodity_in_pkg": "45 g",
+                                "imported_product_country_of_origin": "India",
+                                "manufacturer_or_packer_name": "MTR FOODS PVT LTD, No.1, 2nd &3rd Floor, 100 Feet Inner Ring Road, Ejipura, Bengaluru -560047",
+                                "multiple_products_name_number_or_qty": "NA",
+                                "manufacturer_or_packer_address": "MTR FOODS PVT LTD, No.1, 2nd &3rd Floor, 100 Feet Inner Ring Road, Ejipura, Bengaluru -560047",
+                                "month_year_of_manufacture_packing_import": "10/2023"
+                            },
+                            "@ondc/org/seller_pickup_return": true,
+                            "@ondc/org/contact_details_consumer_care": "John Nov9,John@acme.com,9911991199",
+                            "descriptor": {
+                                "symbol": "https://datalabs.siva3.io/image/Eunimart_groceries_40001445_6-mtr-breakfast-mix-oats-idli.jpg",
+                                "images": [
+                                    "https://datalabs.siva3.io/image/Eunimart_groceries_40001445_6-mtr-breakfast-mix-oats-idli.jpg",
+                                    "https://datalabs.siva3.io/image/Eunimart_groceries_40001445-2_6-mtr-breakfast-mix-oats-idli.jpg",
+                                    "https://datalabs.siva3.io/image/Eunimart_groceries_40001445-3_6-mtr-breakfast-mix-oats-idli.jpg"
+                                ],
+                                "name": "MTR Original Oats Idli Ready Mix, 500 g Pouch",
+                                "short_desc": "MTR Breakfast Mix - Oats Idli fill your tummy instantly with the strong and nutritious. Take the package and break your hunger pang with the greatest flavor and ready to get arranged quickly Oats Idli. It has been extracted from the delicately graded ingredients. It is also completely free from cholesterol and any fake Colors.",
+                                "long_desc": "MTR Breakfast Mix - Oats Idli fill your tummy instantly with the strong and nutritious. Take the package and break your hunger pang with the greatest flavor and ready to get arranged quickly Oats Idli. It has been extracted from the delicately graded ingredients. It is also completely free from cholesterol and any fake Colors."
+                            },
+                            "location_id": "6879",
+                            "tax_rate": "18",
+                            "@ondc/org/available_on_cod": false,
+                            "contact_details_consumer_care_email": "vijai.c@beyondseek.com",
+                            "L2_category": "Snacks & Branded Foods",
+                            "category_id": "Snacks & Branded Foods",
+                            "price": {
+                                "currency": "INR",
+                                "maximum_value": "165",
+                                "value": "165"
+                            },
+                            "id": "434300be-f283-447d-8137-958234517d01",
+                            "@ondc/org/fssai_license_no": "1234587",
+                            "@ondc/org/cancellable": true,
+                            "@ondc/org/tat": "P6D",
+                            "@ondc/org/returnable": true,
+                            "quantity": {
+                                "available": {
+                                    "count": "4"
+                                },
+                                "maximum": {
+                                    "count": "3"
+                                },
+                                "unitized": {
+                                    "measure": {
+                                        "unit": "gram",
+                                        "value": "45"
+                                    }
+                                }
+                            },
+                            "@ondc/org/time_to_ship": "P3D",
+                            "contact_details_consumer_care_name": "vijai",
+                            "contact_details_consumer_care_contactno": "9884012345",
+                            "product_master_uuid": "32ff335a-1ce8-4a9a-b26f-2f6da2d4a456",
+                            "hsn_code": "45454",
+                            "tags": [
+                                {
+                                    "code": "origin",
+                                    "list": [
+                                        {
+                                            "code": "country",
+                                            "value": "IND"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "@ondc/org/return_window": "P14D",
+                            "@ondc/org/statutory_reqs_prepackaged_food": {
+                                "importer_FSSAI_license_no": "494949",
+                                "nutritional_info": "zbannz",
+                                "other_importer_address": "snsnsn",
+                                "importer_address": "sbsb",
+                                "other_importer_name": "zbzbz",
+                                "brand_owner_FSSAI_license_no": "464694",
+                                "net_quantity": "45 g",
+                                "additives_info": "sbbsbs",
+                                "other_premises": "snsns",
+                                "importer_name": "sbsb",
+                                "brand_owner_address": "snsnns",
+                                "ingredients_info": "sbzbsb",
+                                "other_FSSAI_license_no": "1234579",
+                                "brand_owner_name": "MTR",
+                                "imported_product_country_of_origin": "IND",
+                                "manufacturer_or_packer_name": "shsn",
+                                "manufacturer_or_packer_address": "sbsnsn"
+                            },
+                            "tax_type": "gst",
+                            "domain": "Grocery",
+                            "time": {
+                                "label": "enable",
+                                "timestamp": "2023-10-28T14:47:40.655Z"
+                            },
+                            "fulfillment_id": "1"
+                        },
+                        {
+                            "@ondc/org/TAT": "P6D",
+                            "@ondc/org/statutory_reqs_packaged_commodities": {
+                                "common_or_generic_name_of_commodity": "NA",
+                                "net_quantity_or_measure_of_commodity_in_pkg": "50 g",
+                                "imported_product_country_of_origin": "IND",
+                                "manufacturer_or_packer_name": "Aachi",
+                                "multiple_products_name_number_or_qty": "500 g",
+                                "manufacturer_or_packer_address": "NA",
+                                "month_year_of_manufacture_packing_import": "08/2023"
+                            },
+                            "@ondc/org/seller_pickup_return": true,
+                            "@ondc/org/contact_details_consumer_care": "John Nov9,John@acme.com,9911991199",
+                            "descriptor": {
+                                "symbol": "https://firebasestorage.googleapis.com/v0/b/shopeg-dev.appspot.com/o/shopImages%2FVdxkoawpDWWiinBxbUjsYRnPl3x2%2Fimg_1692164210702.jpg?alt=media&token=4f5bd20e-2094-43a2-9a66-71732d1df66f",
+                                "images": [
+                                    "https://firebasestorage.googleapis.com/v0/b/shopeg-dev.appspot.com/o/shopImages%2FVdxkoawpDWWiinBxbUjsYRnPl3x2%2Fimg_1692164210702.jpg?alt=media&token=4f5bd20e-2094-43a2-9a66-71732d1df66f"
+                                ],
+                                "name": "Aachi urdal dal",
+                                "short_desc": "Urad dal",
+                                "long_desc": "urad dal"
+                            },
+                            "location_id": "6879",
+                            "tax_rate": "5",
+                            "@ondc/org/available_on_cod": false,
+                            "contact_details_consumer_care_email": "vijai.c@beyondseek.com",
+                            "L2_category": "Foodgrains",
+                            "category_id": "Foodgrains",
+                            "price": {
+                                "currency": "INR",
+                                "maximum_value": "200",
+                                "value": "185"
+                            },
+                            "id": "406459af-7a0b-4a6f-bf33-4658dff5540d",
+                            "@ondc/org/cancellable": true,
+                            "@ondc/org/tat": "P6D",
+                            "@ondc/org/returnable": true,
+                            "quantity": {
+                                "available": {
+                                    "count": "52"
+                                },
+                                "maximum": {
+                                    "count": "5"
+                                },
+                                "unitized": {
+                                    "measure": {
+                                        "unit": "gram",
+                                        "value": "50"
+                                    }
+                                }
+                            },
+                            "@ondc/org/time_to_ship": "P3D",
+                            "contact_details_consumer_care_name": "vijaj",
+                            "contact_details_consumer_care_contactno": "9884012345",
+                            "hsn_code": "123456",
+                            "tags": [
+                                {
+                                    "code": "origin",
+                                    "list": [
+                                        {
+                                            "code": "country",
+                                            "value": "IND"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "@ondc/org/return_window": "P14D",
+                            "@ondc/org/statutory_reqs_prepackaged_food": {
+                                "importer_FSSAI_license_no": "79494994",
+                                "nutritional_info": "NA",
+                                "other_importer_address": "NA",
+                                "importer_address": "NA",
+                                "other_importer_name": "NA",
+                                "brand_owner_FSSAI_license_no": "123456789",
+                                "net_quantity": "794946494",
+                                "additives_info": "NA",
+                                "other_premises": "NA",
+                                "importer_name": "Aachi",
+                                "brand_owner_address": "NA",
+                                "ingredients_info": "NA",
+                                "other_FSSAI_license_no": "124345648797",
+                                "brand_owner_name": "NA",
+                                "imported_product_country_of_origin": "IND",
+                                "manufacturer_or_packer_name": "NA",
+                                "manufacturer_or_packer_address": "NA"
+                            },
+                            "@ondc/org/mandatory_reqs_veggies_fruits": {
+                                "net_quantity": "50 g"
+                            },
+                            "tax_type": "gst",
+                            "domain": "Grocery",
+                            "time": {
+                                "label": "enable",
+                                "timestamp": "2023-11-08T06:25:57.397Z"
+                            },
+                            "fulfillment_id": "1"
+                        },
+                        {
+                            "@ondc/org/seller_pickup_return": true,
+                            "@ondc/org/contact_details_consumer_care": "John Nov9,John@acme.com,9911991199",
+                            "descriptor": {
+                                "symbol": "https://datalabs.siva3.io/image/Eunimart_groceries_40292294_1-sarati-instant-rava-dosa-mix.jpg",
+                                "images": [
+                                    "https://datalabs.siva3.io/image/Eunimart_groceries_40292294_1-sarati-instant-rava-dosa-mix.jpg",
+                                    "https://datalabs.siva3.io/image/Eunimart_groceries_40292294-2_1-sarati-instant-rava-dosa-mix.jpg",
+                                    "https://datalabs.siva3.io/image/Eunimart_groceries_40292294-3_1-sarati-instant-rava-dosa-mix.jpg"
+                                ],
+                                "name": "Sarati Instant Rava Dosa Mix, 500 g",
+                                "short_desc": "Sarati Instant presents Instant Rava Dosa Mix is Sourced From high-quality grains like Wheat, Millets, Grams and Pulses are grown using nature-friendly farming methods and ensuring the Product is Safe. Delightfully crispy and golden on the edges, Rava Dosa is quite the signature dish. Follow the easy instructions to prepare it in a jiffy! Delightfully crisp and golden rice dosas A delicious traditional breakfast ready in an instant.",
+                                "long_desc": "Sarati Instant presents Instant Rava Dosa Mix is Sourced From high-quality grains like Wheat, Millets, Grams and Pulses are grown using nature-friendly farming methods and ensuring the Product is Safe. Delightfully crispy and golden on the edges, Rava Dosa is quite the signature dish. Follow the easy instructions to prepare it in a jiffy! Delightfully crisp and golden rice dosas A delicious traditional breakfast ready in an instant."
+                            },
+                            "location_id": "6879",
+                            "tax_rate": "18",
+                            "@ondc/org/available_on_cod": true,
+                            "contact_details_consumer_care_email": "vijai.c@beyondseek.com",
+                            "L2_category": "Snacks & Branded Foods",
+                            "category_id": "Snacks & Branded Foods",
+                            "price": {
+                                "currency": "INR",
+                                "maximum_value": "120",
+                                "value": "120"
+                            },
+                            "id": "fe6dd75d-8515-41a3-8e3c-513c67739ac9",
+                            "@ondc/org/cancellable": true,
+                            "@ondc/org/tat": "P6D",
+                            "@ondc/org/returnable": true,
+                            "quantity": {
+                                "available": {
+                                    "count": "3"
+                                },
+                                "maximum": {
+                                    "count": "3"
+                                },
+                                "unitized": {
+                                    "measure": {
+                                        "unit": "gram",
+                                        "value": "8683"
+                                    }
+                                }
+                            },
+                            "@ondc/org/time_to_ship": "P3D",
+                            "contact_details_consumer_care_name": "vijai c",
+                            "contact_details_consumer_care_contactno": "9884012345",
+                            "product_master_uuid": "7d7ad294-bc8d-4547-8fd2-663a31bed682",
+                            "hsn_code": "6868",
+                            "tags": [
+                                {
+                                    "code": "origin",
+                                    "list": [
+                                        {
+                                            "code": "country",
+                                            "value": "IND"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "@ondc/org/return_window": "P14D",
+                            "@ondc/org/statutory_reqs_prepackaged_food": {
+                                "importer_FSSAI_license_no": "8386299",
+                                "nutritional_info": "vuvi",
+                                "other_importer_address": "vuv",
+                                "importer_address": "fuc",
+                                "other_importer_name": "vhvuc",
+                                "brand_owner_FSSAI_license_no": "99888",
+                                "net_quantity": "8683 gram",
+                                "additives_info": "cyvuv",
+                                "other_premises": "vjvu",
+                                "importer_name": "tgg",
+                                "brand_owner_address": "ggf",
+                                "ingredients_info": "xgch",
+                                "other_FSSAI_license_no": "06060",
+                                "brand_owner_name": "Sarati Instant",
+                                "manufacturer_or_packer_name": " g",
+                                "manufacturer_or_packer_address": "vh"
+                            },
+                            "tax_type": "gst",
+                            "domain": "Grocery",
+                            "time": {
+                                "label": "enable",
+                                "timestamp": "2023-11-09T11:57:40.331Z"
                             },
                             "fulfillment_id": "1"
                         },
@@ -7635,7 +464,7 @@
                                 "manufacturer_or_packer_address": "VENDIMIA FOOD PRIVATE LIMITED. Registered Office: #1882, 2nd Floor, 10th Main, 31st Cross, Banashankari, 2nd Stage, Bangalore - 560070, Karnataka",
                                 "month_year_of_manufacture_packing_import": "09/2023"
                             },
-                            "@ondc/org/contact_details_consumer_care": "vijai@ondc.com",
+                            "@ondc/org/contact_details_consumer_care": "John Nov9,John@acme.com,9911991199",
                             "@ondc/org/seller_pickup_return": true,
                             "descriptor": {
                                 "symbol": "https://datalabs.siva3.io/image/Eunimart_groceries_40147743_2-graminway-chatpata-chaat-masala.jpg",
@@ -7719,36 +548,31 @@
                             "fulfillment_id": "1"
                         },
                         {
-                            "@ondc/org/statutory_reqs_packaged_commodities": {
-                                "common_or_generic_name_of_commodity": "Bath & Hand Wash",
-                                "manufacturer_or_packer_name": "Wipro Enterprises (P) Ltd., 8, Wipro House, 80 Ft Road, Koramangala, Bengaluru-560 034, Karnataka",
-                                "multiple_products_name_number_or_qty": "na",
-                                "manufacturer_or_packer_address": "Wipro Enterprises (P) Ltd., 8, Wipro House, 80 Ft Road, Koramangala, Bengaluru-560 034, Karnataka"
-                            },
                             "@ondc/org/seller_pickup_return": true,
+                            "@ondc/org/contact_details_consumer_care": "John Nov9,John@acme.com,9911991199",
                             "descriptor": {
-                                "symbol": "https://datalabs.siva3.io/image/Eunimart_groceries_40240495_2-santoor-blushing-skin-body-wash-enriched-with-indian-wild-rose-himalayan-honey.jpg",
+                                "symbol": "https://datalabs.siva3.io/image/Eunimart_groceries_40292303_1-sarati-instant-shavige-rava-upma-mix-traditional-breakfast.jpg",
                                 "images": [
-                                    "https://datalabs.siva3.io/image/Eunimart_groceries_40240495_2-santoor-blushing-skin-body-wash-enriched-with-indian-wild-rose-himalayan-honey.jpg",
-                                    "https://datalabs.siva3.io/image/Eunimart_groceries_40240495-2_2-santoor-blushing-skin-body-wash-enriched-with-indian-wild-rose-himalayan-honey.jpg",
-                                    "https://datalabs.siva3.io/image/Eunimart_groceries_40240495-3_1-santoor-blushing-skin-body-wash-enriched-with-indian-wild-rose-himalayan-honey.jpg"
+                                    "https://datalabs.siva3.io/image/Eunimart_groceries_40292303_1-sarati-instant-shavige-rava-upma-mix-traditional-breakfast.jpg",
+                                    "https://datalabs.siva3.io/image/Eunimart_groceries_40292303-2_1-sarati-instant-shavige-rava-upma-mix-traditional-breakfast.jpg",
+                                    "https://datalabs.siva3.io/image/Eunimart_groceries_40292303-3_1-sarati-instant-shavige-rava-upma-mix-traditional-breakfast.jpg"
                                 ],
-                                "name": "Santoor Blushing Skin Body Wash - Enriched With Indian Wild Rose & Himalayan Honey, 230 ml",
-                                "short_desc": "Introducing New Santoor Bodywashes, made with organically grown aromatic ingredients which are combined by hand in small batches to make them sensorially rewarding. We take great care to watch what goes into each bottle. Nurture your skin with Santoor Blushing Body Wash, enriched with Indian Wild Roses and Himalayan Honey. It soothes your skin while removing oiliness to give you a fresh, natural no-filter look. It is soap-free and paraben-free!",
-                                "long_desc": "Introducing New Santoor Bodywashes, made with organically grown aromatic ingredients which are combined by hand in small batches to make them sensorially rewarding. We take great care to watch what goes into each bottle. Nurture your skin with Santoor Blushing Body Wash, enriched with Indian Wild Roses and Himalayan Honey. It soothes your skin while removing oiliness to give you a fresh, natural no-filter look. It is soap-free and paraben-free!"
+                                "name": "Sarati Instant Shavige Rava Upma Mix - Traditional Breakfast, 200 g",
+                                "short_desc": "Sarati Instant presents Instant Shavige Rava Upma Mix is Sourced From high-quality grains Like Wheat, Rice millet,Grams and Pulses are grown using nature-friendly farming methods and ensuring the Product is Safe. Upma is appreciated by all for its aroma, texture and taste. Upma is good in taste and easy in cooking that proves to be a healthy breakfast always and ever. Instant Shavige Rava Upma mix-make upma like granny or mommy did. No more waiting, just steaming!",
+                                "long_desc": "Sarati Instant presents Instant Shavige Rava Upma Mix is Sourced From high-quality grains Like Wheat, Rice millet,Grams and Pulses are grown using nature-friendly farming methods and ensuring the Product is Safe. Upma is appreciated by all for its aroma, texture and taste. Upma is good in taste and easy in cooking that proves to be a healthy breakfast always and ever. Instant Shavige Rava Upma mix-make upma like granny or mommy did. No more waiting, just steaming!"
                             },
                             "location_id": "6879",
                             "tax_rate": "18",
                             "@ondc/org/available_on_cod": true,
                             "contact_details_consumer_care_email": "vijai.c@beyondseek.com",
-                            "L2_category": "Beauty & Hygiene",
-                            "category_id": "Beauty & Hygiene",
+                            "L2_category": "Snacks & Branded Foods",
+                            "category_id": "Snacks & Branded Foods",
                             "price": {
                                 "currency": "INR",
-                                "maximum_value": "184",
-                                "value": "184"
+                                "maximum_value": "85",
+                                "value": "85"
                             },
-                            "id": "5374bee7-2c22-470f-8846-d1273ff98003",
+                            "id": "b7b972ad-2992-4692-99fa-d7358f8431d2",
                             "@ondc/org/cancellable": true,
                             "@ondc/org/tat": "P6D",
                             "@ondc/org/returnable": true,
@@ -7762,15 +586,15 @@
                                 "unitized": {
                                     "measure": {
                                         "unit": "gram",
-                                        "value": "50"
+                                        "value": "55"
                                     }
                                 }
                             },
                             "@ondc/org/time_to_ship": "P3D",
-                            "contact_details_consumer_care_name": "vijai",
-                            "contact_details_consumer_care_contactno": "9884012345",
-                            "product_master_uuid": "44b070dd-b140-4335-acd4-056843904878",
-                            "hsn_code": "123456",
+                            "contact_details_consumer_care_name": "vijai ",
+                            "contact_details_consumer_care_contactno": "9884044494",
+                            "product_master_uuid": "5e44e8a6-665c-4190-8ce7-1c5ff371d2b3",
+                            "hsn_code": "1234567890",
                             "tags": [
                                 {
                                     "code": "origin",
@@ -7783,57 +607,72 @@
                                 }
                             ],
                             "@ondc/org/return_window": "P14D",
+                            "@ondc/org/statutory_reqs_prepackaged_food": {
+                                "importer_FSSAI_license_no": "555888",
+                                "nutritional_info": "na",
+                                "other_importer_address": "chch",
+                                "importer_address": "ggg",
+                                "other_importer_name": "chch",
+                                "brand_owner_FSSAI_license_no": "8888",
+                                "additives_info": "na",
+                                "other_premises": "cucuc",
+                                "importer_name": "cfgf",
+                                "brand_owner_address": "vijai ",
+                                "ingredients_info": "na",
+                                "other_FSSAI_license_no": "868686868",
+                                "brand_owner_name": "Sarati Instant",
+                                "manufacturer_or_packer_name": "vijai ",
+                                "manufacturer_or_packer_address": "vijai "
+                            },
                             "tax_type": "gst",
                             "domain": "Grocery",
                             "time": {
                                 "label": "enable",
-                                "timestamp": "2023-10-27T12:04:19.387Z"
+                                "timestamp": "2023-11-09T11:59:45.631Z"
                             },
                             "fulfillment_id": "1"
                         },
                         {
                             "@ondc/org/TAT": "P6D",
                             "@ondc/org/statutory_reqs_packaged_commodities": {
-                                "common_or_generic_name_of_commodity": "",
-                                "net_quantity_or_measure_of_commodity_in_pkg": "2 kg",
-                                "consumer_care_details": "",
-                                "imported_product_country_of_origin": "ITC India Pvt ltd. 404, Powai, Mumbai- 400071",
-                                "description": "Atta",
-                                "manufacturer_or_packer_name": "ITC India Pvt ltd",
-                                "multiple_products_name_number_or_qty": "2",
-                                "manufacturer_or_packer_address": "",
-                                "month_year_of_manufacture_packing_import": "",
-                                "contact_details_consumer_care": "1800-100-123"
+                                "net_quantity_or_measure_of_commodity_in_pkg": "7949 Kg",
+                                "common_or_generic_name_of_commodity": "sbsbs",
+                                "imported_product_country_of_origin": "India",
+                                "manufacturer_or_packer_name": "Panchakarma Herbs Pvt. Ltd. Village Katri Shankarpur Sarai, Near Ganga Barrage Kanpur Nagar, Bilhaur Tahsil, Kanpur Nagar Uttar Pradesh 208 002",
+                                "multiple_products_name_number_or_qty": "baba",
+                                "manufacturer_or_packer_address": "hshshs",
+                                "month_year_of_manufacture_packing_import": "09/2023"
                             },
-                            "return_window": null,
                             "@ondc/org/seller_pickup_return": true,
-                            "@ondc/org/contact_details_consumer_care": "ondc-support@shopeg.in",
+                            "@ondc/org/contact_details_consumer_care": "John Nov9,John@acme.com,9911991199",
                             "descriptor": {
-                                "symbol": "https://shopeg.in/i/eg.png",
+                                "symbol": "https://datalabs.siva3.io/image/Eunimart_groceries_40228625_2-indisecrets-organic-tulsi-honey-chamomile.jpg",
                                 "images": [
-                                    "https://shopeg.in/i/eg.png"
+                                    "https://datalabs.siva3.io/image/Eunimart_groceries_40228625_2-indisecrets-organic-tulsi-honey-chamomile.jpg",
+                                    "https://datalabs.siva3.io/image/Eunimart_groceries_40228625-2_2-indisecrets-organic-tulsi-honey-chamomile.jpg",
+                                    "https://datalabs.siva3.io/image/Eunimart_groceries_40228625-3_2-indisecrets-organic-tulsi-honey-chamomile.jpg"
                                 ],
-                                "name": "Ashirvad 2 kg atta",
-                                "short_desc": "Ashiiiirvad 2kg atta",
-                                "long_desc": ""
+                                "name": "IndiSecrets Organic Chamomile Tea - Tulsi Honey, 36 g (20 Bags x 1.8 g each)",
+                                "short_desc": "IndiSecrets Organic Chamomile Tea - Tulsi Honey",
+                                "long_desc": "IndiSecrets Organic Chamomile Tea - Tulsi Honey"
                             },
                             "location_id": "6879",
-                            "tax_rate": "18",
+                            "tax_rate": "5",
                             "@ondc/org/available_on_cod": false,
-                            "L2_category": "Foodgrains",
-                            "category_id": "Foodgrains",
+                            "L2_category": "Beverages",
+                            "category_id": "Beverages",
                             "price": {
                                 "currency": "INR",
-                                "maximum_value": "145",
-                                "value": "140"
+                                "maximum_value": "139",
+                                "value": "139"
                             },
-                            "id": "vijai-asdf-4889-a7c4-11223344",
+                            "location_details.id": "6879",
+                            "id": "4c539226-d858-4841-935a-811ee68ca531",
                             "@ondc/org/cancellable": true,
-                            "@ondc/org/allergen_information": "",
                             "@ondc/org/returnable": true,
                             "quantity": {
                                 "available": {
-                                    "count": "10"
+                                    "count": "3"
                                 },
                                 "maximum": {
                                     "count": "3"
@@ -7841,24 +680,13 @@
                                 "unitized": {
                                     "measure": {
                                         "unit": "Kg",
-                                        "value": "2"
+                                        "value": "7949"
                                     }
                                 }
                             },
                             "@ondc/org/time_to_ship": "P3D",
-                            "hsn_code": "1000",
-                            "@ondc/org/seller_return_pickup": false,
-                            "fulfillment_id": "1",
+                            "hsn_code": "4949",
                             "tags": [
-                                {
-                                    "code": "test_test2",
-                                    "list": [
-                                        {
-                                            "code": "test_test2",
-                                            "value": "veg "
-                                        }
-                                    ]
-                                },
                                 {
                                     "code": "veg_nonveg",
                                     "list": [
@@ -7871,95 +699,25 @@
                             ],
                             "@ondc/org/return_window": "P14D",
                             "@ondc/org/statutory_reqs_prepackaged_food": {
-                                "food_additive": "",
-                                "nutritional_information": "",
-                                "brand_owner_name": "",
-                                "consumer_care_details": "",
-                                "country_of_origin_for_imported_product": "",
-                                "brand_owner_FSSAI_license_no": "12345",
-                                "list_of_ingredients": "",
-                                "storage_information": "",
-                                "other_premises": null
-                            },
-                            "@ondc/org/mandatory_reqs_veggies_fruits": {
-                                "net_quantity": null
-                            },
-                            "tax_type": "gst",
-                            "domain": "Grocery",
-                            "time": {
-                                "label": "enable",
-                                "timestamp": "2023-10-18T08:49:13.972Z"
-                            }
-                        },
-                        {
-                            "@ondc/org/TAT": "P6D",
-                            "@ondc/org/statutory_reqs_packaged_commodities": {
-                                "net_quantity_or_measure_of_commodity_in_pkg": "50 g",
-                                "imported_product_country_of_origin": "IND",
-                                "manufacturer_or_packer_name": "vijai "
-                            },
-                            "@ondc/org/seller_pickup_return": true,
-                            "@ondc/org/contact_details_consumer_care": "trc",
-                            "descriptor": {
-                                "symbol": "https://firebasestorage.googleapis.com/v0/b/shopeg-dev.appspot.com/o/shopImages%2FVdxkoawpDWWiinBxbUjsYRnPl3x2%2Fimg_1693752066186.jpg?alt=media&token=57d2bf69-4849-4d61-8fdf-61637c692335",
-                                "images": [
-                                    "https://firebasestorage.googleapis.com/v0/b/shopeg-dev.appspot.com/o/shopImages%2FVdxkoawpDWWiinBxbUjsYRnPl3x2%2Fimg_1693752066186.jpg?alt=media&token=57d2bf69-4849-4d61-8fdf-61637c692335"
-                                ],
-                                "name": "tedt",
-                                "short_desc": "cyy",
-                                "long_desc": "cyycgcgc"
-                            },
-                            "location_id": "6879",
-                            "tax_rate": "18",
-                            "@ondc/org/available_on_cod": false,
-                            "L2_category": "Gourmet & World Foods",
-                            "category_id": "Gourmet & World Foods",
-                            "price": {
-                                "currency": "INR",
-                                "maximum_value": "250",
-                                "value": "250"
-                            },
-                            "id": "a28b82f8-0500-469f-a4ac-928cc1428964",
-                            "@ondc/org/cancellable": true,
-                            "@ondc/org/returnable": true,
-                            "quantity": {
-                                "available": {
-                                    "count": "5"
-                                },
-                                "maximum": {
-                                    "count": "5"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "g",
-                                        "value": "50"
-                                    }
-                                }
-                            },
-                            "@ondc/org/time_to_ship": "P3D",
-                            "hsn_code": "123456",
-                            "tags": [],
-                            "@ondc/org/return_window": "P14D",
-                            "@ondc/org/statutory_reqs_prepackaged_food": {
-                                "importer_FSSAI_license_no": null,
-                                "nutritional_info": null,
-                                "other_importer_address": null,
+                                "importer_FSSAI_license_no": "464646",
+                                "nutritional_info": "bzbz",
+                                "other_importer_address": "shshs",
                                 "importer_fssai_logo": null,
-                                "importer_address": null,
-                                "other_importer_name": null,
-                                "brand_owner_FSSAI_license_no": "1235",
-                                "net_quantity": null,
-                                "additives_info": null,
-                                "other_premises": null,
-                                "importer_name": null,
-                                "brand_owner_address": null,
+                                "importer_address": "ahha",
+                                "other_importer_name": "shhs",
+                                "brand_owner_FSSAI_license_no": "4646",
+                                "net_quantity": "7646",
+                                "additives_info": "zghz",
+                                "other_premises": "sbsbbs",
+                                "importer_name": "avav",
+                                "brand_owner_address": "zhah",
                                 "brand_owner_fssai_logo": null,
-                                "ingredients_info": null,
-                                "other_FSSAI_license_no": null,
-                                "brand_owner_name": null,
-                                "imported_product_country_of_origin": null,
-                                "manufacturer_or_packer_name": null,
-                                "manufacturer_or_packer_address": null
+                                "ingredients_info": "zhshbs",
+                                "other_FSSAI_license_no": "4949",
+                                "brand_owner_name": "shsh",
+                                "imported_product_country_of_origin": "IND",
+                                "manufacturer_or_packer_name": "svsv",
+                                "manufacturer_or_packer_address": "zhhs"
                             },
                             "tax_type": "gst",
                             "domain": "Grocery",
@@ -7972,121 +730,43 @@
                         {
                             "@ondc/org/TAT": "P6D",
                             "@ondc/org/statutory_reqs_packaged_commodities": {
-                                "net_quantity_or_measure_of_commodity_in_pkg": "100 ml",
-                                "imported_product_country_of_origin": "IND",
-                                "manufacturer_or_packer_name": "vijai"
+                                "common_or_generic_name_of_commodity": "Chocolates & Candies",
+                                "net_quantity_or_measure_of_commodity_in_pkg": "20 g",
+                                "imported_product_country_of_origin": "‎India",
+                                "description": "Nestle Munch Chocolate",
+                                "manufacturer_or_packer_name": "Nestle India Limited",
+                                "multiple_products_name_number_or_qty": "avsv",
+                                "manufacturer_or_packer_address": "Nestle India Limited",
+                                "month_year_of_manufacture_packing_import": "09/2023"
                             },
                             "@ondc/org/seller_pickup_return": true,
-                            "@ondc/org/contact_details_consumer_care": "vijai",
+                            "@ondc/org/contact_details_consumer_care": "John Nov9,John@acme.com,9911991199",
                             "descriptor": {
-                                "symbol": "https://firebasestorage.googleapis.com/v0/b/shopeg-dev.appspot.com/o/shopImages%2FVdxkoawpDWWiinBxbUjsYRnPl3x2%2Fimg_1693750531066.jpg?alt=media&token=8dab3d29-75be-45c6-8682-a5c812862acf",
+                                "symbol": "https://jsdagro.com/public/storage/jsd_nes_mmc25.jpg",
                                 "images": [
-                                    "https://firebasestorage.googleapis.com/v0/b/shopeg-dev.appspot.com/o/shopImages%2FVdxkoawpDWWiinBxbUjsYRnPl3x2%2Fimg_1693750531066.jpg?alt=media&token=8dab3d29-75be-45c6-8682-a5c812862acf"
+                                    "https://jsdagro.com/public/storage/jsd_nes_mmc25.jpg"
                                 ],
-                                "name": "test",
-                                "short_desc": "test",
-                                "long_desc": "test"
+                                "name": "Nestle Munch Chocolate",
+                                "short_desc": "Nestle has created a delightfully crunchy and chocolatey wafer chocolate. Take a bite of this luscious, crunchy chocolate that melts in your lips! Nestle Munch chocolate is a rich and creamy chocolate flavour on the exterior and a crunchy multilayered wafer within.",
+                                "long_desc": "Nestle has created a delightfully crunchy and chocolatey wafer chocolate. Take a bite of this luscious, crunchy chocolate that melts in your lips! Nestle Munch chocolate is a rich and creamy chocolate flavour on the exterior and a crunchy multilayered wafer within."
                             },
                             "location_id": "6879",
                             "tax_rate": "18",
                             "@ondc/org/available_on_cod": false,
-                            "L2_category": "Gourmet & World Foods",
-                            "category_id": "Gourmet & World Foods",
+                            "L2_category": "Snacks & Branded Foods",
+                            "category_id": "Snacks & Branded Foods",
                             "price": {
                                 "currency": "INR",
-                                "maximum_value": "100",
-                                "value": "75"
+                                "maximum_value": "10",
+                                "value": "10"
                             },
-                            "id": "9773acf5-eb86-4943-9a30-f8e4f8612b34",
+                            "location_details.id": "6879",
+                            "id": "e8b5b233-82fc-4809-99f8-e1adcaa701fe",
                             "@ondc/org/cancellable": true,
                             "@ondc/org/returnable": true,
                             "quantity": {
                                 "available": {
-                                    "count": "222"
-                                },
-                                "maximum": {
-                                    "count": "22"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "ml",
-                                        "value": "100"
-                                    }
-                                }
-                            },
-                            "@ondc/org/time_to_ship": "P3D",
-                            "hsn_code": "123454",
-                            "tags": [],
-                            "@ondc/org/return_window": "P14D",
-                            "@ondc/org/statutory_reqs_prepackaged_food": {
-                                "importer_FSSAI_license_no": null,
-                                "nutritional_info": null,
-                                "other_importer_address": null,
-                                "importer_fssai_logo": null,
-                                "importer_address": null,
-                                "other_importer_name": null,
-                                "brand_owner_FSSAI_license_no": "1212",
-                                "net_quantity": null,
-                                "additives_info": null,
-                                "other_premises": null,
-                                "importer_name": null,
-                                "brand_owner_address": null,
-                                "brand_owner_fssai_logo": null,
-                                "ingredients_info": null,
-                                "other_FSSAI_license_no": null,
-                                "brand_owner_name": null,
-                                "imported_product_country_of_origin": null,
-                                "manufacturer_or_packer_name": null,
-                                "manufacturer_or_packer_address": null
-                            },
-                            "tax_type": "gst",
-                            "domain": "Grocery",
-                            "time": {
-                                "label": "enable",
-                                "timestamp": "2023-10-18T08:49:13.972Z"
-                            },
-                            "fulfillment_id": "1"
-                        },
-                        {
-                            "@ondc/org/TAT": "P6D",
-                            "@ondc/org/statutory_reqs_packaged_commodities": {
-                                "common_or_generic_name_of_commodity": "Bath & Hand Wash",
-                                "net_quantity_or_measure_of_commodity_in_pkg": "50 g",
-                                "imported_product_country_of_origin": "India",
-                                "description": "Nivea Body Wash Gel - Waterlily & Oil Shower, 125 ml",
-                                "manufacturer_or_packer_name": "NIVEA India Pvt. Ltd., 4th Floor, AGH, Phoenix Market City, Kurla (W), Mumbai-400070.",
-                                "manufacturer_or_packer_address": "NIVEA India Pvt. Ltd., 4th Floor, AGH, Phoenix Market City, Kurla (W), Mumbai-400070.",
-                                "month_year_of_manufacture_packing_import": ""
-                            },
-                            "@ondc/org/seller_pickup_return": true,
-                            "@ondc/org/contact_details_consumer_care": "vijain7000@gmail.com",
-                            "descriptor": {
-                                "symbol": "https://datalabs.siva3.io/image/Eunimart_groceries_40180786_5-nivea-body-wash-gel-waterlily-oil-shower.jpg",
-                                "images": [
-                                    "https://datalabs.siva3.io/image/Eunimart_groceries_40180786_5-nivea-body-wash-gel-waterlily-oil-shower.jpg",
-                                    "https://datalabs.siva3.io/image/Eunimart_groceries_40180786-2_6-nivea-body-wash-gel-waterlily-oil-shower.jpg",
-                                    "https://datalabs.siva3.io/image/Eunimart_groceries_40180786-3_6-nivea-body-wash-gel-waterlily-oil-shower.jpg"
-                                ],
-                                "name": "Nivea Body Wash Gel - Waterlily & Oil Shower, 125 ml",
-                                "short_desc": "Give your skin refreshing care with Nivea waterlily and oil shower gel. Enriched with care oil pearls that moisturise your skin, making it soft and supple. Let this fresh shower gel envelop your skin with a silky soft foam, while its invigorating scent of waterlily flowers stimulates your senses.",
-                                "long_desc": "Give your skin refreshing care with Nivea waterlily and oil shower gel. Enriched with care oil pearls that moisturise your skin, making it soft and supple. Let this fresh shower gel envelop your skin with a silky soft foam, while its invigorating scent of waterlily flowers stimulates your senses."
-                            },
-                            "location_id": "6879",
-                            "tax_rate": "18",
-                            "@ondc/org/available_on_cod": false,
-                            "L2_category": "Beauty & Hygiene",
-                            "category_id": "Beauty & Hygiene",
-                            "price": {
-                                "currency": "INR",
-                                "maximum_value": "112",
-                                "value": "112"
-                            },
-                            "id": "769622e2-faaf-4bf6-a957-dc759a9a67c5",
-                            "@ondc/org/cancellable": true,
-                            "@ondc/org/returnable": true,
-                            "quantity": {
-                                "available": {
-                                    "count": "4"
+                                    "count": "3"
                                 },
                                 "maximum": {
                                     "count": "3"
@@ -8094,40 +774,195 @@
                                 "unitized": {
                                     "measure": {
                                         "unit": "g",
-                                        "value": "50"
+                                        "value": "20"
                                     }
                                 }
                             },
                             "@ondc/org/time_to_ship": "P3D",
-                            "hsn_code": "1234567890",
-                            "tags": [],
+                            "hsn_code": "4664",
+                            "tags": [
+                                {
+                                    "code": "veg_nonveg",
+                                    "list": [
+                                        {
+                                            "code": "veg",
+                                            "value": "yes"
+                                        }
+                                    ]
+                                }
+                            ],
                             "@ondc/org/return_window": "P14D",
                             "@ondc/org/statutory_reqs_prepackaged_food": {
-                                "importer_FSSAI_license_no": null,
-                                "nutritional_info": null,
-                                "other_importer_address": null,
-                                "importer_fssai_logo": null,
-                                "importer_address": null,
-                                "other_importer_name": null,
-                                "brand_owner_FSSAI_license_no": null,
-                                "net_quantity": null,
-                                "additives_info": null,
-                                "other_premises": null,
-                                "importer_name": null,
-                                "brand_owner_address": null,
-                                "brand_owner_fssai_logo": null,
-                                "ingredients_info": null,
-                                "other_FSSAI_license_no": null,
-                                "brand_owner_name": "Nivea",
-                                "imported_product_country_of_origin": null,
-                                "manufacturer_or_packer_name": null,
-                                "manufacturer_or_packer_address": null
+                                "importer_FSSAI_license_no": "466464",
+                                "nutritional_info": "sbsb",
+                                "other_importer_address": "bBB",
+                                "importer_address": "bBB",
+                                "other_importer_name": "Habba",
+                                "brand_owner_FSSAI_license_no": "49464",
+                                "net_quantity": "20",
+                                "additives_info": "bzbzb",
+                                "other_premises": "bsbab",
+                                "importer_name": "Gg",
+                                "brand_owner_address": "shahBh",
+                                "ingredients_info": "zvbB",
+                                "other_FSSAI_license_no": "79979",
+                                "brand_owner_name": "zhzh",
+                                "imported_product_country_of_origin": "IND",
+                                "manufacturer_or_packer_name": "haha",
+                                "manufacturer_or_packer_address": "zhzh"
                             },
                             "tax_type": "gst",
                             "domain": "Grocery",
                             "time": {
                                 "label": "enable",
                                 "timestamp": "2023-10-18T08:49:13.972Z"
+                            },
+                            "fulfillment_id": "1"
+                        },
+                        {
+                            "@ondc/org/TAT": "P6D",
+                            "@ondc/org/statutory_reqs_packaged_commodities": {
+                                "net_quantity_or_measure_of_commodity_in_pkg": "76 g",
+                                "common_or_generic_name_of_commodity": "Ghs",
+                                "imported_product_country_of_origin": "India",
+                                "manufacturer_or_packer_name": "PIDILITE INDUSTRIES LTD., MFD. By. Hira Industries Ltd, Survey No. 89, Near Agarwal Udyog Nagar, Valiv, Vasai (East), Thane, Maharashtra - 401208. Sheil Industries Plot 1813, 3rd Phase, G.I.D.C., Vapi IE, Valsad, Gujrat-396195. In case of complaints contact Consumer care, PO Box No. 17411, Mumbai-400059. Tollfree 18002666066 csc@pidilite.com",
+                                "multiple_products_name_number_or_qty": "svsv",
+                                "manufacturer_or_packer_address": "svbzbz",
+                                "month_year_of_manufacture_packing_import": "09/2023"
+                            },
+                            "@ondc/org/seller_pickup_return": true,
+                            "@ondc/org/contact_details_consumer_care": "John Nov9,John@acme.com,9911991199",
+                            "descriptor": {
+                                "symbol": "https://datalabs.siva3.io/image/Eunimart_groceries_222661_1-fevicol-mr-angular-tip-applicator-white-adhesive-glue-pen.jpg",
+                                "images": [
+                                    "https://datalabs.siva3.io/image/Eunimart_groceries_222661_1-fevicol-mr-angular-tip-applicator-white-adhesive-glue-pen.jpg"
+                                ],
+                                "name": "Fevicol MR Angular Tip Applicator - White Adhesive, Glue Pen, 4 x 22.5 g Multipack",
+                                "short_desc": "Loved for its superior quality and ease of application, it is a synthetic white adhesive used to stick paper, cardboard, thermocol, fabrics, etc. It is also used in handicrafts activities like doll making, shell crafts and collage projects. It can be utilised in bonding different materials, where one of the surfaces to be bonded must be porous. Fevicol strongly binds wood, plywood, laminate, veneers, MDF, all types of boards and cork. Sports goods and bookbinding are made with it.\r\n\r\nUniversal craft glue is ideal for pasting materials from papers, candy sticks, corrugated sheets to heavy craft accessories and making slime. Classic white glue formula that becomes invisible when dry gives a clean finish to project work/article. Easily peels away from hands and clothes for quick cleanup.\r\n\r\nFeatures:\r\n\r\nItem Dimensions LxWxH : 20 x 20 x 147 Millimeters\r\nColour‎: White",
+                                "long_desc": "Loved for its superior quality and ease of application, it is a synthetic white adhesive used to stick paper, cardboard, thermocol, fabrics, etc. It is also used in handicrafts activities like doll making, shell crafts and collage projects. It can be utilised in bonding different materials, where one of the surfaces to be bonded must be porous. Fevicol strongly binds wood, plywood, laminate, veneers, MDF, all types of boards and cork. Sports goods and bookbinding are made with it.\r\n\r\nUniversal craft glue is ideal for pasting materials from papers, candy sticks, corrugated sheets to heavy craft accessories and making slime. Classic white glue formula that becomes invisible when dry gives a clean finish to project work/article. Easily peels away from hands and clothes for quick cleanup.\r\n\r\nFeatures:\r\n\r\nItem Dimensions LxWxH : 20 x 20 x 147 Millimeters\r\nColour‎: White"
+                            },
+                            "location_id": "6879",
+                            "tax_rate": "5",
+                            "@ondc/org/available_on_cod": false,
+                            "L2_category": "Pet Care",
+                            "category_id": "Pet Care",
+                            "price": {
+                                "currency": "INR",
+                                "maximum_value": "60",
+                                "value": "60"
+                            },
+                            "location_details.id": "6879",
+                            "id": "930be6c2-4bd9-4836-958b-e0c5a74f12ed",
+                            "@ondc/org/cancellable": true,
+                            "@ondc/org/returnable": true,
+                            "quantity": {
+                                "available": {
+                                    "count": "3"
+                                },
+                                "maximum": {
+                                    "count": "3"
+                                },
+                                "unitized": {
+                                    "measure": {
+                                        "unit": "g",
+                                        "value": "76"
+                                    }
+                                }
+                            },
+                            "@ondc/org/time_to_ship": "P3D",
+                            "hsn_code": "4646",
+                            "tags": [],
+                            "@ondc/org/return_window": "P14D",
+                            "tax_type": "gst",
+                            "domain": "Grocery",
+                            "time": {
+                                "label": "enable",
+                                "timestamp": "2023-10-18T08:49:13.972Z"
+                            },
+                            "fulfillment_id": "1"
+                        },
+                        {
+                            "@ondc/org/seller_pickup_return": true,
+                            "@ondc/org/contact_details_consumer_care": "John Nov9,John@acme.com,9911991199",
+                            "descriptor": {
+                                "symbol": "https://datalabs.siva3.io/image/Eunimart_groceries_40292294_1-sarati-instant-rava-dosa-mix.jpg",
+                                "images": [
+                                    "https://datalabs.siva3.io/image/Eunimart_groceries_40292294_1-sarati-instant-rava-dosa-mix.jpg",
+                                    "https://datalabs.siva3.io/image/Eunimart_groceries_40292294-2_1-sarati-instant-rava-dosa-mix.jpg",
+                                    "https://datalabs.siva3.io/image/Eunimart_groceries_40292294-3_1-sarati-instant-rava-dosa-mix.jpg"
+                                ],
+                                "name": "Sarati Instant Rava Dosa Mix, 500 g",
+                                "short_desc": "Sarati Instant presents Instant Rava Dosa Mix is Sourced From high-quality grains like Wheat, Millets, Grams and Pulses are grown using nature-friendly farming methods and ensuring the Product is Safe. Delightfully crispy and golden on the edges, Rava Dosa is quite the signature dish. Follow the easy instructions to prepare it in a jiffy! Delightfully crisp and golden rice dosas A delicious traditional breakfast ready in an instant.",
+                                "long_desc": "Sarati Instant presents Instant Rava Dosa Mix is Sourced From high-quality grains like Wheat, Millets, Grams and Pulses are grown using nature-friendly farming methods and ensuring the Product is Safe. Delightfully crispy and golden on the edges, Rava Dosa is quite the signature dish. Follow the easy instructions to prepare it in a jiffy! Delightfully crisp and golden rice dosas A delicious traditional breakfast ready in an instant."
+                            },
+                            "location_id": "6879",
+                            "tax_rate": "18",
+                            "@ondc/org/available_on_cod": true,
+                            "contact_details_consumer_care_email": "vijai.c@beyondseek.com",
+                            "L2_category": "Snacks & Branded Foods",
+                            "category_id": "Snacks & Branded Foods",
+                            "price": {
+                                "currency": "INR",
+                                "maximum_value": "120",
+                                "value": "120"
+                            },
+                            "id": "7c1592e7-3fdd-4b33-afbf-e6920f38ac41",
+                            "@ondc/org/cancellable": true,
+                            "@ondc/org/tat": "P6D",
+                            "@ondc/org/returnable": true,
+                            "quantity": {
+                                "available": {
+                                    "count": "3"
+                                },
+                                "maximum": {
+                                    "count": "3"
+                                },
+                                "unitized": {
+                                    "measure": {
+                                        "unit": "gram",
+                                        "value": "8683"
+                                    }
+                                }
+                            },
+                            "@ondc/org/time_to_ship": "P3D",
+                            "contact_details_consumer_care_name": "vijai ",
+                            "contact_details_consumer_care_contactno": "9884012345",
+                            "product_master_uuid": "7d7ad294-bc8d-4547-8fd2-663a31bed682",
+                            "hsn_code": "6868",
+                            "tags": [
+                                {
+                                    "code": "origin",
+                                    "list": [
+                                        {
+                                            "code": "country",
+                                            "value": "IND"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "@ondc/org/return_window": "P14D",
+                            "@ondc/org/statutory_reqs_prepackaged_food": {
+                                "importer_FSSAI_license_no": "8386299",
+                                "nutritional_info": "vuvi",
+                                "other_importer_address": "vuv",
+                                "importer_address": "fuc",
+                                "other_importer_name": "vhvuc",
+                                "brand_owner_FSSAI_license_no": "99888",
+                                "additives_info": "cyvuv",
+                                "other_premises": "vjvu",
+                                "importer_name": "tgg",
+                                "brand_owner_address": "ggf",
+                                "ingredients_info": "xgch",
+                                "other_FSSAI_license_no": "06060",
+                                "brand_owner_name": "Sarati Instant",
+                                "manufacturer_or_packer_name": " g",
+                                "manufacturer_or_packer_address": "vh"
+                            },
+                            "tax_type": "gst",
+                            "domain": "Grocery",
+                            "time": {
+                                "label": "enable",
+                                "timestamp": "2023-11-09T11:56:58.180Z"
                             },
                             "fulfillment_id": "1"
                         },
@@ -8143,7 +978,7 @@
                                 "month_year_of_manufacture_packing_import": "09/2023"
                             },
                             "@ondc/org/seller_pickup_return": true,
-                            "@ondc/org/contact_details_consumer_care": "vijai.c@beyondseek.com",
+                            "@ondc/org/contact_details_consumer_care": "John Nov9,John@acme.com,9911991199",
                             "descriptor": {
                                 "symbol": "https://datalabs.siva3.io/image/Eunimart_groceries_40093816_1-kwality-powder-dry-mango.jpg",
                                 "images": [
@@ -8233,7 +1068,7 @@
                                 "month_year_of_manufacture_packing_import": "09/2023"
                             },
                             "@ondc/org/seller_pickup_return": true,
-                            "@ondc/org/contact_details_consumer_care": "sbsbsb",
+                            "@ondc/org/contact_details_consumer_care": "John Nov9,John@acme.com,9911991199",
                             "descriptor": {
                                 "symbol": "https://firebasestorage.googleapis.com/v0/b/shopeg-dev.appspot.com/o/shopImages%2FVdxkoawpDWWiinBxbUjsYRnPl3x2%2Fimg_1695207606097.jpg?alt=media&token=0097099e-bcb9-4759-9b79-c0aca5bed185",
                                 "images": [
@@ -8323,7 +1158,7 @@
                                 "month_year_of_manufacture_packing_import": "09/2023"
                             },
                             "@ondc/org/seller_pickup_return": true,
-                            "@ondc/org/contact_details_consumer_care": "ReckittBenckiserIndiaPvtLtd",
+                            "@ondc/org/contact_details_consumer_care": "John Nov9,John@acme.com,9911991199",
                             "descriptor": {
                                 "symbol": "https://datalabs.siva3.io/image/Eunimart_groceries_40242024_3-harpic-disinfectant-bathroom-cleaner-liquid-removes-tough-stains-lemon-fragrance.jpg",
                                 "images": [
@@ -8377,6 +1212,104 @@
                         {
                             "@ondc/org/TAT": "P6D",
                             "@ondc/org/statutory_reqs_packaged_commodities": {
+                                "common_or_generic_name_of_commodity": "Ready To Cook & Eat",
+                                "net_quantity_or_measure_of_commodity_in_pkg": "45 g",
+                                "imported_product_country_of_origin": "IND",
+                                "manufacturer_or_packer_name": "Pagariya Food products pvt ltd, Plot no. 302-A, Phase -2, KIADB Industrial Area, Harohalli, T:Kanakapura D:Ramanagara-562112, Karnataka.",
+                                "multiple_products_name_number_or_qty": "sbsb",
+                                "manufacturer_or_packer_address": "Pagariya Food products pvt ltd, Plot no. 302-A, Phase -2, KIADB Industrial Area, Harohalli, T:Kanakapura D:Ramanagara-562112, Karnataka.",
+                                "month_year_of_manufacture_packing_import": "10/2023"
+                            },
+                            "@ondc/org/seller_pickup_return": true,
+                            "@ondc/org/contact_details_consumer_care": "John Nov9,John@acme.com,9911991199",
+                            "descriptor": {
+                                "symbol": "https://datalabs.siva3.io/image/Eunimart_groceries_40200146_2-happychef-icing-sugar.jpg",
+                                "images": [
+                                    "https://datalabs.siva3.io/image/Eunimart_groceries_40200146_2-happychef-icing-sugar.jpg",
+                                    "https://datalabs.siva3.io/image/Eunimart_groceries_40200146-2_2-happychef-icing-sugar.jpg",
+                                    "https://datalabs.siva3.io/image/Eunimart_groceries_40200146-3_2-happychef-icing-sugar.jpg"
+                                ],
+                                "name": "HappyChef Icing Sugar, 100 g",
+                                "short_desc": "A good icing can elevate your dessert like no other.\r\nbrings to you HappyChef Icing Sugar, a premium quality icing sugar that adds sweet goodness to the icing for your favourite treat. Use it in cakes, desserts, icing and decoration - this bag of sweetness is a must-have. Explore Happy Chef's full range of premium baking ingredients and dessert mixes and whip up sweet treats that everyone will love.",
+                                "long_desc": "A good icing can elevate your dessert like no other.\r\nbrings to you HappyChef Icing Sugar, a premium quality icing sugar that adds sweet goodness to the icing for your favourite treat. Use it in cakes, desserts, icing and decoration - this bag of sweetness is a must-have. Explore Happy Chef's full range of premium baking ingredients and dessert mixes and whip up sweet treats that everyone will love."
+                            },
+                            "location_id": "6879",
+                            "tax_rate": "18",
+                            "@ondc/org/available_on_cod": false,
+                            "contact_details_consumer_care_email": "vijai.c@beyondseek.com",
+                            "L2_category": "Snacks & Branded Foods",
+                            "category_id": "Snacks & Branded Foods",
+                            "price": {
+                                "currency": "INR",
+                                "maximum_value": "39",
+                                "value": "39"
+                            },
+                            "id": "6b242dbf-11df-4d2e-9f95-e912b6701888",
+                            "@ondc/org/fssai_license_no": "255555",
+                            "@ondc/org/cancellable": true,
+                            "@ondc/org/tat": "P6D",
+                            "@ondc/org/returnable": true,
+                            "quantity": {
+                                "available": {
+                                    "count": "3"
+                                },
+                                "maximum": {
+                                    "count": "3"
+                                },
+                                "unitized": {
+                                    "measure": {
+                                        "unit": "gram",
+                                        "value": "45"
+                                    }
+                                }
+                            },
+                            "@ondc/org/time_to_ship": "P3D",
+                            "contact_details_consumer_care_name": "vijai ",
+                            "contact_details_consumer_care_contactno": "9884012345",
+                            "product_master_uuid": "630f68b8-c842-4ff3-8460-82b1e7b1dc5e",
+                            "hsn_code": "464664",
+                            "tags": [
+                                {
+                                    "code": "origin",
+                                    "list": [
+                                        {
+                                            "code": "country",
+                                            "value": "IND"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "@ondc/org/return_window": "P14D",
+                            "@ondc/org/statutory_reqs_prepackaged_food": {
+                                "importer_FSSAI_license_no": "794949",
+                                "nutritional_info": "zhshs",
+                                "other_importer_address": "sbsbs",
+                                "importer_address": "zbsb",
+                                "other_importer_name": "zhhzhs",
+                                "brand_owner_FSSAI_license_no": "46464",
+                                "net_quantity": "45 g",
+                                "additives_info": "shshs",
+                                "other_premises": "sbsnns",
+                                "importer_name": "zhzh",
+                                "brand_owner_address": "sjsj",
+                                "ingredients_info": "zbzbzb",
+                                "other_FSSAI_license_no": "49494",
+                                "brand_owner_name": "HappyChef",
+                                "imported_product_country_of_origin": "IND",
+                                "manufacturer_or_packer_name": "shsj",
+                                "manufacturer_or_packer_address": "sbsh"
+                            },
+                            "tax_type": "gst",
+                            "domain": "Grocery",
+                            "time": {
+                                "label": "enable",
+                                "timestamp": "2023-10-28T11:57:33.316Z"
+                            },
+                            "fulfillment_id": "1"
+                        },
+                        {
+                            "@ondc/org/TAT": "P6D",
+                            "@ondc/org/statutory_reqs_packaged_commodities": {
                                 "common_or_generic_name_of_commodity": "Sauces, Spreads & Dips",
                                 "net_quantity_or_measure_of_commodity_in_pkg": "480 g",
                                 "imported_product_country_of_origin": "India",
@@ -8387,7 +1320,7 @@
                                 "month_year_of_manufacture_packing_import": ""
                             },
                             "@ondc/org/seller_pickup_return": true,
-                            "@ondc/org/contact_details_consumer_care": "Cremica",
+                            "@ondc/org/contact_details_consumer_care": "John Nov9,John@acme.com,9911991199",
                             "descriptor": {
                                 "symbol": "https://datalabs.siva3.io/image/Eunimart_groceries_40121207_2-cremica-mix-fruit-jam.jpg",
                                 "images": [
@@ -8402,6 +1335,7 @@
                             "tax_rate": "18",
                             "location_id": "6879",
                             "@ondc/org/available_on_cod": false,
+                            "contact_details_consumer_care_email": "vijai.c@beyondseek.com",
                             "L2_category": "Gourmet & World Foods",
                             "category_id": "Gourmet & World Foods",
                             "price": {
@@ -8411,6 +1345,7 @@
                             },
                             "id": "34061b98-a5c9-4a9d-aab2-20e434dcfff0",
                             "@ondc/org/cancellable": true,
+                            "@ondc/org/tat": "P6D",
                             "@ondc/org/returnable": true,
                             "quantity": {
                                 "available": {
@@ -8421,20 +1356,22 @@
                                 },
                                 "unitized": {
                                     "measure": {
-                                        "unit": "g",
+                                        "unit": "gram",
                                         "value": "480"
                                     }
                                 }
                             },
                             "@ondc/org/time_to_ship": "P3D",
+                            "contact_details_consumer_care_name": "vijai ",
+                            "contact_details_consumer_care_contactno": "9884012345",
                             "hsn_code": "123456789",
                             "tags": [
                                 {
-                                    "code": "veg_nonveg",
+                                    "code": "origin",
                                     "list": [
                                         {
-                                            "code": "veg",
-                                            "value": "yes"
+                                            "code": "country",
+                                            "value": "IND"
                                         }
                                     ]
                                 }
@@ -8463,432 +1400,104 @@
                             "domain": "Grocery",
                             "time": {
                                 "label": "enable",
-                                "timestamp": "2023-10-18T08:49:13.972Z"
+                                "timestamp": "2023-10-28T12:17:20.704Z"
                             },
                             "fulfillment_id": "1"
                         },
                         {
-                            "@ondc/org/TAT": "P6D",
                             "@ondc/org/statutory_reqs_packaged_commodities": {
-                                "net_quantity_or_measure_of_commodity_in_pkg": "330 ml",
+                                "common_or_generic_name_of_commodity": "Ready To Cook & Eat",
+                                "net_quantity_or_measure_of_commodity_in_pkg": "45 g",
                                 "imported_product_country_of_origin": "India",
-                                "manufacturer_or_packer_name": "Mad Men Ferments Privated Limited, Bannerghatta Road, No.60-70 Ground Floor NS Palya, Industrial Area, Bengaluru, Bengaluru Urban, Karnataka, 560076"
+                                "manufacturer_or_packer_name": "To Be Update",
+                                "multiple_products_name_number_or_qty": "sbsbs",
+                                "manufacturer_or_packer_address": "To Be Update",
+                                "month_year_of_manufacture_packing_import": "10/2023"
                             },
                             "@ondc/org/seller_pickup_return": true,
-                            "@ondc/org/contact_details_consumer_care": "vijai",
+                            "@ondc/org/contact_details_consumer_care": "John Nov9,John@acme.com,9911991199",
                             "descriptor": {
-                                "symbol": "https://datalabs.siva3.io/image/Eunimart_groceries_40292871_1-local-ferment-co-shrub-soda-burnt-lemon-pepper-berry-handcrafted-refreshing-beverage.jpg",
+                                "symbol": "https://www.bigbasket.com/media/uploads/p/l/100005351_7-gits-rice-idli-breakfast-mix-with-no-preservatives.jpg?tr=w-640,q=80",
                                 "images": [
-                                    "https://datalabs.siva3.io/image/Eunimart_groceries_40292871_1-local-ferment-co-shrub-soda-burnt-lemon-pepper-berry-handcrafted-refreshing-beverage.jpg",
-                                    "https://datalabs.siva3.io/image/Eunimart_groceries_40292871-2_1-local-ferment-co-shrub-soda-burnt-lemon-pepper-berry-handcrafted-refreshing-beverage.jpg",
-                                    "https://datalabs.siva3.io/image/Eunimart_groceries_40292871-3_1-local-ferment-co-shrub-soda-burnt-lemon-pepper-berry-handcrafted-refreshing-beverage.jpg"
+                                    "https://www.bigbasket.com/media/uploads/p/l/100005351_7-gits-rice-idli-breakfast-mix-with-no-preservatives.jpg?tr=w-640,q=80",
+                                    "https://www.bigbasket.com/media/uploads/p/l/100005351-2_2-gits-rice-idli-breakfast-mix-with-no-preservatives.jpg?tr=w-640,q=80",
+                                    "https://www.bigbasket.com/media/uploads/p/l/100005351-4_2-gits-rice-idli-breakfast-mix-with-no-preservatives.jpg?tr=w-640,q=80"
                                 ],
-                                "name": "Local Ferment Co Shrub Soda - Burnt Lemon Pepper Berry, Handcrafted, Refreshing Beverage, 330 ml",
-                                "short_desc": "Bring the party to you with this palate-blasting explosion of flavours! Each smoky profile of fruit and spice and everything nice, sparks across your tongue like they're trying to rocket off to space - and that's where this drink might take you too. Do tell the sixth dimension we said hello, eh? Burnt Lemon Pepper Berry is a bit of a mouthful, we know - a mouthful of fizz and organic benefits. The fun of this is that the ingredients are charred to give a jolt of caramelization, and even better, this process shaves off those extra additives and calories. Shrub sodas are an ‘it’ drink these days, and we at LFC are slaying the game in our very own lab!",
-                                "long_desc": "Bring the party to you with this palate-blasting explosion of flavours! Each smoky profile of fruit and spice and everything nice, sparks across your tongue like they're trying to rocket off to space - and that's where this drink might take you too. Do tell the sixth dimension we said hello, eh? Burnt Lemon Pepper Berry is a bit of a mouthful, we know - a mouthful of fizz and organic benefits. The fun of this is that the ingredients are charred to give a jolt of caramelization, and even better, this process shaves off those extra additives and calories. Shrub sodas are an ‘it’ drink these days, and we at LFC are slaying the game in our very own lab!"
+                                "name": "Gits Breakfast Mix - Rice Idli, 200 g Carton",
+                                "short_desc": "Rice Idli is undoubtedly the most popular and preferred breakfast in South India. When you crave Idlis at home, Gits has you covered with its Instant Rice Idli Mix that allows you to make ninety tasty idlis with minimal effort. The idlis made with this ready-mix powder are soft and fluffy in texture and a healthy and filling breakfast. Gits Instant Rice Idli Mix is 100% vegetarian, free from preservatives, artificial colour and flavour. Made with high-quality full-grain rice, this Gits Rice Idli Mix is all that you need to make your morning better. Gits has been leading the instant mix market for over fifty years and touching the lives of Indians across the world with its wide range of products.\r\n\r\nBenefits -\r\n\r\nAuthentic South Indian Rice Idli mix\r\nEasy to make rice idli breakfast mix in just 3 simple steps, makes 18 per pack\r\nNo preservatives, artificial flavours or colours\r\nSafe and hygienic packaging",
+                                "long_desc": "Rice Idli is undoubtedly the most popular and preferred breakfast in South India. When you crave Idlis at home, Gits has you covered with its Instant Rice Idli Mix that allows you to make ninety tasty idlis with minimal effort. The idlis made with this ready-mix powder are soft and fluffy in texture and a healthy and filling breakfast. Gits Instant Rice Idli Mix is 100% vegetarian, free from preservatives, artificial colour and flavour. Made with high-quality full-grain rice, this Gits Rice Idli Mix is all that you need to make your morning better. Gits has been leading the instant mix market for over fifty years and touching the lives of Indians across the world with its wide range of products.\r\n\r\nBenefits -\r\n\r\nAuthentic South Indian Rice Idli mix\r\nEasy to make rice idli breakfast mix in just 3 simple steps, makes 18 per pack\r\nNo preservatives, artificial flavours or colours\r\nSafe and hygienic packaging"
                             },
                             "location_id": "6879",
-                            "tax_rate": "28",
-                            "@ondc/org/available_on_cod": false,
-                            "L2_category": "Beverages",
-                            "category_id": "Beverages",
-                            "price": {
-                                "currency": "INR",
-                                "maximum_value": "180",
-                                "value": "180"
-                            },
-                            "id": "57782304-314c-4f73-94d6-6c1b4a3628ba",
-                            "@ondc/org/cancellable": true,
-                            "@ondc/org/returnable": true,
-                            "quantity": {
-                                "available": {
-                                    "count": "3"
-                                },
-                                "maximum": {
-                                    "count": "3"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "ml",
-                                        "value": "330"
-                                    }
-                                }
-                            },
-                            "@ondc/org/time_to_ship": "P3D",
-                            "hsn_code": "1234",
-                            "tags": [],
-                            "@ondc/org/return_window": "P14D",
-                            "@ondc/org/statutory_reqs_prepackaged_food": {
-                                "importer_FSSAI_license_no": null,
-                                "nutritional_info": null,
-                                "other_importer_address": null,
-                                "importer_fssai_logo": null,
-                                "importer_address": null,
-                                "other_importer_name": null,
-                                "brand_owner_FSSAI_license_no": "1234567890",
-                                "net_quantity": null,
-                                "additives_info": null,
-                                "other_premises": null,
-                                "importer_name": null,
-                                "brand_owner_address": null,
-                                "brand_owner_fssai_logo": null,
-                                "ingredients_info": null,
-                                "other_FSSAI_license_no": null,
-                                "brand_owner_name": null,
-                                "imported_product_country_of_origin": null,
-                                "manufacturer_or_packer_name": null,
-                                "manufacturer_or_packer_address": null
-                            },
-                            "tax_type": "gst",
-                            "domain": "Grocery",
-                            "time": {
-                                "label": "enable",
-                                "timestamp": "2023-10-18T08:49:13.972Z"
-                            },
-                            "fulfillment_id": "1"
-                        },
-                        {
-                            "@ondc/org/TAT": "P6D",
-                            "@ondc/org/statutory_reqs_packaged_commodities": {
-                                "net_quantity_or_measure_of_commodity_in_pkg": "7949 Kg",
-                                "common_or_generic_name_of_commodity": "sbsbs",
-                                "imported_product_country_of_origin": "India",
-                                "manufacturer_or_packer_name": "Panchakarma Herbs Pvt. Ltd. Village Katri Shankarpur Sarai, Near Ganga Barrage Kanpur Nagar, Bilhaur Tahsil, Kanpur Nagar Uttar Pradesh 208 002",
-                                "multiple_products_name_number_or_qty": "baba",
-                                "manufacturer_or_packer_address": "hshshs",
-                                "month_year_of_manufacture_packing_import": "09/2023"
-                            },
-                            "@ondc/org/seller_pickup_return": true,
-                            "@ondc/org/contact_details_consumer_care": "vijai",
-                            "descriptor": {
-                                "symbol": "https://datalabs.siva3.io/image/Eunimart_groceries_40228625_2-indisecrets-organic-tulsi-honey-chamomile.jpg",
-                                "images": [
-                                    "https://datalabs.siva3.io/image/Eunimart_groceries_40228625_2-indisecrets-organic-tulsi-honey-chamomile.jpg",
-                                    "https://datalabs.siva3.io/image/Eunimart_groceries_40228625-2_2-indisecrets-organic-tulsi-honey-chamomile.jpg",
-                                    "https://datalabs.siva3.io/image/Eunimart_groceries_40228625-3_2-indisecrets-organic-tulsi-honey-chamomile.jpg"
-                                ],
-                                "name": "IndiSecrets Organic Chamomile Tea - Tulsi Honey, 36 g (20 Bags x 1.8 g each)",
-                                "short_desc": "IndiSecrets Organic Chamomile Tea - Tulsi Honey",
-                                "long_desc": "IndiSecrets Organic Chamomile Tea - Tulsi Honey"
-                            },
-                            "location_id": "6879",
-                            "tax_rate": "5",
-                            "@ondc/org/available_on_cod": false,
-                            "L2_category": "Beverages",
-                            "category_id": "Beverages",
-                            "price": {
-                                "currency": "INR",
-                                "maximum_value": "139",
-                                "value": "139"
-                            },
-                            "location_details.id": "6879",
-                            "id": "4c539226-d858-4841-935a-811ee68ca531",
-                            "@ondc/org/cancellable": true,
-                            "@ondc/org/returnable": true,
-                            "quantity": {
-                                "available": {
-                                    "count": "3"
-                                },
-                                "maximum": {
-                                    "count": "3"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "Kg",
-                                        "value": "7949"
-                                    }
-                                }
-                            },
-                            "@ondc/org/time_to_ship": "P3D",
-                            "hsn_code": "4949",
-                            "tags": [
-                                {
-                                    "code": "veg_nonveg",
-                                    "list": [
-                                        {
-                                            "code": "veg",
-                                            "value": "yes"
-                                        }
-                                    ]
-                                }
-                            ],
-                            "@ondc/org/return_window": "P14D",
-                            "@ondc/org/statutory_reqs_prepackaged_food": {
-                                "importer_FSSAI_license_no": "464646",
-                                "nutritional_info": "bzbz",
-                                "other_importer_address": "shshs",
-                                "importer_fssai_logo": null,
-                                "importer_address": "ahha",
-                                "other_importer_name": "shhs",
-                                "brand_owner_FSSAI_license_no": "4646",
-                                "net_quantity": "7646",
-                                "additives_info": "zghz",
-                                "other_premises": "sbsbbs",
-                                "importer_name": "avav",
-                                "brand_owner_address": "zhah",
-                                "brand_owner_fssai_logo": null,
-                                "ingredients_info": "zhshbs",
-                                "other_FSSAI_license_no": "4949",
-                                "brand_owner_name": "shsh",
-                                "imported_product_country_of_origin": "IND",
-                                "manufacturer_or_packer_name": "svsv",
-                                "manufacturer_or_packer_address": "zhhs"
-                            },
-                            "tax_type": "gst",
-                            "domain": "Grocery",
-                            "time": {
-                                "label": "enable",
-                                "timestamp": "2023-10-18T08:49:13.972Z"
-                            },
-                            "fulfillment_id": "1"
-                        },
-                        {
-                            "@ondc/org/TAT": "P6D",
-                            "@ondc/org/statutory_reqs_packaged_commodities": {
-                                "net_quantity_or_measure_of_commodity_in_pkg": "76 g",
-                                "common_or_generic_name_of_commodity": "Ghs",
-                                "imported_product_country_of_origin": "India",
-                                "manufacturer_or_packer_name": "PIDILITE INDUSTRIES LTD., MFD. By. Hira Industries Ltd, Survey No. 89, Near Agarwal Udyog Nagar, Valiv, Vasai (East), Thane, Maharashtra - 401208. Sheil Industries Plot 1813, 3rd Phase, G.I.D.C., Vapi IE, Valsad, Gujrat-396195. In case of complaints contact Consumer care, PO Box No. 17411, Mumbai-400059. Tollfree 18002666066 csc@pidilite.com",
-                                "multiple_products_name_number_or_qty": "svsv",
-                                "manufacturer_or_packer_address": "svbzbz",
-                                "month_year_of_manufacture_packing_import": "09/2023"
-                            },
-                            "@ondc/org/seller_pickup_return": true,
-                            "@ondc/org/contact_details_consumer_care": "vijai",
-                            "descriptor": {
-                                "symbol": "https://datalabs.siva3.io/image/Eunimart_groceries_222661_1-fevicol-mr-angular-tip-applicator-white-adhesive-glue-pen.jpg",
-                                "images": [
-                                    "https://datalabs.siva3.io/image/Eunimart_groceries_222661_1-fevicol-mr-angular-tip-applicator-white-adhesive-glue-pen.jpg"
-                                ],
-                                "name": "Fevicol MR Angular Tip Applicator - White Adhesive, Glue Pen, 4 x 22.5 g Multipack",
-                                "short_desc": "Loved for its superior quality and ease of application, it is a synthetic white adhesive used to stick paper, cardboard, thermocol, fabrics, etc. It is also used in handicrafts activities like doll making, shell crafts and collage projects. It can be utilised in bonding different materials, where one of the surfaces to be bonded must be porous. Fevicol strongly binds wood, plywood, laminate, veneers, MDF, all types of boards and cork. Sports goods and bookbinding are made with it.\r\n\r\nUniversal craft glue is ideal for pasting materials from papers, candy sticks, corrugated sheets to heavy craft accessories and making slime. Classic white glue formula that becomes invisible when dry gives a clean finish to project work/article. Easily peels away from hands and clothes for quick cleanup.\r\n\r\nFeatures:\r\n\r\nItem Dimensions LxWxH : 20 x 20 x 147 Millimeters\r\nColour‎: White",
-                                "long_desc": "Loved for its superior quality and ease of application, it is a synthetic white adhesive used to stick paper, cardboard, thermocol, fabrics, etc. It is also used in handicrafts activities like doll making, shell crafts and collage projects. It can be utilised in bonding different materials, where one of the surfaces to be bonded must be porous. Fevicol strongly binds wood, plywood, laminate, veneers, MDF, all types of boards and cork. Sports goods and bookbinding are made with it.\r\n\r\nUniversal craft glue is ideal for pasting materials from papers, candy sticks, corrugated sheets to heavy craft accessories and making slime. Classic white glue formula that becomes invisible when dry gives a clean finish to project work/article. Easily peels away from hands and clothes for quick cleanup.\r\n\r\nFeatures:\r\n\r\nItem Dimensions LxWxH : 20 x 20 x 147 Millimeters\r\nColour‎: White"
-                            },
-                            "location_id": "6879",
-                            "tax_rate": "5",
-                            "@ondc/org/available_on_cod": false,
-                            "L2_category": "Pet Care",
-                            "category_id": "Pet Care",
-                            "price": {
-                                "currency": "INR",
-                                "maximum_value": "60",
-                                "value": "60"
-                            },
-                            "location_details.id": "6879",
-                            "id": "930be6c2-4bd9-4836-958b-e0c5a74f12ed",
-                            "@ondc/org/cancellable": true,
-                            "@ondc/org/returnable": true,
-                            "quantity": {
-                                "available": {
-                                    "count": "3"
-                                },
-                                "maximum": {
-                                    "count": "3"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "g",
-                                        "value": "76"
-                                    }
-                                }
-                            },
-                            "@ondc/org/time_to_ship": "P3D",
-                            "hsn_code": "4646",
-                            "tags": [],
-                            "@ondc/org/return_window": "P14D",
-                            "tax_type": "gst",
-                            "domain": "Grocery",
-                            "time": {
-                                "label": "enable",
-                                "timestamp": "2023-10-18T08:49:13.972Z"
-                            },
-                            "fulfillment_id": "1"
-                        },
-                        {
-                            "@ondc/org/TAT": "P6D",
-                            "@ondc/org/statutory_reqs_packaged_commodities": {
-                                "common_or_generic_name_of_commodity": "Spices & Masala",
-                                "net_quantity_or_measure_of_commodity_in_pkg": "200 g",
-                                "imported_product_country_of_origin": "IND",
-                                "description": "Everest Masala - Chhole, 200 g Jar",
-                                "manufacturer_or_packer_name": "4/B,L.B.S Marg, Vikhroli(W), Mumbai-400083,Maharastra",
-                                "multiple_products_name_number_or_qty": "km",
-                                "manufacturer_or_packer_address": "4/B,L.B.S Marg, Vikhroli(W), Mumbai-400083,Maharastra",
-                                "month_year_of_manufacture_packing_import": ""
-                            },
-                            "@ondc/org/seller_pickup_return": true,
-                            "@ondc/org/contact_details_consumer_care": "Everest",
-                            "descriptor": {
-                                "symbol": "https://datalabs.siva3.io/image/Eunimart_groceries_40129026_4-everest-masala-chhole.jpg",
-                                "images": [
-                                    "https://datalabs.siva3.io/image/Eunimart_groceries_40129026_4-everest-masala-chhole.jpg",
-                                    "https://datalabs.siva3.io/image/Eunimart_groceries_40129026-2_4-everest-masala-chhole.jpg",
-                                    "https://datalabs.siva3.io/image/Eunimart_groceries_40129026-3_4-everest-masala-chhole.jpg"
-                                ],
-                                "name": "Everest Masala - Chhole, 200 g Jar",
-                                "short_desc": "Everest presents their authentic range of masalas that are blended with a wide variety of handpicked and selected spices that bring a whole new flavour and meaning to your dishes. Rake up your favourite recipes and cuisines by adding this magical blend of Everest masalas.",
-                                "long_desc": "Everest presents their authentic range of masalas that are blended with a wide variety of handpicked and selected spices that bring a whole new flavour and meaning to your dishes. Rake up your favourite recipes and cuisines by adding this magical blend of Everest masalas."
-                            },
                             "tax_rate": "18",
-                            "location_id": "6879",
                             "@ondc/org/available_on_cod": false,
-                            "L2_category": "Masala & Seasoning",
-                            "category_id": "Masala & Seasoning",
+                            "contact_details_consumer_care_email": "vijai.c@beyondseek.com",
+                            "L2_category": "Snacks & Branded Foods",
+                            "category_id": "Snacks & Branded Foods",
                             "price": {
                                 "currency": "INR",
-                                "maximum_value": "162",
-                                "value": "162"
+                                "maximum_value": "72.18",
+                                "value": "72.18"
                             },
-                            "id": "f52e7ea6-1f24-4c84-a783-7cf74da3300e",
+                            "id": "212d131a-d863-4f6c-b9e5-64e31a033ac5",
+                            "@ondc/org/fssai_license_no": "1234567890",
                             "@ondc/org/cancellable": true,
+                            "@ondc/org/tat": "P6D",
                             "@ondc/org/returnable": true,
                             "quantity": {
                                 "available": {
-                                    "count": "5"
+                                    "count": "8"
                                 },
                                 "maximum": {
-                                    "count": "2"
+                                    "count": "3"
                                 },
                                 "unitized": {
                                     "measure": {
-                                        "unit": "g",
-                                        "value": "200"
+                                        "unit": "gram",
+                                        "value": "45"
                                     }
                                 }
                             },
                             "@ondc/org/time_to_ship": "P3D",
-                            "hsn_code": "1234567",
+                            "contact_details_consumer_care_name": "vijai ",
+                            "contact_details_consumer_care_contactno": "9884012345",
+                            "product_master_uuid": "72dd0d6c-9f6b-48dd-a09b-db8adfd53679",
+                            "hsn_code": "46464",
                             "tags": [
                                 {
-                                    "code": "veg_nonveg",
+                                    "code": "origin",
                                     "list": [
                                         {
-                                            "code": "veg",
-                                            "value": "yes"
+                                            "code": "country",
+                                            "value": "IND"
                                         }
                                     ]
                                 }
                             ],
                             "@ondc/org/return_window": "P14D",
                             "@ondc/org/statutory_reqs_prepackaged_food": {
-                                "importer_FSSAI_license_no": "686868",
-                                "nutritional_info": " bchhcc",
-                                "other_importer_address": "ufuf",
-                                "importer_fssai_logo": null,
-                                "importer_address": "chcuuf",
-                                "other_importer_name": "fiif",
-                                "brand_owner_FSSAI_license_no": "123456789",
-                                "net_quantity": "5335",
-                                "additives_info": "xhch",
-                                "other_premises": "hxhxxh",
-                                "importer_name": "hcucuf",
-                                "brand_owner_address": "ch",
-                                "brand_owner_fssai_logo": null,
-                                "ingredients_info": "ccv",
-                                "other_FSSAI_license_no": "6886",
-                                "brand_owner_name": "xhc",
+                                "importer_FSSAI_license_no": "454994",
+                                "nutritional_info": "sbbss",
+                                "other_importer_address": "zbsbsb",
+                                "importer_address": "sbbs",
+                                "other_importer_name": "sbzbs",
+                                "brand_owner_FSSAI_license_no": "464949",
+                                "net_quantity": "45 g",
+                                "additives_info": "snsjns",
+                                "other_premises": "sjsjs",
+                                "importer_name": "zbzbs",
+                                "brand_owner_address": "zhshsh",
+                                "ingredients_info": "zhs",
+                                "other_FSSAI_license_no": "794646",
+                                "brand_owner_name": "Gits",
                                 "imported_product_country_of_origin": "IND",
-                                "manufacturer_or_packer_name": "chcj",
-                                "manufacturer_or_packer_address": "chch"
+                                "manufacturer_or_packer_name": "sbsbsb",
+                                "manufacturer_or_packer_address": "shshsj"
                             },
                             "tax_type": "gst",
                             "domain": "Grocery",
                             "time": {
                                 "label": "enable",
-                                "timestamp": "2023-10-18T08:49:13.972Z"
-                            },
-                            "fulfillment_id": "1"
-                        },
-                        {
-                            "@ondc/org/TAT": "P6D",
-                            "@ondc/org/statutory_reqs_packaged_commodities": {
-                                "common_or_generic_name_of_commodity": "NA",
-                                "net_quantity_or_measure_of_commodity_in_pkg": "50 g",
-                                "imported_product_country_of_origin": "IND",
-                                "manufacturer_or_packer_name": "Aachi",
-                                "multiple_products_name_number_or_qty": "500 g",
-                                "manufacturer_or_packer_address": "NA",
-                                "month_year_of_manufacture_packing_import": "08/2023"
-                            },
-                            "@ondc/org/seller_pickup_return": true,
-                            "@ondc/org/contact_details_consumer_care": "9884044494",
-                            "descriptor": {
-                                "symbol": "https://firebasestorage.googleapis.com/v0/b/shopeg-dev.appspot.com/o/shopImages%2FVdxkoawpDWWiinBxbUjsYRnPl3x2%2Fimg_1692164210702.jpg?alt=media&token=4f5bd20e-2094-43a2-9a66-71732d1df66f",
-                                "images": [
-                                    "https://firebasestorage.googleapis.com/v0/b/shopeg-dev.appspot.com/o/shopImages%2FVdxkoawpDWWiinBxbUjsYRnPl3x2%2Fimg_1692164210702.jpg?alt=media&token=4f5bd20e-2094-43a2-9a66-71732d1df66f"
-                                ],
-                                "name": "Aachi urdal dal",
-                                "short_desc": "Urad dal",
-                                "long_desc": "urad dal"
-                            },
-                            "location_id": "6879",
-                            "tax_rate": "5",
-                            "@ondc/org/available_on_cod": false,
-                            "L2_category": "Foodgrains",
-                            "category_id": "Foodgrains",
-                            "price": {
-                                "currency": "INR",
-                                "maximum_value": "200",
-                                "value": "185"
-                            },
-                            "id": "406459af-7a0b-4a6f-bf33-4658dff5540d",
-                            "@ondc/org/cancellable": true,
-                            "@ondc/org/returnable": true,
-                            "quantity": {
-                                "available": {
-                                    "count": "52"
-                                },
-                                "maximum": {
-                                    "count": "5"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "g",
-                                        "value": "50"
-                                    }
-                                }
-                            },
-                            "@ondc/org/time_to_ship": "P3D",
-                            "hsn_code": "123456",
-                            "tags": [
-                                {
-                                    "code": "veg_nonveg",
-                                    "list": [
-                                        {
-                                            "code": "veg",
-                                            "value": "yes"
-                                        }
-                                    ]
-                                }
-                            ],
-                            "@ondc/org/return_window": "P14D",
-                            "@ondc/org/statutory_reqs_prepackaged_food": {
-                                "importer_FSSAI_license_no": "79494994",
-                                "nutritional_info": "NA",
-                                "other_importer_address": "NA",
-                                "importer_address": "NA",
-                                "other_importer_name": "NA",
-                                "brand_owner_FSSAI_license_no": "123456789",
-                                "net_quantity": "794946494",
-                                "additives_info": "NA",
-                                "other_premises": "NA",
-                                "importer_name": "Aachi",
-                                "brand_owner_address": "NA",
-                                "ingredients_info": "NA",
-                                "other_FSSAI_license_no": "124345648797",
-                                "brand_owner_name": "NA",
-                                "imported_product_country_of_origin": "IND",
-                                "manufacturer_or_packer_name": "NA",
-                                "manufacturer_or_packer_address": "NA"
-                            },
-                            "@ondc/org/mandatory_reqs_veggies_fruits": {
-                                "net_quantity": "50 g"
-                            },
-                            "tax_type": "gst",
-                            "domain": "Grocery",
-                            "time": {
-                                "label": "enable",
-                                "timestamp": "2023-10-18T08:49:13.972Z"
+                                "timestamp": "2023-10-28T11:22:19.925Z"
                             },
                             "fulfillment_id": "1"
                         }
@@ -8915,7 +1524,107 @@
                                 },
                                 {
                                     "code": "category",
+                                    "value": "Masala & Seasoning"
+                                },
+                                {
+                                    "code": "type",
+                                    "value": "10"
+                                },
+                                {
+                                    "code": "val",
+                                    "value": "75.5"
+                                },
+                                {
+                                    "code": "unit",
+                                    "value": "km"
+                                }
+                            ]
+                        },
+                        {
+                            "code": "serviceability",
+                            "list": [
+                                {
+                                    "code": "location",
+                                    "value": "6879"
+                                },
+                                {
+                                    "code": "category",
+                                    "value": "Snacks & Branded Foods"
+                                },
+                                {
+                                    "code": "type",
+                                    "value": "10"
+                                },
+                                {
+                                    "code": "val",
+                                    "value": "75.5"
+                                },
+                                {
+                                    "code": "unit",
+                                    "value": "km"
+                                }
+                            ]
+                        },
+                        {
+                            "code": "serviceability",
+                            "list": [
+                                {
+                                    "code": "location",
+                                    "value": "6879"
+                                },
+                                {
+                                    "code": "category",
+                                    "value": "Foodgrains"
+                                },
+                                {
+                                    "code": "type",
+                                    "value": "10"
+                                },
+                                {
+                                    "code": "val",
+                                    "value": "75.5"
+                                },
+                                {
+                                    "code": "unit",
+                                    "value": "km"
+                                }
+                            ]
+                        },
+                        {
+                            "code": "serviceability",
+                            "list": [
+                                {
+                                    "code": "location",
+                                    "value": "6879"
+                                },
+                                {
+                                    "code": "category",
                                     "value": "Pet Care"
+                                },
+                                {
+                                    "code": "type",
+                                    "value": "10"
+                                },
+                                {
+                                    "code": "val",
+                                    "value": "75.5"
+                                },
+                                {
+                                    "code": "unit",
+                                    "value": "km"
+                                }
+                            ]
+                        },
+                        {
+                            "code": "serviceability",
+                            "list": [
+                                {
+                                    "code": "location",
+                                    "value": "6879"
+                                },
+                                {
+                                    "code": "category",
+                                    "value": "Cleaning & Household"
                                 },
                                 {
                                     "code": "type",
@@ -8937,28 +1646,20 @@
                     "id": "rOebEZL96U8iln27G7Fm",
                     "time": {
                         "label": "enable",
-                        "timestamp": "2023-10-27T16:00:20.865Z"
+                        "timestamp": "2023-11-10T12:00:06.880Z"
                     },
                     "ttl": "P1D",
                     "descriptor": {
-                        "symbol": "https://www.bigbasket.com/media/uploads/p/l/40172087_6-sleepy-owl-cold-brew-coffee-classic.jpg",
-                        "images": [
-                            "https://www.bigbasket.com/media/uploads/p/l/40172087_6-sleepy-owl-cold-brew-coffee-classic.jpg"
-                        ],
                         "name": "B shop",
                         "short_desc": "Fresh Grocery Items updated schedule ",
-                        "long_desc": "Fresh Grocery Items"
+                        "long_desc": "Fresh Grocery Items updated schedule ",
+                        "symbol": "https://shopeg.in/i/eg.png",
+                        "images": [
+                            "https://shopeg.in/i/eg.png"
+                        ]
                     },
                     "locations": [
                         {
-                            "schedule": {
-                                "times": [
-                                    "0800",
-                                    "2100"
-                                ],
-                                "holidays": [],
-                                "frequency": "PT13H"
-                            },
                             "address": {
                                 "door": "67, 2nd Cross Road, 2nd Cross Road",
                                 "country": "India",
@@ -8982,149 +1683,47 @@
                                 },
                                 "days": "1,2,3,4,5,6,7",
                                 "label": "enable",
-                                "timestamp": "2023-10-27T16:00:20.865Z"
+                                "timestamp": "2023-11-10T12:00:06.880Z"
                             },
                             "circle": {
                                 "gps": "13.000985121772416,77.53780119522966",
                                 "radius": {
                                     "unit": "km",
-                                    "value": "5"
+                                    "value": "5.0"
                                 }
                             }
                         }
                     ],
                     "items": [
                         {
-                            "@ondc/org/TAT": "PT12H",
-                            "@ondc/org/statutory_reqs_packaged_commodities": {
-                                "common_or_generic_name_of_commodity": "Coffee",
-                                "net_quantity_or_measure_of_commodity_in_pkg": "Nos",
-                                "imported_product_country_of_origin": "IND",
-                                "manufacturer_or_packer_name": "Amrit Corp Ltd (Unit Amrit Food), Amrit Nagar, G.T. Road, Ghaziabad, U.P. - 201009 & 145/1, Ground Floor, Shahpur Jat, Delhi-110049",
-                                "multiple_products_name_number_or_qty": "qbsdh",
-                                "manufacturer_or_packer_address": "Amrit Corp Ltd (Unit Amrit Food), Amrit Nagar, G.T. Road, Ghaziabad, U.P. - 201009 & 145/1, Ground Floor, Shahpur Jat, Delhi-110049",
-                                "month_year_of_manufacture_packing_import": "10/2023"
-                            },
-                            "@ondc/org/statutory_reqs_packaged_commodities.imported_product_country_of_origin": "IND",
                             "@ondc/org/seller_pickup_return": true,
-                            "@ondc/org/contact_details_consumer_care": "john,john@email.com,9911991112",
+                            "@ondc/org/contact_details_consumer_care": "John Nov9,John@acme.com,9911991199",
                             "descriptor": {
-                                "symbol": "https://www.bigbasket.com/media/uploads/p/l/40172087_6-sleepy-owl-cold-brew-coffee-classic.jpg",
+                                "symbol": "https://datalabs.siva3.io/image/Eunimart_groceries_40179749_18-nestle-kitkat-dessert-delight-rich-choco-fudge-chocolate-crispy-wafer.jpg",
                                 "images": [
-                                    "https://www.bigbasket.com/media/uploads/p/l/40172087_6-sleepy-owl-cold-brew-coffee-classic.jpg"
+                                    "https://datalabs.siva3.io/image/Eunimart_groceries_40179749_18-nestle-kitkat-dessert-delight-rich-choco-fudge-chocolate-crispy-wafer.jpg",
+                                    "https://datalabs.siva3.io/image/Eunimart_groceries_40179749-2_473-nestle-kitkat-dessert-delight-rich-choco-fudge-chocolate-crispy-wafer.jpg",
+                                    "https://datalabs.siva3.io/image/Eunimart_groceries_40179749-3_474-nestle-kitkat-dessert-delight-rich-choco-fudge-chocolate-crispy-wafer.jpg"
                                 ],
-                                "name": "Sleepy Owl Classic Iced Coffee - Made With Cold Brew, 200 ml Bottle",
-                                "short_desc": "Sleepy Owl Classic is a cold-brewed iced coffee made from the highest quality 100% Grade A coffee sourced straight from Chikmagalur. Made with just 8 grams of sugar and a little milk, Sleepy Owl Classic is the perfect functional beverage for all lovers of coffee. The bottles contain 200ml of iced coffee and are made with love at our production facility in Ghaziabad. Each bottle has a shelf life of 120 days, which is achieved without any preservatives due to a special production process we use. The bottles are capped with easy-to-pull pop-off caps and have an ambient shelf life meaning they can be stored in cold or warm temperatures. These ready-to-drink bottles are India's first and only bottled iced coffee drink that contains nothing except coffee, milk, and sugar. No preservatives, no stabilisers, no emulsifiers, and no chemicals. Our mission at Sleepy Owl Coffee is to make high-quality cold brew coffee products that you can consume with ease and convenience at home, at work or on the go without having to compromise on taste or health. The same formula applies to the bottles - just chill them, shake them, pop them open, and gulp them down!",
-                                "long_desc": "Sleepy Owl Classic is a cold-brewed iced coffee made from the highest quality 100% Grade A coffee sourced straight from Chikmagalur. Made with just 8 grams of sugar and a little milk, Sleepy Owl Classic is the perfect functional beverage for all lovers of coffee. The bottles contain 200ml of iced coffee and are made with love at our production facility in Ghaziabad. Each bottle has a shelf life of 120 days, which is achieved without any preservatives due to a special production process we use. The bottles are capped with easy-to-pull pop-off caps and have an ambient shelf life meaning they can be stored in cold or warm temperatures. These ready-to-drink bottles are India's first and only bottled iced coffee drink that contains nothing except coffee, milk, and sugar. No preservatives, no stabilisers, no emulsifiers, and no chemicals. Our mission at Sleepy Owl Coffee is to make high-quality cold brew coffee products that you can consume with ease and convenience at home, at work or on the go without having to compromise on taste or health. The same formula applies to the bottles - just chill them, shake them, pop them open, and gulp them down!"
-                            },
-                            "location_id": "6271",
-                            "tax_rate": "5",
-                            "@ondc/org/available_on_cod": false,
-                            "L2_category": "Beverages",
-                            "category_id": "Beverages",
-                            "price": {
-                                "currency": "INR",
-                                "maximum_value": "110",
-                                "value": "110"
-                            },
-                            "@ondc/org/statutory_reqs_prepackaged_food.imported_product_country_of_origin": "IND",
-                            "id": "93091a6b-323e-444b-955e-c6f9678e2804",
-                            "@ondc/org/cancellable": true,
-                            "@ondc/org/returnable": true,
-                            "quantity": {
-                                "available": {
-                                    "count": "3"
-                                },
-                                "maximum": {
-                                    "count": "3"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "Nos",
-                                        "value": "46446"
-                                    }
-                                }
-                            },
-                            "@ondc/org/time_to_ship": "PT2H",
-                            "product_master_uuid": "89ebf116-3559-404c-9e04-5f76f884a6fd",
-                            "hsn_code": "1111",
-                            "tags": [
-                                {
-                                    "code": "veg_nonveg",
-                                    "list": [
-                                        {
-                                            "code": "veg",
-                                            "value": "yes"
-                                        }
-                                    ]
-                                }
-                            ],
-                            "@ondc/org/return_window": "P14D",
-                            "@ondc/org/statutory_reqs_prepackaged_food": {
-                                "importer_FSSAI_license_no": "544554",
-                                "nutritional_info": "hdhdh",
-                                "other_importer_address": "hdfhd",
-                                "importer_address": "hdhdhd",
-                                "other_importer_name": "hdfh",
-                                "brand_owner_FSSAI_license_no": "54545",
-                                "net_quantity": "1",
-                                "additives_info": "hddhhd",
-                                "other_premises": "her",
-                                "importer_name": "bddhhd",
-                                "brand_owner_address": "hdfh",
-                                "ingredients_info": "bddjd",
-                                "other_FSSAI_license_no": "545555",
-                                "brand_owner_name": "Sleepy Owl",
-                                "imported_product_country_of_origin": "IND",
-                                "manufacturer_or_packer_name": "gdfhdh",
-                                "manufacturer_or_packer_address": "ududh"
-                            },
-                            "tax_type": "gst",
-                            "domain": "Grocery",
-                            "time": {
-                                "label": "enable",
-                                "timestamp": "2023-10-19T09:05:08.791Z"
-                            },
-                            "fulfillment_id": "1"
-                        },
-                        {
-                            "@ondc/org/TAT": "PT12H",
-                            "@ondc/org/statutory_reqs_packaged_commodities": {
-                                "common_or_generic_name_of_commodity": "Men's Grooming",
-                                "net_quantity_or_measure_of_commodity_in_pkg": "1515 Nos",
-                                "imported_product_country_of_origin": "IND",
-                                "manufacturer_or_packer_name": "Celine Health Care. 15- Sicop Industrial Area, SICOP Units, Kathua, Jammu and Kashmir 184102",
-                                "multiple_products_name_number_or_qty": "whe",
-                                "manufacturer_or_packer_address": "Celine Health Care. 15- Sicop Industrial Area, SICOP Units, Kathua, Jammu and Kashmir 184102",
-                                "month_year_of_manufacture_packing_import": "10/2023"
-                            },
-                            "@ondc/org/statutory_reqs_packaged_commodities.imported_product_country_of_origin": "IND",
-                            "@ondc/org/seller_pickup_return": true,
-                            "@ondc/org/contact_details_consumer_care": "john,john@email.com,9911991112",
-                            "descriptor": {
-                                "symbol": "https://datalabs.siva3.io/image/Eunimart_groceries_30004608_6-park-avenue-bathing-soap-good-morning.jpg",
-                                "images": [
-                                    "https://datalabs.siva3.io/image/Eunimart_groceries_30004608_6-park-avenue-bathing-soap-good-morning.jpg",
-                                    "https://datalabs.siva3.io/image/Eunimart_groceries_30004608-2_2-park-avenue-bathing-soap-good-morning.jpg",
-                                    "https://datalabs.siva3.io/image/Eunimart_groceries_30004608-3_1-park-avenue-bathing-soap-good-morning.jpg"
-                                ],
-                                "name": "Park Avenue Bathing Soap - Good Morning, 125 g",
-                                "short_desc": "Park Avenue Good Morning soap has the goodness of shea butter that mausturises skin and tea tree oil, which helps fight bacteria.",
-                                "long_desc": "Park Avenue Good Morning soap has the goodness of shea butter that mausturises skin and tea tree oil, which helps fight bacteria."
+                                "name": "Nestle KitKat - Dessert Delight, Rich Choco Fudge Wafer Bar, Gift Pack, 150 g",
+                                "short_desc": "Celebrate the season of love and capture the joy of togetherness with KitKat Dessert Delight Rich Choco Fudge. This Valentine‚s Day, gift KitKat Dessert Delight Rich Choco Fudge and spread happiness with an indulgent play of rich chocolate and signature KIT KAT crispiness that brings you to delight in every bite. This Nestle chocolate gift pack is perfect for your special someone. Just unwrap the pack, slide your fingers through the foil, break off 3 cubes and enjoy. The pack contains a Greeting Card with a special message in to delight your loved one.",
+                                "long_desc": "Celebrate the season of love and capture the joy of togetherness with KitKat Dessert Delight Rich Choco Fudge. This Valentine‚s Day, gift KitKat Dessert Delight Rich Choco Fudge and spread happiness with an indulgent play of rich chocolate and signature KIT KAT crispiness that brings you to delight in every bite. This Nestle chocolate gift pack is perfect for your special someone. Just unwrap the pack, slide your fingers through the foil, break off 3 cubes and enjoy. The pack contains a Greeting Card with a special message in to delight your loved one."
                             },
                             "location_id": "6271",
                             "tax_rate": "28",
-                            "@ondc/org/available_on_cod": false,
-                            "L2_category": "Beauty & Hygiene",
-                            "category_id": "Beauty & Hygiene",
+                            "@ondc/org/available_on_cod": true,
+                            "contact_details_consumer_care_email": "ghy@gui.con",
+                            "L2_category": "Snacks & Branded Foods",
+                            "category_id": "Snacks & Branded Foods",
                             "price": {
                                 "currency": "INR",
-                                "maximum_value": "60",
-                                "value": "60"
+                                "maximum_value": "170",
+                                "value": "170"
                             },
-                            "@ondc/org/statutory_reqs_prepackaged_food.imported_product_country_of_origin": "IND",
-                            "id": "63e3595e-d3d7-4bf7-bcf1-2c5449621931",
+                            "id": "cdd75c83-28c4-4b20-a1f2-7695a04275f0",
+                            "@ondc/org/fssai_license_no": "2555",
                             "@ondc/org/cancellable": true,
+                            "@ondc/org/tat": "PT4H",
                             "@ondc/org/returnable": true,
                             "quantity": {
                                 "available": {
@@ -9135,689 +1734,50 @@
                                 },
                                 "unitized": {
                                     "measure": {
-                                        "unit": "Nos",
-                                        "value": "1515"
-                                    }
-                                }
-                            },
-                            "@ondc/org/time_to_ship": "PT2H",
-                            "product_master_uuid": "149d97b0-d702-4866-9562-dafc04db112b",
-                            "hsn_code": "15151",
-                            "tags": [],
-                            "@ondc/org/return_window": "P14D",
-                            "tax_type": "gst",
-                            "domain": "Grocery",
-                            "time": {
-                                "label": "enable",
-                                "timestamp": "2023-10-19T09:05:08.791Z"
-                            },
-                            "fulfillment_id": "1"
-                        },
-                        {
-                            "@ondc/org/TAT": "PT12H",
-                            "@ondc/org/statutory_reqs_packaged_commodities": {
-                                "common_or_generic_name_of_commodity": "Salt & Sugar",
-                                "net_quantity_or_measure_of_commodity_in_pkg": "1 Nos",
-                                "imported_product_country_of_origin": "IND",
-                                "manufacturer_or_packer_name": "ITC",
-                                "multiple_products_name_number_or_qty": "bdbfdb",
-                                "manufacturer_or_packer_address": "ITC",
-                                "month_year_of_manufacture_packing_import": "10/2023"
-                            },
-                            "@ondc/org/statutory_reqs_packaged_commodities.imported_product_country_of_origin": "IND",
-                            "@ondc/org/seller_pickup_return": true,
-                            "@ondc/org/contact_details_consumer_care": "john,john@email.com,9911991112",
-                            "descriptor": {
-                                "symbol": "https://m.media-amazon.com/images/I/81NrftYFxsL._SL1500_.jpg",
-                                "images": [
-                                    "https://m.media-amazon.com/images/I/81NrftYFxsL._SL1500_.jpg"
-                                ],
-                                "name": "Aashirvaad Salt,with 4-Step advantage, 1kg\r\n",
-                                "short_desc": "Aashirvaad ensures that only good quality ingredients reach your kitchen and Aashirvaad Iodised Salt stays true to that promise. Made from natural sea salt crystals with a 4-step advantage process, Aashirvaad Iodised Salt ensures that you and your family receive pure goodness of nature, daily. Aashirvaad Iodised Salt is obtained by first, evaporating sea water or brine in shallow basins by sunlight and wind for 3 weeks. When the water evaporates, a salt bed forms at the bottom of the basin. This salt is then collected, and put through an elaborate cleansing process and finally, enriched with Iodine to take care of your family’s Iodine requirements. The moisture-proof packaging ensures a free-flowing granular form that enables easy handling as well as clean storage. Aashirvaad Iodised salt's 4 step advantange is what gives your meals a balanced, original taste - free of any impurities. We take extra care to ensure that only quality salt reaches your home. Simply because we know that it is the only way you would have it! About Aashirvaad: Aashirvaad stands for purity, expert sourcing and quality, and believes in giving you nothing but the best. Hence the ingredients are carefully hand-picked and processed with the same love and care with which you prepare your food. Aashirvaad has a wide range of products - atta, ghee, salt, spices and instant mixes. To lock in the freshness and nutritional quality of its products, Aashirvaad uses world class packaging technology which retains the original, high quality flavour. About ITC ITC is one of India’s foremost companies with its presence in FMCG, Hotels, Packaging, Paperboards & Specialty Papers, Agri & IT Businesses. ITC Brands are designed and customized to delight diverse tastes, needs and lifestyles. With quality and innovation at the core along with contemporary packaging, customer insights and a formidable nationwide distribution network, ITC has been delighting millions of households every day since 1910. A brand that is made in India, for the world.",
-                                "long_desc": "Aashirvaad ensures that only good quality ingredients reach your kitchen and Aashirvaad Iodised Salt stays true to that promise. Made from natural sea salt crystals with a 4-step advantage process, Aashirvaad Iodised Salt ensures that you and your family receive pure goodness of nature, daily. Aashirvaad Iodised Salt is obtained by first, evaporating sea water or brine in shallow basins by sunlight and wind for 3 weeks. When the water evaporates, a salt bed forms at the bottom of the basin. This salt is then collected, and put through an elaborate cleansing process and finally, enriched with Iodine to take care of your family’s Iodine requirements. The moisture-proof packaging ensures a free-flowing granular form that enables easy handling as well as clean storage. Aashirvaad Iodised salt's 4 step advantange is what gives your meals a balanced, original taste - free of any impurities. We take extra care to ensure that only quality salt reaches your home. Simply because we know that it is the only way you would have it! About Aashirvaad: Aashirvaad stands for purity, expert sourcing and quality, and believes in giving you nothing but the best. Hence the ingredients are carefully hand-picked and processed with the same love and care with which you prepare your food. Aashirvaad has a wide range of products - atta, ghee, salt, spices and instant mixes. To lock in the freshness and nutritional quality of its products, Aashirvaad uses world class packaging technology which retains the original, high quality flavour. About ITC ITC is one of India’s foremost companies with its presence in FMCG, Hotels, Packaging, Paperboards & Specialty Papers, Agri & IT Businesses. ITC Brands are designed and customized to delight diverse tastes, needs and lifestyles. With quality and innovation at the core along with contemporary packaging, customer insights and a formidable nationwide distribution network, ITC has been delighting millions of households every day since 1910. A brand that is made in India, for the world."
-                            },
-                            "location_id": "6271",
-                            "tax_rate": "5",
-                            "@ondc/org/available_on_cod": false,
-                            "L2_category": "Masala & Seasoning",
-                            "category_id": "Masala & Seasoning",
-                            "price": {
-                                "currency": "INR",
-                                "maximum_value": "23",
-                                "value": "23"
-                            },
-                            "@ondc/org/statutory_reqs_prepackaged_food.imported_product_country_of_origin": "IND",
-                            "id": "6ff7768d-66dc-4ad3-a4b9-291c9eadfdb8",
-                            "@ondc/org/cancellable": true,
-                            "@ondc/org/returnable": true,
-                            "quantity": {
-                                "available": {
-                                    "count": "3"
-                                },
-                                "maximum": {
-                                    "count": "3"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "Nos",
+                                        "unit": "unit",
                                         "value": "1"
                                     }
                                 }
                             },
                             "@ondc/org/time_to_ship": "PT2H",
-                            "product_master_uuid": "e30a257a-9d65-47ff-9d49-417cdaea8f2c",
-                            "hsn_code": "555",
+                            "contact_details_consumer_care_name": "gghhh",
+                            "contact_details_consumer_care_contactno": "5258888888",
+                            "product_master_uuid": "8ef6de0a-2db5-4c10-bfe1-ce996c7ee2ab",
+                            "hsn_code": "522585555",
                             "tags": [
                                 {
-                                    "code": "veg_nonveg",
+                                    "code": "origin",
                                     "list": [
                                         {
-                                            "code": "veg",
-                                            "value": "yes"
+                                            "code": "country",
+                                            "value": "IND"
                                         }
                                     ]
                                 }
                             ],
                             "@ondc/org/return_window": "P14D",
                             "@ondc/org/statutory_reqs_prepackaged_food": {
-                                "importer_FSSAI_license_no": "188148",
-                                "nutritional_info": "hdhfh",
-                                "other_importer_address": "hrhddh",
-                                "importer_address": "bdnfbf",
-                                "other_importer_name": "bdnd",
-                                "brand_owner_FSSAI_license_no": "211804",
-                                "net_quantity": "1",
-                                "additives_info": "nrfmfj",
-                                "other_premises": "brndj",
-                                "importer_name": "dhdhdj",
-                                "brand_owner_address": "bfbffj",
-                                "ingredients_info": "bdnjf",
-                                "other_FSSAI_license_no": "51515",
-                                "brand_owner_name": "Aashirvaad",
-                                "imported_product_country_of_origin": "IND",
-                                "manufacturer_or_packer_name": "jrjr",
-                                "manufacturer_or_packer_address": "brjfjf"
+                                "importer_FSSAI_license_no": "2588",
+                                "nutritional_info": "hhhh",
+                                "other_importer_address": "hhhh",
+                                "importer_address": "yhhhh",
+                                "other_importer_name": "ghhhhh",
+                                "brand_owner_FSSAI_license_no": "2555",
+                                "additives_info": "ghhh",
+                                "other_premises": "yhhh",
+                                "importer_name": "hhhh",
+                                "brand_owner_address": "yhhh",
+                                "ingredients_info": "chocolate ",
+                                "other_FSSAI_license_no": "2588",
+                                "brand_owner_name": "Nestle",
+                                "manufacturer_or_packer_name": "guhb",
+                                "manufacturer_or_packer_address": "hyh"
                             },
                             "tax_type": "gst",
                             "domain": "Grocery",
                             "time": {
                                 "label": "enable",
-                                "timestamp": "2023-10-19T09:05:08.791Z"
-                            },
-                            "fulfillment_id": "1"
-                        },
-                        {
-                            "@ondc/org/TAT": "PT12H",
-                            "@ondc/org/statutory_reqs_packaged_commodities": {
-                                "common_or_generic_name_of_commodity": "Flour & Grains",
-                                "net_quantity_or_measure_of_commodity_in_pkg": "1 Nos",
-                                "imported_product_country_of_origin": "IND",
-                                "manufacturer_or_packer_name": "General Mills India Pvt ltd. 902, Ventura, Hiranandani Buisness Park, Powai, Mumbai- 400076",
-                                "multiple_products_name_number_or_qty": "1",
-                                "manufacturer_or_packer_address": "General Mills India Pvt ltd. 902, Ventura, Hiranandani Buisness Park, Powai, Mumbai- 400076",
-                                "month_year_of_manufacture_packing_import": "10/2023"
-                            },
-                            "@ondc/org/statutory_reqs_packaged_commodities.imported_product_country_of_origin": "IND",
-                            "@ondc/org/contact_details_consumer_care": "john,john@email.com,9911991112",
-                            "@ondc/org/seller_pickup_return": true,
-                            "descriptor": {
-                                "symbol": "https://www.bigbasket.com/media/uploads/p/l/124657_8-pillsbury-atta-chakki-fresh.jpg?tr=w-640,q=80",
-                                "images": [
-                                    "https://www.bigbasket.com/media/uploads/p/l/124657_8-pillsbury-atta-chakki-fresh.jpg?tr=w-640,q=80",
-                                    "https://www.bigbasket.com/media/uploads/p/l/124657-2_3-pillsbury-atta-chakki-fresh.jpg?tr=w-640,q=80",
-                                    "https://www.bigbasket.com/media/uploads/p/l/124657-3_3-pillsbury-atta-chakki-fresh.jpg?tr=w-640,q=80"
-                                ],
-                                "name": "Pillsbury Atta/Gavhache Peeth - Chakki Fresh, 10 kg Pouch",
-                                "short_desc": "Rotis made from Pillsbury Chakki Fresh Atta is a healthy option for those who prefer rotis and chapattis (Indian bread) to rice. As this atta or wheat flour is known to contain three parts of the whole wheat grain, you can be assured of wholesome nourishment when you are eating rotis made from this wheat flour.",
-                                "long_desc": "Rotis made from Pillsbury Chakki Fresh Atta is a healthy option for those who prefer rotis and chapattis (Indian bread) to rice. As this atta or wheat flour is known to contain three parts of the whole wheat grain, you can be assured of wholesome nourishment when you are eating rotis made from this wheat flour."
-                            },
-                            "location_id": "6271",
-                            "tax_rate": "5",
-                            "@ondc/org/available_on_cod": false,
-                            "L2_category": "Foodgrains",
-                            "category_id": "Foodgrains",
-                            "price": {
-                                "currency": "INR",
-                                "maximum_value": "450",
-                                "value": "450"
-                            },
-                            "@ondc/org/statutory_reqs_prepackaged_food.imported_product_country_of_origin": "IND",
-                            "id": "b7f7cbcd-8928-4974-9ed4-ff01f1c8dfa3",
-                            "@ondc/org/cancellable": true,
-                            "@ondc/org/returnable": true,
-                            "quantity": {
-                                "available": {
-                                    "count": "3"
-                                },
-                                "maximum": {
-                                    "count": "3"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "Nos",
-                                        "value": "1"
-                                    }
-                                }
-                            },
-                            "@ondc/org/time_to_ship": "PT2H",
-                            "product_master_uuid": "29f8f73c-7777-41c1-8ddc-a192d28149f0",
-                            "hsn_code": "5555",
-                            "tags": [
-                                {
-                                    "code": "veg_nonveg",
-                                    "list": [
-                                        {
-                                            "code": "veg",
-                                            "value": "yes"
-                                        }
-                                    ]
-                                }
-                            ],
-                            "@ondc/org/return_window": "P14D",
-                            "@ondc/org/statutory_reqs_prepackaged_food": {
-                                "importer_FSSAI_license_no": "858",
-                                "nutritional_info": "hddjdj",
-                                "other_importer_address": "shehdb",
-                                "importer_address": "hdjdjd",
-                                "other_importer_name": "bdbdd",
-                                "brand_owner_FSSAI_license_no": "645458448848484",
-                                "net_quantity": "1",
-                                "additives_info": "djdjjd",
-                                "other_premises": "dudjd",
-                                "importer_name": "hshdjd",
-                                "brand_owner_address": "dudjdj",
-                                "ingredients_info": "wheat flour",
-                                "other_FSSAI_license_no": "1515181188",
-                                "brand_owner_name": "Pillsbury",
-                                "imported_product_country_of_origin": "IND",
-                                "manufacturer_or_packer_name": "djjddh",
-                                "manufacturer_or_packer_address": "hdfjjd"
-                            },
-                            "tax_type": "gst",
-                            "domain": "Grocery",
-                            "time": {
-                                "label": "enable",
-                                "timestamp": "2023-10-19T09:05:08.791Z"
-                            },
-                            "fulfillment_id": "1"
-                        },
-                        {
-                            "@ondc/org/TAT": "PT12H",
-                            "@ondc/org/statutory_reqs_packaged_commodities": {
-                                "common_or_generic_name_of_commodity": "Men's Grooming",
-                                "net_quantity_or_measure_of_commodity_in_pkg": "555 Nos",
-                                "imported_product_country_of_origin": "IND",
-                                "manufacturer_or_packer_name": "Celine Health Care. 15- Sicop Industrial Area, SICOP Units, Kathua, Jammu and Kashmir 184102",
-                                "multiple_products_name_number_or_qty": "ghh",
-                                "manufacturer_or_packer_address": "Celine Health Care. 15- Sicop Industrial Area, SICOP Units, Kathua, Jammu and Kashmir 184102",
-                                "month_year_of_manufacture_packing_import": "10/2023"
-                            },
-                            "@ondc/org/statutory_reqs_packaged_commodities.imported_product_country_of_origin": "IND",
-                            "@ondc/org/seller_pickup_return": true,
-                            "@ondc/org/contact_details_consumer_care": "john,john@email.com,9911991112",
-                            "descriptor": {
-                                "symbol": "https://datalabs.siva3.io/image/Eunimart_groceries_290490_6-park-avenue-bathing-soap-cool-blue.jpg",
-                                "images": [
-                                    "https://datalabs.siva3.io/image/Eunimart_groceries_290490_6-park-avenue-bathing-soap-cool-blue.jpg",
-                                    "https://datalabs.siva3.io/image/Eunimart_groceries_290490-2_2-park-avenue-bathing-soap-cool-blue.jpg",
-                                    "https://datalabs.siva3.io/image/Eunimart_groceries_290490-3_1-park-avenue-bathing-soap-cool-blue.jpg"
-                                ],
-                                "name": "Park Avenue Bathing Soap - Cool Blue, 125 g",
-                                "short_desc": "Park Avenue Cool blue soap is infused with a multi-mineral energizer that spreads freshness throughout you body",
-                                "long_desc": "Park Avenue Cool blue soap is infused with a multi-mineral energizer that spreads freshness throughout you body"
-                            },
-                            "location_id": "6271",
-                            "tax_rate": "5",
-                            "@ondc/org/available_on_cod": false,
-                            "L2_category": "Beauty & Hygiene",
-                            "category_id": "Beauty & Hygiene",
-                            "price": {
-                                "currency": "INR",
-                                "maximum_value": "63",
-                                "value": "63"
-                            },
-                            "@ondc/org/statutory_reqs_prepackaged_food.imported_product_country_of_origin": "IND",
-                            "id": "e06763ff-23b9-4b8b-a131-398c9afa710d",
-                            "@ondc/org/cancellable": true,
-                            "@ondc/org/returnable": true,
-                            "quantity": {
-                                "available": {
-                                    "count": "3"
-                                },
-                                "maximum": {
-                                    "count": "3"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "Nos",
-                                        "value": "555"
-                                    }
-                                }
-                            },
-                            "@ondc/org/time_to_ship": "PT2H",
-                            "product_master_uuid": "96edc7e8-e9f6-4509-87b6-e48de6a62ad5",
-                            "hsn_code": "55885",
-                            "tags": [],
-                            "@ondc/org/return_window": "P14D",
-                            "tax_type": "gst",
-                            "domain": "Grocery",
-                            "time": {
-                                "label": "enable",
-                                "timestamp": "2023-10-19T09:05:08.791Z"
-                            },
-                            "fulfillment_id": "1"
-                        },
-                        {
-                            "@ondc/org/TAT": "PT12H",
-                            "@ondc/org/statutory_reqs_packaged_commodities": {
-                                "common_or_generic_name_of_commodity": "Coffee",
-                                "net_quantity_or_measure_of_commodity_in_pkg": "1 Nos",
-                                "imported_product_country_of_origin": "IND",
-                                "manufacturer_or_packer_name": "Hindustan Unilever Limited, Unilever House, B D Sawant Marg, Chakala, Anderi E, Mumbai - 400099",
-                                "multiple_products_name_number_or_qty": "hdfhhd",
-                                "manufacturer_or_packer_address": "Hindustan Unilever Limited, Unilever House, B D Sawant Marg, Chakala, Anderi E, Mumbai - 400099",
-                                "month_year_of_manufacture_packing_import": "10/2023"
-                            },
-                            "@ondc/org/statutory_reqs_packaged_commodities.imported_product_country_of_origin": "IND",
-                            "@ondc/org/seller_pickup_return": true,
-                            "@ondc/org/contact_details_consumer_care": "john,john@email.com,9911991112",
-                            "descriptor": {
-                                "symbol": "https://www.bigbasket.com/media/uploads/p/xxl/266584_22-bru-instant-coffee.jpg",
-                                "images": [
-                                    "https://www.bigbasket.com/media/uploads/p/xxl/266584_22-bru-instant-coffee.jpg",
-                                    "https://datalabs.siva3.io/image/Eunimart_groceries_266531-2_13-bru-instant-coffee.jpg",
-                                    "https://datalabs.siva3.io/image/Eunimart_groceries_266531-3_13-bru-instant-coffee.jpg"
-                                ],
-                                "name": "BRU Instant Coffee, 50 g",
-                                "short_desc": "BRU Instant Coffee was launched in 1968 and was Indias first coffee-chicory mix instant coffee. It is the perfect mix of 70% coffee and 30% chicory and is made from a fine blend of the choicest plantation and Robusta beans. These coffee beans are first roasted to perfection, then the new and enhanced process ensures that the fresh coffee aroma is preserved so that you get a rich coffee taste beyond compare. Bru Instant coffee can be used to make an aromatic cup of hot coffee as well as a refreshing glass of cold coffee. With Bru Instant, you can now discover a great coffee experience with your loved ones.\r\nABOUT BRU\r\nA part of Hindustan Unilever Ltd. , BRU Coffee is Indias largest and favourite coffee brand that offers a wide variety of coffee products. Since 1968, BRU has been a pioneer in bringing the authentic taste of coffee to Indian consumers. The best coffee beans are selected from across innumerable coffee trails and are freshly roasted, to serve a great cup of rich, irresistible coffee. BRU has four distinct offerings - BRU Instant and BRU Gold in Instant coffee, BRU Green Label and BRU Select in Filter coffee. BRU-ed with love and blended with passion, BRU Coffee celebrates authenticity in coffee and relationships.",
-                                "long_desc": "BRU Instant Coffee was launched in 1968 and was Indias first coffee-chicory mix instant coffee. It is the perfect mix of 70% coffee and 30% chicory and is made from a fine blend of the choicest plantation and Robusta beans. These coffee beans are first roasted to perfection, then the new and enhanced process ensures that the fresh coffee aroma is preserved so that you get a rich coffee taste beyond compare. Bru Instant coffee can be used to make an aromatic cup of hot coffee as well as a refreshing glass of cold coffee. With Bru Instant, you can now discover a great coffee experience with your loved ones.\r\nABOUT BRU\r\nA part of Hindustan Unilever Ltd. , BRU Coffee is Indias largest and favourite coffee brand that offers a wide variety of coffee products. Since 1968, BRU has been a pioneer in bringing the authentic taste of coffee to Indian consumers. The best coffee beans are selected from across innumerable coffee trails and are freshly roasted, to serve a great cup of rich, irresistible coffee. BRU has four distinct offerings - BRU Instant and BRU Gold in Instant coffee, BRU Green Label and BRU Select in Filter coffee. BRU-ed with love and blended with passion, BRU Coffee celebrates authenticity in coffee and relationships."
-                            },
-                            "location_id": "6271",
-                            "tax_rate": "18",
-                            "@ondc/org/available_on_cod": false,
-                            "L2_category": "Beverages",
-                            "category_id": "Beverages",
-                            "price": {
-                                "currency": "INR",
-                                "maximum_value": "97",
-                                "value": "97"
-                            },
-                            "@ondc/org/statutory_reqs_prepackaged_food.imported_product_country_of_origin": "IND",
-                            "id": "6b71c4cc-cbb6-4df9-9186-1005623ae756",
-                            "@ondc/org/cancellable": true,
-                            "@ondc/org/returnable": true,
-                            "quantity": {
-                                "available": {
-                                    "count": "3"
-                                },
-                                "maximum": {
-                                    "count": "3"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "Nos",
-                                        "value": "1"
-                                    }
-                                }
-                            },
-                            "@ondc/org/time_to_ship": "PT2H",
-                            "product_master_uuid": "a1c069e1-60b0-481e-84bf-dbd8682bbfc2",
-                            "hsn_code": "145588",
-                            "tags": [
-                                {
-                                    "code": "veg_nonveg",
-                                    "list": [
-                                        {
-                                            "code": "veg",
-                                            "value": "yes"
-                                        }
-                                    ]
-                                }
-                            ],
-                            "@ondc/org/return_window": "P14D",
-                            "@ondc/org/statutory_reqs_prepackaged_food": {
-                                "importer_FSSAI_license_no": "121010",
-                                "nutritional_info": "hehedh",
-                                "other_importer_address": "jdjd",
-                                "importer_address": "djfjjf",
-                                "other_importer_name": "hdnd",
-                                "brand_owner_FSSAI_license_no": "515118",
-                                "net_quantity": "14664",
-                                "additives_info": "hehedh",
-                                "other_premises": "djdj",
-                                "importer_name": "bdbdd",
-                                "brand_owner_address": "hdhdhf",
-                                "ingredients_info": "hendbd",
-                                "other_FSSAI_license_no": "8558",
-                                "brand_owner_name": "BRU",
-                                "imported_product_country_of_origin": "IND",
-                                "manufacturer_or_packer_name": "hdhdh",
-                                "manufacturer_or_packer_address": "hhdfhfj"
-                            },
-                            "tax_type": "gst",
-                            "domain": "Grocery",
-                            "time": {
-                                "label": "enable",
-                                "timestamp": "2023-10-19T09:05:08.791Z"
-                            },
-                            "fulfillment_id": "1"
-                        },
-                        {
-                            "@ondc/org/TAT": "PT12H",
-                            "@ondc/org/statutory_reqs_packaged_commodities": {
-                                "common_or_generic_name_of_commodity": "Coffee",
-                                "net_quantity_or_measure_of_commodity_in_pkg": "1 Nos",
-                                "imported_product_country_of_origin": "IND",
-                                "manufacturer_or_packer_name": "Amrit Corp Ltd (Unit Amrit Food), Amrit Nagar, G.T. Road, Ghaziabad, U.P. - 201009 & 145/1, Ground Floor, Shahpur Jat, Delhi-110049",
-                                "multiple_products_name_number_or_qty": "xhhdd",
-                                "manufacturer_or_packer_address": "Amrit Corp Ltd (Unit Amrit Food), Amrit Nagar, G.T. Road, Ghaziabad, U.P. - 201009 & 145/1, Ground Floor, Shahpur Jat, Delhi-110049",
-                                "month_year_of_manufacture_packing_import": "10/2023"
-                            },
-                            "@ondc/org/statutory_reqs_packaged_commodities.imported_product_country_of_origin": "IND",
-                            "@ondc/org/seller_pickup_return": true,
-                            "@ondc/org/contact_details_consumer_care": "john,john@email.com,9911991112",
-                            "descriptor": {
-                                "symbol": "https://www.bigbasket.com/media/uploads/p/l/1213465_1-sleepy-owl-cold-brew-coffee-classic.jpg",
-                                "images": [
-                                    "https://www.bigbasket.com/media/uploads/p/l/1213465_1-sleepy-owl-cold-brew-coffee-classic.jpg"
-                                ],
-                                "name": "Sleepy Owl Cold Brew Coffee - Classic, 6x200 ml Multipack",
-                                "short_desc": "Sleepy Owl Classic is a cold-brewed iced coffee made from the highest quality 100% Grade A coffee sourced straight from Chikmagalur. Made with just 8 grams of sugar and a little milk, Sleepy Owl Classic is the perfect functional beverage for all lovers of coffee. The bottles contain 200ml of iced coffee and are made with love at our production facility in Ghaziabad. Each bottle has a shelf life of 120 days, which is achieved without any preservatives due to a special production process we use. \r\n\r\nThe bottles are capped with easy to pull pop off caps and have an ambient shelf life meaning they can be stored in cold or warm temperature. These ready-to-drink bottles are India’s first and only bottled iced coffee drink that contains nothing except coffee, milk, and sugar. No preservatives, no stabilisers, no emulsifiers, and no chemicals. \r\n\r\nOur mission at Sleepy Owl Coffee is to make high-quality cold brew coffee products that you can consume with ease and convenience at home, at work or on the go without having to compromise on taste or health. The same formula applies to the bottles - just chill them, shake them, pop them open, and gulp them down!",
-                                "long_desc": "Sleepy Owl Classic is a cold-brewed iced coffee made from the highest quality 100% Grade A coffee sourced straight from Chikmagalur. Made with just 8 grams of sugar and a little milk, Sleepy Owl Classic is the perfect functional beverage for all lovers of coffee. The bottles contain 200ml of iced coffee and are made with love at our production facility in Ghaziabad. Each bottle has a shelf life of 120 days, which is achieved without any preservatives due to a special production process we use. \r\n\r\nThe bottles are capped with easy to pull pop off caps and have an ambient shelf life meaning they can be stored in cold or warm temperature. These ready-to-drink bottles are India’s first and only bottled iced coffee drink that contains nothing except coffee, milk, and sugar. No preservatives, no stabilisers, no emulsifiers, and no chemicals. \r\n\r\nOur mission at Sleepy Owl Coffee is to make high-quality cold brew coffee products that you can consume with ease and convenience at home, at work or on the go without having to compromise on taste or health. The same formula applies to the bottles - just chill them, shake them, pop them open, and gulp them down!"
-                            },
-                            "location_id": "6271",
-                            "tax_rate": "18",
-                            "@ondc/org/available_on_cod": false,
-                            "L2_category": "Beverages",
-                            "category_id": "Beverages",
-                            "price": {
-                                "currency": "INR",
-                                "maximum_value": "660",
-                                "value": "660"
-                            },
-                            "@ondc/org/statutory_reqs_prepackaged_food.imported_product_country_of_origin": "IND",
-                            "id": "93f3866e-687f-43b4-a709-0ea694f62487",
-                            "@ondc/org/cancellable": true,
-                            "@ondc/org/returnable": true,
-                            "quantity": {
-                                "available": {
-                                    "count": "3"
-                                },
-                                "maximum": {
-                                    "count": "3"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "Nos",
-                                        "value": "1"
-                                    }
-                                }
-                            },
-                            "@ondc/org/time_to_ship": "PT2H",
-                            "product_master_uuid": "ebd99aa2-ed6f-455a-bef2-497dc86f6d1b",
-                            "hsn_code": "8484",
-                            "tags": [
-                                {
-                                    "code": "veg_nonveg",
-                                    "list": [
-                                        {
-                                            "code": "veg",
-                                            "value": "yes"
-                                        }
-                                    ]
-                                }
-                            ],
-                            "@ondc/org/return_window": "P14D",
-                            "@ondc/org/statutory_reqs_prepackaged_food": {
-                                "importer_FSSAI_license_no": "5555",
-                                "nutritional_info": "brbfb",
-                                "other_importer_address": "hfhf",
-                                "importer_address": "ehhe",
-                                "other_importer_name": "bfbf",
-                                "brand_owner_FSSAI_license_no": "54484",
-                                "net_quantity": "1",
-                                "additives_info": "jrjrh",
-                                "other_premises": "hfjf",
-                                "importer_name": "dhhdd",
-                                "brand_owner_address": "hehed",
-                                "ingredients_info": "nddbd",
-                                "other_FSSAI_license_no": "1555",
-                                "brand_owner_name": "Sleepy Owl",
-                                "imported_product_country_of_origin": "IND",
-                                "manufacturer_or_packer_name": "hrfhd",
-                                "manufacturer_or_packer_address": "fhhf"
-                            },
-                            "tax_type": "gst",
-                            "domain": "Grocery",
-                            "time": {
-                                "label": "enable",
-                                "timestamp": "2023-10-19T09:05:08.791Z"
-                            },
-                            "fulfillment_id": "1"
-                        },
-                        {
-                            "@ondc/org/TAT": "PT12H",
-                            "@ondc/org/statutory_reqs_packaged_commodities": {
-                                "common_or_generic_name_of_commodity": "Oils",
-                                "net_quantity_or_measure_of_commodity_in_pkg": "1 Nos",
-                                "imported_product_country_of_origin": "IND",
-                                "manufacturer_or_packer_name": "Mother Dairy Fruit & Vegetable Pvt. Ltd.\r\nMother Dairy, Patarganj, Delhi - 110092.\r\n\r\nBhawani Silicate Industries\r\nF-143, Udyog Vihar, Jetpura, Jaipur - 303704, Rajasthan. Shnodevi Refoils & Solvex, Plot No. 235/3, Gidc, Chandisar, Taluka - Palanpur, Dist.- Banaskantha - 385510, Gujarat.\r\n\r\nBhawani Silicate Industries\r\nG1, 175-176, Udyog Vihar, Jetpura, Jaipur - 303704, Rajasthan.",
-                                "multiple_products_name_number_or_qty": "hedg",
-                                "manufacturer_or_packer_address": "Mother Dairy Fruit & Vegetable Pvt. Ltd.\r\nMother Dairy, Patarganj, Delhi - 110092.\r\n\r\nBhawani Silicate Industries\r\nF-143, Udyog Vihar, Jetpura, Jaipur - 303704, Rajasthan. Shnodevi Refoils & Solvex, Plot No. 235/3, Gidc, Chandisar, Taluka - Palanpur, Dist.- Banaskantha - 385510, Gujarat.\r\n\r\nBhawani Silicate Industries\r\nG1, 175-176, Udyog Vihar, Jetpura, Jaipur - 303704, Rajasthan.",
-                                "month_year_of_manufacture_packing_import": "10/2023"
-                            },
-                            "@ondc/org/statutory_reqs_packaged_commodities.imported_product_country_of_origin": "IND",
-                            "@ondc/org/seller_pickup_return": true,
-                            "@ondc/org/contact_details_consumer_care": "john,john@email.com,9911991112",
-                            "descriptor": {
-                                "symbol": "https://www.jiomart.com/images/product/original/490063645/dhara-kachi-ghani-mustard-oil-1-l-product-images-o490063645-p490063645-0-202205172236.jpg",
-                                "images": [
-                                    "https://www.jiomart.com/images/product/original/490063645/dhara-kachi-ghani-mustard-oil-1-l-product-images-o490063645-p490063645-0-202205172236.jpg",
-                                    "https://www.jiomart.com/images/product/original/490063645/dhara-kachi-ghani-mustard-oil-1-l-product-images-o490063645-p490063645-1-202205172236.jpg"
-                                ],
-                                "name": "Dhara Kachi Ghani Mustard Oil - 1L",
-                                "short_desc": "Dhara Kachi Ghani Mustard Oil, traditionally extracted from the first press of mustard seeds, comes with a high pungency level and strong aroma. Being pure, our cooking oil retains its natural properties and mustard oil benefits. Its strong aroma and pungency spice up your cooking.",
-                                "long_desc": "Dhara Kachi Ghani Mustard Oil, traditionally extracted from the first press of mustard seeds, comes with a high pungency level and strong aroma. Being pure, our cooking oil retains its natural properties and mustard oil benefits. Its strong aroma and pungency spice up your cooking."
-                            },
-                            "location_id": "6271",
-                            "tax_rate": "5",
-                            "@ondc/org/available_on_cod": false,
-                            "L2_category": "Oil & Ghee",
-                            "category_id": "Oil & Ghee",
-                            "price": {
-                                "currency": "INR",
-                                "maximum_value": "180",
-                                "value": "180"
-                            },
-                            "@ondc/org/statutory_reqs_prepackaged_food.imported_product_country_of_origin": "IND",
-                            "id": "df6cb5c0-7b45-4de4-8e23-810b14810ace",
-                            "@ondc/org/cancellable": true,
-                            "@ondc/org/returnable": true,
-                            "quantity": {
-                                "available": {
-                                    "count": "3"
-                                },
-                                "maximum": {
-                                    "count": "3"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "Nos",
-                                        "value": "1"
-                                    }
-                                }
-                            },
-                            "@ondc/org/time_to_ship": "PT2H",
-                            "product_master_uuid": "3c15c97c-9e2f-4a2e-9bf9-07954642f5d2",
-                            "hsn_code": "121512",
-                            "tags": [
-                                {
-                                    "code": "veg_nonveg",
-                                    "list": [
-                                        {
-                                            "code": "veg",
-                                            "value": "yes"
-                                        }
-                                    ]
-                                }
-                            ],
-                            "@ondc/org/return_window": "P14D",
-                            "@ondc/org/statutory_reqs_prepackaged_food": {
-                                "importer_FSSAI_license_no": "5151",
-                                "nutritional_info": "bdhd",
-                                "other_importer_address": "hehd",
-                                "importer_address": "hehe",
-                                "other_importer_name": "benend",
-                                "brand_owner_FSSAI_license_no": "151581",
-                                "net_quantity": "1",
-                                "additives_info": "beehe",
-                                "other_premises": "herh",
-                                "importer_name": "wheh",
-                                "brand_owner_address": "ejjerj",
-                                "ingredients_info": " sdvd",
-                                "other_FSSAI_license_no": "5484",
-                                "brand_owner_name": "Dhara",
-                                "imported_product_country_of_origin": "IND",
-                                "manufacturer_or_packer_name": "bebd",
-                                "manufacturer_or_packer_address": "bebd"
-                            },
-                            "tax_type": "gst",
-                            "domain": "Grocery",
-                            "time": {
-                                "label": "enable",
-                                "timestamp": "2023-10-19T09:05:08.791Z"
-                            },
-                            "fulfillment_id": "1"
-                        },
-                        {
-                            "@ondc/org/TAT": "PT12H",
-                            "@ondc/org/statutory_reqs_packaged_commodities": {
-                                "common_or_generic_name_of_commodity": "Men's Grooming",
-                                "net_quantity_or_measure_of_commodity_in_pkg": "1 Nos",
-                                "imported_product_country_of_origin": "IND",
-                                "manufacturer_or_packer_name": "Celine Health Care. 15- Sicop Industrial Area, SICOP Units, Kathua, Jammu and Kashmir 184102",
-                                "multiple_products_name_number_or_qty": "dg",
-                                "manufacturer_or_packer_address": "Celine Health Care. 15- Sicop Industrial Area, SICOP Units, Kathua, Jammu and Kashmir 184102",
-                                "month_year_of_manufacture_packing_import": "10/2023"
-                            },
-                            "@ondc/org/statutory_reqs_packaged_commodities.imported_product_country_of_origin": "IND",
-                            "@ondc/org/seller_pickup_return": true,
-                            "@ondc/org/contact_details_consumer_care": "john,john@email.com,9911991112",
-                            "descriptor": {
-                                "symbol": "https://www.bigbasket.com/media/uploads/p/l/40101860_4-park-avenue-fragrant-soap-cool-blue.jpg?tr=w-1080,q=80",
-                                "images": [
-                                    "https://www.bigbasket.com/media/uploads/p/l/40101860_4-park-avenue-fragrant-soap-cool-blue.jpg?tr=w-1080,q=80",
-                                    "https://datalabs.siva3.io/image/Eunimart_groceries_40101860-2_3-park-avenue-fragrant-soap-cool-blue.jpg",
-                                    "https://datalabs.siva3.io/image/Eunimart_groceries_40101860-3_2-park-avenue-fragrant-soap-cool-blue.jpg"
-                                ],
-                                "name": "Park Avenue Fragrant Soap - Cool Blue, 125 g (Buy 3 & Get 1 Free)",
-                                "short_desc": "Park Avenue Cool-blue soap keeps you cool in the scorching heat of summer. The cool effect achieved from the mint extracts and other cooling components keeps you cool and light-headed even during the tiresome sunny days. Park Avenue Cool Blue Soap contains extra cooling properties which makes you feel an exotic chillness reminding you of the poles in summer! It gives you a tingling sensation of ice that sets your pulse racing.",
-                                "long_desc": "Park Avenue Cool-blue soap keeps you cool in the scorching heat of summer. The cool effect achieved from the mint extracts and other cooling components keeps you cool and light-headed even during the tiresome sunny days. Park Avenue Cool Blue Soap contains extra cooling properties which makes you feel an exotic chillness reminding you of the poles in summer! It gives you a tingling sensation of ice that sets your pulse racing."
-                            },
-                            "location_id": "6271",
-                            "tax_rate": "5",
-                            "@ondc/org/available_on_cod": false,
-                            "L2_category": "Beauty & Hygiene",
-                            "category_id": "Beauty & Hygiene",
-                            "price": {
-                                "currency": "INR",
-                                "maximum_value": "108",
-                                "value": "108"
-                            },
-                            "@ondc/org/statutory_reqs_prepackaged_food.imported_product_country_of_origin": "IND",
-                            "id": "85a15f3c-10e0-4053-9362-1971abdd5a1a",
-                            "@ondc/org/cancellable": true,
-                            "@ondc/org/returnable": true,
-                            "quantity": {
-                                "available": {
-                                    "count": "3"
-                                },
-                                "maximum": {
-                                    "count": "3"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "Nos",
-                                        "value": "1"
-                                    }
-                                }
-                            },
-                            "@ondc/org/time_to_ship": "PT2H",
-                            "product_master_uuid": "dcc7961a-a8f2-4d62-851a-385712d32f16",
-                            "hsn_code": "555",
-                            "tags": [],
-                            "@ondc/org/return_window": "P14D",
-                            "tax_type": "gst",
-                            "domain": "Grocery",
-                            "time": {
-                                "label": "enable",
-                                "timestamp": "2023-10-19T09:05:08.791Z"
-                            },
-                            "fulfillment_id": "1"
-                        },
-                        {
-                            "@ondc/org/TAT": "PT12H",
-                            "@ondc/org/statutory_reqs_packaged_commodities": {
-                                "common_or_generic_name_of_commodity": "Men's Grooming",
-                                "net_quantity_or_measure_of_commodity_in_pkg": "5454 Nos",
-                                "imported_product_country_of_origin": "IND",
-                                "manufacturer_or_packer_name": "Celine Health Care. 15- Sicop Industrial Area, SICOP Units, Kathua, Jammu and Kashmir 184102",
-                                "multiple_products_name_number_or_qty": "hehe",
-                                "manufacturer_or_packer_address": "Celine Health Care. 15- Sicop Industrial Area, SICOP Units, Kathua, Jammu and Kashmir 184102",
-                                "month_year_of_manufacture_packing_import": "10/2023"
-                            },
-                            "@ondc/org/statutory_reqs_packaged_commodities.imported_product_country_of_origin": "IND",
-                            "@ondc/org/seller_pickup_return": true,
-                            "@ondc/org/contact_details_consumer_care": "john,john@email.com,9911991112",
-                            "descriptor": {
-                                "symbol": "https://datalabs.siva3.io/image/Eunimart_groceries_30004610_6-park-avenue-bathing-soap-luxury.jpg",
-                                "images": [
-                                    "https://datalabs.siva3.io/image/Eunimart_groceries_30004610_6-park-avenue-bathing-soap-luxury.jpg",
-                                    "https://datalabs.siva3.io/image/Eunimart_groceries_30004610-2_2-park-avenue-bathing-soap-luxury.jpg",
-                                    "https://datalabs.siva3.io/image/Eunimart_groceries_30004610-3_1-park-avenue-bathing-soap-luxury.jpg"
-                                ],
-                                "name": "Park Avenue Bathing Soap - Luxury, 125 g",
-                                "short_desc": "Park Avenue Luxury soap has the goodness of shea butter that mausturises skin and re-hydrates your entire body - leaving you with a feeling of freshness.",
-                                "long_desc": "Park Avenue Luxury soap has the goodness of shea butter that mausturises skin and re-hydrates your entire body - leaving you with a feeling of freshness."
-                            },
-                            "location_id": "6271",
-                            "tax_rate": "18",
-                            "@ondc/org/available_on_cod": false,
-                            "L2_category": "Beauty & Hygiene",
-                            "category_id": "Beauty & Hygiene",
-                            "price": {
-                                "currency": "INR",
-                                "maximum_value": "63",
-                                "value": "63"
-                            },
-                            "@ondc/org/statutory_reqs_prepackaged_food.imported_product_country_of_origin": "IND",
-                            "id": "d4fe9127-da17-4201-92cb-969502cb3cb1",
-                            "@ondc/org/cancellable": true,
-                            "@ondc/org/returnable": true,
-                            "quantity": {
-                                "available": {
-                                    "count": "3"
-                                },
-                                "maximum": {
-                                    "count": "3"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "Nos",
-                                        "value": "5454"
-                                    }
-                                }
-                            },
-                            "@ondc/org/time_to_ship": "PT2H",
-                            "product_master_uuid": "89e1066c-37b2-4429-b383-b6c5e926c02d",
-                            "hsn_code": "544584",
-                            "tags": [],
-                            "@ondc/org/return_window": "P14D",
-                            "tax_type": "gst",
-                            "domain": "Grocery",
-                            "time": {
-                                "label": "enable",
-                                "timestamp": "2023-10-19T09:05:08.791Z"
+                                "timestamp": "2023-11-09T07:54:39.789Z"
                             },
                             "fulfillment_id": "1"
                         },
@@ -9834,54 +1794,57 @@
                             },
                             "@ondc/org/statutory_reqs_packaged_commodities.imported_product_country_of_origin": "IND",
                             "@ondc/org/seller_pickup_return": true,
-                            "@ondc/org/contact_details_consumer_care": "john,john@email.com,9911991112",
+                            "@ondc/org/contact_details_consumer_care": "John Nov9,John@acme.com,9911991199",
                             "descriptor": {
                                 "symbol": "https://www.bigbasket.com/media/uploads/p/xxl/40059447_6-everest-kasuri-methi.jpg",
                                 "images": [
                                     "https://www.bigbasket.com/media/uploads/p/xxl/40059447_6-everest-kasuri-methi.jpg"
                                 ],
-                                "name": "EVEREST KASURI METHI 25 G\r\n",
-                                "short_desc": "Sun-dried, pleasantly flavoured, Fenugreek leaves which is dried in hot air in controlled conditions, is a great taste enhancer. It adds flavour and texture to vegetables, pulses and lentils, parathas and chapattis.\r\n",
-                                "long_desc": "Sun-dried, pleasantly flavoured, Fenugreek leaves which is dried in hot air in controlled conditions, is a great taste enhancer. It adds flavour and texture to vegetables, pulses and lentils, parathas and chapattis.\r\n"
+                                "name": "EVEREST KASURI METHI 25 G\n",
+                                "short_desc": "Sun-dried, pleasantly flavoured, Fenugreek leaves which is dried in hot air in controlled conditions, is a great taste enhancer. It adds flavour and texture to vegetables, pulses and lentils, parathas and chapattis.\n",
+                                "long_desc": "Sun-dried, pleasantly flavoured, Fenugreek leaves which is dried in hot air in controlled conditions, is a great taste enhancer. It adds flavour and texture to vegetables, pulses and lentils, parathas and chapattis.\n"
                             },
                             "location_id": "6271",
                             "tax_rate": "18",
                             "@ondc/org/available_on_cod": false,
+                            "contact_details_consumer_care_email": "jon@hdjd.com",
                             "L2_category": "Masala & Seasoning",
                             "category_id": "Masala & Seasoning",
                             "price": {
                                 "currency": "INR",
-                                "maximum_value": "23",
+                                "maximum_value": "26",
                                 "value": "23"
                             },
-                            "@ondc/org/statutory_reqs_prepackaged_food.imported_product_country_of_origin": "IND",
                             "id": "8fcb8ccd-0a60-49ad-8c08-cfd5f2c705fd",
                             "@ondc/org/cancellable": true,
+                            "@ondc/org/tat": "PT4H",
                             "@ondc/org/returnable": true,
                             "quantity": {
                                 "available": {
-                                    "count": "3"
+                                    "count": "8"
                                 },
                                 "maximum": {
-                                    "count": "3"
+                                    "count": "4"
                                 },
                                 "unitized": {
                                     "measure": {
-                                        "unit": "Nos",
+                                        "unit": "unit",
                                         "value": "1"
                                     }
                                 }
                             },
                             "@ondc/org/time_to_ship": "PT2H",
+                            "contact_details_consumer_care_name": "hehdb",
+                            "contact_details_consumer_care_contactno": "6265655995",
                             "product_master_uuid": "6b45c17c-3950-4de7-b6bb-0e45bc737351",
                             "hsn_code": "124848",
                             "tags": [
                                 {
-                                    "code": "veg_nonveg",
+                                    "code": "origin",
                                     "list": [
                                         {
-                                            "code": "veg",
-                                            "value": "yes"
+                                            "code": "country",
+                                            "value": "IND"
                                         }
                                     ]
                                 }
@@ -9910,49 +1873,1089 @@
                             "domain": "Grocery",
                             "time": {
                                 "label": "enable",
-                                "timestamp": "2023-10-19T09:05:08.791Z"
+                                "timestamp": "2023-11-10T07:57:35.798Z"
                             },
                             "fulfillment_id": "1"
                         },
                         {
-                            "@ondc/org/TAT": "PT12H",
                             "@ondc/org/statutory_reqs_packaged_commodities": {
-                                "common_or_generic_name_of_commodity": "Men's Grooming",
-                                "net_quantity_or_measure_of_commodity_in_pkg": "1 Nos",
-                                "imported_product_country_of_origin": "IND",
-                                "manufacturer_or_packer_name": "WIPRO ENTERPRISE PVT LTD",
-                                "multiple_products_name_number_or_qty": "wheh",
-                                "manufacturer_or_packer_address": "WIPRO ENTERPRISE PVT LTD",
-                                "month_year_of_manufacture_packing_import": "10/2023"
+                                "common_or_generic_name_of_commodity": "Spices & Masala",
+                                "manufacturer_or_packer_name": "Eastern Condiments Pvt Ltd NO 15, Eastern Valley, Adimali. Kerala : 522212",
+                                "manufacturer_or_packer_address": "Eastern Condiments Pvt Ltd NO 15, Eastern Valley, Adimali. Kerala : 522212",
+                                "month_year_of_manufacture_packing_import": "11/2023"
                             },
-                            "@ondc/org/statutory_reqs_packaged_commodities.imported_product_country_of_origin": "IND",
                             "@ondc/org/seller_pickup_return": true,
-                            "@ondc/org/contact_details_consumer_care": "john,john@email.com,9911991112",
+                            "@ondc/org/contact_details_consumer_care": "John Nov9,John@acme.com,9911991199",
                             "descriptor": {
-                                "symbol": "https://datalabs.siva3.io/image/Eunimart_groceries_272269_4-yardley-london-elegance-deodorizing-talc-for-men.jpg",
+                                "symbol": "https://www.bigbasket.com/media/uploads/p/xxl/100270873_4-eastern-powder-coriander.jpg",
                                 "images": [
-                                    "https://datalabs.siva3.io/image/Eunimart_groceries_272269_4-yardley-london-elegance-deodorizing-talc-for-men.jpg",
-                                    "https://datalabs.siva3.io/image/Eunimart_groceries_272269-2_1-yardley-london-elegance-deodorizing-talc-for-men.jpg",
-                                    "https://datalabs.siva3.io/image/Eunimart_groceries_272269-3_1-yardley-london-elegance-deodorizing-talc-for-men.jpg"
+                                    "https://www.bigbasket.com/media/uploads/p/xxl/100270873_4-eastern-powder-coriander.jpg",
+                                    "https://www.bigbasket.com/media/uploads/p/xxl/100270873-2_2-eastern-powder-coriander.jpg",
+                                    "https://www.bigbasket.com/media/uploads/p/xxl/100270873-3_2-eastern-powder-coriander.jpg"
                                 ],
-                                "name": "Yardley London Elegance Deodorising Talc - For Men, 250 g",
-                                "short_desc": "This luxury perfumed talc leaves your skin feeling soft and fragrant throughout the day. The fragrance will keep you refreshed and comfortable. The rich and the authentic fragrances from the house of Yardley, which will keep you energizing and rejuvenating.",
-                                "long_desc": "This luxury perfumed talc leaves your skin feeling soft and fragrant throughout the day. The fragrance will keep you refreshed and comfortable. The rich and the authentic fragrances from the house of Yardley, which will keep you energizing and rejuvenating."
+                                "name": "Eastern Coriander Powder - Perfect Colour, Smell & Taste, 100 g Pouch",
+                                "short_desc": "Eastern Condiments, Your Perfect Taste Partner, specializes in the production and distribution of ready-to-use spices, Masala blends, rice Powders, coffee, tea, pickles, and more. Craft your dishes to Perfection with Eastern's delectable range of condiments and more. Dive into the wholesome blend of exotic & aromatic spices, and make deliciously delightful dishes on the daily! From imparting the appetizing fire to your dishes to making them palatable and tantalizing, Eastern Masalas and Powders give the right amount of hue and taste to your food! Explore Eastern's range of Perfectly curated straight and blended spices - Eastern Chilli Powder, Eastern Turmeric Powder, Eastern Coriander Powder, Eastern Kashmiri Chilli Powder, Eastern Garam Masala, Eastern Meat Masala, Eastern Sambar Powder, Eastern Chicken Masala, Eastern Biriyani Masala Powder, Eastern Fish Masala, Eastern Kabab Masala",
+                                "long_desc": "Eastern Condiments, Your Perfect Taste Partner, specializes in the production and distribution of ready-to-use spices, Masala blends, rice Powders, coffee, tea, pickles, and more. Craft your dishes to Perfection with Eastern's delectable range of condiments and more. Dive into the wholesome blend of exotic & aromatic spices, and make deliciously delightful dishes on the daily! From imparting the appetizing fire to your dishes to making them palatable and tantalizing, Eastern Masalas and Powders give the right amount of hue and taste to your food! Explore Eastern's range of Perfectly curated straight and blended spices - Eastern Chilli Powder, Eastern Turmeric Powder, Eastern Coriander Powder, Eastern Kashmiri Chilli Powder, Eastern Garam Masala, Eastern Meat Masala, Eastern Sambar Powder, Eastern Chicken Masala, Eastern Biriyani Masala Powder, Eastern Fish Masala, Eastern Kabab Masala"
                             },
                             "location_id": "6271",
                             "tax_rate": "5",
+                            "@ondc/org/available_on_cod": true,
+                            "contact_details_consumer_care_email": "ghh@gj.com",
+                            "L2_category": "Masala & Seasoning",
+                            "category_id": "Masala & Seasoning",
+                            "price": {
+                                "currency": "INR",
+                                "maximum_value": "37",
+                                "value": "37"
+                            },
+                            "id": "a208c5d2-0598-4a73-80f6-eb79f0a7f425",
+                            "@ondc/org/cancellable": true,
+                            "@ondc/org/tat": "PT4H",
+                            "@ondc/org/returnable": true,
+                            "quantity": {
+                                "available": {
+                                    "count": "3"
+                                },
+                                "maximum": {
+                                    "count": "3"
+                                },
+                                "unitized": {
+                                    "measure": {
+                                        "unit": "unit",
+                                        "value": "100 g"
+                                    }
+                                }
+                            },
+                            "@ondc/org/time_to_ship": "PT2H",
+                            "contact_details_consumer_care_name": "dgghjj",
+                            "contact_details_consumer_care_contactno": "2585858855",
+                            "product_master_uuid": "dc3bc39c-6199-469f-b2a7-2b3faf19d41e",
+                            "hsn_code": "552266988",
+                            "tags": [
+                                {
+                                    "code": "origin",
+                                    "list": [
+                                        {
+                                            "code": "country",
+                                            "value": "IND"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "@ondc/org/return_window": "P14D",
+                            "tax_type": "gst",
+                            "domain": "Grocery",
+                            "time": {
+                                "label": "enable",
+                                "timestamp": "2023-11-09T07:47:28.730Z"
+                            },
+                            "fulfillment_id": "1"
+                        },
+                        {
+                            "@ondc/org/seller_pickup_return": true,
+                            "@ondc/org/contact_details_consumer_care": "John Nov9,John@acme.com,9911991199",
+                            "descriptor": {
+                                "symbol": "https://datalabs.siva3.io/image/Eunimart_groceries_266597_12-taj-mahal-rich-flavourful-tea.jpg",
+                                "images": [
+                                    "https://datalabs.siva3.io/image/Eunimart_groceries_266597_12-taj-mahal-rich-flavourful-tea.jpg",
+                                    "https://datalabs.siva3.io/image/Eunimart_groceries_266597-2_7-taj-mahal-rich-flavourful-tea.jpg",
+                                    "https://datalabs.siva3.io/image/Eunimart_groceries_266597-3_6-taj-mahal-rich-flavourful-tea.jpg"
+                                ],
+                                "name": "Taj Mahal Rich & Flavourful Tea, 100 g",
+                                "short_desc": "When the history of Tea is written down, 1966 will be a celebrated Chapter. For in that year, Brooke Bond Taj Mahal Tea was born, with a promise - To foster excellence in each Cup. Fifty years on, we have not forgotten that promise. Ordinary teas usually provide either strength or just flavour. However, Only Brooke Bond Taj Mahal Tea contains the precious essence of the Finest fresh tea leaves, giving you the perfect balance of strength and flavour. A flavour, which can only be matched by the exquisite melodies composed by the maestros who have been our ambassadors over the decades. Rigour in selection and blending. The tea from every tea estate has its own taste - because of its terroir, pluck and flush. How then do we turn it all into the unique Taj experience for our customers - year after year? Enter our master tasters and blenders, and their traditions, built over many years. It takes millions of tastings and years of experience to be a taste for Taj Mahal Tea. The brew is golden-orange in colour, has a rich taste and an uplifting aroma. So go ahead, savour the flavour of this historic blend, and enjoy the perfect taste of this priceless cup of tea and exclaim- Wah Taj!\r\n\r\n\r\nTaj Mahal Teas are Tasted, graded and perfectly blended at the Brooke bond Tea Excellence Centre\r\nTaj Mahal tea comes in a Unique Flavor Lock pack\r\nA cup of Taj Mahal tea invites you to cheer your senses\r\nThe perfect balance of strength and flavour\r\nBlended Since 1966\r\nAlso available in Teabags",
+                                "long_desc": "When the history of Tea is written down, 1966 will be a celebrated Chapter. For in that year, Brooke Bond Taj Mahal Tea was born, with a promise - To foster excellence in each Cup. Fifty years on, we have not forgotten that promise. Ordinary teas usually provide either strength or just flavour. However, Only Brooke Bond Taj Mahal Tea contains the precious essence of the Finest fresh tea leaves, giving you the perfect balance of strength and flavour. A flavour, which can only be matched by the exquisite melodies composed by the maestros who have been our ambassadors over the decades. Rigour in selection and blending. The tea from every tea estate has its own taste - because of its terroir, pluck and flush. How then do we turn it all into the unique Taj experience for our customers - year after year? Enter our master tasters and blenders, and their traditions, built over many years. It takes millions of tastings and years of experience to be a taste for Taj Mahal Tea. The brew is golden-orange in colour, has a rich taste and an uplifting aroma. So go ahead, savour the flavour of this historic blend, and enjoy the perfect taste of this priceless cup of tea and exclaim- Wah Taj!\r\n\r\n\r\nTaj Mahal Teas are Tasted, graded and perfectly blended at the Brooke bond Tea Excellence Centre\r\nTaj Mahal tea comes in a Unique Flavor Lock pack\r\nA cup of Taj Mahal tea invites you to cheer your senses\r\nThe perfect balance of strength and flavour\r\nBlended Since 1966\r\nAlso available in Teabags"
+                            },
+                            "location_id": "6271",
+                            "tax_rate": "18",
+                            "@ondc/org/available_on_cod": true,
+                            "contact_details_consumer_care_email": "ghy@ghh.con",
+                            "L2_category": "Beverages",
+                            "category_id": "Beverages",
+                            "price": {
+                                "currency": "INR",
+                                "maximum_value": "95",
+                                "value": "95"
+                            },
+                            "id": "954659be-d626-46f9-8a36-31f9bece177d",
+                            "@ondc/org/cancellable": true,
+                            "@ondc/org/tat": "PT4H",
+                            "@ondc/org/returnable": true,
+                            "quantity": {
+                                "available": {
+                                    "count": "3"
+                                },
+                                "maximum": {
+                                    "count": "3"
+                                },
+                                "unitized": {
+                                    "measure": {
+                                        "unit": "unit",
+                                        "value": "1"
+                                    }
+                                }
+                            },
+                            "@ondc/org/time_to_ship": "PT2H",
+                            "contact_details_consumer_care_name": "bh",
+                            "contact_details_consumer_care_contactno": "52522888",
+                            "product_master_uuid": "37796d97-7cf8-47de-8317-62ad1b51c2ae",
+                            "hsn_code": "25888",
+                            "tags": [
+                                {
+                                    "code": "origin",
+                                    "list": [
+                                        {
+                                            "code": "country",
+                                            "value": "IND"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "@ondc/org/return_window": "P14D",
+                            "@ondc/org/statutory_reqs_prepackaged_food": {
+                                "importer_FSSAI_license_no": "5888",
+                                "nutritional_info": "yuhh",
+                                "other_importer_address": "yhbb",
+                                "importer_address": "yhhb",
+                                "other_importer_name": "hhhh",
+                                "brand_owner_FSSAI_license_no": "5225888",
+                                "additives_info": "hhh",
+                                "other_premises": "hbbb",
+                                "importer_name": "hbbh",
+                                "brand_owner_address": "bb b",
+                                "ingredients_info": "tea",
+                                "other_FSSAI_license_no": "5888",
+                                "brand_owner_name": "Taj Mahal",
+                                "manufacturer_or_packer_name": "ygh",
+                                "manufacturer_or_packer_address": "hyy"
+                            },
+                            "tax_type": "gst",
+                            "domain": "Grocery",
+                            "time": {
+                                "label": "enable",
+                                "timestamp": "2023-11-09T07:55:34.958Z"
+                            },
+                            "fulfillment_id": "1"
+                        },
+                        {
+                            "@ondc/org/seller_pickup_return": true,
+                            "@ondc/org/contact_details_consumer_care": "John Nov9,John@acme.com,9911991199",
+                            "descriptor": {
+                                "symbol": "https://datalabs.siva3.io/image/Eunimart_groceries_204214_2-happilo-cashews-whole-100-natural-premium.jpg",
+                                "images": [
+                                    "https://datalabs.siva3.io/image/Eunimart_groceries_204214_2-happilo-cashews-whole-100-natural-premium.jpg",
+                                    "https://datalabs.siva3.io/image/Eunimart_groceries_204214-2_1-happilo-cashews-whole-100-natural-premium.jpg",
+                                    "https://datalabs.siva3.io/image/Eunimart_groceries_204214-3_1-happilo-cashews-whole-100-natural-premium.jpg"
+                                ],
+                                "name": "Happilo Cashews - Whole, 100% Natural Premium, 2x200 g Multipack",
+                                "short_desc": "Our cashews are a real treat. These are the best nuts you can ever find. They are delightfully rich and tasty, a nutritious treat that will make a great snack time.",
+                                "long_desc": "Our cashews are a real treat. These are the best nuts you can ever find. They are delightfully rich and tasty, a nutritious treat that will make a great snack time."
+                            },
+                            "location_id": "6271",
+                            "tax_rate": "18",
+                            "@ondc/org/available_on_cod": true,
+                            "contact_details_consumer_care_email": "djjd@dhdj.com",
+                            "L2_category": "Snacks & Branded Foods",
+                            "category_id": "Snacks & Branded Foods",
+                            "price": {
+                                "currency": "INR",
+                                "maximum_value": "423",
+                                "value": "423"
+                            },
+                            "id": "6ccd31e2-e972-4c5c-a46c-afd32ffc5018",
+                            "@ondc/org/cancellable": true,
+                            "@ondc/org/tat": "PT4H",
+                            "@ondc/org/returnable": true,
+                            "quantity": {
+                                "available": {
+                                    "count": "5"
+                                },
+                                "maximum": {
+                                    "count": "3"
+                                },
+                                "unitized": {
+                                    "measure": {
+                                        "unit": "unit",
+                                        "value": "1"
+                                    }
+                                }
+                            },
+                            "@ondc/org/time_to_ship": "PT2H",
+                            "contact_details_consumer_care_name": "bdbdbd",
+                            "contact_details_consumer_care_contactno": "6161918446",
+                            "product_master_uuid": "de548794-f79b-4914-ae5b-5a9171e4e4cf",
+                            "hsn_code": "548484",
+                            "tags": [
+                                {
+                                    "code": "origin",
+                                    "list": [
+                                        {
+                                            "code": "country",
+                                            "value": "IND"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "@ondc/org/return_window": "P14D",
+                            "@ondc/org/statutory_reqs_prepackaged_food": {
+                                "importer_FSSAI_license_no": "252525",
+                                "nutritional_info": "rururu",
+                                "other_importer_address": "hrjrhr",
+                                "importer_address": "hrjrjr",
+                                "other_importer_name": "rjjrjr",
+                                "brand_owner_FSSAI_license_no": "515252",
+                                "additives_info": "rujrrj",
+                                "other_premises": "urjrjr",
+                                "importer_name": "urjrjr",
+                                "brand_owner_address": "uejrjr",
+                                "ingredients_info": "jejr",
+                                "other_FSSAI_license_no": "5252525",
+                                "brand_owner_name": "Happilo",
+                                "manufacturer_or_packer_name": "irrjjr",
+                                "manufacturer_or_packer_address": "jjr"
+                            },
+                            "tax_type": "gst",
+                            "domain": "Grocery",
+                            "time": {
+                                "label": "enable",
+                                "timestamp": "2023-11-09T14:16:46.813Z"
+                            },
+                            "fulfillment_id": "1"
+                        },
+                        {
+                            "@ondc/org/seller_pickup_return": true,
+                            "@ondc/org/contact_details_consumer_care": "John Nov9,John@acme.com,9911991199",
+                            "descriptor": {
+                                "symbol": "https://datalabs.siva3.io/image/Eunimart_groceries_279023_18-dr-oetker-funfoods-mayonnaise-classic.jpg",
+                                "images": [
+                                    "https://datalabs.siva3.io/image/Eunimart_groceries_279023_18-dr-oetker-funfoods-mayonnaise-classic.jpg",
+                                    "https://datalabs.siva3.io/image/Eunimart_groceries_279023-2_9-dr-oetker-funfoods-mayonnaise-classic.jpg",
+                                    "https://datalabs.siva3.io/image/Eunimart_groceries_279023-3_9-dr-oetker-funfoods-mayonnaise-classic.jpg"
+                                ],
+                                "name": "Dr. Oetker FunFoods Mayonnaise Classic, 245 g",
+                                "short_desc": "FunFoods by Dr Oetker Classic Mayonnaise with egg is a smooth and creamy combination that gives a rich and fulfilling taste. It is a perfect core ingredient for a wide array of western dishes such as ham-sandwiches, Chicken-Tikka wraps and also as a creamy dip for chicken/fish nuggets. It is Trans Fat-Free, smooth and creamy.",
+                                "long_desc": "FunFoods by Dr Oetker Classic Mayonnaise with egg is a smooth and creamy combination that gives a rich and fulfilling taste. It is a perfect core ingredient for a wide array of western dishes such as ham-sandwiches, Chicken-Tikka wraps and also as a creamy dip for chicken/fish nuggets. It is Trans Fat-Free, smooth and creamy."
+                            },
+                            "location_id": "6271",
+                            "tax_rate": "18",
+                            "@ondc/org/available_on_cod": true,
+                            "contact_details_consumer_care_email": "hdd@db.com",
+                            "L2_category": "Gourmet & World Foods",
+                            "category_id": "Gourmet & World Foods",
+                            "price": {
+                                "currency": "INR",
+                                "maximum_value": "89",
+                                "value": "89"
+                            },
+                            "id": "99090915-90b8-4ba4-8e27-861c5d9a30a3",
+                            "@ondc/org/cancellable": true,
+                            "@ondc/org/tat": "PT4H",
+                            "@ondc/org/returnable": true,
+                            "quantity": {
+                                "available": {
+                                    "count": "3"
+                                },
+                                "maximum": {
+                                    "count": "3"
+                                },
+                                "unitized": {
+                                    "measure": {
+                                        "unit": "unit",
+                                        "value": "1"
+                                    }
+                                }
+                            },
+                            "@ondc/org/time_to_ship": "PT2H",
+                            "contact_details_consumer_care_name": "hdhd",
+                            "contact_details_consumer_care_contactno": "8585858858",
+                            "product_master_uuid": "84b6e1eb-3b1d-44c7-b874-678b51052bc8",
+                            "hsn_code": "545448",
+                            "tags": [
+                                {
+                                    "code": "origin",
+                                    "list": [
+                                        {
+                                            "code": "country",
+                                            "value": "IND"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "@ondc/org/return_window": "P14D",
+                            "@ondc/org/statutory_reqs_prepackaged_food": {
+                                "importer_FSSAI_license_no": "5152525",
+                                "nutritional_info": "ududhd",
+                                "other_importer_address": "hehrhr",
+                                "importer_address": "hrhrhr",
+                                "other_importer_name": "hehrh",
+                                "brand_owner_FSSAI_license_no": "21545555",
+                                "additives_info": "irjrjf",
+                                "other_premises": "rhhr",
+                                "importer_name": "rhhrbf",
+                                "brand_owner_address": "hehrb",
+                                "ingredients_info": "jdjd",
+                                "other_FSSAI_license_no": "225225",
+                                "brand_owner_name": "Dr. Oetker",
+                                "manufacturer_or_packer_name": "jehrdh",
+                                "manufacturer_or_packer_address": "jrjr"
+                            },
+                            "tax_type": "gst",
+                            "domain": "Grocery",
+                            "time": {
+                                "label": "enable",
+                                "timestamp": "2023-11-09T13:38:56.097Z"
+                            },
+                            "fulfillment_id": "1"
+                        },
+                        {
+                            "@ondc/org/statutory_reqs_packaged_commodities": {
+                                "common_or_generic_name_of_commodity": "Snacks & Namkeen",
+                                "net_quantity_or_measure_of_commodity_in_pkg": "55 Nos",
+                                "imported_product_country_of_origin": "IND",
+                                "manufacturer_or_packer_name": "Happilo International Pvt Ltd, 7, 1st floor, yeshwantpur, Bangalore 560022.",
+                                "multiple_products_name_number_or_qty": "hdfj",
+                                "manufacturer_or_packer_address": "Happilo International Pvt Ltd, 7, 1st floor, yeshwantpur, Bangalore 560022.",
+                                "month_year_of_manufacture_packing_import": "10/2023"
+                            },
+                            "@ondc/org/seller_pickup_return": true,
+                            "@ondc/org/contact_details_consumer_care": "John Nov9,John@acme.com,9911991199",
+                            "descriptor": {
+                                "symbol": "https://www.bigbasket.com/media/uploads/p/l/40123721_4-happilo-premium-pumpkin-seeds-all-natural.jpg",
+                                "images": [
+                                    "https://www.bigbasket.com/media/uploads/p/l/40123721_4-happilo-premium-pumpkin-seeds-all-natural.jpg",
+                                    "https://www.bigbasket.com/media/uploads/p/l/40123721-2_4-happilo-premium-pumpkin-seeds-all-natural.jpg",
+                                    "https://www.bigbasket.com/media/uploads/p/l/40123721-3_4-happilo-premium-pumpkin-seeds-all-natural.jpg"
+                                ],
+                                "name": "Happilo Premium Pumpkin Seeds - All Natural, 200 g",
+                                "short_desc": "Happilo has travelled the world to get you the finest gourmet dried fruits, nuts, berries and dates that are 100% natural and authentic. Happilo Pumpkin seeds may be small, but they are packed with a variety of valuable nutrients. Eating only a small amount of them can provide you with several health benefits. You could incorporate them into meals by sprinkling them into salads, soups or cereals or just snacks directly. Pumpkin seeds are a superfood, which you can snack on any time of the day.",
+                                "long_desc": "Happilo has travelled the world to get you the finest gourmet dried fruits, nuts, berries and dates that are 100% natural and authentic. Happilo Pumpkin seeds may be small, but they are packed with a variety of valuable nutrients. Eating only a small amount of them can provide you with several health benefits. You could incorporate them into meals by sprinkling them into salads, soups or cereals or just snacks directly. Pumpkin seeds are a superfood, which you can snack on any time of the day."
+                            },
+                            "location_id": "6271",
+                            "tax_rate": "5",
+                            "@ondc/org/available_on_cod": false,
+                            "contact_details_consumer_care_email": "shehdj@dhdj.com",
+                            "L2_category": "Snacks & Branded Foods",
+                            "category_id": "Snacks & Branded Foods",
+                            "price": {
+                                "currency": "INR",
+                                "maximum_value": "240",
+                                "value": "240"
+                            },
+                            "id": "7abbe7ca-1728-4993-82b7-6e17e001854f",
+                            "@ondc/org/fssai_license_no": "845451814854",
+                            "@ondc/org/cancellable": true,
+                            "@ondc/org/tat": "PT4H",
+                            "@ondc/org/returnable": true,
+                            "quantity": {
+                                "available": {
+                                    "count": "4"
+                                },
+                                "maximum": {
+                                    "count": "3"
+                                },
+                                "unitized": {
+                                    "measure": {
+                                        "unit": "dozen",
+                                        "value": "55"
+                                    }
+                                }
+                            },
+                            "@ondc/org/time_to_ship": "PT2H",
+                            "contact_details_consumer_care_name": "hshddh",
+                            "contact_details_consumer_care_contactno": "1551844844",
+                            "product_master_uuid": "9966b697-454a-410d-a762-4095e4dcbe41",
+                            "hsn_code": "5152",
+                            "tags": [
+                                {
+                                    "code": "origin",
+                                    "list": [
+                                        {
+                                            "code": "country",
+                                            "value": "IND"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "@ondc/org/return_window": "P14D",
+                            "@ondc/org/statutory_reqs_prepackaged_food": {
+                                "importer_FSSAI_license_no": "1515181",
+                                "nutritional_info": "hdjd",
+                                "other_importer_address": "hdjd",
+                                "importer_address": "jdjdjd",
+                                "other_importer_name": "hchdhd",
+                                "brand_owner_FSSAI_license_no": "5555555",
+                                "net_quantity": "1",
+                                "additives_info": "jrjr",
+                                "other_premises": "ufjf",
+                                "importer_name": "hdhdhd",
+                                "brand_owner_address": "happilo ",
+                                "ingredients_info": "jddj",
+                                "other_FSSAI_license_no": "121215",
+                                "brand_owner_name": "Happilo",
+                                "imported_product_country_of_origin": "IND",
+                                "manufacturer_or_packer_name": "jrjf",
+                                "manufacturer_or_packer_address": "jfjf"
+                            },
+                            "tax_type": "gst",
+                            "domain": "Grocery",
+                            "time": {
+                                "label": "enable",
+                                "timestamp": "2023-11-10T06:29:23.388Z"
+                            },
+                            "fulfillment_id": "1"
+                        },
+                        {
+                            "@ondc/org/seller_pickup_return": true,
+                            "@ondc/org/contact_details_consumer_care": "John Nov9,John@acme.com,9911991199",
+                            "descriptor": {
+                                "symbol": "https://www.bigbasket.com/media/uploads/p/xxl/1214335_4-britannia-treat-croissant-vanilla-creme-roll-100-veg.jpg",
+                                "images": [
+                                    "https://www.bigbasket.com/media/uploads/p/xxl/1214335_4-britannia-treat-croissant-vanilla-creme-roll-100-veg.jpg",
+                                    "https://www.bigbasket.com/media/uploads/p/xxl/1214335-2_4-britannia-treat-croissant-vanilla-creme-roll-100-veg.jpg",
+                                    "https://www.bigbasket.com/media/uploads/p/xxl/1214335-3_4-britannia-treat-croissant-vanilla-creme-roll-100-veg.jpg"
+                                ],
+                                "name": "Britannia Treat Croissant - Vanilla Creme Filling, 100% Veg, Soft, 6x45 g Multipack",
+                                "short_desc": "Treat your taste buds with this all-new indulgent Britannia Treat Croissant made using the best flour from across the country, kneaded into the softest dough and baked to perfection. Every bite of the delicious treat gives the heavenly taste of smooth, velvety crème made with Vanilla, oozing out of layers of soft, fluffy bread that will melt in your mouth, creating an irresistible experience. It is a unique twist on your everyday snack, perfect to curb mid-day cravings or midnight hunger pangs.",
+                                "long_desc": "Treat your taste buds with this all-new indulgent Britannia Treat Croissant made using the best flour from across the country, kneaded into the softest dough and baked to perfection. Every bite of the delicious treat gives the heavenly taste of smooth, velvety crème made with Vanilla, oozing out of layers of soft, fluffy bread that will melt in your mouth, creating an irresistible experience. It is a unique twist on your everyday snack, perfect to curb mid-day cravings or midnight hunger pangs."
+                            },
+                            "location_id": "6271",
+                            "tax_rate": "5",
+                            "@ondc/org/available_on_cod": true,
+                            "contact_details_consumer_care_email": "hdhddj@jddj.com",
+                            "L2_category": "Snacks & Branded Foods",
+                            "category_id": "Snacks & Branded Foods",
+                            "price": {
+                                "currency": "INR",
+                                "maximum_value": "105.6",
+                                "value": "105.6"
+                            },
+                            "id": "a687aab3-df94-4bf1-9639-1414995ff937",
+                            "@ondc/org/fssai_license_no": "5454545454",
+                            "@ondc/org/cancellable": true,
+                            "@ondc/org/tat": "PT4H",
+                            "@ondc/org/returnable": true,
+                            "quantity": {
+                                "available": {
+                                    "count": "3"
+                                },
+                                "maximum": {
+                                    "count": "3"
+                                },
+                                "unitized": {
+                                    "measure": {
+                                        "unit": "unit",
+                                        "value": "1"
+                                    }
+                                }
+                            },
+                            "@ondc/org/time_to_ship": "PT2H",
+                            "contact_details_consumer_care_name": "hdhddhdjf",
+                            "contact_details_consumer_care_contactno": "1515848484",
+                            "product_master_uuid": "503108cd-6d99-48e4-8f1c-5a95f9b17540",
+                            "hsn_code": "088888",
+                            "tags": [
+                                {
+                                    "code": "origin",
+                                    "list": [
+                                        {
+                                            "code": "country",
+                                            "value": "IND"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "@ondc/org/return_window": "P14D",
+                            "@ondc/org/statutory_reqs_prepackaged_food": {
+                                "importer_FSSAI_license_no": "515181",
+                                "nutritional_info": "hsjdjdj",
+                                "other_importer_address": "hehdhdhd",
+                                "importer_address": "hejdhd",
+                                "other_importer_name": "hehehe",
+                                "brand_owner_FSSAI_license_no": "5454545454",
+                                "additives_info": "hdhdjd",
+                                "other_premises": "yeheeh",
+                                "importer_name": "hdhdhd",
+                                "brand_owner_address": "hejdj",
+                                "ingredients_info": "hshdd",
+                                "other_FSSAI_license_no": "515118",
+                                "brand_owner_name": "Britannia",
+                                "manufacturer_or_packer_name": "hshdj",
+                                "manufacturer_or_packer_address": "hdjdj"
+                            },
+                            "tax_type": "gst",
+                            "domain": "Grocery",
+                            "time": {
+                                "label": "enable",
+                                "timestamp": "2023-11-09T07:52:07.476Z"
+                            },
+                            "fulfillment_id": "1"
+                        },
+                        {
+                            "@ondc/org/statutory_reqs_packaged_commodities": {
+                                "common_or_generic_name_of_commodity": "hdjfjf",
+                                "manufacturer_or_packer_name": "hdjdnfnf",
+                                "manufacturer_or_packer_address": "hdjdfj",
+                                "month_year_of_manufacture_packing_import": "11/2023"
+                            },
+                            "@ondc/org/seller_pickup_return": true,
+                            "@ondc/org/contact_details_consumer_care": "John Nov9,John@acme.com,9911991199",
+                            "descriptor": {
+                                "symbol": "https://firebasestorage.googleapis.com/v0/b/shopeg-dev.appspot.com/o/shopImages%2FWy4ujm1L2gZH18LCxz2FHu1J21Y2%2Fimg_1699342255752.jpg?alt=media&token=0f481b9d-cb4f-4fdb-ad56-576830bd3db7",
+                                "images": [
+                                    "https://firebasestorage.googleapis.com/v0/b/shopeg-dev.appspot.com/o/shopImages%2FWy4ujm1L2gZH18LCxz2FHu1J21Y2%2Fimg_1699342255752.jpg?alt=media&token=0f481b9d-cb4f-4fdb-ad56-576830bd3db7"
+                                ],
+                                "name": "Sample custom item",
+                                "short_desc": "sample desc",
+                                "long_desc": "sample desc"
+                            },
+                            "location_id": "6271",
+                            "tax_rate": "5",
+                            "@ondc/org/available_on_cod": true,
+                            "contact_details_consumer_care_email": "hddh@djdj.com",
+                            "L2_category": "Beauty & Hygiene",
+                            "category_id": "Beauty & Hygiene",
+                            "price": {
+                                "currency": "INR",
+                                "maximum_value": "500",
+                                "value": "500"
+                            },
+                            "id": "b3cac5fc-10e6-440d-80ef-d313b39c4925",
+                            "@ondc/org/cancellable": true,
+                            "@ondc/org/tat": "PT4H",
+                            "@ondc/org/returnable": true,
+                            "quantity": {
+                                "available": {
+                                    "count": "3"
+                                },
+                                "maximum": {
+                                    "count": "3"
+                                },
+                                "unitized": {
+                                    "measure": {
+                                        "unit": "unit",
+                                        "value": "1"
+                                    }
+                                }
+                            },
+                            "@ondc/org/time_to_ship": "PT2H",
+                            "contact_details_consumer_care_name": "bdbdd",
+                            "contact_details_consumer_care_contactno": "5181858585",
+                            "hsn_code": "8484848",
+                            "tags": [
+                                {
+                                    "code": "origin",
+                                    "list": [
+                                        {
+                                            "code": "country",
+                                            "value": "IND"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "@ondc/org/return_window": "P14D",
+                            "tax_type": "gst",
+                            "domain": "Grocery",
+                            "time": {
+                                "label": "enable",
+                                "timestamp": "2023-11-07T07:31:40.646Z"
+                            },
+                            "fulfillment_id": "1"
+                        },
+                        {
+                            "@ondc/org/statutory_reqs_packaged_commodities": {
+                                "common_or_generic_name_of_commodity": "Spices & Masala",
+                                "manufacturer_or_packer_name": "Eastern Condiments Pvt Ltd NO 15, Eastern Valley, Adimali. Kerala : 522212",
+                                "manufacturer_or_packer_address": "Eastern Condiments Pvt Ltd NO 15, Eastern Valley, Adimali. Kerala : 522212",
+                                "month_year_of_manufacture_packing_import": "11/2023"
+                            },
+                            "@ondc/org/seller_pickup_return": true,
+                            "@ondc/org/contact_details_consumer_care": "John Nov9,John@acme.com,9911991199",
+                            "descriptor": {
+                                "symbol": "https://datalabs.siva3.io/image/Eunimart_groceries_40011546_3-eastern-mix-vangi-bhath-brinjal-rice.jpg",
+                                "images": [
+                                    "https://datalabs.siva3.io/image/Eunimart_groceries_40011546_3-eastern-mix-vangi-bhath-brinjal-rice.jpg",
+                                    "https://datalabs.siva3.io/image/Eunimart_groceries_40011546-2_1-eastern-mix-vangi-bhath-brinjal-rice.jpg",
+                                    "https://datalabs.siva3.io/image/Eunimart_groceries_40011546-3_1-eastern-mix-vangi-bhath-brinjal-rice.jpg"
+                                ],
+                                "name": "Eastern Mix - Vangi Bhath (Brinjal Rice), 100 g Pouch",
+                                "short_desc": "Step 1. Cook 175g of rice and keep aside, Step 2. Fry 175g, of brinjal and 100g vegetables with a pinch of turmeric in 1/2 teaspoon of cooking oil, Step 3: Add 3 1/2 teaspoons of Eastern Vangi Bhath if desired, Step 4. Season it with 3 tablespoon of cooking oil, 1/4 teaspoon of mustard, 1/2 teaspoon of chilli, Steps 5. Add Fried copra and cooked rice, Mix well and Serve hot.",
+                                "long_desc": "Step 1. Cook 175g of rice and keep aside, Step 2. Fry 175g, of brinjal and 100g vegetables with a pinch of turmeric in 1/2 teaspoon of cooking oil, Step 3: Add 3 1/2 teaspoons of Eastern Vangi Bhath if desired, Step 4. Season it with 3 tablespoon of cooking oil, 1/4 teaspoon of mustard, 1/2 teaspoon of chilli, Steps 5. Add Fried copra and cooked rice, Mix well and Serve hot."
+                            },
+                            "location_id": "6271",
+                            "tax_rate": "18",
+                            "@ondc/org/available_on_cod": true,
+                            "contact_details_consumer_care_email": "vhjh@fhh.com",
+                            "L2_category": "Masala & Seasoning",
+                            "category_id": "Masala & Seasoning",
+                            "price": {
+                                "currency": "INR",
+                                "maximum_value": "55",
+                                "value": "55"
+                            },
+                            "id": "50085138-905f-4ef4-a49d-4f32baf13b97",
+                            "@ondc/org/cancellable": true,
+                            "@ondc/org/tat": "PT4H",
+                            "@ondc/org/returnable": true,
+                            "quantity": {
+                                "available": {
+                                    "count": "3"
+                                },
+                                "maximum": {
+                                    "count": "3"
+                                },
+                                "unitized": {
+                                    "measure": {
+                                        "unit": "unit",
+                                        "value": "1"
+                                    }
+                                }
+                            },
+                            "@ondc/org/time_to_ship": "PT2H",
+                            "contact_details_consumer_care_name": "vhjjhj",
+                            "contact_details_consumer_care_contactno": "9900009999",
+                            "product_master_uuid": "2a99e8f4-34b1-42e6-b703-e150370d1033",
+                            "hsn_code": "28566883",
+                            "tags": [
+                                {
+                                    "code": "origin",
+                                    "list": [
+                                        {
+                                            "code": "country",
+                                            "value": "IND"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "@ondc/org/return_window": "P14D",
+                            "tax_type": "gst",
+                            "domain": "Grocery",
+                            "time": {
+                                "label": "enable",
+                                "timestamp": "2023-11-09T10:28:46.578Z"
+                            },
+                            "fulfillment_id": "1"
+                        }
+                    ],
+                    "fulfillments": [
+                        {
+                            "contact": {
+                                "email": "ondc-support@shopeg.in",
+                                "phone": "8618563552"
+                            },
+                            "id": "1",
+                            "type": "Delivery",
+                            "tracking": false,
+                            "@ondc/org/TAT": "PT12H"
+                        }
+                    ],
+                    "tags": [
+                        {
+                            "code": "serviceability",
+                            "list": [
+                                {
+                                    "code": "location",
+                                    "value": "6271"
+                                },
+                                {
+                                    "code": "category",
+                                    "value": "Beverages"
+                                },
+                                {
+                                    "code": "type",
+                                    "value": "10"
+                                },
+                                {
+                                    "code": "val",
+                                    "value": "5.0"
+                                },
+                                {
+                                    "code": "unit",
+                                    "value": "km"
+                                }
+                            ]
+                        },
+                        {
+                            "code": "serviceability",
+                            "list": [
+                                {
+                                    "code": "location",
+                                    "value": "6271"
+                                },
+                                {
+                                    "code": "category",
+                                    "value": "Gourmet & World Foods"
+                                },
+                                {
+                                    "code": "type",
+                                    "value": "10"
+                                },
+                                {
+                                    "code": "val",
+                                    "value": "5.0"
+                                },
+                                {
+                                    "code": "unit",
+                                    "value": "km"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "id": "0Wd118zdPd6l0Wr1bhH2",
+                    "time": {
+                        "label": "enable",
+                        "timestamp": "2023-11-10T12:00:06.880Z"
+                    },
+                    "ttl": "P1D",
+                    "descriptor": {
+                        "symbol": "https://firebasestorage.googleapis.com/v0/b/shopeg-dev.appspot.com/o/shopImages%2FVdxkoawpDWWiinBxbUjsYRnPl3x2%2F2023-09-14%2015%3A57%3A02.340168.jpg?alt=media&token=a39143e1-ed61-4305-a74a-32fcc2c2e972",
+                        "images": [
+                            "https://firebasestorage.googleapis.com/v0/b/shopeg-dev.appspot.com/o/shopImages%2FVdxkoawpDWWiinBxbUjsYRnPl3x2%2F2023-09-14%2015%3A57%3A02.340168.jpg?alt=media&token=a39143e1-ed61-4305-a74a-32fcc2c2e972"
+                        ],
+                        "name": "Vijai's ondc preprod Bangalore 1",
+                        "short_desc": "Vijai\\'s ondc preprod Bangalore 1",
+                        "long_desc": "Vijai's ondc preprod Bangalore 1"
+                    },
+                    "locations": [
+                        {
+                            "schedule": {
+                                "times": [
+                                    "0800"
+                                ],
+                                "holidays": [],
+                                "frequency": "PT12H"
+                            },
+                            "address": {
+                                "door": "circle road",
+                                "country": "India",
+                                "city": "Bengaluru",
+                                "street": "jayanagar",
+                                "area_code": "560011",
+                                "name": "Vijai's ondc preprod Bangalore 1",
+                                "locality": "NA",
+                                "state": "Karnataka",
+                                "building": "circle road"
+                            },
+                            "id": "6897",
+                            "gps": "12.931629470130435,77.58015017956495",
+                            "time": {
+                                "schedule": {
+                                    "holidays": []
+                                },
+                                "range": {
+                                    "start": "0800",
+                                    "end": "2000"
+                                },
+                                "days": "1,2,3,4,5,6,7",
+                                "label": "enable",
+                                "timestamp": "2023-11-10T12:00:06.880Z"
+                            },
+                            "circle": {
+                                "gps": "12.931629470130435,77.58015017956495",
+                                "radius": {
+                                    "unit": "km",
+                                    "value": "12"
+                                }
+                            }
+                        }
+                    ],
+                    "items": [
+                        {
+                            "@ondc/org/TAT": "P3D",
+                            "@ondc/org/statutory_reqs_packaged_commodities": {
+                                "common_or_generic_name_of_commodity": "Bath & Hand Wash",
+                                "net_quantity_or_measure_of_commodity_in_pkg": "900 ml",
+                                "imported_product_country_of_origin": "India",
+                                "manufacturer_or_packer_name": "ITC LTD, 37, J.L. Nehru Road, Kolkata - 7000 71, West Bengal",
+                                "multiple_products_name_number_or_qty": "Fiama",
+                                "manufacturer_or_packer_address": "ITC LTD, 37, J.L. Nehru Road, Kolkata - 7000 71, West Bengal",
+                                "month_year_of_manufacture_packing_import": "10/2023"
+                            },
+                            "@ondc/org/seller_pickup_return": true,
+                            "@ondc/org/contact_details_consumer_care": "John Nov9,John@acme.com,9911991199",
+                            "descriptor": {
+                                "symbol": "https://datalabs.siva3.io/image/Eunimart_groceries_40225322_1-fiama-shower-gel-with-skin-conditioners-blackcurrant-bearberry-family-pack.jpg",
+                                "images": [
+                                    "https://datalabs.siva3.io/image/Eunimart_groceries_40225322_1-fiama-shower-gel-with-skin-conditioners-blackcurrant-bearberry-family-pack.jpg",
+                                    "https://datalabs.siva3.io/image/Eunimart_groceries_40225322-2_1-fiama-shower-gel-with-skin-conditioners-blackcurrant-bearberry-family-pack.jpg",
+                                    "https://datalabs.siva3.io/image/Eunimart_groceries_40225322-3_1-fiama-shower-gel-with-skin-conditioners-blackcurrant-bearberry-family-pack.jpg"
+                                ],
+                                "name": "Fiama Shower Gel - With Skin Conditioners, Blackcurrant & Bearberry, Family Pack, 900 ml",
+                                "short_desc": "Wash away the troubles of your day, with the foamy, fresh, and fun Fiama Shower Gel. And while you enjoy your Fiama bath, let its skin-conditioners work their magic to give your skin a radiant glow. This Blackcurrant and Bearberry shower gel has an indulgent fragrance that transforms a normal shower into a spa-like experience. It is filled with the goodness of natural ingredients, which helps your skin glow. So get ready to make every bath, a highlight of your day.",
+                                "long_desc": "Wash away the troubles of your day, with the foamy, fresh, and fun Fiama Shower Gel. And while you enjoy your Fiama bath, let its skin-conditioners work their magic to give your skin a radiant glow. This Blackcurrant and Bearberry shower gel has an indulgent fragrance that transforms a normal shower into a spa-like experience. It is filled with the goodness of natural ingredients, which helps your skin glow. So get ready to make every bath, a highlight of your day."
+                            },
+                            "location_id": "6897",
+                            "tax_rate": "18",
                             "@ondc/org/available_on_cod": false,
                             "L2_category": "Beauty & Hygiene",
                             "category_id": "Beauty & Hygiene",
                             "price": {
                                 "currency": "INR",
-                                "maximum_value": "161",
-                                "value": "161"
+                                "maximum_value": "749",
+                                "value": "749"
                             },
-                            "@ondc/org/statutory_reqs_prepackaged_food.imported_product_country_of_origin": "IND",
-                            "id": "32545f38-516a-45a9-82ae-22ab11247b07",
+                            "id": "424bad43-ce9f-4d86-9fa0-f0879ed2d6f5",
                             "@ondc/org/cancellable": true,
                             "@ondc/org/returnable": true,
+                            "quantity": {
+                                "available": {
+                                    "count": "3"
+                                },
+                                "maximum": {
+                                    "count": "3"
+                                },
+                                "unitized": {
+                                    "measure": {
+                                        "unit": "ml",
+                                        "value": "900"
+                                    }
+                                }
+                            },
+                            "@ondc/org/time_to_ship": "P2D",
+                            "product_master_uuid": "717b0552-7deb-4ec8-9f73-0314b39c33bb",
+                            "hsn_code": "12345678",
+                            "tags": [],
+                            "@ondc/org/return_window": "P14D",
+                            "tax_type": "gst",
+                            "domain": "Grocery",
+                            "time": {
+                                "label": "enable",
+                                "timestamp": "2023-10-17T09:52:03.095Z"
+                            },
+                            "fulfillment_id": "1"
+                        },
+                        {
+                            "@ondc/org/TAT": "P3D",
+                            "@ondc/org/statutory_reqs_packaged_commodities": {
+                                "common_or_generic_name_of_commodity": "Flour & Grains",
+                                "net_quantity_or_measure_of_commodity_in_pkg": "1 Kg",
+                                "imported_product_country_of_origin": "India",
+                                "manufacturer_or_packer_name": "ITC Limited, 37, J.L. Nehru Road, Kolkata- 700071",
+                                "multiple_products_name_number_or_qty": "Ashirvad ",
+                                "manufacturer_or_packer_address": "ITC Limited, 37, J.L. Nehru Road, Kolkata- 700071",
+                                "month_year_of_manufacture_packing_import": "10/2023"
+                            },
+                            "@ondc/org/seller_pickup_return": true,
+                            "@ondc/org/contact_details_consumer_care": "John Nov9,John@acme.com,9911991199",
+                            "descriptor": {
+                                "symbol": "https://datalabs.siva3.io/image/Eunimart_groceries_61826_8-aashirvaad-atta-whole-wheat.jpg",
+                                "images": [
+                                    "https://datalabs.siva3.io/image/Eunimart_groceries_61826_8-aashirvaad-atta-whole-wheat.jpg",
+                                    "https://datalabs.siva3.io/image/Eunimart_groceries_61826-2_4-aashirvaad-atta-whole-wheat.jpg",
+                                    "https://datalabs.siva3.io/image/Eunimart_groceries_61826-3_3-aashirvaad-atta-whole-wheat.jpg"
+                                ],
+                                "name": "Aashirvaad Atta/Godihittu - Whole Wheat, 2 kg",
+                                "short_desc": "Launched on 27th May 2002, Aashirvaad Whole Wheat Atta has now become number one in branded packaged atta across the country. Behind every Aashirvaad pack are the Indian farmers and Aashirvaad experts who’ve made the atta with extra care. Aashirvaad prides itself in making 100% pure whole wheat atta with all its natural dietary fibres intact which ensure that you and your family receive optimum nutrition for a healthy life. Directly sourced from a wide network of Indian rural farmers, Aashirvaad Superior MP Atta is Made in India. They are showered with just the right amount of rain and sun-kissed to perfection which allows the grains to be heavy on the palm and amber in colour. The grain produce goes through a 3-step cleaning process that ensures the best quality of wheat grains. These expertly sourced grains undergo mechanised packaging that ensures zero human contact and 100% safety. To ensure the retention of the wheat’s high nutritional value, the grains are ground using the traditional ‘chakki’ method. This helps locking-in the highest nutritional value in whole wheat flour. The dietary fibres and natural nutrients help in easy digestion and supporting immunity which is essential for your family’s daily intake. The dough made from Aashirvaad Superior MP Atta absorbs more water which makes sure that the rotis remain softer for a longer period. You and your family can lead a fit and healthier lifestyle as you enjoy soft, fluffy and delicious rotis from this naturally protein-rich whole wheat atta",
+                                "long_desc": "Launched on 27th May 2002, Aashirvaad Whole Wheat Atta has now become number one in branded packaged atta across the country. Behind every Aashirvaad pack are the Indian farmers and Aashirvaad experts who’ve made the atta with extra care. Aashirvaad prides itself in making 100% pure whole wheat atta with all its natural dietary fibres intact which ensure that you and your family receive optimum nutrition for a healthy life. Directly sourced from a wide network of Indian rural farmers, Aashirvaad Superior MP Atta is Made in India. They are showered with just the right amount of rain and sun-kissed to perfection which allows the grains to be heavy on the palm and amber in colour. The grain produce goes through a 3-step cleaning process that ensures the best quality of wheat grains. These expertly sourced grains undergo mechanised packaging that ensures zero human contact and 100% safety. To ensure the retention of the wheat’s high nutritional value, the grains are ground using the traditional ‘chakki’ method. This helps locking-in the highest nutritional value in whole wheat flour. The dietary fibres and natural nutrients help in easy digestion and supporting immunity which is essential for your family’s daily intake. The dough made from Aashirvaad Superior MP Atta absorbs more water which makes sure that the rotis remain softer for a longer period. You and your family can lead a fit and healthier lifestyle as you enjoy soft, fluffy and delicious rotis from this naturally protein-rich whole wheat atta"
+                            },
+                            "location_id": "6897",
+                            "tax_rate": "18",
+                            "@ondc/org/available_on_cod": false,
+                            "L2_category": "Foodgrains",
+                            "category_id": "Foodgrains",
+                            "price": {
+                                "currency": "INR",
+                                "maximum_value": "118",
+                                "value": "118"
+                            },
+                            "id": "297537d6-e250-42f4-b40f-bb6aa6664d64",
+                            "@ondc/org/cancellable": true,
+                            "@ondc/org/returnable": true,
+                            "quantity": {
+                                "available": {
+                                    "count": "3"
+                                },
+                                "maximum": {
+                                    "count": "3"
+                                },
+                                "unitized": {
+                                    "measure": {
+                                        "unit": "Kg",
+                                        "value": "1"
+                                    }
+                                }
+                            },
+                            "@ondc/org/time_to_ship": "P2D",
+                            "product_master_uuid": "ee8af00f-fb6a-4e20-9867-2fb22c77b726",
+                            "hsn_code": "464664",
+                            "tags": [
+                                {
+                                    "code": "veg_nonveg",
+                                    "list": [
+                                        {
+                                            "code": "veg",
+                                            "value": "yes"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "@ondc/org/return_window": "P14D",
+                            "@ondc/org/statutory_reqs_prepackaged_food": {
+                                "importer_FSSAI_license_no": "196464",
+                                "nutritional_info": "shshhss",
+                                "other_importer_address": "shsh",
+                                "importer_address": "Yys",
+                                "other_importer_name": "shsh",
+                                "brand_owner_FSSAI_license_no": "464664",
+                                "net_quantity": "1",
+                                "additives_info": "hahhs",
+                                "other_premises": "shsh",
+                                "importer_name": "shsh",
+                                "brand_owner_address": "ahaha",
+                                "ingredients_info": "Haghs",
+                                "other_FSSAI_license_no": "46464",
+                                "brand_owner_name": "Aashirvaad",
+                                "imported_product_country_of_origin": "IND",
+                                "manufacturer_or_packer_name": "shhshs",
+                                "manufacturer_or_packer_address": "svsvgs"
+                            },
+                            "tax_type": "gst",
+                            "domain": "Grocery",
+                            "time": {
+                                "label": "enable",
+                                "timestamp": "2023-10-17T09:52:03.095Z"
+                            },
+                            "fulfillment_id": "1"
+                        }
+                    ],
+                    "fulfillments": [
+                        {
+                            "contact": {
+                                "phone": "8618563552",
+                                "email": "ondc-support@shopeg.in"
+                            },
+                            "id": "1",
+                            "type": "Delivery",
+                            "@ondc/org/provider_name": "Vijai's ondc preprod Bangalore 1",
+                            "@ondc/org/TAT": "P3D"
+                        }
+                    ],
+                    "tags": [
+                        {
+                            "code": "serviceability",
+                            "list": [
+                                {
+                                    "code": "location",
+                                    "value": "6897"
+                                },
+                                {
+                                    "code": "category",
+                                    "value": "Beauty & Hygiene"
+                                },
+                                {
+                                    "code": "type",
+                                    "value": "10"
+                                },
+                                {
+                                    "code": "val",
+                                    "value": "12"
+                                },
+                                {
+                                    "code": "unit",
+                                    "value": "km"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "id": "cK4NBOIKU0Rf2M0Qv9qX",
+                    "time": {
+                        "label": "enable",
+                        "timestamp": "2023-11-10T12:00:06.880Z"
+                    },
+                    "ttl": "P1D",
+                    "descriptor": {
+                        "symbol": "https://www.bigbasket.com/media/uploads/p/l/40183413_10-bb-home-stainless-steel-deep-dabbastorage-container-no-12-plain.jpg?tr=w-1080,q=80",
+                        "name": "SLV grocery store",
+                        "short_desc": "Fresh grocery ",
+                        "images": [
+                            "https://www.bigbasket.com/media/uploads/p/l/40183413_10-bb-home-stainless-steel-deep-dabbastorage-container-no-12-plain.jpg?tr=w-1080,q=80"
+                        ],
+                        "long_desc": "Fresh grocery "
+                    },
+                    "locations": [
+                        {
+                            "schedule": {
+                                "times": [
+                                    "0702",
+                                    "2300"
+                                ],
+                                "holidays": [],
+                                "frequency": "PT15H"
+                            },
+                            "address": {
+                                "door": "67, 2nd Cross Road, 2nd Cross Road",
+                                "country": "India",
+                                "city": "Bengaluru",
+                                "street": "Basaveshwara Nagar, Bengaluru",
+                                "area_code": "560079",
+                                "name": "SLV grocery store",
+                                "locality": "",
+                                "state": "KA",
+                                "building": "67, 2nd Cross Road, 2nd Cross Road"
+                            },
+                            "id": "6908",
+                            "gps": "13.000997251887071,77.53779746937829",
+                            "time": {
+                                "schedule": {
+                                    "holidays": []
+                                },
+                                "range": {
+                                    "start": "0702",
+                                    "end": "2300"
+                                },
+                                "days": "1,2,3,4,5,6,7",
+                                "label": "enable",
+                                "timestamp": "2023-11-10T12:00:06.880Z"
+                            },
+                            "circle": {
+                                "gps": "13.000997251887071,77.53779746937829",
+                                "radius": {
+                                    "unit": "km",
+                                    "value": "5"
+                                }
+                            }
+                        }
+                    ],
+                    "items": [
+                        {
+                            "@ondc/org/TAT": "P2D",
+                            "@ondc/org/statutory_reqs_packaged_commodities": {
+                                "common_or_generic_name_of_commodity": "Utensils & Cookware",
+                                "net_quantity_or_measure_of_commodity_in_pkg": "1 Nos",
+                                "imported_product_country_of_origin": "India",
+                                "manufacturer_or_packer_name": "Neelam Appliances Ltd., Neelam House,Fafadia Industrial Estate, Waliv, Vasai, Dist. Palghar.Maharashtra-401208",
+                                "multiple_products_name_number_or_qty": "1",
+                                "manufacturer_or_packer_address": "Neelam Appliances Ltd., Neelam House,Fafadia Industrial Estate, Waliv, Vasai, Dist. Palghar.Maharashtra-401208",
+                                "month_year_of_manufacture_packing_import": "09/2023"
+                            },
+                            "@ondc/org/seller_pickup_return": true,
+                            "@ondc/org/contact_details_consumer_care": "John Nov9,John@acme.com,9911991199",
+                            "descriptor": {
+                                "symbol": "https://www.bigbasket.com/media/uploads/p/l/40183413_10-bb-home-stainless-steel-deep-dabbastorage-container-no-12-plain.jpg?tr=w-1080,q=80",
+                                "images": [
+                                    "https://www.bigbasket.com/media/uploads/p/l/40183413_10-bb-home-stainless-steel-deep-dabbastorage-container-no-12-plain.jpg?tr=w-1080,q=80",
+                                    "https://www.bigbasket.com/media/uploads/p/l/40183413-2_11-bb-home-stainless-steel-deep-dabbastorage-container-no-12-plain.jpg?tr=w-1080,q=80",
+                                    "https://www.bigbasket.com/media/uploads/p/l/40183413-3_11-bb-home-stainless-steel-deep-dabbastorage-container-no-12-plain.jpg?tr=w-1080,q=80"
+                                ],
+                                "name": "BB Home Deep Dabba/Storage Container - No.12, Plain, Stainless Steel, Durable, 1.9 l (1 pc)",
+                                "short_desc": "BB Home Canister/Container Deep Dabba is a long cylindrical-shaped storage container, made of fine quality stainless steel that is durable and ideal for storing grains, snacks and other edibles. They are easy to clean and maintain. They add a great addition to your modular kitchen.",
+                                "long_desc": "BB Home Canister/Container Deep Dabba is a long cylindrical-shaped storage container, made of fine quality stainless steel that is durable and ideal for storing grains, snacks and other edibles. They are easy to clean and maintain. They add a great addition to your modular kitchen."
+                            },
+                            "location_id": "6908",
+                            "tax_rate": "5",
+                            "@ondc/org/available_on_cod": false,
+                            "L2_category": "Kitchen Accessories",
+                            "category_id": "Kitchen Accessories",
+                            "price": {
+                                "currency": "INR",
+                                "maximum_value": "299",
+                                "value": "299"
+                            },
+                            "id": "e278c2c9-3e50-4062-b73d-14976103ef81",
+                            "@ondc/org/cancellable": true,
+                            "@ondc/org/returnable": false,
                             "quantity": {
                                 "available": {
                                     "count": "3"
@@ -9967,16 +2970,107 @@
                                     }
                                 }
                             },
-                            "@ondc/org/time_to_ship": "PT2H",
-                            "product_master_uuid": "20feedd9-cf01-4fc7-aba4-94fc9b3c8c4c",
-                            "hsn_code": "1111",
+                            "@ondc/org/time_to_ship": "P1D",
+                            "product_master_uuid": "426cd36c-4c0d-4f2e-859d-5a819fc6e4f6",
+                            "hsn_code": "12345",
                             "tags": [],
-                            "@ondc/org/return_window": "P14D",
+                            "@ondc/org/return_window": "7 Days",
                             "tax_type": "gst",
                             "domain": "Grocery",
                             "time": {
                                 "label": "enable",
-                                "timestamp": "2023-10-19T09:05:08.791Z"
+                                "timestamp": "2023-11-09T18:11:41.851Z"
+                            },
+                            "fulfillment_id": "1"
+                        },
+                        {
+                            "@ondc/org/TAT": "P2D",
+                            "@ondc/org/statutory_reqs_packaged_commodities": {
+                                "common_or_generic_name_of_commodity": "Spices & Masala",
+                                "net_quantity_or_measure_of_commodity_in_pkg": "1545 Nos",
+                                "imported_product_country_of_origin": "India",
+                                "manufacturer_or_packer_name": "S.Everest Food Products Pvt. Ltd.",
+                                "multiple_products_name_number_or_qty": "dhdh",
+                                "manufacturer_or_packer_address": "S.Everest Food Products Pvt. Ltd.",
+                                "month_year_of_manufacture_packing_import": "10/2023"
+                            },
+                            "@ondc/org/seller_pickup_return": true,
+                            "@ondc/org/contact_details_consumer_care": "John Nov9,John@acme.com,9911991199",
+                            "descriptor": {
+                                "symbol": "https://www.bigbasket.com/media/uploads/p/xxl/40059447_6-everest-kasuri-methi.jpg",
+                                "images": [
+                                    "https://www.bigbasket.com/media/uploads/p/xxl/40059447_6-everest-kasuri-methi.jpg"
+                                ],
+                                "name": "EVEREST KASURI METHI 25 G\r\n",
+                                "short_desc": "Sun-dried, pleasantly flavoured, Fenugreek leaves which is dried in hot air in controlled conditions, is a great taste enhancer. It adds flavour and texture to vegetables, pulses and lentils, parathas and chapattis.\r\n",
+                                "long_desc": "Sun-dried, pleasantly flavoured, Fenugreek leaves which is dried in hot air in controlled conditions, is a great taste enhancer. It adds flavour and texture to vegetables, pulses and lentils, parathas and chapattis.\r\n"
+                            },
+                            "location_id": "6908",
+                            "tax_rate": "5",
+                            "@ondc/org/available_on_cod": false,
+                            "L2_category": "Masala & Seasoning",
+                            "category_id": "Masala & Seasoning",
+                            "price": {
+                                "currency": "INR",
+                                "maximum_value": "23",
+                                "value": "23"
+                            },
+                            "id": "96eb055a-4956-412f-b78c-f5ab80043fdb",
+                            "@ondc/org/cancellable": true,
+                            "@ondc/org/returnable": false,
+                            "quantity": {
+                                "available": {
+                                    "count": "3"
+                                },
+                                "maximum": {
+                                    "count": "3"
+                                },
+                                "unitized": {
+                                    "measure": {
+                                        "unit": "Nos",
+                                        "value": "1545"
+                                    }
+                                }
+                            },
+                            "@ondc/org/time_to_ship": "P1D",
+                            "product_master_uuid": "6b45c17c-3950-4de7-b6bb-0e45bc737351",
+                            "hsn_code": "1554",
+                            "tags": [
+                                {
+                                    "code": "veg_nonveg",
+                                    "list": [
+                                        {
+                                            "code": "veg",
+                                            "value": "yes"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "@ondc/org/return_window": "7 Days",
+                            "@ondc/org/statutory_reqs_prepackaged_food": {
+                                "importer_FSSAI_license_no": "5255",
+                                "nutritional_info": "dhdh",
+                                "other_importer_address": "yrhf",
+                                "importer_address": "hehd",
+                                "other_importer_name": "hdhfh",
+                                "brand_owner_FSSAI_license_no": "545555",
+                                "net_quantity": "1545 Nos",
+                                "additives_info": "hdfh",
+                                "other_premises": "jdjf",
+                                "importer_name": "hehd",
+                                "brand_owner_address": "fhhffh",
+                                "ingredients_info": "hdhd",
+                                "other_FSSAI_license_no": "959555885",
+                                "brand_owner_name": "Everest",
+                                "imported_product_country_of_origin": "IND",
+                                "manufacturer_or_packer_name": "herh",
+                                "manufacturer_or_packer_address": "ruru"
+                            },
+                            "tax_type": "gst",
+                            "domain": "Grocery",
+                            "time": {
+                                "label": "enable",
+                                "timestamp": "2023-11-09T18:11:41.851Z"
                             },
                             "fulfillment_id": "1"
                         }
@@ -9989,8 +3083,8 @@
                             },
                             "id": "1",
                             "type": "Delivery",
-                            "@ondc/org/provider_name": "B shop",
-                            "@ondc/org/TAT": "PT12H"
+                            "@ondc/org/provider_name": "SLV grocery store",
+                            "@ondc/org/TAT": "P2D"
                         }
                     ],
                     "tags": [
@@ -9999,11 +3093,11 @@
                             "list": [
                                 {
                                     "code": "location",
-                                    "value": "6271"
+                                    "value": "6908"
                                 },
                                 {
                                     "code": "category",
-                                    "value": "Oil & Ghee"
+                                    "value": "Kitchen Accessories"
                                 },
                                 {
                                     "code": "type",
@@ -10020,6 +3114,22 @@
                             ]
                         }
                     ]
+                }
+            ],
+            "bpp/descriptor": {
+                "name": "ShopEG",
+                "symbol": "https://shopeg.in/i/eg.png",
+                "short_desc": "ShopEG",
+                "long_desc": "ShopEG: Online Angadi",
+                "code": "EG",
+                "images": [
+                    "https://shopeg.in/i/eg.png"
+                ]
+            },
+            "bpp/fulfillments": [
+                {
+                    "id": "1",
+                    "type": "Delivery"
                 }
             ]
         }

--- a/ShopEG/With buyer-app-preprod-v2.ondc.org/Group A/Flow 1/full_catalog_search.json
+++ b/ShopEG/With buyer-app-preprod-v2.ondc.org/Group A/Flow 1/full_catalog_search.json
@@ -7,9 +7,9 @@
         "core_version": "1.2.0",
         "bap_id": "buyer-app-preprod-v2.ondc.org",
         "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
-        "transaction_id": "c74f20b5-0b27-476a-b059-75680c3cf40a",
-        "message_id": "fcba7f68-554f-4e8c-ad58-a13298392081",
-        "timestamp": "2023-10-27T16:00:01.317Z",
+        "transaction_id": "4e4731c5-6dbd-4700-9b22-c71e885c89a6",
+        "message_id": "56016590-44b4-4a0a-bbfe-4e34f12a27ce",
+        "timestamp": "2023-11-10T12:00:02.049Z",
         "ttl": "PT30S"
     },
     "message": {

--- a/ShopEG/With buyer-app-preprod-v2.ondc.org/Group A/Flow 1/incremental_on_search.json
+++ b/ShopEG/With buyer-app-preprod-v2.ondc.org/Group A/Flow 1/incremental_on_search.json
@@ -7,43 +7,27 @@
         "core_version": "1.2.0",
         "bap_id": "buyer-app-preprod-v2.ondc.org",
         "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
-        "transaction_id": "55303e1a-3f57-4852-a420-de018903aa7f",
-        "message_id": "964efaf7-d881-4e2c-99d3-fb68d01fb22c",
-        "timestamp": "2023-10-28T19:40:01.316Z",
+        "transaction_id": "53566a71-3b41-469b-a604-9e7fc5f9864f",
+        "message_id": "b9864f69-da68-4675-a742-955c7933504e",
+        "timestamp": "2023-11-10T15:10:12.876Z",
         "ttl": "PT30S",
         "bpp_uri": "https://dev-api.shopeg.in/ondc/bpp",
         "bpp_id": "dev-api.shopeg.in"
     },
     "message": {
         "catalog": {
-            "bpp/fulfillments": [
-                {
-                    "id": "1",
-                    "type": "Delivery"
-                }
-            ],
-            "bpp/descriptor": {
-                "name": "ShopEG",
-                "symbol": "https://shopeg.in/i/eg.png",
-                "short_desc": "ShopEG",
-                "long_desc": "ShopEG: Online Angadi",
-                "code": "EG",
-                "images": [
-                    "https://shopeg.in/i/eg.png"
-                ]
-            },
             "bpp/providers": [
                 {
                     "id": "rOebEZL96U8iln27G7Fm",
                     "time": {
                         "label": "enable",
-                        "timestamp": "2023-10-28T19:40:01.316Z"
+                        "timestamp": "2023-11-10T15:10:12.876Z"
                     },
                     "ttl": "P1D",
                     "descriptor": {
-                        "symbol": "https://datalabs.siva3.io/image/Eunimart_groceries_30004608_6-park-avenue-bathing-soap-good-morning.jpg",
+                        "symbol": "https://firebasestorage.googleapis.com/v0/b/shopeg-dev.appspot.com/o/shopImages%2FWy4ujm1L2gZH18LCxz2FHu1J21Y2%2F2023-11-10%2011%3A58%3A54.715423.jpg?alt=media&token=f6963c1a-e676-4ad1-82a5-129969620010",
                         "images": [
-                            "https://datalabs.siva3.io/image/Eunimart_groceries_30004608_6-park-avenue-bathing-soap-good-morning.jpg"
+                            "https://firebasestorage.googleapis.com/v0/b/shopeg-dev.appspot.com/o/shopImages%2FWy4ujm1L2gZH18LCxz2FHu1J21Y2%2F2023-11-10%2011%3A58%3A54.715423.jpg?alt=media&token=f6963c1a-e676-4ad1-82a5-129969620010"
                         ],
                         "name": "B shop",
                         "short_desc": "Fresh Grocery Items updated schedule ",
@@ -51,14 +35,6 @@
                     },
                     "locations": [
                         {
-                            "schedule": {
-                                "times": [
-                                    "0800",
-                                    "2100"
-                                ],
-                                "holidays": [],
-                                "frequency": "PT13H"
-                            },
                             "address": {
                                 "door": "67, 2nd Cross Road, 2nd Cross Road",
                                 "country": "India",
@@ -82,78 +58,66 @@
                                 },
                                 "days": "1,2,3,4,5,6,7",
                                 "label": "enable",
-                                "timestamp": "2023-10-28T19:40:01.316Z"
+                                "timestamp": "2023-11-10T15:10:12.876Z"
                             },
                             "circle": {
                                 "gps": "13.000985121772416,77.53780119522966",
                                 "radius": {
                                     "unit": "km",
-                                    "value": "5.0"
+                                    "value": "8.0"
                                 }
                             }
                         }
                     ],
                     "items": [
                         {
-                            "@ondc/org/TAT": "PT12H",
-                            "@ondc/org/statutory_reqs_packaged_commodities": {
-                                "common_or_generic_name_of_commodity": "Men's Grooming",
-                                "net_quantity_or_measure_of_commodity_in_pkg": "1515 Nos",
-                                "imported_product_country_of_origin": "IND",
-                                "manufacturer_or_packer_name": "Celine Health Care. 15- Sicop Industrial Area, SICOP Units, Kathua, Jammu and Kashmir 184102",
-                                "multiple_products_name_number_or_qty": "whe",
-                                "manufacturer_or_packer_address": "Celine Health Care. 15- Sicop Industrial Area, SICOP Units, Kathua, Jammu and Kashmir 184102",
-                                "month_year_of_manufacture_packing_import": "10/2023"
-                            },
-                            "@ondc/org/statutory_reqs_packaged_commodities.imported_product_country_of_origin": "IND",
                             "@ondc/org/seller_pickup_return": true,
-                            "@ondc/org/contact_details_consumer_care": "john,john@email.com,9911991112",
+                            "@ondc/org/contact_details_consumer_care": "John Nov9,John@acme.com,9911991199",
                             "descriptor": {
-                                "symbol": "https://datalabs.siva3.io/image/Eunimart_groceries_30004608_6-park-avenue-bathing-soap-good-morning.jpg",
+                                "symbol": "https://datalabs.siva3.io/image/Eunimart_groceries_204214_2-happilo-cashews-whole-100-natural-premium.jpg",
                                 "images": [
-                                    "https://datalabs.siva3.io/image/Eunimart_groceries_30004608_6-park-avenue-bathing-soap-good-morning.jpg",
-                                    "https://datalabs.siva3.io/image/Eunimart_groceries_30004608-2_2-park-avenue-bathing-soap-good-morning.jpg",
-                                    "https://datalabs.siva3.io/image/Eunimart_groceries_30004608-3_1-park-avenue-bathing-soap-good-morning.jpg"
+                                    "https://datalabs.siva3.io/image/Eunimart_groceries_204214_2-happilo-cashews-whole-100-natural-premium.jpg",
+                                    "https://datalabs.siva3.io/image/Eunimart_groceries_204214-2_1-happilo-cashews-whole-100-natural-premium.jpg",
+                                    "https://datalabs.siva3.io/image/Eunimart_groceries_204214-3_1-happilo-cashews-whole-100-natural-premium.jpg"
                                 ],
-                                "name": "Park Avenue Bathing Soap - Good Morning, 125 g",
-                                "short_desc": "Park Avenue Good Morning soap has the goodness of shea butter that mausturises skin and tea tree oil, which helps fight bacteria.",
-                                "long_desc": "Park Avenue Good Morning soap has the goodness of shea butter that mausturises skin and tea tree oil, which helps fight bacteria."
+                                "name": "Happilo Cashews - Whole, 100% Natural Premium, 2x200 g Multipack",
+                                "short_desc": "Our cashews are a real treat. These are the best nuts you can ever find. They are delightfully rich and tasty, a nutritious treat that will make a great snack time.",
+                                "long_desc": "Our cashews are a real treat. These are the best nuts you can ever find. They are delightfully rich and tasty, a nutritious treat that will make a great snack time."
                             },
                             "location_id": "6271",
-                            "tax_rate": "28",
-                            "@ondc/org/available_on_cod": false,
-                            "contact_details_consumer_care_email": "dhd@djjd.com",
-                            "L2_category": "Beauty & Hygiene",
-                            "category_id": "Beauty & Hygiene",
+                            "tax_rate": "18",
+                            "@ondc/org/available_on_cod": true,
+                            "contact_details_consumer_care_email": "djjd@dhdj.com",
+                            "L2_category": "Snacks & Branded Foods",
+                            "category_id": "Snacks & Branded Foods",
                             "price": {
                                 "currency": "INR",
-                                "maximum_value": "60",
-                                "value": "60"
+                                "maximum_value": "451",
+                                "value": "423"
                             },
-                            "@ondc/org/statutory_reqs_prepackaged_food.imported_product_country_of_origin": "IND",
-                            "id": "63e3595e-d3d7-4bf7-bcf1-2c5449621931",
+                            "id": "6ccd31e2-e972-4c5c-a46c-afd32ffc5018",
                             "@ondc/org/cancellable": true,
                             "@ondc/org/tat": "PT4H",
                             "@ondc/org/returnable": true,
                             "quantity": {
                                 "available": {
-                                    "count": "9"
+                                    "count": "5"
                                 },
                                 "maximum": {
-                                    "count": "5"
+                                    "count": "3"
                                 },
                                 "unitized": {
                                     "measure": {
                                         "unit": "unit",
-                                        "value": "1515"
+                                        "value": "1"
                                     }
                                 }
                             },
                             "@ondc/org/time_to_ship": "PT2H",
-                            "contact_details_consumer_care_name": "gdhdbd",
-                            "contact_details_consumer_care_contactno": "4548848485",
-                            "product_master_uuid": "149d97b0-d702-4866-9562-dafc04db112b",
-                            "hsn_code": "15151",
+                            "contact_details_consumer_care_name": "bdbdbd",
+                            "contact_details_consumer_care_contactno": "6161918446",
+                            "product_master_uuid": "de548794-f79b-4914-ae5b-5a9171e4e4cf",
+                            "hsn_code": "548484",
                             "tags": [
                                 {
                                     "code": "origin",
@@ -166,11 +130,28 @@
                                 }
                             ],
                             "@ondc/org/return_window": "P14D",
+                            "@ondc/org/statutory_reqs_prepackaged_food": {
+                                "importer_FSSAI_license_no": "252525",
+                                "nutritional_info": "rururu",
+                                "other_importer_address": "hrjrhr",
+                                "importer_address": "hrjrjr",
+                                "other_importer_name": "rjjrjr",
+                                "brand_owner_FSSAI_license_no": "515252",
+                                "additives_info": "rujrrj",
+                                "other_premises": "urjrjr",
+                                "importer_name": "urjrjr",
+                                "brand_owner_address": "uejrjr",
+                                "ingredients_info": "jejr",
+                                "other_FSSAI_license_no": "5252525",
+                                "brand_owner_name": "Happilo",
+                                "manufacturer_or_packer_name": "irrjjr",
+                                "manufacturer_or_packer_address": "jjr"
+                            },
                             "tax_type": "gst",
                             "domain": "Grocery",
                             "time": {
                                 "label": "enable",
-                                "timestamp": "2023-10-28T19:39:27.837Z"
+                                "timestamp": "2023-11-10T15:08:44.200Z"
                             },
                             "fulfillment_id": "1"
                         }
@@ -178,12 +159,12 @@
                     "fulfillments": [
                         {
                             "contact": {
-                                "phone": "8618563552",
-                                "email": "ondc-support@shopeg.in"
+                                "email": "ondc-support@shopeg.in",
+                                "phone": "8618563552"
                             },
                             "id": "1",
                             "type": "Delivery",
-                            "@ondc/org/provider_name": "B shop",
+                            "tracking": false,
                             "@ondc/org/TAT": "PT12H"
                         }
                     ],
@@ -197,7 +178,7 @@
                                 },
                                 {
                                     "code": "category",
-                                    "value": "Beauty & Hygiene"
+                                    "value": "Snacks & Branded Foods"
                                 },
                                 {
                                     "code": "type",
@@ -205,7 +186,7 @@
                                 },
                                 {
                                     "code": "val",
-                                    "value": "5.0"
+                                    "value": "8.0"
                                 },
                                 {
                                     "code": "unit",

--- a/ShopEG/With buyer-app-preprod-v2.ondc.org/Group A/Flow 1/incremental_saerch.json
+++ b/ShopEG/With buyer-app-preprod-v2.ondc.org/Group A/Flow 1/incremental_saerch.json
@@ -3,32 +3,30 @@
         "domain": "ONDC:RET10",
         "action": "search",
         "country": "IND",
-        "city": "std:080",
+        "city": "*",
         "core_version": "1.2.0",
         "bap_id": "buyer-app-preprod-v2.ondc.org",
         "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
-        "transaction_id": "0686430c-1570-440f-b494-1f526f92c55b",
-        "message_id": "e9217862-0f7a-43ab-843d-7c37386115c2",
-        "timestamp": "2023-10-26T16:09:51.186Z",
+        "transaction_id": "be287cea-975a-46da-bfd6-d8511ca209eb",
+        "message_id": "dfda7022-6236-48c2-9975-b1bfa7413ca4",
+        "timestamp": "2023-11-08T19:31:39.236Z",
         "ttl": "PT30S"
     },
-    "message": {
-        "intent": {
-            "payment": {
-                "@ondc/org/buyer_app_finder_fee_type": "percent",
-                "@ondc/org/buyer_app_finder_fee_amount": "3"
-            },
-            "tags": [
-                {
-                    "code": "catalog_inc",
-                    "list": [
-                        {
-                            "code": "mode",
-                            "value": "start"
-                        }
-                    ]
-                }
-            ]
-        }
+    "intent": {
+        "payment": {
+            "@ondc/org/buyer_app_finder_fee_type": "percent",
+            "@ondc/org/buyer_app_finder_fee_amount": "3"
+        },
+        "tags": [
+            {
+                "code": "catalog_inc",
+                "list": [
+                    {
+                        "code": "mode",
+                        "value": "start"
+                    }
+                ]
+            }
+        ]
     }
 }

--- a/ShopEG/With buyer-app-preprod-v2.ondc.org/Group A/Flow 2/confirm.json
+++ b/ShopEG/With buyer-app-preprod-v2.ondc.org/Group A/Flow 2/confirm.json
@@ -8,51 +8,44 @@
         "bap_id": "buyer-app-preprod-v2.ondc.org",
         "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
         "bpp_uri": "https://dev-api.shopeg.in/ondc/bpp",
-        "transaction_id": "6d87f6cc-7705-4d6e-8991-a2b502059d1f",
-        "message_id": "079e5b53-faf9-4e71-b90f-ed007822186f",
-        "timestamp": "2023-10-27T18:45:42.189Z",
+        "transaction_id": "8a269a55-f535-4912-8205-23f46ce51684",
+        "message_id": "30c15a19-b5ec-4eaf-a798-da6e07905080",
+        "timestamp": "2023-11-10T17:38:51.889Z",
         "bpp_id": "dev-api.shopeg.in",
         "ttl": "PT30S"
     },
     "message": {
         "order": {
-            "id": "2023-10-27-132181",
+            "id": "2023-11-10-689893",
             "state": "Created",
             "billing": {
                 "address": {
-                    "name": "Basanth",
-                    "building": "VHBCS Layout",
-                    "locality": "70 2nd cross road",
+                    "name": "Basanth Home",
+                    "building": "Building name",
+                    "locality": "1st Cross Road",
                     "city": "Bengaluru",
                     "state": "Karnataka",
                     "country": "IND",
-                    "area_code": "560086"
+                    "area_code": "560079"
                 },
-                "phone": "8618563552",
-                "name": "Basanth",
+                "phone": "9900990099",
+                "name": "Basanth Home",
                 "email": "basanth@shopeg.in",
-                "created_at": "2023-10-27T18:45:35.717Z",
-                "updated_at": "2023-10-27T18:45:35.717Z"
+                "created_at": "2023-11-10T17:38:49.586Z",
+                "updated_at": "2023-11-10T17:38:49.586Z"
             },
             "items": [
                 {
-                    "id": "93091a6b-323e-444b-955e-c6f9678e2804",
+                    "id": "7abbe7ca-1728-4993-82b7-6e17e001854f",
                     "quantity": {
                         "count": 2
                     },
                     "fulfillment_id": "1"
                 },
                 {
-                    "id": "8fcb8ccd-0a60-49ad-8c08-cfd5f2c705fd",
+                    "id": "954659be-d626-46f9-8a36-31f9bece177d",
                     "quantity": {
-                        "count": 3
-                    },
-                    "fulfillment_id": "1"
-                },
-                {
-                    "id": "e06763ff-23b9-4b8b-a131-398c9afa710d",
-                    "quantity": {
-                        "count": 2
+                        "count": 1
                     },
                     "fulfillment_id": "1"
                 }
@@ -65,13 +58,13 @@
                     }
                 ],
                 "descriptor": {
-                    "symbol": "https://www.bigbasket.com/media/uploads/p/l/40172087_6-sleepy-owl-cold-brew-coffee-classic.jpg",
-                    "images": [
-                        "https://www.bigbasket.com/media/uploads/p/l/40172087_6-sleepy-owl-cold-brew-coffee-classic.jpg"
-                    ],
                     "name": "B shop",
                     "short_desc": "Fresh Grocery Items updated schedule ",
-                    "long_desc": "Fresh Grocery Items"
+                    "long_desc": "Fresh Grocery Items updated schedule ",
+                    "symbol": "https://shopeg.in/i/eg.png",
+                    "images": [
+                        "https://shopeg.in/i/eg.png"
+                    ]
                 }
             },
             "fulfillments": [
@@ -81,21 +74,21 @@
                     "end": {
                         "contact": {
                             "email": "basanth@shopeg.in",
-                            "phone": "8618563552"
+                            "phone": "9900990099"
                         },
                         "person": {
-                            "name": "Basanth"
+                            "name": "Basanth Home"
                         },
                         "location": {
-                            "gps": "13.005504, 77.538237",
+                            "gps": "13.000483926941195, 77.5379921271815",
                             "address": {
-                                "name": "Basanth",
-                                "building": "VHBCS Layout",
-                                "locality": "70 2nd cross road",
+                                "name": "Basanth Home",
+                                "building": "Building name",
+                                "locality": "1st Cross Road",
                                 "city": "Bengaluru",
                                 "state": "Karnataka",
                                 "country": "IND",
-                                "area_code": "560086"
+                                "area_code": "560079"
                             }
                         }
                     },
@@ -106,9 +99,9 @@
                 "uri": "https://juspay.in/",
                 "tl_method": "http/get",
                 "params": {
-                    "amount": "437.92",
+                    "amount": "596.32",
                     "currency": "INR",
-                    "transaction_id": "6d87f6cc-7705-4d6e-8991-a2b502059d1f"
+                    "transaction_id": "8a269a55-f535-4912-8205-23f46ce51684"
                 },
                 "status": "PAID",
                 "type": "ON-ORDER",
@@ -132,20 +125,20 @@
             "quote": {
                 "breakup": [
                     {
-                        "@ondc/org/item_id": "93091a6b-323e-444b-955e-c6f9678e2804",
+                        "@ondc/org/item_id": "7abbe7ca-1728-4993-82b7-6e17e001854f",
                         "@ondc/org/item_quantity": {
                             "count": 2
                         },
-                        "title": "Sleepy Owl Classic Iced Coffee - Made With Cold Brew, 200 ml Bottle",
+                        "title": "Happilo Premium Pumpkin Seeds - All Natural, 200 g",
                         "@ondc/org/title_type": "item",
                         "price": {
                             "currency": "INR",
-                            "value": "220.00"
+                            "value": "480.00"
                         },
                         "item": {
                             "quantity": {
                                 "available": {
-                                    "count": "3"
+                                    "count": "4"
                                 },
                                 "maximum": {
                                     "count": "3"
@@ -153,20 +146,20 @@
                             },
                             "price": {
                                 "currency": "INR",
-                                "value": "110.00"
+                                "value": "240.00"
                             }
                         }
                     },
                     {
-                        "@ondc/org/item_id": "8fcb8ccd-0a60-49ad-8c08-cfd5f2c705fd",
+                        "@ondc/org/item_id": "954659be-d626-46f9-8a36-31f9bece177d",
                         "@ondc/org/item_quantity": {
-                            "count": 3
+                            "count": 1
                         },
-                        "title": "EVEREST KASURI METHI 25 G\r\n",
+                        "title": "Taj Mahal Rich & Flavourful Tea, 100 g",
                         "@ondc/org/title_type": "item",
                         "price": {
                             "currency": "INR",
-                            "value": "69.00"
+                            "value": "95.00"
                         },
                         "item": {
                             "quantity": {
@@ -179,33 +172,7 @@
                             },
                             "price": {
                                 "currency": "INR",
-                                "value": "23.00"
-                            }
-                        }
-                    },
-                    {
-                        "@ondc/org/item_id": "e06763ff-23b9-4b8b-a131-398c9afa710d",
-                        "@ondc/org/item_quantity": {
-                            "count": 2
-                        },
-                        "title": "Park Avenue Bathing Soap - Cool Blue, 125 g",
-                        "@ondc/org/title_type": "item",
-                        "price": {
-                            "currency": "INR",
-                            "value": "126.00"
-                        },
-                        "item": {
-                            "quantity": {
-                                "available": {
-                                    "count": "3"
-                                },
-                                "maximum": {
-                                    "count": "3"
-                                }
-                            },
-                            "price": {
-                                "currency": "INR",
-                                "value": "63.00"
+                                "value": "95.00"
                             }
                         }
                     },
@@ -215,7 +182,7 @@
                         "@ondc/org/title_type": "delivery",
                         "price": {
                             "currency": "INR",
-                            "value": "7.95"
+                            "value": "0.93"
                         }
                     },
                     {
@@ -224,13 +191,13 @@
                         "@ondc/org/title_type": "misc",
                         "price": {
                             "currency": "INR",
-                            "value": "14.97"
+                            "value": "20.39"
                         }
                     }
                 ],
                 "price": {
                     "currency": "INR",
-                    "value": "437.92"
+                    "value": "596.32"
                 },
                 "ttl": "P1D"
             },
@@ -240,7 +207,7 @@
                     "list": [
                         {
                             "code": "tax_number",
-                            "value": "BUYER-APP-GSTN"
+                            "value": "29AAJCB5249A1ZR"
                         }
                     ]
                 },
@@ -249,13 +216,13 @@
                     "list": [
                         {
                             "code": "tax_number",
-                            "value": "BUYER-APP-GSTN"
+                            "value": "BUYER-APP-GSTN-ONDC"
                         }
                     ]
                 }
             ],
-            "created_at": "2023-10-27T18:45:42.189Z",
-            "updated_at": "2023-10-27T18:45:42.189Z"
+            "created_at": "2023-11-10T17:38:51.889Z",
+            "updated_at": "2023-11-10T17:38:51.889Z"
         }
     }
 }

--- a/ShopEG/With buyer-app-preprod-v2.ondc.org/Group A/Flow 2/init.json
+++ b/ShopEG/With buyer-app-preprod-v2.ondc.org/Group A/Flow 2/init.json
@@ -8,9 +8,9 @@
         "bap_id": "buyer-app-preprod-v2.ondc.org",
         "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
         "bpp_uri": "https://dev-api.shopeg.in/ondc/bpp",
-        "transaction_id": "6d87f6cc-7705-4d6e-8991-a2b502059d1f",
-        "message_id": "3a4a056a-b215-45aa-9bdb-a9dbebec1635",
-        "timestamp": "2023-10-27T18:45:35.717Z",
+        "transaction_id": "8a269a55-f535-4912-8205-23f46ce51684",
+        "message_id": "c68938d1-e7da-4f47-b11d-b4e7bbec294f",
+        "timestamp": "2023-11-10T17:38:49.586Z",
         "bpp_id": "dev-api.shopeg.in",
         "ttl": "PT30S"
     },
@@ -26,7 +26,7 @@
             },
             "items": [
                 {
-                    "id": "93091a6b-323e-444b-955e-c6f9678e2804",
+                    "id": "7abbe7ca-1728-4993-82b7-6e17e001854f",
                     "quantity": {
                         "count": 2
                     },
@@ -34,17 +34,9 @@
                     "fulfillment_id": "1"
                 },
                 {
-                    "id": "8fcb8ccd-0a60-49ad-8c08-cfd5f2c705fd",
+                    "id": "954659be-d626-46f9-8a36-31f9bece177d",
                     "quantity": {
-                        "count": 3
-                    },
-                    "location_id": "6271",
-                    "fulfillment_id": "1"
-                },
-                {
-                    "id": "e06763ff-23b9-4b8b-a131-398c9afa710d",
-                    "quantity": {
-                        "count": 2
+                        "count": 1
                     },
                     "location_id": "6271",
                     "fulfillment_id": "1"
@@ -52,19 +44,21 @@
             ],
             "billing": {
                 "address": {
-                    "building": "VHBCS Layout",
+                    "building": "Building name",
                     "city": "Bengaluru",
                     "state": "Karnataka",
                     "country": "IND",
-                    "area_code": "560086",
-                    "locality": "70 2nd cross road",
-                    "name": "Basanth"
+                    "lat": "13.000483926941195",
+                    "lng": "77.5379921271815",
+                    "area_code": "560079",
+                    "locality": "1st Cross Road",
+                    "name": "Basanth Home"
                 },
-                "phone": "8618563552",
-                "name": "Basanth",
+                "phone": "9900990099",
+                "name": "Basanth Home",
                 "email": "basanth@shopeg.in",
-                "created_at": "2023-10-27T18:45:35.717Z",
-                "updated_at": "2023-10-27T18:45:35.717Z"
+                "created_at": "2023-11-10T17:38:49.586Z",
+                "updated_at": "2023-11-10T17:38:49.586Z"
             },
             "fulfillments": [
                 {
@@ -73,18 +67,20 @@
                     "end": {
                         "contact": {
                             "email": "basanth@shopeg.in",
-                            "phone": "8618563552"
+                            "phone": "9900990099"
                         },
                         "location": {
-                            "gps": "13.005504, 77.538237",
+                            "gps": "13.000483926941195, 77.5379921271815",
                             "address": {
-                                "building": "VHBCS Layout",
+                                "building": "Building name",
                                 "city": "Bengaluru",
                                 "state": "Karnataka",
                                 "country": "IND",
-                                "area_code": "560086",
-                                "locality": "70 2nd cross road",
-                                "name": "Basanth"
+                                "lat": "13.000483926941195",
+                                "lng": "77.5379921271815",
+                                "area_code": "560079",
+                                "locality": "1st Cross Road",
+                                "name": "Basanth Home"
                             }
                         }
                     }

--- a/ShopEG/With buyer-app-preprod-v2.ondc.org/Group A/Flow 2/on_confirm.json
+++ b/ShopEG/With buyer-app-preprod-v2.ondc.org/Group A/Flow 2/on_confirm.json
@@ -8,51 +8,44 @@
         "bap_id": "buyer-app-preprod-v2.ondc.org",
         "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
         "bpp_uri": "https://dev-api.shopeg.in/ondc/bpp",
-        "transaction_id": "6d87f6cc-7705-4d6e-8991-a2b502059d1f",
-        "message_id": "079e5b53-faf9-4e71-b90f-ed007822186f",
-        "timestamp": "2023-10-27T18:45:42.440Z",
+        "transaction_id": "8a269a55-f535-4912-8205-23f46ce51684",
+        "message_id": "30c15a19-b5ec-4eaf-a798-da6e07905080",
+        "timestamp": "2023-11-10T17:38:52.131Z",
         "bpp_id": "dev-api.shopeg.in",
         "ttl": "PT30S"
     },
     "message": {
         "order": {
-            "id": "2023-10-27-132181",
+            "id": "2023-11-10-689893",
             "state": "Created",
             "billing": {
                 "address": {
-                    "name": "Basanth",
-                    "building": "VHBCS Layout",
-                    "locality": "70 2nd cross road",
+                    "name": "Basanth Home",
+                    "building": "Building name",
+                    "locality": "1st Cross Road",
                     "city": "Bengaluru",
                     "state": "Karnataka",
                     "country": "IND",
-                    "area_code": "560086"
+                    "area_code": "560079"
                 },
-                "phone": "8618563552",
-                "name": "Basanth",
+                "phone": "9900990099",
+                "name": "Basanth Home",
                 "email": "basanth@shopeg.in",
-                "created_at": "2023-10-27T18:45:35.717Z",
-                "updated_at": "2023-10-27T18:45:35.717Z"
+                "created_at": "2023-11-10T17:38:49.586Z",
+                "updated_at": "2023-11-10T17:38:49.586Z"
             },
             "items": [
                 {
-                    "id": "93091a6b-323e-444b-955e-c6f9678e2804",
+                    "id": "7abbe7ca-1728-4993-82b7-6e17e001854f",
                     "quantity": {
                         "count": 2
                     },
                     "fulfillment_id": "1"
                 },
                 {
-                    "id": "8fcb8ccd-0a60-49ad-8c08-cfd5f2c705fd",
+                    "id": "954659be-d626-46f9-8a36-31f9bece177d",
                     "quantity": {
-                        "count": 3
-                    },
-                    "fulfillment_id": "1"
-                },
-                {
-                    "id": "e06763ff-23b9-4b8b-a131-398c9afa710d",
-                    "quantity": {
-                        "count": 2
+                        "count": 1
                     },
                     "fulfillment_id": "1"
                 }
@@ -65,13 +58,13 @@
                     }
                 ],
                 "descriptor": {
-                    "symbol": "https://www.bigbasket.com/media/uploads/p/l/40172087_6-sleepy-owl-cold-brew-coffee-classic.jpg",
-                    "images": [
-                        "https://www.bigbasket.com/media/uploads/p/l/40172087_6-sleepy-owl-cold-brew-coffee-classic.jpg"
-                    ],
                     "name": "B shop",
                     "short_desc": "Fresh Grocery Items updated schedule ",
-                    "long_desc": "Fresh Grocery Items"
+                    "long_desc": "Fresh Grocery Items updated schedule ",
+                    "symbol": "https://shopeg.in/i/eg.png",
+                    "images": [
+                        "https://shopeg.in/i/eg.png"
+                    ]
                 }
             },
             "fulfillments": [
@@ -81,30 +74,37 @@
                     "end": {
                         "contact": {
                             "email": "basanth@shopeg.in",
-                            "phone": "8618563552"
+                            "phone": "9900990099"
                         },
                         "person": {
-                            "name": "Basanth"
+                            "name": "Basanth Home"
                         },
                         "location": {
-                            "gps": "13.005504, 77.538237",
+                            "gps": "13.000483926941195, 77.5379921271815",
                             "address": {
-                                "name": "Basanth",
-                                "building": "VHBCS Layout",
-                                "locality": "70 2nd cross road",
+                                "name": "Basanth Home",
+                                "building": "Building name",
+                                "locality": "1st Cross Road",
                                 "city": "Bengaluru",
                                 "state": "Karnataka",
                                 "country": "IND",
-                                "area_code": "560086"
+                                "area_code": "560079"
+                            }
+                        },
+                        "time": {
+                            "range": {
+                                "end": "2023-11-11T05:38:51.889Z",
+                                "start": "2023-11-10T23:38:52.889Z"
                             }
                         }
                     },
                     "type": "Delivery",
                     "@ondc/org/provider_name": "B shop",
+                    "@ondc/org/TAT": "PT12H",
                     "start": {
                         "contact": {
-                            "phone": "8618563552",
-                            "email": "ondc-support@shopeg.in"
+                            "email": "ondc-support@shopeg.in",
+                            "phone": "8618563552"
                         },
                         "location": {
                             "descriptor": {
@@ -124,8 +124,8 @@
                         },
                         "time": {
                             "range": {
-                                "end": "2023-10-28T00:45:42.381Z",
-                                "start": "2023-10-27T18:45:42.381Z"
+                                "end": "2023-11-10T23:38:52.048Z",
+                                "start": "2023-11-10T17:38:52.048Z"
                             }
                         }
                     },
@@ -141,9 +141,9 @@
                 "uri": "https://juspay.in/",
                 "tl_method": "http/get",
                 "params": {
-                    "amount": "437.92",
+                    "amount": "596.32",
                     "currency": "INR",
-                    "transaction_id": "6d87f6cc-7705-4d6e-8991-a2b502059d1f"
+                    "transaction_id": "8a269a55-f535-4912-8205-23f46ce51684"
                 },
                 "status": "PAID",
                 "type": "ON-ORDER",
@@ -167,20 +167,20 @@
             "quote": {
                 "breakup": [
                     {
-                        "@ondc/org/item_id": "93091a6b-323e-444b-955e-c6f9678e2804",
+                        "@ondc/org/item_id": "7abbe7ca-1728-4993-82b7-6e17e001854f",
                         "@ondc/org/item_quantity": {
                             "count": 2
                         },
-                        "title": "Sleepy Owl Classic Iced Coffee - Made With Cold Brew, 200 ml Bottle",
+                        "title": "Happilo Premium Pumpkin Seeds - All Natural, 200 g",
                         "@ondc/org/title_type": "item",
                         "price": {
                             "currency": "INR",
-                            "value": "220.00"
+                            "value": "480.00"
                         },
                         "item": {
                             "quantity": {
                                 "available": {
-                                    "count": "3"
+                                    "count": "4"
                                 },
                                 "maximum": {
                                     "count": "3"
@@ -188,20 +188,20 @@
                             },
                             "price": {
                                 "currency": "INR",
-                                "value": "110.00"
+                                "value": "240.00"
                             }
                         }
                     },
                     {
-                        "@ondc/org/item_id": "8fcb8ccd-0a60-49ad-8c08-cfd5f2c705fd",
+                        "@ondc/org/item_id": "954659be-d626-46f9-8a36-31f9bece177d",
                         "@ondc/org/item_quantity": {
-                            "count": 3
+                            "count": 1
                         },
-                        "title": "EVEREST KASURI METHI 25 G\r\n",
+                        "title": "Taj Mahal Rich & Flavourful Tea, 100 g",
                         "@ondc/org/title_type": "item",
                         "price": {
                             "currency": "INR",
-                            "value": "69.00"
+                            "value": "95.00"
                         },
                         "item": {
                             "quantity": {
@@ -214,33 +214,7 @@
                             },
                             "price": {
                                 "currency": "INR",
-                                "value": "23.00"
-                            }
-                        }
-                    },
-                    {
-                        "@ondc/org/item_id": "e06763ff-23b9-4b8b-a131-398c9afa710d",
-                        "@ondc/org/item_quantity": {
-                            "count": 2
-                        },
-                        "title": "Park Avenue Bathing Soap - Cool Blue, 125 g",
-                        "@ondc/org/title_type": "item",
-                        "price": {
-                            "currency": "INR",
-                            "value": "126.00"
-                        },
-                        "item": {
-                            "quantity": {
-                                "available": {
-                                    "count": "3"
-                                },
-                                "maximum": {
-                                    "count": "3"
-                                }
-                            },
-                            "price": {
-                                "currency": "INR",
-                                "value": "63.00"
+                                "value": "95.00"
                             }
                         }
                     },
@@ -250,7 +224,7 @@
                         "@ondc/org/title_type": "delivery",
                         "price": {
                             "currency": "INR",
-                            "value": "7.95"
+                            "value": "0.93"
                         }
                     },
                     {
@@ -259,13 +233,13 @@
                         "@ondc/org/title_type": "misc",
                         "price": {
                             "currency": "INR",
-                            "value": "14.97"
+                            "value": "20.39"
                         }
                     }
                 ],
                 "price": {
                     "currency": "INR",
-                    "value": "437.92"
+                    "value": "596.32"
                 },
                 "ttl": "P1D"
             },
@@ -275,7 +249,7 @@
                     "list": [
                         {
                             "code": "tax_number",
-                            "value": "BUYER-APP-GSTN"
+                            "value": "29AAJCB5249A1ZR"
                         }
                     ]
                 },
@@ -284,13 +258,13 @@
                     "list": [
                         {
                             "code": "tax_number",
-                            "value": "BUYER-APP-GSTN"
+                            "value": "BUYER-APP-GSTN-ONDC"
                         }
                     ]
                 }
             ],
-            "created_at": "2023-10-27T18:45:42.189Z",
-            "updated_at": "2023-10-27T18:45:42.440Z"
+            "created_at": "2023-11-10T17:38:51.889Z",
+            "updated_at": "2023-11-10T17:38:52.131Z"
         }
     }
 }

--- a/ShopEG/With buyer-app-preprod-v2.ondc.org/Group A/Flow 2/on_init.json
+++ b/ShopEG/With buyer-app-preprod-v2.ondc.org/Group A/Flow 2/on_init.json
@@ -8,9 +8,9 @@
         "bap_id": "buyer-app-preprod-v2.ondc.org",
         "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
         "bpp_uri": "https://dev-api.shopeg.in/ondc/bpp",
-        "transaction_id": "6d87f6cc-7705-4d6e-8991-a2b502059d1f",
-        "message_id": "3a4a056a-b215-45aa-9bdb-a9dbebec1635",
-        "timestamp": "2023-10-27T18:45:35.845Z",
+        "transaction_id": "8a269a55-f535-4912-8205-23f46ce51684",
+        "message_id": "c68938d1-e7da-4f47-b11d-b4e7bbec294f",
+        "timestamp": "2023-11-10T17:38:49.791Z",
         "bpp_id": "dev-api.shopeg.in",
         "ttl": "PT30S"
     },
@@ -18,19 +18,21 @@
         "order": {
             "billing": {
                 "address": {
-                    "building": "VHBCS Layout",
+                    "building": "Building name",
                     "city": "Bengaluru",
                     "state": "Karnataka",
                     "country": "IND",
-                    "area_code": "560086",
-                    "locality": "70 2nd cross road",
-                    "name": "Basanth"
+                    "lat": "13.000483926941195",
+                    "lng": "77.5379921271815",
+                    "area_code": "560079",
+                    "locality": "1st Cross Road",
+                    "name": "Basanth Home"
                 },
-                "phone": "8618563552",
-                "name": "Basanth",
+                "phone": "9900990099",
+                "name": "Basanth Home",
                 "email": "basanth@shopeg.in",
-                "created_at": "2023-10-27T18:45:35.717Z",
-                "updated_at": "2023-10-27T18:45:35.717Z"
+                "created_at": "2023-11-10T17:38:49.586Z",
+                "updated_at": "2023-11-10T17:38:49.586Z"
             },
             "fulfillments": [
                 {
@@ -39,18 +41,20 @@
                     "end": {
                         "contact": {
                             "email": "basanth@shopeg.in",
-                            "phone": "8618563552"
+                            "phone": "9900990099"
                         },
                         "location": {
-                            "gps": "13.005504, 77.538237",
+                            "gps": "13.000483926941195, 77.5379921271815",
                             "address": {
-                                "building": "VHBCS Layout",
+                                "building": "Building name",
                                 "city": "Bengaluru",
                                 "state": "Karnataka",
                                 "country": "IND",
-                                "area_code": "560086",
-                                "locality": "70 2nd cross road",
-                                "name": "Basanth"
+                                "lat": "13.000483926941195",
+                                "lng": "77.5379921271815",
+                                "area_code": "560079",
+                                "locality": "1st Cross Road",
+                                "name": "Basanth Home"
                             }
                         }
                     },
@@ -60,7 +64,7 @@
             ],
             "items": [
                 {
-                    "id": "93091a6b-323e-444b-955e-c6f9678e2804",
+                    "id": "7abbe7ca-1728-4993-82b7-6e17e001854f",
                     "quantity": {
                         "count": 2
                     },
@@ -68,17 +72,9 @@
                     "fulfillment_id": "1"
                 },
                 {
-                    "id": "8fcb8ccd-0a60-49ad-8c08-cfd5f2c705fd",
+                    "id": "954659be-d626-46f9-8a36-31f9bece177d",
                     "quantity": {
-                        "count": 3
-                    },
-                    "location_id": "6271",
-                    "fulfillment_id": "1"
-                },
-                {
-                    "id": "e06763ff-23b9-4b8b-a131-398c9afa710d",
-                    "quantity": {
-                        "count": 2
+                        "count": 1
                     },
                     "location_id": "6271",
                     "fulfillment_id": "1"
@@ -110,20 +106,20 @@
             "quote": {
                 "breakup": [
                     {
-                        "@ondc/org/item_id": "93091a6b-323e-444b-955e-c6f9678e2804",
+                        "@ondc/org/item_id": "7abbe7ca-1728-4993-82b7-6e17e001854f",
                         "@ondc/org/item_quantity": {
                             "count": 2
                         },
-                        "title": "Sleepy Owl Classic Iced Coffee - Made With Cold Brew, 200 ml Bottle",
+                        "title": "Happilo Premium Pumpkin Seeds - All Natural, 200 g",
                         "@ondc/org/title_type": "item",
                         "price": {
                             "currency": "INR",
-                            "value": "220.00"
+                            "value": "480.00"
                         },
                         "item": {
                             "quantity": {
                                 "available": {
-                                    "count": "3"
+                                    "count": "4"
                                 },
                                 "maximum": {
                                     "count": "3"
@@ -131,20 +127,20 @@
                             },
                             "price": {
                                 "currency": "INR",
-                                "value": "110.00"
+                                "value": "240.00"
                             }
                         }
                     },
                     {
-                        "@ondc/org/item_id": "8fcb8ccd-0a60-49ad-8c08-cfd5f2c705fd",
+                        "@ondc/org/item_id": "954659be-d626-46f9-8a36-31f9bece177d",
                         "@ondc/org/item_quantity": {
-                            "count": 3
+                            "count": 1
                         },
-                        "title": "EVEREST KASURI METHI 25 G\r\n",
+                        "title": "Taj Mahal Rich & Flavourful Tea, 100 g",
                         "@ondc/org/title_type": "item",
                         "price": {
                             "currency": "INR",
-                            "value": "69.00"
+                            "value": "95.00"
                         },
                         "item": {
                             "quantity": {
@@ -157,33 +153,7 @@
                             },
                             "price": {
                                 "currency": "INR",
-                                "value": "23.00"
-                            }
-                        }
-                    },
-                    {
-                        "@ondc/org/item_id": "e06763ff-23b9-4b8b-a131-398c9afa710d",
-                        "@ondc/org/item_quantity": {
-                            "count": 2
-                        },
-                        "title": "Park Avenue Bathing Soap - Cool Blue, 125 g",
-                        "@ondc/org/title_type": "item",
-                        "price": {
-                            "currency": "INR",
-                            "value": "126.00"
-                        },
-                        "item": {
-                            "quantity": {
-                                "available": {
-                                    "count": "3"
-                                },
-                                "maximum": {
-                                    "count": "3"
-                                }
-                            },
-                            "price": {
-                                "currency": "INR",
-                                "value": "63.00"
+                                "value": "95.00"
                             }
                         }
                     },
@@ -193,7 +163,7 @@
                         "@ondc/org/title_type": "delivery",
                         "price": {
                             "currency": "INR",
-                            "value": "7.95"
+                            "value": "0.93"
                         }
                     },
                     {
@@ -202,16 +172,27 @@
                         "@ondc/org/title_type": "misc",
                         "price": {
                             "currency": "INR",
-                            "value": "14.97"
+                            "value": "20.39"
                         }
                     }
                 ],
                 "price": {
-                    "value": "437.92",
+                    "value": "596.32",
                     "currency": "INR"
                 },
                 "ttl": "P1D"
-            }
+            },
+            "tags": [
+                {
+                    "code": "bpp_terms",
+                    "list": [
+                        {
+                            "code": "tax_number",
+                            "value": "29AAJCB5249A1ZR"
+                        }
+                    ]
+                }
+            ]
         }
     }
 }

--- a/ShopEG/With buyer-app-preprod-v2.ondc.org/Group A/Flow 2/on_select.json
+++ b/ShopEG/With buyer-app-preprod-v2.ondc.org/Group A/Flow 2/on_select.json
@@ -8,9 +8,9 @@
         "bap_id": "buyer-app-preprod-v2.ondc.org",
         "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
         "bpp_uri": "https://dev-api.shopeg.in/ondc/bpp",
-        "transaction_id": "6d87f6cc-7705-4d6e-8991-a2b502059d1f",
-        "message_id": "f696d0fc-db3e-4d86-924d-878843164f06",
-        "timestamp": "2023-10-27T18:45:28.760Z",
+        "transaction_id": "8a269a55-f535-4912-8205-23f46ce51684",
+        "message_id": "3315a0e9-e717-421a-88cd-fd27ca31fb8e",
+        "timestamp": "2023-11-10T17:38:30.927Z",
         "bpp_id": "dev-api.shopeg.in",
         "ttl": "PT30S"
     },
@@ -26,7 +26,7 @@
             },
             "items": [
                 {
-                    "id": "93091a6b-323e-444b-955e-c6f9678e2804",
+                    "id": "7abbe7ca-1728-4993-82b7-6e17e001854f",
                     "quantity": {
                         "count": 2
                     },
@@ -34,17 +34,9 @@
                     "fulfillment_id": "1"
                 },
                 {
-                    "id": "8fcb8ccd-0a60-49ad-8c08-cfd5f2c705fd",
+                    "id": "954659be-d626-46f9-8a36-31f9bece177d",
                     "quantity": {
-                        "count": 3
-                    },
-                    "location_id": "6271",
-                    "fulfillment_id": "1"
-                },
-                {
-                    "id": "e06763ff-23b9-4b8b-a131-398c9afa710d",
-                    "quantity": {
-                        "count": 2
+                        "count": 1
                     },
                     "location_id": "6271",
                     "fulfillment_id": "1"
@@ -67,20 +59,20 @@
             "quote": {
                 "breakup": [
                     {
-                        "@ondc/org/item_id": "93091a6b-323e-444b-955e-c6f9678e2804",
+                        "@ondc/org/item_id": "7abbe7ca-1728-4993-82b7-6e17e001854f",
                         "@ondc/org/item_quantity": {
                             "count": 2
                         },
-                        "title": "Sleepy Owl Classic Iced Coffee - Made With Cold Brew, 200 ml Bottle",
+                        "title": "Happilo Premium Pumpkin Seeds - All Natural, 200 g",
                         "@ondc/org/title_type": "item",
                         "price": {
                             "currency": "INR",
-                            "value": "220.00"
+                            "value": "480.00"
                         },
                         "item": {
                             "quantity": {
                                 "available": {
-                                    "count": "3"
+                                    "count": "4"
                                 },
                                 "maximum": {
                                     "count": "3"
@@ -88,20 +80,20 @@
                             },
                             "price": {
                                 "currency": "INR",
-                                "value": "110.00"
+                                "value": "240.00"
                             }
                         }
                     },
                     {
-                        "@ondc/org/item_id": "8fcb8ccd-0a60-49ad-8c08-cfd5f2c705fd",
+                        "@ondc/org/item_id": "954659be-d626-46f9-8a36-31f9bece177d",
                         "@ondc/org/item_quantity": {
-                            "count": 3
+                            "count": 1
                         },
-                        "title": "EVEREST KASURI METHI 25 G\r\n",
+                        "title": "Taj Mahal Rich & Flavourful Tea, 100 g",
                         "@ondc/org/title_type": "item",
                         "price": {
                             "currency": "INR",
-                            "value": "69.00"
+                            "value": "95.00"
                         },
                         "item": {
                             "quantity": {
@@ -114,33 +106,7 @@
                             },
                             "price": {
                                 "currency": "INR",
-                                "value": "23.00"
-                            }
-                        }
-                    },
-                    {
-                        "@ondc/org/item_id": "e06763ff-23b9-4b8b-a131-398c9afa710d",
-                        "@ondc/org/item_quantity": {
-                            "count": 2
-                        },
-                        "title": "Park Avenue Bathing Soap - Cool Blue, 125 g",
-                        "@ondc/org/title_type": "item",
-                        "price": {
-                            "currency": "INR",
-                            "value": "126.00"
-                        },
-                        "item": {
-                            "quantity": {
-                                "available": {
-                                    "count": "3"
-                                },
-                                "maximum": {
-                                    "count": "3"
-                                }
-                            },
-                            "price": {
-                                "currency": "INR",
-                                "value": "63.00"
+                                "value": "95.00"
                             }
                         }
                     },
@@ -150,7 +116,7 @@
                         "@ondc/org/title_type": "delivery",
                         "price": {
                             "currency": "INR",
-                            "value": "7.95"
+                            "value": "0.93"
                         }
                     },
                     {
@@ -159,12 +125,12 @@
                         "@ondc/org/title_type": "misc",
                         "price": {
                             "currency": "INR",
-                            "value": "14.97"
+                            "value": "20.39"
                         }
                     }
                 ],
                 "price": {
-                    "value": "437.92",
+                    "value": "596.32",
                     "currency": "INR"
                 },
                 "ttl": "P1D"

--- a/ShopEG/With buyer-app-preprod-v2.ondc.org/Group A/Flow 2/on_status_delivered.json
+++ b/ShopEG/With buyer-app-preprod-v2.ondc.org/Group A/Flow 2/on_status_delivered.json
@@ -8,52 +8,45 @@
         "bap_id": "buyer-app-preprod-v2.ondc.org",
         "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
         "bpp_uri": "https://dev-api.shopeg.in/ondc/bpp",
-        "transaction_id": "6d87f6cc-7705-4d6e-8991-a2b502059d1f",
-        "message_id": "0fb2e8df-16ea-4622-9d0c-48fe0a04a0a0",
-        "timestamp": "2023-10-27T18:49:30.576Z",
+        "transaction_id": "8a269a55-f535-4912-8205-23f46ce51684",
+        "message_id": "59be1653-f54d-4aa3-a9e9-439a99bf7b4e",
+        "timestamp": "2023-11-10T17:42:34.335Z",
         "bpp_id": "dev-api.shopeg.in",
         "ttl": "PT30S"
     },
     "message": {
         "order": {
-            "id": "2023-10-27-132181",
+            "id": "2023-11-10-689893",
             "state": "Completed",
             "billing": {
                 "address": {
-                    "name": "Basanth",
-                    "building": "VHBCS Layout",
-                    "locality": "70 2nd cross road",
+                    "name": "Basanth Home",
+                    "building": "Building name",
+                    "locality": "1st Cross Road",
                     "city": "Bengaluru",
                     "state": "Karnataka",
                     "country": "IND",
-                    "area_code": "560086"
+                    "area_code": "560079"
                 },
-                "phone": "8618563552",
-                "name": "Basanth",
+                "phone": "9900990099",
+                "name": "Basanth Home",
                 "email": "basanth@shopeg.in",
-                "created_at": "2023-10-27T18:45:35.717Z",
-                "updated_at": "2023-10-27T18:45:35.717Z"
+                "created_at": "2023-11-10T17:38:49.586Z",
+                "updated_at": "2023-11-10T17:38:49.586Z"
             },
             "items": [
                 {
                     "quantity": {
                         "count": 2
                     },
-                    "id": "93091a6b-323e-444b-955e-c6f9678e2804",
+                    "id": "7abbe7ca-1728-4993-82b7-6e17e001854f",
                     "fulfillment_id": "1"
                 },
                 {
                     "quantity": {
-                        "count": 3
+                        "count": 1
                     },
-                    "id": "8fcb8ccd-0a60-49ad-8c08-cfd5f2c705fd",
-                    "fulfillment_id": "1"
-                },
-                {
-                    "quantity": {
-                        "count": 2
-                    },
-                    "id": "e06763ff-23b9-4b8b-a131-398c9afa710d",
+                    "id": "954659be-d626-46f9-8a36-31f9bece177d",
                     "fulfillment_id": "1"
                 }
             ],
@@ -65,17 +58,18 @@
                     }
                 ],
                 "descriptor": {
-                    "symbol": "https://www.bigbasket.com/media/uploads/p/l/40172087_6-sleepy-owl-cold-brew-coffee-classic.jpg",
-                    "images": [
-                        "https://www.bigbasket.com/media/uploads/p/l/40172087_6-sleepy-owl-cold-brew-coffee-classic.jpg"
-                    ],
                     "name": "B shop",
                     "short_desc": "Fresh Grocery Items updated schedule ",
-                    "long_desc": "Fresh Grocery Items"
+                    "long_desc": "Fresh Grocery Items updated schedule ",
+                    "symbol": "https://shopeg.in/i/eg.png",
+                    "images": [
+                        "https://shopeg.in/i/eg.png"
+                    ]
                 }
             },
             "fulfillments": [
                 {
+                    "@ondc/org/TAT": "PT12H",
                     "start": {
                         "contact": {
                             "phone": "8618563552",
@@ -99,44 +93,43 @@
                         },
                         "time": {
                             "range": {
-                                "start": "2023-10-27T18:45:42.381Z",
-                                "end": "2023-10-28T00:45:42.381Z"
+                                "start": "2023-11-10T17:38:52.048Z",
+                                "end": "2023-11-10T23:38:52.048Z"
                             },
-                            "timestamp": "2023-10-27T18:49:08.359Z"
+                            "timestamp": "2023-11-10T17:42:03.875Z"
                         }
                     },
                     "end": {
                         "person": {
-                            "name": "Basanth"
+                            "name": "Basanth Home"
                         },
                         "contact": {
-                            "phone": "8618563552",
+                            "phone": "9900990099",
                             "email": "basanth@shopeg.in"
                         },
                         "location": {
                             "address": {
                                 "country": "IND",
                                 "city": "Bengaluru",
-                                "area_code": "560086",
-                                "name": "Basanth",
-                                "locality": "70 2nd cross road",
+                                "area_code": "560079",
+                                "name": "Basanth Home",
+                                "locality": "1st Cross Road",
                                 "state": "Karnataka",
-                                "building": "VHBCS Layout"
+                                "building": "Building name"
                             },
-                            "gps": "13.005504, 77.538237"
+                            "gps": "13.000483926941195, 77.5379921271815"
                         },
                         "time": {
                             "range": {
-                                "start": "2023-10-28T00:45:43.189Z",
-                                "end": "2023-10-28T06:45:42.189Z"
+                                "start": "2023-11-10T23:38:52.889Z",
+                                "end": "2023-11-11T05:38:51.889Z"
                             },
-                            "timestamp": "2023-10-27T18:49:30.576Z"
+                            "timestamp": "2023-11-10T17:42:34.335Z"
                         },
                         "instructions": {
-                            "name": "Proof of delivery",
-                            "images": [
-                                "https://firebasestorage.googleapis.com/v0/b/shopeg-dev.appspot.com/o/orders%2FdeliveryImages%2FrOebEZL96U8iln27G7Fm%2F4341%2Fimg_1698432560330.jpg?alt=media&token=2103947d-46cb-4480-b32d-eadf55e519a7"
-                            ]
+                            "code": "3",
+                            "name": "ONDC Order",
+                            "long_desc": "No code required."
                         }
                     },
                     "id": "1",
@@ -155,9 +148,9 @@
                 "uri": "https://juspay.in/",
                 "tl_method": "http/get",
                 "params": {
-                    "amount": "437.92",
+                    "amount": "596.32",
                     "currency": "INR",
-                    "transaction_id": "6d87f6cc-7705-4d6e-8991-a2b502059d1f"
+                    "transaction_id": "8a269a55-f535-4912-8205-23f46ce51684"
                 },
                 "status": "PAID",
                 "type": "ON-ORDER",
@@ -181,11 +174,11 @@
             "quote": {
                 "breakup": [
                     {
-                        "@ondc/org/item_id": "93091a6b-323e-444b-955e-c6f9678e2804",
+                        "@ondc/org/item_id": "7abbe7ca-1728-4993-82b7-6e17e001854f",
                         "item": {
                             "quantity": {
                                 "available": {
-                                    "count": "3"
+                                    "count": "4"
                                 },
                                 "maximum": {
                                     "count": "3"
@@ -193,21 +186,21 @@
                             },
                             "price": {
                                 "currency": "INR",
-                                "value": "110.00"
+                                "value": "240.00"
                             }
                         },
                         "price": {
                             "currency": "INR",
-                            "value": "220.00"
+                            "value": "480.00"
                         },
                         "@ondc/org/title_type": "item",
-                        "title": "Sleepy Owl Classic Iced Coffee - Made With Cold Brew, 200 ml Bottle",
+                        "title": "Happilo Premium Pumpkin Seeds - All Natural, 200 g",
                         "@ondc/org/item_quantity": {
                             "count": 2
                         }
                     },
                     {
-                        "@ondc/org/item_id": "8fcb8ccd-0a60-49ad-8c08-cfd5f2c705fd",
+                        "@ondc/org/item_id": "954659be-d626-46f9-8a36-31f9bece177d",
                         "item": {
                             "quantity": {
                                 "available": {
@@ -219,50 +212,24 @@
                             },
                             "price": {
                                 "currency": "INR",
-                                "value": "23.00"
+                                "value": "95.00"
                             }
                         },
                         "price": {
                             "currency": "INR",
-                            "value": "69.00"
+                            "value": "95.00"
                         },
                         "@ondc/org/title_type": "item",
-                        "title": "EVEREST KASURI METHI 25 G\r\n",
+                        "title": "Taj Mahal Rich & Flavourful Tea, 100 g",
                         "@ondc/org/item_quantity": {
-                            "count": 3
-                        }
-                    },
-                    {
-                        "@ondc/org/item_id": "e06763ff-23b9-4b8b-a131-398c9afa710d",
-                        "item": {
-                            "quantity": {
-                                "available": {
-                                    "count": "3"
-                                },
-                                "maximum": {
-                                    "count": "3"
-                                }
-                            },
-                            "price": {
-                                "currency": "INR",
-                                "value": "63.00"
-                            }
-                        },
-                        "price": {
-                            "currency": "INR",
-                            "value": "126.00"
-                        },
-                        "@ondc/org/title_type": "item",
-                        "title": "Park Avenue Bathing Soap - Cool Blue, 125 g",
-                        "@ondc/org/item_quantity": {
-                            "count": 2
+                            "count": 1
                         }
                     },
                     {
                         "@ondc/org/item_id": "1",
                         "price": {
                             "currency": "INR",
-                            "value": "7.95"
+                            "value": "0.93"
                         },
                         "@ondc/org/title_type": "delivery",
                         "title": "Delivery charges"
@@ -271,7 +238,7 @@
                         "@ondc/org/item_id": "1",
                         "price": {
                             "currency": "INR",
-                            "value": "14.97"
+                            "value": "20.39"
                         },
                         "@ondc/org/title_type": "misc",
                         "title": "Convenience Fee"
@@ -279,7 +246,7 @@
                 ],
                 "price": {
                     "currency": "INR",
-                    "value": "437.92"
+                    "value": "596.32"
                 },
                 "ttl": "P1D"
             },
@@ -289,7 +256,7 @@
                     "list": [
                         {
                             "code": "tax_number",
-                            "value": "BUYER-APP-GSTN"
+                            "value": "29AAJCB5249A1ZR"
                         }
                     ]
                 },
@@ -298,17 +265,17 @@
                     "list": [
                         {
                             "code": "tax_number",
-                            "value": "BUYER-APP-GSTN"
+                            "value": "BUYER-APP-GSTN-ONDC"
                         }
                     ]
                 }
             ],
-            "created_at": "2023-10-27T18:45:42.189Z",
-            "updated_at": "2023-10-27T18:49:30.576Z",
+            "created_at": "2023-11-10T17:38:51.889Z",
+            "updated_at": "2023-11-10T17:42:34.335Z",
             "documents": [
                 {
                     "label": "Invoice",
-                    "url": "https://dev-api.shopeg.in/api/client/order/ondc/invoice/2023-10-27-132181"
+                    "url": "https://dev-api.shopeg.in/api/client/order/ondc/invoice/2023-11-10-689893"
                 }
             ]
         }

--- a/ShopEG/With buyer-app-preprod-v2.ondc.org/Group A/Flow 2/on_status_out_for_delivery.json
+++ b/ShopEG/With buyer-app-preprod-v2.ondc.org/Group A/Flow 2/on_status_out_for_delivery.json
@@ -8,52 +8,45 @@
         "bap_id": "buyer-app-preprod-v2.ondc.org",
         "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
         "bpp_uri": "https://dev-api.shopeg.in/ondc/bpp",
-        "transaction_id": "6d87f6cc-7705-4d6e-8991-a2b502059d1f",
-        "message_id": "fcc59888-c8ab-47b6-9aac-1829c5d060f9",
-        "timestamp": "2023-10-27T18:49:08.359Z",
+        "transaction_id": "8a269a55-f535-4912-8205-23f46ce51684",
+        "message_id": "c74ad4a7-a9fb-4252-bdd5-b2001a5b8c61",
+        "timestamp": "2023-11-10T17:42:03.875Z",
         "bpp_id": "dev-api.shopeg.in",
         "ttl": "PT30S"
     },
     "message": {
         "order": {
-            "id": "2023-10-27-132181",
+            "id": "2023-11-10-689893",
             "state": "In-progress",
             "billing": {
                 "address": {
-                    "name": "Basanth",
-                    "building": "VHBCS Layout",
-                    "locality": "70 2nd cross road",
+                    "name": "Basanth Home",
+                    "building": "Building name",
+                    "locality": "1st Cross Road",
                     "city": "Bengaluru",
                     "state": "Karnataka",
                     "country": "IND",
-                    "area_code": "560086"
+                    "area_code": "560079"
                 },
-                "phone": "8618563552",
-                "name": "Basanth",
+                "phone": "9900990099",
+                "name": "Basanth Home",
                 "email": "basanth@shopeg.in",
-                "created_at": "2023-10-27T18:45:35.717Z",
-                "updated_at": "2023-10-27T18:45:35.717Z"
+                "created_at": "2023-11-10T17:38:49.586Z",
+                "updated_at": "2023-11-10T17:38:49.586Z"
             },
             "items": [
                 {
                     "quantity": {
                         "count": 2
                     },
-                    "id": "93091a6b-323e-444b-955e-c6f9678e2804",
+                    "id": "7abbe7ca-1728-4993-82b7-6e17e001854f",
                     "fulfillment_id": "1"
                 },
                 {
                     "quantity": {
-                        "count": 3
+                        "count": 1
                     },
-                    "id": "8fcb8ccd-0a60-49ad-8c08-cfd5f2c705fd",
-                    "fulfillment_id": "1"
-                },
-                {
-                    "quantity": {
-                        "count": 2
-                    },
-                    "id": "e06763ff-23b9-4b8b-a131-398c9afa710d",
+                    "id": "954659be-d626-46f9-8a36-31f9bece177d",
                     "fulfillment_id": "1"
                 }
             ],
@@ -65,17 +58,18 @@
                     }
                 ],
                 "descriptor": {
-                    "symbol": "https://www.bigbasket.com/media/uploads/p/l/40172087_6-sleepy-owl-cold-brew-coffee-classic.jpg",
-                    "images": [
-                        "https://www.bigbasket.com/media/uploads/p/l/40172087_6-sleepy-owl-cold-brew-coffee-classic.jpg"
-                    ],
                     "name": "B shop",
                     "short_desc": "Fresh Grocery Items updated schedule ",
-                    "long_desc": "Fresh Grocery Items"
+                    "long_desc": "Fresh Grocery Items updated schedule ",
+                    "symbol": "https://shopeg.in/i/eg.png",
+                    "images": [
+                        "https://shopeg.in/i/eg.png"
+                    ]
                 }
             },
             "fulfillments": [
                 {
+                    "@ondc/org/TAT": "PT12H",
                     "start": {
                         "contact": {
                             "phone": "8618563552",
@@ -99,36 +93,36 @@
                         },
                         "time": {
                             "range": {
-                                "start": "2023-10-27T18:45:42.381Z",
-                                "end": "2023-10-28T00:45:42.381Z"
+                                "start": "2023-11-10T17:38:52.048Z",
+                                "end": "2023-11-10T23:38:52.048Z"
                             },
-                            "timestamp": "2023-10-27T18:49:08.359Z"
+                            "timestamp": "2023-11-10T17:42:03.875Z"
                         }
                     },
                     "end": {
                         "person": {
-                            "name": "Basanth"
+                            "name": "Basanth Home"
                         },
                         "contact": {
-                            "phone": "8618563552",
+                            "phone": "9900990099",
                             "email": "basanth@shopeg.in"
                         },
                         "location": {
                             "address": {
                                 "country": "IND",
                                 "city": "Bengaluru",
-                                "area_code": "560086",
-                                "name": "Basanth",
-                                "locality": "70 2nd cross road",
+                                "area_code": "560079",
+                                "name": "Basanth Home",
+                                "locality": "1st Cross Road",
                                 "state": "Karnataka",
-                                "building": "VHBCS Layout"
+                                "building": "Building name"
                             },
-                            "gps": "13.005504, 77.538237"
+                            "gps": "13.000483926941195, 77.5379921271815"
                         },
                         "time": {
                             "range": {
-                                "end": "2023-10-28T06:45:42.189Z",
-                                "start": "2023-10-28T00:45:43.189Z"
+                                "start": "2023-11-10T23:38:52.889Z",
+                                "end": "2023-11-11T05:38:51.889Z"
                             }
                         }
                     },
@@ -148,9 +142,9 @@
                 "uri": "https://juspay.in/",
                 "tl_method": "http/get",
                 "params": {
-                    "amount": "437.92",
+                    "amount": "596.32",
                     "currency": "INR",
-                    "transaction_id": "6d87f6cc-7705-4d6e-8991-a2b502059d1f"
+                    "transaction_id": "8a269a55-f535-4912-8205-23f46ce51684"
                 },
                 "status": "PAID",
                 "type": "ON-ORDER",
@@ -174,11 +168,11 @@
             "quote": {
                 "breakup": [
                     {
-                        "@ondc/org/item_id": "93091a6b-323e-444b-955e-c6f9678e2804",
+                        "@ondc/org/item_id": "7abbe7ca-1728-4993-82b7-6e17e001854f",
                         "item": {
                             "quantity": {
                                 "available": {
-                                    "count": "3"
+                                    "count": "4"
                                 },
                                 "maximum": {
                                     "count": "3"
@@ -186,21 +180,21 @@
                             },
                             "price": {
                                 "currency": "INR",
-                                "value": "110.00"
+                                "value": "240.00"
                             }
                         },
                         "price": {
                             "currency": "INR",
-                            "value": "220.00"
+                            "value": "480.00"
                         },
                         "@ondc/org/title_type": "item",
-                        "title": "Sleepy Owl Classic Iced Coffee - Made With Cold Brew, 200 ml Bottle",
+                        "title": "Happilo Premium Pumpkin Seeds - All Natural, 200 g",
                         "@ondc/org/item_quantity": {
                             "count": 2
                         }
                     },
                     {
-                        "@ondc/org/item_id": "8fcb8ccd-0a60-49ad-8c08-cfd5f2c705fd",
+                        "@ondc/org/item_id": "954659be-d626-46f9-8a36-31f9bece177d",
                         "item": {
                             "quantity": {
                                 "available": {
@@ -212,50 +206,24 @@
                             },
                             "price": {
                                 "currency": "INR",
-                                "value": "23.00"
+                                "value": "95.00"
                             }
                         },
                         "price": {
                             "currency": "INR",
-                            "value": "69.00"
+                            "value": "95.00"
                         },
                         "@ondc/org/title_type": "item",
-                        "title": "EVEREST KASURI METHI 25 G\r\n",
+                        "title": "Taj Mahal Rich & Flavourful Tea, 100 g",
                         "@ondc/org/item_quantity": {
-                            "count": 3
-                        }
-                    },
-                    {
-                        "@ondc/org/item_id": "e06763ff-23b9-4b8b-a131-398c9afa710d",
-                        "item": {
-                            "quantity": {
-                                "available": {
-                                    "count": "3"
-                                },
-                                "maximum": {
-                                    "count": "3"
-                                }
-                            },
-                            "price": {
-                                "currency": "INR",
-                                "value": "63.00"
-                            }
-                        },
-                        "price": {
-                            "currency": "INR",
-                            "value": "126.00"
-                        },
-                        "@ondc/org/title_type": "item",
-                        "title": "Park Avenue Bathing Soap - Cool Blue, 125 g",
-                        "@ondc/org/item_quantity": {
-                            "count": 2
+                            "count": 1
                         }
                     },
                     {
                         "@ondc/org/item_id": "1",
                         "price": {
                             "currency": "INR",
-                            "value": "7.95"
+                            "value": "0.93"
                         },
                         "@ondc/org/title_type": "delivery",
                         "title": "Delivery charges"
@@ -264,7 +232,7 @@
                         "@ondc/org/item_id": "1",
                         "price": {
                             "currency": "INR",
-                            "value": "14.97"
+                            "value": "20.39"
                         },
                         "@ondc/org/title_type": "misc",
                         "title": "Convenience Fee"
@@ -272,7 +240,7 @@
                 ],
                 "price": {
                     "currency": "INR",
-                    "value": "437.92"
+                    "value": "596.32"
                 },
                 "ttl": "P1D"
             },
@@ -282,7 +250,7 @@
                     "list": [
                         {
                             "code": "tax_number",
-                            "value": "BUYER-APP-GSTN"
+                            "value": "29AAJCB5249A1ZR"
                         }
                     ]
                 },
@@ -291,17 +259,17 @@
                     "list": [
                         {
                             "code": "tax_number",
-                            "value": "BUYER-APP-GSTN"
+                            "value": "BUYER-APP-GSTN-ONDC"
                         }
                     ]
                 }
             ],
-            "created_at": "2023-10-27T18:45:42.189Z",
-            "updated_at": "2023-10-27T18:49:08.359Z",
+            "created_at": "2023-11-10T17:38:51.889Z",
+            "updated_at": "2023-11-10T17:42:03.875Z",
             "documents": [
                 {
                     "label": "Invoice",
-                    "url": "https://dev-api.shopeg.in/api/client/order/ondc/invoice/2023-10-27-132181"
+                    "url": "https://dev-api.shopeg.in/api/client/order/ondc/invoice/2023-11-10-689893"
                 }
             ]
         }

--- a/ShopEG/With buyer-app-preprod-v2.ondc.org/Group A/Flow 2/on_status_packed.json
+++ b/ShopEG/With buyer-app-preprod-v2.ondc.org/Group A/Flow 2/on_status_packed.json
@@ -8,52 +8,45 @@
         "bap_id": "buyer-app-preprod-v2.ondc.org",
         "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
         "bpp_uri": "https://dev-api.shopeg.in/ondc/bpp",
-        "transaction_id": "6d87f6cc-7705-4d6e-8991-a2b502059d1f",
-        "message_id": "31f1373e-e353-44a1-8187-9ec46d1923e3",
-        "timestamp": "2023-10-27T18:48:34.373Z",
+        "transaction_id": "8a269a55-f535-4912-8205-23f46ce51684",
+        "message_id": "ee09e8a0-d18c-4083-81e2-8d5c18a279fa",
+        "timestamp": "2023-11-10T17:41:58.807Z",
         "bpp_id": "dev-api.shopeg.in",
         "ttl": "PT30S"
     },
     "message": {
         "order": {
-            "id": "2023-10-27-132181",
+            "id": "2023-11-10-689893",
             "state": "In-progress",
             "billing": {
                 "address": {
-                    "name": "Basanth",
-                    "building": "VHBCS Layout",
-                    "locality": "70 2nd cross road",
+                    "name": "Basanth Home",
+                    "building": "Building name",
+                    "locality": "1st Cross Road",
                     "city": "Bengaluru",
                     "state": "Karnataka",
                     "country": "IND",
-                    "area_code": "560086"
+                    "area_code": "560079"
                 },
-                "phone": "8618563552",
-                "name": "Basanth",
+                "phone": "9900990099",
+                "name": "Basanth Home",
                 "email": "basanth@shopeg.in",
-                "created_at": "2023-10-27T18:45:35.717Z",
-                "updated_at": "2023-10-27T18:45:35.717Z"
+                "created_at": "2023-11-10T17:38:49.586Z",
+                "updated_at": "2023-11-10T17:38:49.586Z"
             },
             "items": [
                 {
                     "quantity": {
                         "count": 2
                     },
-                    "id": "93091a6b-323e-444b-955e-c6f9678e2804",
+                    "id": "7abbe7ca-1728-4993-82b7-6e17e001854f",
                     "fulfillment_id": "1"
                 },
                 {
                     "quantity": {
-                        "count": 3
+                        "count": 1
                     },
-                    "id": "8fcb8ccd-0a60-49ad-8c08-cfd5f2c705fd",
-                    "fulfillment_id": "1"
-                },
-                {
-                    "quantity": {
-                        "count": 2
-                    },
-                    "id": "e06763ff-23b9-4b8b-a131-398c9afa710d",
+                    "id": "954659be-d626-46f9-8a36-31f9bece177d",
                     "fulfillment_id": "1"
                 }
             ],
@@ -65,17 +58,18 @@
                     }
                 ],
                 "descriptor": {
-                    "symbol": "https://www.bigbasket.com/media/uploads/p/l/40172087_6-sleepy-owl-cold-brew-coffee-classic.jpg",
-                    "images": [
-                        "https://www.bigbasket.com/media/uploads/p/l/40172087_6-sleepy-owl-cold-brew-coffee-classic.jpg"
-                    ],
                     "name": "B shop",
                     "short_desc": "Fresh Grocery Items updated schedule ",
-                    "long_desc": "Fresh Grocery Items"
+                    "long_desc": "Fresh Grocery Items updated schedule ",
+                    "symbol": "https://shopeg.in/i/eg.png",
+                    "images": [
+                        "https://shopeg.in/i/eg.png"
+                    ]
                 }
             },
             "fulfillments": [
                 {
+                    "@ondc/org/TAT": "PT12H",
                     "start": {
                         "contact": {
                             "phone": "8618563552",
@@ -99,30 +93,36 @@
                         },
                         "time": {
                             "range": {
-                                "start": "2023-10-27T18:45:42.381Z",
-                                "end": "2023-10-28T00:45:42.381Z"
+                                "start": "2023-11-10T17:38:52.048Z",
+                                "end": "2023-11-10T23:38:52.048Z"
                             }
                         }
                     },
                     "end": {
                         "person": {
-                            "name": "Basanth"
+                            "name": "Basanth Home"
                         },
                         "contact": {
-                            "phone": "8618563552",
+                            "phone": "9900990099",
                             "email": "basanth@shopeg.in"
                         },
                         "location": {
                             "address": {
                                 "country": "IND",
                                 "city": "Bengaluru",
-                                "area_code": "560086",
-                                "name": "Basanth",
-                                "locality": "70 2nd cross road",
+                                "area_code": "560079",
+                                "name": "Basanth Home",
+                                "locality": "1st Cross Road",
                                 "state": "Karnataka",
-                                "building": "VHBCS Layout"
+                                "building": "Building name"
                             },
-                            "gps": "13.005504, 77.538237"
+                            "gps": "13.000483926941195, 77.5379921271815"
+                        },
+                        "time": {
+                            "range": {
+                                "start": "2023-11-10T23:38:52.889Z",
+                                "end": "2023-11-11T05:38:51.889Z"
+                            }
                         }
                     },
                     "id": "1",
@@ -141,9 +141,9 @@
                 "uri": "https://juspay.in/",
                 "tl_method": "http/get",
                 "params": {
-                    "amount": "437.92",
+                    "amount": "596.32",
                     "currency": "INR",
-                    "transaction_id": "6d87f6cc-7705-4d6e-8991-a2b502059d1f"
+                    "transaction_id": "8a269a55-f535-4912-8205-23f46ce51684"
                 },
                 "status": "PAID",
                 "type": "ON-ORDER",
@@ -167,11 +167,11 @@
             "quote": {
                 "breakup": [
                     {
-                        "@ondc/org/item_id": "93091a6b-323e-444b-955e-c6f9678e2804",
+                        "@ondc/org/item_id": "7abbe7ca-1728-4993-82b7-6e17e001854f",
                         "item": {
                             "quantity": {
                                 "available": {
-                                    "count": "3"
+                                    "count": "4"
                                 },
                                 "maximum": {
                                     "count": "3"
@@ -179,21 +179,21 @@
                             },
                             "price": {
                                 "currency": "INR",
-                                "value": "110.00"
+                                "value": "240.00"
                             }
                         },
                         "price": {
                             "currency": "INR",
-                            "value": "220.00"
+                            "value": "480.00"
                         },
                         "@ondc/org/title_type": "item",
-                        "title": "Sleepy Owl Classic Iced Coffee - Made With Cold Brew, 200 ml Bottle",
+                        "title": "Happilo Premium Pumpkin Seeds - All Natural, 200 g",
                         "@ondc/org/item_quantity": {
                             "count": 2
                         }
                     },
                     {
-                        "@ondc/org/item_id": "8fcb8ccd-0a60-49ad-8c08-cfd5f2c705fd",
+                        "@ondc/org/item_id": "954659be-d626-46f9-8a36-31f9bece177d",
                         "item": {
                             "quantity": {
                                 "available": {
@@ -205,50 +205,24 @@
                             },
                             "price": {
                                 "currency": "INR",
-                                "value": "23.00"
+                                "value": "95.00"
                             }
                         },
                         "price": {
                             "currency": "INR",
-                            "value": "69.00"
+                            "value": "95.00"
                         },
                         "@ondc/org/title_type": "item",
-                        "title": "EVEREST KASURI METHI 25 G\r\n",
+                        "title": "Taj Mahal Rich & Flavourful Tea, 100 g",
                         "@ondc/org/item_quantity": {
-                            "count": 3
-                        }
-                    },
-                    {
-                        "@ondc/org/item_id": "e06763ff-23b9-4b8b-a131-398c9afa710d",
-                        "item": {
-                            "quantity": {
-                                "available": {
-                                    "count": "3"
-                                },
-                                "maximum": {
-                                    "count": "3"
-                                }
-                            },
-                            "price": {
-                                "currency": "INR",
-                                "value": "63.00"
-                            }
-                        },
-                        "price": {
-                            "currency": "INR",
-                            "value": "126.00"
-                        },
-                        "@ondc/org/title_type": "item",
-                        "title": "Park Avenue Bathing Soap - Cool Blue, 125 g",
-                        "@ondc/org/item_quantity": {
-                            "count": 2
+                            "count": 1
                         }
                     },
                     {
                         "@ondc/org/item_id": "1",
                         "price": {
                             "currency": "INR",
-                            "value": "7.95"
+                            "value": "0.93"
                         },
                         "@ondc/org/title_type": "delivery",
                         "title": "Delivery charges"
@@ -257,7 +231,7 @@
                         "@ondc/org/item_id": "1",
                         "price": {
                             "currency": "INR",
-                            "value": "14.97"
+                            "value": "20.39"
                         },
                         "@ondc/org/title_type": "misc",
                         "title": "Convenience Fee"
@@ -265,7 +239,7 @@
                 ],
                 "price": {
                     "currency": "INR",
-                    "value": "437.92"
+                    "value": "596.32"
                 },
                 "ttl": "P1D"
             },
@@ -275,7 +249,7 @@
                     "list": [
                         {
                             "code": "tax_number",
-                            "value": "BUYER-APP-GSTN"
+                            "value": "29AAJCB5249A1ZR"
                         }
                     ]
                 },
@@ -284,13 +258,13 @@
                     "list": [
                         {
                             "code": "tax_number",
-                            "value": "BUYER-APP-GSTN"
+                            "value": "BUYER-APP-GSTN-ONDC"
                         }
                     ]
                 }
             ],
-            "created_at": "2023-10-27T18:45:42.189Z",
-            "updated_at": "2023-10-27T18:48:34.373Z"
+            "created_at": "2023-11-10T17:38:51.889Z",
+            "updated_at": "2023-11-10T17:41:58.807Z"
         }
     }
 }

--- a/ShopEG/With buyer-app-preprod-v2.ondc.org/Group A/Flow 2/on_status_pending.json
+++ b/ShopEG/With buyer-app-preprod-v2.ondc.org/Group A/Flow 2/on_status_pending.json
@@ -8,51 +8,44 @@
         "bap_id": "buyer-app-preprod-v2.ondc.org",
         "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
         "bpp_uri": "https://dev-api.shopeg.in/ondc/bpp",
-        "transaction_id": "6d87f6cc-7705-4d6e-8991-a2b502059d1f",
-        "message_id": "4d76ea5c-d46c-4d61-b74a-f4ed1cc800eb",
-        "timestamp": "2023-10-27T18:48:22.358Z",
+        "transaction_id": "8a269a55-f535-4912-8205-23f46ce51684",
+        "message_id": "603e99f3-f6ed-4a03-95b6-c1400daa4a7e",
+        "timestamp": "2023-11-10T17:39:21.817Z",
         "bpp_id": "dev-api.shopeg.in",
         "ttl": "PT30S"
     },
     "message": {
         "order": {
-            "id": "2023-10-27-132181",
+            "id": "2023-11-10-689893",
             "state": "In-progress",
             "billing": {
                 "address": {
-                    "name": "Basanth",
-                    "building": "VHBCS Layout",
-                    "locality": "70 2nd cross road",
+                    "name": "Basanth Home",
+                    "building": "Building name",
+                    "locality": "1st Cross Road",
                     "city": "Bengaluru",
                     "state": "Karnataka",
                     "country": "IND",
-                    "area_code": "560086"
+                    "area_code": "560079"
                 },
-                "phone": "8618563552",
-                "name": "Basanth",
+                "phone": "9900990099",
+                "name": "Basanth Home",
                 "email": "basanth@shopeg.in",
-                "created_at": "2023-10-27T18:45:35.717Z",
-                "updated_at": "2023-10-27T18:45:35.717Z"
+                "created_at": "2023-11-10T17:38:49.586Z",
+                "updated_at": "2023-11-10T17:38:49.586Z"
             },
             "items": [
                 {
-                    "id": "93091a6b-323e-444b-955e-c6f9678e2804",
+                    "id": "7abbe7ca-1728-4993-82b7-6e17e001854f",
                     "quantity": {
                         "count": 2
                     },
                     "fulfillment_id": "1"
                 },
                 {
-                    "id": "8fcb8ccd-0a60-49ad-8c08-cfd5f2c705fd",
+                    "id": "954659be-d626-46f9-8a36-31f9bece177d",
                     "quantity": {
-                        "count": 3
-                    },
-                    "fulfillment_id": "1"
-                },
-                {
-                    "id": "e06763ff-23b9-4b8b-a131-398c9afa710d",
-                    "quantity": {
-                        "count": 2
+                        "count": 1
                     },
                     "fulfillment_id": "1"
                 }
@@ -65,17 +58,18 @@
                     }
                 ],
                 "descriptor": {
-                    "symbol": "https://www.bigbasket.com/media/uploads/p/l/40172087_6-sleepy-owl-cold-brew-coffee-classic.jpg",
-                    "images": [
-                        "https://www.bigbasket.com/media/uploads/p/l/40172087_6-sleepy-owl-cold-brew-coffee-classic.jpg"
-                    ],
                     "name": "B shop",
                     "short_desc": "Fresh Grocery Items updated schedule ",
-                    "long_desc": "Fresh Grocery Items"
+                    "long_desc": "Fresh Grocery Items updated schedule ",
+                    "symbol": "https://shopeg.in/i/eg.png",
+                    "images": [
+                        "https://shopeg.in/i/eg.png"
+                    ]
                 }
             },
             "fulfillments": [
                 {
+                    "@ondc/org/TAT": "PT12H",
                     "start": {
                         "contact": {
                             "phone": "8618563552",
@@ -99,30 +93,36 @@
                         },
                         "time": {
                             "range": {
-                                "start": "2023-10-27T18:45:42.381Z",
-                                "end": "2023-10-28T00:45:42.381Z"
+                                "start": "2023-11-10T17:38:52.048Z",
+                                "end": "2023-11-10T23:38:52.048Z"
                             }
                         }
                     },
                     "end": {
                         "person": {
-                            "name": "Basanth"
+                            "name": "Basanth Home"
                         },
                         "contact": {
-                            "phone": "8618563552",
+                            "phone": "9900990099",
                             "email": "basanth@shopeg.in"
                         },
                         "location": {
                             "address": {
                                 "country": "IND",
                                 "city": "Bengaluru",
-                                "area_code": "560086",
-                                "name": "Basanth",
-                                "locality": "70 2nd cross road",
+                                "area_code": "560079",
+                                "name": "Basanth Home",
+                                "locality": "1st Cross Road",
                                 "state": "Karnataka",
-                                "building": "VHBCS Layout"
+                                "building": "Building name"
                             },
-                            "gps": "13.005504, 77.538237"
+                            "gps": "13.000483926941195, 77.5379921271815"
+                        },
+                        "time": {
+                            "range": {
+                                "start": "2023-11-10T23:38:52.889Z",
+                                "end": "2023-11-11T05:38:51.889Z"
+                            }
                         }
                     },
                     "id": "1",
@@ -141,9 +141,9 @@
                 "uri": "https://juspay.in/",
                 "tl_method": "http/get",
                 "params": {
-                    "amount": "437.92",
+                    "amount": "596.32",
                     "currency": "INR",
-                    "transaction_id": "6d87f6cc-7705-4d6e-8991-a2b502059d1f"
+                    "transaction_id": "8a269a55-f535-4912-8205-23f46ce51684"
                 },
                 "status": "PAID",
                 "type": "ON-ORDER",
@@ -167,20 +167,20 @@
             "quote": {
                 "breakup": [
                     {
-                        "@ondc/org/item_id": "93091a6b-323e-444b-955e-c6f9678e2804",
+                        "@ondc/org/item_id": "7abbe7ca-1728-4993-82b7-6e17e001854f",
                         "@ondc/org/item_quantity": {
                             "count": 2
                         },
-                        "title": "Sleepy Owl Classic Iced Coffee - Made With Cold Brew, 200 ml Bottle",
+                        "title": "Happilo Premium Pumpkin Seeds - All Natural, 200 g",
                         "@ondc/org/title_type": "item",
                         "price": {
                             "currency": "INR",
-                            "value": "220.00"
+                            "value": "480.00"
                         },
                         "item": {
                             "quantity": {
                                 "available": {
-                                    "count": "3"
+                                    "count": "4"
                                 },
                                 "maximum": {
                                     "count": "3"
@@ -188,20 +188,20 @@
                             },
                             "price": {
                                 "currency": "INR",
-                                "value": "110.00"
+                                "value": "240.00"
                             }
                         }
                     },
                     {
-                        "@ondc/org/item_id": "8fcb8ccd-0a60-49ad-8c08-cfd5f2c705fd",
+                        "@ondc/org/item_id": "954659be-d626-46f9-8a36-31f9bece177d",
                         "@ondc/org/item_quantity": {
-                            "count": 3
+                            "count": 1
                         },
-                        "title": "EVEREST KASURI METHI 25 G\r\n",
+                        "title": "Taj Mahal Rich & Flavourful Tea, 100 g",
                         "@ondc/org/title_type": "item",
                         "price": {
                             "currency": "INR",
-                            "value": "69.00"
+                            "value": "95.00"
                         },
                         "item": {
                             "quantity": {
@@ -214,33 +214,7 @@
                             },
                             "price": {
                                 "currency": "INR",
-                                "value": "23.00"
-                            }
-                        }
-                    },
-                    {
-                        "@ondc/org/item_id": "e06763ff-23b9-4b8b-a131-398c9afa710d",
-                        "@ondc/org/item_quantity": {
-                            "count": 2
-                        },
-                        "title": "Park Avenue Bathing Soap - Cool Blue, 125 g",
-                        "@ondc/org/title_type": "item",
-                        "price": {
-                            "currency": "INR",
-                            "value": "126.00"
-                        },
-                        "item": {
-                            "quantity": {
-                                "available": {
-                                    "count": "3"
-                                },
-                                "maximum": {
-                                    "count": "3"
-                                }
-                            },
-                            "price": {
-                                "currency": "INR",
-                                "value": "63.00"
+                                "value": "95.00"
                             }
                         }
                     },
@@ -250,7 +224,7 @@
                         "@ondc/org/title_type": "delivery",
                         "price": {
                             "currency": "INR",
-                            "value": "7.95"
+                            "value": "0.93"
                         }
                     },
                     {
@@ -259,13 +233,13 @@
                         "@ondc/org/title_type": "misc",
                         "price": {
                             "currency": "INR",
-                            "value": "14.97"
+                            "value": "20.39"
                         }
                     }
                 ],
                 "price": {
                     "currency": "INR",
-                    "value": "437.92"
+                    "value": "596.32"
                 },
                 "ttl": "P1D"
             },
@@ -275,7 +249,7 @@
                     "list": [
                         {
                             "code": "tax_number",
-                            "value": "BUYER-APP-GSTN"
+                            "value": "29AAJCB5249A1ZR"
                         }
                     ]
                 },
@@ -284,13 +258,13 @@
                     "list": [
                         {
                             "code": "tax_number",
-                            "value": "BUYER-APP-GSTN"
+                            "value": "BUYER-APP-GSTN-ONDC"
                         }
                     ]
                 }
             ],
-            "created_at": "2023-10-27T18:45:42.189Z",
-            "updated_at": "2023-10-27T18:48:22.358Z"
+            "created_at": "2023-11-10T17:38:51.889Z",
+            "updated_at": "2023-11-10T17:39:21.817Z"
         }
     }
 }

--- a/ShopEG/With buyer-app-preprod-v2.ondc.org/Group A/Flow 2/select.json
+++ b/ShopEG/With buyer-app-preprod-v2.ondc.org/Group A/Flow 2/select.json
@@ -8,9 +8,9 @@
         "bap_id": "buyer-app-preprod-v2.ondc.org",
         "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
         "bpp_uri": "https://dev-api.shopeg.in/ondc/bpp",
-        "transaction_id": "6d87f6cc-7705-4d6e-8991-a2b502059d1f",
-        "message_id": "f696d0fc-db3e-4d86-924d-878843164f06",
-        "timestamp": "2023-10-27T18:45:28.564Z",
+        "transaction_id": "8a269a55-f535-4912-8205-23f46ce51684",
+        "message_id": "3315a0e9-e717-421a-88cd-fd27ca31fb8e",
+        "timestamp": "2023-11-10T17:38:30.763Z",
         "bpp_id": "dev-api.shopeg.in",
         "ttl": "PT30S"
     },
@@ -18,23 +18,16 @@
         "order": {
             "items": [
                 {
-                    "id": "93091a6b-323e-444b-955e-c6f9678e2804",
+                    "id": "7abbe7ca-1728-4993-82b7-6e17e001854f",
                     "quantity": {
                         "count": 2
                     },
                     "location_id": "6271"
                 },
                 {
-                    "id": "8fcb8ccd-0a60-49ad-8c08-cfd5f2c705fd",
+                    "id": "954659be-d626-46f9-8a36-31f9bece177d",
                     "quantity": {
-                        "count": 3
-                    },
-                    "location_id": "6271"
-                },
-                {
-                    "id": "e06763ff-23b9-4b8b-a131-398c9afa710d",
-                    "quantity": {
-                        "count": 2
+                        "count": 1
                     },
                     "location_id": "6271"
                 }
@@ -51,9 +44,9 @@
                 {
                     "end": {
                         "location": {
-                            "gps": "13.005504, 77.538237",
+                            "gps": "13.000483926941195, 77.5379921271815",
                             "address": {
-                                "area_code": "560086"
+                                "area_code": "560079"
                             }
                         }
                     }

--- a/ShopEG/With buyer-app-preprod-v2.ondc.org/Group A/Flow 3/confirm.json
+++ b/ShopEG/With buyer-app-preprod-v2.ondc.org/Group A/Flow 3/confirm.json
@@ -8,37 +8,44 @@
         "bap_id": "buyer-app-preprod-v2.ondc.org",
         "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
         "bpp_uri": "https://dev-api.shopeg.in/ondc/bpp",
-        "transaction_id": "757aa549-96b2-4b8b-8a54-f6f200b623fa",
-        "message_id": "f1ea0ffe-37d2-4ebb-98fa-18c5d0e23e57",
-        "timestamp": "2023-10-27T19:24:38.758Z",
+        "transaction_id": "9bd3a22c-31c8-4455-a322-646de566f3cc",
+        "message_id": "5ebe70f3-37d3-4592-9ed5-68758c4e2ca1",
+        "timestamp": "2023-11-10T18:21:58.655Z",
         "bpp_id": "dev-api.shopeg.in",
         "ttl": "PT30S"
     },
     "message": {
         "order": {
-            "id": "2023-10-27-564020",
+            "id": "2023-11-10-935531",
             "state": "Created",
             "billing": {
                 "address": {
-                    "name": "Basanth",
-                    "building": "VHBCS Layout",
-                    "locality": "70 2nd cross road",
+                    "name": "Basanth Home",
+                    "building": "Building name",
+                    "locality": "1st Cross Road",
                     "city": "Bengaluru",
                     "state": "Karnataka",
                     "country": "IND",
-                    "area_code": "560086"
+                    "area_code": "560079"
                 },
-                "phone": "8618563552",
-                "name": "Basanth",
+                "phone": "9900990099",
+                "name": "Basanth Home",
                 "email": "basanth@shopeg.in",
-                "created_at": "2023-10-27T19:24:04.219Z",
-                "updated_at": "2023-10-27T19:24:04.219Z"
+                "created_at": "2023-11-10T18:21:56.124Z",
+                "updated_at": "2023-11-10T18:21:56.124Z"
             },
             "items": [
                 {
-                    "id": "6ff7768d-66dc-4ad3-a4b9-291c9eadfdb8",
+                    "id": "a208c5d2-0598-4a73-80f6-eb79f0a7f425",
                     "quantity": {
                         "count": 2
+                    },
+                    "fulfillment_id": "1"
+                },
+                {
+                    "id": "a687aab3-df94-4bf1-9639-1414995ff937",
+                    "quantity": {
+                        "count": 1
                     },
                     "fulfillment_id": "1"
                 }
@@ -51,13 +58,13 @@
                     }
                 ],
                 "descriptor": {
-                    "symbol": "https://www.bigbasket.com/media/uploads/p/l/40172087_6-sleepy-owl-cold-brew-coffee-classic.jpg",
-                    "images": [
-                        "https://www.bigbasket.com/media/uploads/p/l/40172087_6-sleepy-owl-cold-brew-coffee-classic.jpg"
-                    ],
                     "name": "B shop",
                     "short_desc": "Fresh Grocery Items updated schedule ",
-                    "long_desc": "Fresh Grocery Items"
+                    "long_desc": "Fresh Grocery Items updated schedule ",
+                    "symbol": "https://shopeg.in/i/eg.png",
+                    "images": [
+                        "https://shopeg.in/i/eg.png"
+                    ]
                 }
             },
             "fulfillments": [
@@ -67,21 +74,21 @@
                     "end": {
                         "contact": {
                             "email": "basanth@shopeg.in",
-                            "phone": "8618563552"
+                            "phone": "9900990099"
                         },
                         "person": {
-                            "name": "Basanth"
+                            "name": "Basanth Home"
                         },
                         "location": {
-                            "gps": "13.005504, 77.538237",
+                            "gps": "13.000483926941195, 77.5379921271815",
                             "address": {
-                                "name": "Basanth",
-                                "building": "VHBCS Layout",
-                                "locality": "70 2nd cross road",
+                                "name": "Basanth Home",
+                                "building": "Building name",
+                                "locality": "1st Cross Road",
                                 "city": "Bengaluru",
                                 "state": "Karnataka",
                                 "country": "IND",
-                                "area_code": "560086"
+                                "area_code": "560079"
                             }
                         }
                     },
@@ -92,9 +99,9 @@
                 "uri": "https://juspay.in/",
                 "tl_method": "http/get",
                 "params": {
-                    "amount": "55.86",
+                    "amount": "186.92",
                     "currency": "INR",
-                    "transaction_id": "757aa549-96b2-4b8b-8a54-f6f200b623fa"
+                    "transaction_id": "9bd3a22c-31c8-4455-a322-646de566f3cc"
                 },
                 "status": "PAID",
                 "type": "ON-ORDER",
@@ -118,15 +125,15 @@
             "quote": {
                 "breakup": [
                     {
-                        "@ondc/org/item_id": "6ff7768d-66dc-4ad3-a4b9-291c9eadfdb8",
+                        "@ondc/org/item_id": "a208c5d2-0598-4a73-80f6-eb79f0a7f425",
                         "@ondc/org/item_quantity": {
                             "count": 2
                         },
-                        "title": "Aashirvaad Salt,with 4-Step advantage, 1kg\r\n",
+                        "title": "Eastern Coriander Powder - Perfect Colour, Smell & Taste, 100 g Pouch",
                         "@ondc/org/title_type": "item",
                         "price": {
                             "currency": "INR",
-                            "value": "46.00"
+                            "value": "74.00"
                         },
                         "item": {
                             "quantity": {
@@ -139,7 +146,33 @@
                             },
                             "price": {
                                 "currency": "INR",
-                                "value": "23.00"
+                                "value": "37.00"
+                            }
+                        }
+                    },
+                    {
+                        "@ondc/org/item_id": "a687aab3-df94-4bf1-9639-1414995ff937",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
+                        },
+                        "title": "Britannia Treat Croissant - Vanilla Creme Filling, 100% Veg, Soft, 6x45 g Multipack",
+                        "@ondc/org/title_type": "item",
+                        "price": {
+                            "currency": "INR",
+                            "value": "105.60"
+                        },
+                        "item": {
+                            "quantity": {
+                                "available": {
+                                    "count": "3"
+                                },
+                                "maximum": {
+                                    "count": "3"
+                                }
+                            },
+                            "price": {
+                                "currency": "INR",
+                                "value": "105.60"
                             }
                         }
                     },
@@ -149,7 +182,7 @@
                         "@ondc/org/title_type": "delivery",
                         "price": {
                             "currency": "INR",
-                            "value": "7.95"
+                            "value": "0.93"
                         }
                     },
                     {
@@ -158,13 +191,13 @@
                         "@ondc/org/title_type": "misc",
                         "price": {
                             "currency": "INR",
-                            "value": "1.91"
+                            "value": "6.39"
                         }
                     }
                 ],
                 "price": {
                     "currency": "INR",
-                    "value": "55.86"
+                    "value": "186.92"
                 },
                 "ttl": "P1D"
             },
@@ -174,7 +207,7 @@
                     "list": [
                         {
                             "code": "tax_number",
-                            "value": "BUYER-APP-GSTN"
+                            "value": "29AAJCB5249A1ZR"
                         }
                     ]
                 },
@@ -183,13 +216,13 @@
                     "list": [
                         {
                             "code": "tax_number",
-                            "value": "BUYER-APP-GSTN"
+                            "value": "BUYER-APP-GSTN-ONDC"
                         }
                     ]
                 }
             ],
-            "created_at": "2023-10-27T19:24:38.758Z",
-            "updated_at": "2023-10-27T19:24:38.758Z"
+            "created_at": "2023-11-10T18:21:58.655Z",
+            "updated_at": "2023-11-10T18:21:58.655Z"
         }
     }
 }

--- a/ShopEG/With buyer-app-preprod-v2.ondc.org/Group A/Flow 3/init.json
+++ b/ShopEG/With buyer-app-preprod-v2.ondc.org/Group A/Flow 3/init.json
@@ -8,9 +8,9 @@
         "bap_id": "buyer-app-preprod-v2.ondc.org",
         "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
         "bpp_uri": "https://dev-api.shopeg.in/ondc/bpp",
-        "transaction_id": "757aa549-96b2-4b8b-8a54-f6f200b623fa",
-        "message_id": "2acaf1f2-a7f3-470c-bcc6-5582af8eb7c6",
-        "timestamp": "2023-10-27T19:24:04.219Z",
+        "transaction_id": "9bd3a22c-31c8-4455-a322-646de566f3cc",
+        "message_id": "b2e89c9c-d911-4da8-a273-256021cf3b5e",
+        "timestamp": "2023-11-10T18:21:56.124Z",
         "bpp_id": "dev-api.shopeg.in",
         "ttl": "PT30S"
     },
@@ -26,9 +26,17 @@
             },
             "items": [
                 {
-                    "id": "6ff7768d-66dc-4ad3-a4b9-291c9eadfdb8",
+                    "id": "a208c5d2-0598-4a73-80f6-eb79f0a7f425",
                     "quantity": {
                         "count": 2
+                    },
+                    "location_id": "6271",
+                    "fulfillment_id": "1"
+                },
+                {
+                    "id": "a687aab3-df94-4bf1-9639-1414995ff937",
+                    "quantity": {
+                        "count": 1
                     },
                     "location_id": "6271",
                     "fulfillment_id": "1"
@@ -36,19 +44,21 @@
             ],
             "billing": {
                 "address": {
-                    "building": "VHBCS Layout",
+                    "building": "Building name",
                     "city": "Bengaluru",
                     "state": "Karnataka",
                     "country": "IND",
-                    "area_code": "560086",
-                    "locality": "70 2nd cross road",
-                    "name": "Basanth"
+                    "lat": "13.000483926941195",
+                    "lng": "77.5379921271815",
+                    "area_code": "560079",
+                    "locality": "1st Cross Road",
+                    "name": "Basanth Home"
                 },
-                "phone": "8618563552",
-                "name": "Basanth",
+                "phone": "9900990099",
+                "name": "Basanth Home",
                 "email": "basanth@shopeg.in",
-                "created_at": "2023-10-27T19:24:04.219Z",
-                "updated_at": "2023-10-27T19:24:04.219Z"
+                "created_at": "2023-11-10T18:21:56.124Z",
+                "updated_at": "2023-11-10T18:21:56.124Z"
             },
             "fulfillments": [
                 {
@@ -57,18 +67,20 @@
                     "end": {
                         "contact": {
                             "email": "basanth@shopeg.in",
-                            "phone": "8618563552"
+                            "phone": "9900990099"
                         },
                         "location": {
-                            "gps": "13.005504, 77.538237",
+                            "gps": "13.000483926941195, 77.5379921271815",
                             "address": {
-                                "building": "VHBCS Layout",
+                                "building": "Building name",
                                 "city": "Bengaluru",
                                 "state": "Karnataka",
                                 "country": "IND",
-                                "area_code": "560086",
-                                "locality": "70 2nd cross road",
-                                "name": "Basanth"
+                                "lat": "13.000483926941195",
+                                "lng": "77.5379921271815",
+                                "area_code": "560079",
+                                "locality": "1st Cross Road",
+                                "name": "Basanth Home"
                             }
                         }
                     }

--- a/ShopEG/With buyer-app-preprod-v2.ondc.org/Group A/Flow 3/on_confirm.json
+++ b/ShopEG/With buyer-app-preprod-v2.ondc.org/Group A/Flow 3/on_confirm.json
@@ -8,37 +8,44 @@
         "bap_id": "buyer-app-preprod-v2.ondc.org",
         "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
         "bpp_uri": "https://dev-api.shopeg.in/ondc/bpp",
-        "transaction_id": "757aa549-96b2-4b8b-8a54-f6f200b623fa",
-        "message_id": "f1ea0ffe-37d2-4ebb-98fa-18c5d0e23e57",
-        "timestamp": "2023-10-27T19:24:38.896Z",
+        "transaction_id": "9bd3a22c-31c8-4455-a322-646de566f3cc",
+        "message_id": "5ebe70f3-37d3-4592-9ed5-68758c4e2ca1",
+        "timestamp": "2023-11-10T18:21:58.804Z",
         "bpp_id": "dev-api.shopeg.in",
         "ttl": "PT30S"
     },
     "message": {
         "order": {
-            "id": "2023-10-27-564020",
+            "id": "2023-11-10-935531",
             "state": "Created",
             "billing": {
                 "address": {
-                    "name": "Basanth",
-                    "building": "VHBCS Layout",
-                    "locality": "70 2nd cross road",
+                    "name": "Basanth Home",
+                    "building": "Building name",
+                    "locality": "1st Cross Road",
                     "city": "Bengaluru",
                     "state": "Karnataka",
                     "country": "IND",
-                    "area_code": "560086"
+                    "area_code": "560079"
                 },
-                "phone": "8618563552",
-                "name": "Basanth",
+                "phone": "9900990099",
+                "name": "Basanth Home",
                 "email": "basanth@shopeg.in",
-                "created_at": "2023-10-27T19:24:04.219Z",
-                "updated_at": "2023-10-27T19:24:04.219Z"
+                "created_at": "2023-11-10T18:21:56.124Z",
+                "updated_at": "2023-11-10T18:21:56.124Z"
             },
             "items": [
                 {
-                    "id": "6ff7768d-66dc-4ad3-a4b9-291c9eadfdb8",
+                    "id": "a208c5d2-0598-4a73-80f6-eb79f0a7f425",
                     "quantity": {
                         "count": 2
+                    },
+                    "fulfillment_id": "1"
+                },
+                {
+                    "id": "a687aab3-df94-4bf1-9639-1414995ff937",
+                    "quantity": {
+                        "count": 1
                     },
                     "fulfillment_id": "1"
                 }
@@ -51,13 +58,13 @@
                     }
                 ],
                 "descriptor": {
-                    "symbol": "https://www.bigbasket.com/media/uploads/p/l/40172087_6-sleepy-owl-cold-brew-coffee-classic.jpg",
-                    "images": [
-                        "https://www.bigbasket.com/media/uploads/p/l/40172087_6-sleepy-owl-cold-brew-coffee-classic.jpg"
-                    ],
                     "name": "B shop",
                     "short_desc": "Fresh Grocery Items updated schedule ",
-                    "long_desc": "Fresh Grocery Items"
+                    "long_desc": "Fresh Grocery Items updated schedule ",
+                    "symbol": "https://shopeg.in/i/eg.png",
+                    "images": [
+                        "https://shopeg.in/i/eg.png"
+                    ]
                 }
             },
             "fulfillments": [
@@ -67,30 +74,37 @@
                     "end": {
                         "contact": {
                             "email": "basanth@shopeg.in",
-                            "phone": "8618563552"
+                            "phone": "9900990099"
                         },
                         "person": {
-                            "name": "Basanth"
+                            "name": "Basanth Home"
                         },
                         "location": {
-                            "gps": "13.005504, 77.538237",
+                            "gps": "13.000483926941195, 77.5379921271815",
                             "address": {
-                                "name": "Basanth",
-                                "building": "VHBCS Layout",
-                                "locality": "70 2nd cross road",
+                                "name": "Basanth Home",
+                                "building": "Building name",
+                                "locality": "1st Cross Road",
                                 "city": "Bengaluru",
                                 "state": "Karnataka",
                                 "country": "IND",
-                                "area_code": "560086"
+                                "area_code": "560079"
+                            }
+                        },
+                        "time": {
+                            "range": {
+                                "end": "2023-11-11T06:21:58.655Z",
+                                "start": "2023-11-11T00:21:59.655Z"
                             }
                         }
                     },
                     "type": "Delivery",
                     "@ondc/org/provider_name": "B shop",
+                    "@ondc/org/TAT": "PT12H",
                     "start": {
                         "contact": {
-                            "phone": "8618563552",
-                            "email": "ondc-support@shopeg.in"
+                            "email": "ondc-support@shopeg.in",
+                            "phone": "8618563552"
                         },
                         "location": {
                             "descriptor": {
@@ -110,8 +124,8 @@
                         },
                         "time": {
                             "range": {
-                                "end": "2023-10-28T01:24:38.858Z",
-                                "start": "2023-10-27T19:24:38.858Z"
+                                "end": "2023-11-11T00:21:58.747Z",
+                                "start": "2023-11-10T18:21:58.747Z"
                             }
                         }
                     },
@@ -127,9 +141,9 @@
                 "uri": "https://juspay.in/",
                 "tl_method": "http/get",
                 "params": {
-                    "amount": "55.86",
+                    "amount": "186.92",
                     "currency": "INR",
-                    "transaction_id": "757aa549-96b2-4b8b-8a54-f6f200b623fa"
+                    "transaction_id": "9bd3a22c-31c8-4455-a322-646de566f3cc"
                 },
                 "status": "PAID",
                 "type": "ON-ORDER",
@@ -153,15 +167,15 @@
             "quote": {
                 "breakup": [
                     {
-                        "@ondc/org/item_id": "6ff7768d-66dc-4ad3-a4b9-291c9eadfdb8",
+                        "@ondc/org/item_id": "a208c5d2-0598-4a73-80f6-eb79f0a7f425",
                         "@ondc/org/item_quantity": {
                             "count": 2
                         },
-                        "title": "Aashirvaad Salt,with 4-Step advantage, 1kg\r\n",
+                        "title": "Eastern Coriander Powder - Perfect Colour, Smell & Taste, 100 g Pouch",
                         "@ondc/org/title_type": "item",
                         "price": {
                             "currency": "INR",
-                            "value": "46.00"
+                            "value": "74.00"
                         },
                         "item": {
                             "quantity": {
@@ -174,7 +188,33 @@
                             },
                             "price": {
                                 "currency": "INR",
-                                "value": "23.00"
+                                "value": "37.00"
+                            }
+                        }
+                    },
+                    {
+                        "@ondc/org/item_id": "a687aab3-df94-4bf1-9639-1414995ff937",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
+                        },
+                        "title": "Britannia Treat Croissant - Vanilla Creme Filling, 100% Veg, Soft, 6x45 g Multipack",
+                        "@ondc/org/title_type": "item",
+                        "price": {
+                            "currency": "INR",
+                            "value": "105.60"
+                        },
+                        "item": {
+                            "quantity": {
+                                "available": {
+                                    "count": "3"
+                                },
+                                "maximum": {
+                                    "count": "3"
+                                }
+                            },
+                            "price": {
+                                "currency": "INR",
+                                "value": "105.60"
                             }
                         }
                     },
@@ -184,7 +224,7 @@
                         "@ondc/org/title_type": "delivery",
                         "price": {
                             "currency": "INR",
-                            "value": "7.95"
+                            "value": "0.93"
                         }
                     },
                     {
@@ -193,13 +233,13 @@
                         "@ondc/org/title_type": "misc",
                         "price": {
                             "currency": "INR",
-                            "value": "1.91"
+                            "value": "6.39"
                         }
                     }
                 ],
                 "price": {
                     "currency": "INR",
-                    "value": "55.86"
+                    "value": "186.92"
                 },
                 "ttl": "P1D"
             },
@@ -209,7 +249,7 @@
                     "list": [
                         {
                             "code": "tax_number",
-                            "value": "BUYER-APP-GSTN"
+                            "value": "29AAJCB5249A1ZR"
                         }
                     ]
                 },
@@ -218,13 +258,13 @@
                     "list": [
                         {
                             "code": "tax_number",
-                            "value": "BUYER-APP-GSTN"
+                            "value": "BUYER-APP-GSTN-ONDC"
                         }
                     ]
                 }
             ],
-            "created_at": "2023-10-27T19:24:38.758Z",
-            "updated_at": "2023-10-27T19:24:38.896Z"
+            "created_at": "2023-11-10T18:21:58.655Z",
+            "updated_at": "2023-11-10T18:21:58.804Z"
         }
     }
 }

--- a/ShopEG/With buyer-app-preprod-v2.ondc.org/Group A/Flow 3/on_init.json
+++ b/ShopEG/With buyer-app-preprod-v2.ondc.org/Group A/Flow 3/on_init.json
@@ -8,9 +8,9 @@
         "bap_id": "buyer-app-preprod-v2.ondc.org",
         "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
         "bpp_uri": "https://dev-api.shopeg.in/ondc/bpp",
-        "transaction_id": "757aa549-96b2-4b8b-8a54-f6f200b623fa",
-        "message_id": "2acaf1f2-a7f3-470c-bcc6-5582af8eb7c6",
-        "timestamp": "2023-10-27T19:24:04.350Z",
+        "transaction_id": "9bd3a22c-31c8-4455-a322-646de566f3cc",
+        "message_id": "b2e89c9c-d911-4da8-a273-256021cf3b5e",
+        "timestamp": "2023-11-10T18:21:56.278Z",
         "bpp_id": "dev-api.shopeg.in",
         "ttl": "PT30S"
     },
@@ -18,19 +18,21 @@
         "order": {
             "billing": {
                 "address": {
-                    "building": "VHBCS Layout",
+                    "building": "Building name",
                     "city": "Bengaluru",
                     "state": "Karnataka",
                     "country": "IND",
-                    "area_code": "560086",
-                    "locality": "70 2nd cross road",
-                    "name": "Basanth"
+                    "lat": "13.000483926941195",
+                    "lng": "77.5379921271815",
+                    "area_code": "560079",
+                    "locality": "1st Cross Road",
+                    "name": "Basanth Home"
                 },
-                "phone": "8618563552",
-                "name": "Basanth",
+                "phone": "9900990099",
+                "name": "Basanth Home",
                 "email": "basanth@shopeg.in",
-                "created_at": "2023-10-27T19:24:04.219Z",
-                "updated_at": "2023-10-27T19:24:04.219Z"
+                "created_at": "2023-11-10T18:21:56.124Z",
+                "updated_at": "2023-11-10T18:21:56.124Z"
             },
             "fulfillments": [
                 {
@@ -39,18 +41,20 @@
                     "end": {
                         "contact": {
                             "email": "basanth@shopeg.in",
-                            "phone": "8618563552"
+                            "phone": "9900990099"
                         },
                         "location": {
-                            "gps": "13.005504, 77.538237",
+                            "gps": "13.000483926941195, 77.5379921271815",
                             "address": {
-                                "building": "VHBCS Layout",
+                                "building": "Building name",
                                 "city": "Bengaluru",
                                 "state": "Karnataka",
                                 "country": "IND",
-                                "area_code": "560086",
-                                "locality": "70 2nd cross road",
-                                "name": "Basanth"
+                                "lat": "13.000483926941195",
+                                "lng": "77.5379921271815",
+                                "area_code": "560079",
+                                "locality": "1st Cross Road",
+                                "name": "Basanth Home"
                             }
                         }
                     },
@@ -60,9 +64,17 @@
             ],
             "items": [
                 {
-                    "id": "6ff7768d-66dc-4ad3-a4b9-291c9eadfdb8",
+                    "id": "a208c5d2-0598-4a73-80f6-eb79f0a7f425",
                     "quantity": {
                         "count": 2
+                    },
+                    "location_id": "6271",
+                    "fulfillment_id": "1"
+                },
+                {
+                    "id": "a687aab3-df94-4bf1-9639-1414995ff937",
+                    "quantity": {
+                        "count": 1
                     },
                     "location_id": "6271",
                     "fulfillment_id": "1"
@@ -94,15 +106,15 @@
             "quote": {
                 "breakup": [
                     {
-                        "@ondc/org/item_id": "6ff7768d-66dc-4ad3-a4b9-291c9eadfdb8",
+                        "@ondc/org/item_id": "a208c5d2-0598-4a73-80f6-eb79f0a7f425",
                         "@ondc/org/item_quantity": {
                             "count": 2
                         },
-                        "title": "Aashirvaad Salt,with 4-Step advantage, 1kg\r\n",
+                        "title": "Eastern Coriander Powder - Perfect Colour, Smell & Taste, 100 g Pouch",
                         "@ondc/org/title_type": "item",
                         "price": {
                             "currency": "INR",
-                            "value": "46.00"
+                            "value": "74.00"
                         },
                         "item": {
                             "quantity": {
@@ -115,7 +127,33 @@
                             },
                             "price": {
                                 "currency": "INR",
-                                "value": "23.00"
+                                "value": "37.00"
+                            }
+                        }
+                    },
+                    {
+                        "@ondc/org/item_id": "a687aab3-df94-4bf1-9639-1414995ff937",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
+                        },
+                        "title": "Britannia Treat Croissant - Vanilla Creme Filling, 100% Veg, Soft, 6x45 g Multipack",
+                        "@ondc/org/title_type": "item",
+                        "price": {
+                            "currency": "INR",
+                            "value": "105.60"
+                        },
+                        "item": {
+                            "quantity": {
+                                "available": {
+                                    "count": "3"
+                                },
+                                "maximum": {
+                                    "count": "3"
+                                }
+                            },
+                            "price": {
+                                "currency": "INR",
+                                "value": "105.60"
                             }
                         }
                     },
@@ -125,7 +163,7 @@
                         "@ondc/org/title_type": "delivery",
                         "price": {
                             "currency": "INR",
-                            "value": "7.95"
+                            "value": "0.93"
                         }
                     },
                     {
@@ -134,16 +172,27 @@
                         "@ondc/org/title_type": "misc",
                         "price": {
                             "currency": "INR",
-                            "value": "1.91"
+                            "value": "6.39"
                         }
                     }
                 ],
                 "price": {
-                    "value": "55.86",
+                    "value": "186.92",
                     "currency": "INR"
                 },
                 "ttl": "P1D"
-            }
+            },
+            "tags": [
+                {
+                    "code": "bpp_terms",
+                    "list": [
+                        {
+                            "code": "tax_number",
+                            "value": "29AAJCB5249A1ZR"
+                        }
+                    ]
+                }
+            ]
         }
     }
 }

--- a/ShopEG/With buyer-app-preprod-v2.ondc.org/Group A/Flow 3/on_select (remove out of stock item from cart).json
+++ b/ShopEG/With buyer-app-preprod-v2.ondc.org/Group A/Flow 3/on_select (remove out of stock item from cart).json
@@ -8,9 +8,9 @@
         "bap_id": "buyer-app-preprod-v2.ondc.org",
         "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
         "bpp_uri": "https://dev-api.shopeg.in/ondc/bpp",
-        "transaction_id": "757aa549-96b2-4b8b-8a54-f6f200b623fa",
-        "message_id": "a424c1dd-4b51-4d7e-8693-450bdaa3f8e4",
-        "timestamp": "2023-10-27T19:23:56.131Z",
+        "transaction_id": "9bd3a22c-31c8-4455-a322-646de566f3cc",
+        "message_id": "ec9a4379-74ac-486c-87d2-29957d1227db",
+        "timestamp": "2023-11-10T18:21:07.273Z",
         "bpp_id": "dev-api.shopeg.in",
         "ttl": "PT30S"
     },
@@ -26,9 +26,17 @@
             },
             "items": [
                 {
-                    "id": "6ff7768d-66dc-4ad3-a4b9-291c9eadfdb8",
+                    "id": "a208c5d2-0598-4a73-80f6-eb79f0a7f425",
                     "quantity": {
                         "count": 2
+                    },
+                    "location_id": "6271",
+                    "fulfillment_id": "1"
+                },
+                {
+                    "id": "a687aab3-df94-4bf1-9639-1414995ff937",
+                    "quantity": {
+                        "count": 1
                     },
                     "location_id": "6271",
                     "fulfillment_id": "1"
@@ -51,15 +59,15 @@
             "quote": {
                 "breakup": [
                     {
-                        "@ondc/org/item_id": "6ff7768d-66dc-4ad3-a4b9-291c9eadfdb8",
+                        "@ondc/org/item_id": "a208c5d2-0598-4a73-80f6-eb79f0a7f425",
                         "@ondc/org/item_quantity": {
                             "count": 2
                         },
-                        "title": "Aashirvaad Salt,with 4-Step advantage, 1kg\r\n",
+                        "title": "Eastern Coriander Powder - Perfect Colour, Smell & Taste, 100 g Pouch",
                         "@ondc/org/title_type": "item",
                         "price": {
                             "currency": "INR",
-                            "value": "46.00"
+                            "value": "74.00"
                         },
                         "item": {
                             "quantity": {
@@ -72,7 +80,33 @@
                             },
                             "price": {
                                 "currency": "INR",
-                                "value": "23.00"
+                                "value": "37.00"
+                            }
+                        }
+                    },
+                    {
+                        "@ondc/org/item_id": "a687aab3-df94-4bf1-9639-1414995ff937",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
+                        },
+                        "title": "Britannia Treat Croissant - Vanilla Creme Filling, 100% Veg, Soft, 6x45 g Multipack",
+                        "@ondc/org/title_type": "item",
+                        "price": {
+                            "currency": "INR",
+                            "value": "105.60"
+                        },
+                        "item": {
+                            "quantity": {
+                                "available": {
+                                    "count": "3"
+                                },
+                                "maximum": {
+                                    "count": "3"
+                                }
+                            },
+                            "price": {
+                                "currency": "INR",
+                                "value": "105.60"
                             }
                         }
                     },
@@ -82,7 +116,7 @@
                         "@ondc/org/title_type": "delivery",
                         "price": {
                             "currency": "INR",
-                            "value": "7.95"
+                            "value": "12.89"
                         }
                     },
                     {
@@ -91,12 +125,12 @@
                         "@ondc/org/title_type": "misc",
                         "price": {
                             "currency": "INR",
-                            "value": "1.91"
+                            "value": "6.81"
                         }
                     }
                 ],
                 "price": {
-                    "value": "55.86",
+                    "value": "199.30",
                     "currency": "INR"
                 },
                 "ttl": "P1D"

--- a/ShopEG/With buyer-app-preprod-v2.ondc.org/Group A/Flow 3/on_select (with 1 out of stock item).json
+++ b/ShopEG/With buyer-app-preprod-v2.ondc.org/Group A/Flow 3/on_select (with 1 out of stock item).json
@@ -8,9 +8,9 @@
         "bap_id": "buyer-app-preprod-v2.ondc.org",
         "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
         "bpp_uri": "https://dev-api.shopeg.in/ondc/bpp",
-        "transaction_id": "c40b5bda-e8bc-4b6c-ad93-77be44b9e46f",
-        "message_id": "bea0463e-d767-4603-9234-0ef7c326db08",
-        "timestamp": "2023-10-27T19:23:17.529Z",
+        "transaction_id": "9bd3a22c-31c8-4455-a322-646de566f3cc",
+        "message_id": "4030ca8b-854d-4f43-a8a1-df72cb0dc2c4",
+        "timestamp": "2023-11-10T18:19:53.822Z",
         "bpp_id": "dev-api.shopeg.in",
         "ttl": "PT30S"
     },
@@ -26,17 +26,25 @@
             },
             "items": [
                 {
-                    "id": "8fcb8ccd-0a60-49ad-8c08-cfd5f2c705fd",
+                    "id": "cdd75c83-28c4-4b20-a1f2-7695a04275f0",
                     "quantity": {
-                        "count": 1
+                        "count": 3
                     },
                     "location_id": "6271",
                     "fulfillment_id": "1"
                 },
                 {
-                    "id": "6ff7768d-66dc-4ad3-a4b9-291c9eadfdb8",
+                    "id": "a208c5d2-0598-4a73-80f6-eb79f0a7f425",
                     "quantity": {
                         "count": 2
+                    },
+                    "location_id": "6271",
+                    "fulfillment_id": "1"
+                },
+                {
+                    "id": "a687aab3-df94-4bf1-9639-1414995ff937",
+                    "quantity": {
+                        "count": 1
                     },
                     "location_id": "6271",
                     "fulfillment_id": "1"
@@ -59,11 +67,11 @@
             "quote": {
                 "breakup": [
                     {
-                        "@ondc/org/item_id": "8fcb8ccd-0a60-49ad-8c08-cfd5f2c705fd",
+                        "@ondc/org/item_id": "cdd75c83-28c4-4b20-a1f2-7695a04275f0",
                         "@ondc/org/item_quantity": {
                             "count": 0
                         },
-                        "title": "EVEREST KASURI METHI 25 G\n",
+                        "title": "Nestle KitKat - Dessert Delight, Rich Choco Fudge Wafer Bar, Gift Pack, 150 g",
                         "@ondc/org/title_type": "item",
                         "price": {
                             "currency": "INR",
@@ -80,20 +88,20 @@
                             },
                             "price": {
                                 "currency": "INR",
-                                "value": "23.00"
+                                "value": "170.00"
                             }
                         }
                     },
                     {
-                        "@ondc/org/item_id": "6ff7768d-66dc-4ad3-a4b9-291c9eadfdb8",
+                        "@ondc/org/item_id": "a208c5d2-0598-4a73-80f6-eb79f0a7f425",
                         "@ondc/org/item_quantity": {
                             "count": 2
                         },
-                        "title": "Aashirvaad Salt,with 4-Step advantage, 1kg\r\n",
+                        "title": "Eastern Coriander Powder - Perfect Colour, Smell & Taste, 100 g Pouch",
                         "@ondc/org/title_type": "item",
                         "price": {
                             "currency": "INR",
-                            "value": "46.00"
+                            "value": "74.00"
                         },
                         "item": {
                             "quantity": {
@@ -106,7 +114,33 @@
                             },
                             "price": {
                                 "currency": "INR",
-                                "value": "23.00"
+                                "value": "37.00"
+                            }
+                        }
+                    },
+                    {
+                        "@ondc/org/item_id": "a687aab3-df94-4bf1-9639-1414995ff937",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
+                        },
+                        "title": "Britannia Treat Croissant - Vanilla Creme Filling, 100% Veg, Soft, 6x45 g Multipack",
+                        "@ondc/org/title_type": "item",
+                        "price": {
+                            "currency": "INR",
+                            "value": "105.60"
+                        },
+                        "item": {
+                            "quantity": {
+                                "available": {
+                                    "count": "3"
+                                },
+                                "maximum": {
+                                    "count": "3"
+                                }
+                            },
+                            "price": {
+                                "currency": "INR",
+                                "value": "105.60"
                             }
                         }
                     },
@@ -116,7 +150,7 @@
                         "@ondc/org/title_type": "delivery",
                         "price": {
                             "currency": "INR",
-                            "value": "7.95"
+                            "value": "0.93"
                         }
                     },
                     {
@@ -125,12 +159,12 @@
                         "@ondc/org/title_type": "misc",
                         "price": {
                             "currency": "INR",
-                            "value": "1.91"
+                            "value": "6.39"
                         }
                     }
                 ],
                 "price": {
-                    "value": "55.86",
+                    "value": "186.92",
                     "currency": "INR"
                 },
                 "ttl": "P1D"

--- a/ShopEG/With buyer-app-preprod-v2.ondc.org/Group A/Flow 3/on_status_delivered.json
+++ b/ShopEG/With buyer-app-preprod-v2.ondc.org/Group A/Flow 3/on_status_delivered.json
@@ -8,38 +8,45 @@
         "bap_id": "buyer-app-preprod-v2.ondc.org",
         "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
         "bpp_uri": "https://dev-api.shopeg.in/ondc/bpp",
-        "transaction_id": "757aa549-96b2-4b8b-8a54-f6f200b623fa",
-        "message_id": "65de8060-ea87-4beb-b0ad-295dc528e403",
-        "timestamp": "2023-10-27T19:31:42.418Z",
+        "transaction_id": "9bd3a22c-31c8-4455-a322-646de566f3cc",
+        "message_id": "746a1488-740f-481e-a43a-eb256bbec3e0",
+        "timestamp": "2023-11-10T18:25:26.266Z",
         "bpp_id": "dev-api.shopeg.in",
         "ttl": "PT30S"
     },
     "message": {
         "order": {
-            "id": "2023-10-27-564020",
+            "id": "2023-11-10-935531",
             "state": "Completed",
             "billing": {
                 "address": {
-                    "name": "Basanth",
-                    "building": "VHBCS Layout",
-                    "locality": "70 2nd cross road",
+                    "name": "Basanth Home",
+                    "building": "Building name",
+                    "locality": "1st Cross Road",
                     "city": "Bengaluru",
                     "state": "Karnataka",
                     "country": "IND",
-                    "area_code": "560086"
+                    "area_code": "560079"
                 },
-                "phone": "8618563552",
-                "name": "Basanth",
+                "phone": "9900990099",
+                "name": "Basanth Home",
                 "email": "basanth@shopeg.in",
-                "created_at": "2023-10-27T19:24:04.219Z",
-                "updated_at": "2023-10-27T19:24:04.219Z"
+                "created_at": "2023-11-10T18:21:56.124Z",
+                "updated_at": "2023-11-10T18:21:56.124Z"
             },
             "items": [
                 {
                     "quantity": {
                         "count": 2
                     },
-                    "id": "6ff7768d-66dc-4ad3-a4b9-291c9eadfdb8",
+                    "id": "a208c5d2-0598-4a73-80f6-eb79f0a7f425",
+                    "fulfillment_id": "1"
+                },
+                {
+                    "quantity": {
+                        "count": 1
+                    },
+                    "id": "a687aab3-df94-4bf1-9639-1414995ff937",
                     "fulfillment_id": "1"
                 }
             ],
@@ -51,17 +58,18 @@
                     }
                 ],
                 "descriptor": {
-                    "symbol": "https://www.bigbasket.com/media/uploads/p/l/40172087_6-sleepy-owl-cold-brew-coffee-classic.jpg",
-                    "images": [
-                        "https://www.bigbasket.com/media/uploads/p/l/40172087_6-sleepy-owl-cold-brew-coffee-classic.jpg"
-                    ],
                     "name": "B shop",
                     "short_desc": "Fresh Grocery Items updated schedule ",
-                    "long_desc": "Fresh Grocery Items"
+                    "long_desc": "Fresh Grocery Items updated schedule ",
+                    "symbol": "https://shopeg.in/i/eg.png",
+                    "images": [
+                        "https://shopeg.in/i/eg.png"
+                    ]
                 }
             },
             "fulfillments": [
                 {
+                    "@ondc/org/TAT": "PT12H",
                     "start": {
                         "contact": {
                             "phone": "8618563552",
@@ -85,44 +93,43 @@
                         },
                         "time": {
                             "range": {
-                                "start": "2023-10-27T19:24:38.858Z",
-                                "end": "2023-10-28T01:24:38.858Z"
+                                "start": "2023-11-10T18:21:58.747Z",
+                                "end": "2023-11-11T00:21:58.747Z"
                             },
-                            "timestamp": "2023-10-27T19:30:23.699Z"
+                            "timestamp": "2023-11-10T18:24:59.448Z"
                         }
                     },
                     "end": {
                         "person": {
-                            "name": "Basanth"
+                            "name": "Basanth Home"
                         },
                         "contact": {
-                            "phone": "8618563552",
+                            "phone": "9900990099",
                             "email": "basanth@shopeg.in"
                         },
                         "location": {
                             "address": {
                                 "country": "IND",
                                 "city": "Bengaluru",
-                                "area_code": "560086",
-                                "name": "Basanth",
-                                "locality": "70 2nd cross road",
+                                "area_code": "560079",
+                                "name": "Basanth Home",
+                                "locality": "1st Cross Road",
                                 "state": "Karnataka",
-                                "building": "VHBCS Layout"
+                                "building": "Building name"
                             },
-                            "gps": "13.005504, 77.538237"
+                            "gps": "13.000483926941195, 77.5379921271815"
                         },
                         "time": {
                             "range": {
-                                "start": "2023-10-28T01:24:39.758Z",
-                                "end": "2023-10-28T07:24:38.758Z"
+                                "start": "2023-11-11T00:21:59.655Z",
+                                "end": "2023-11-11T06:21:58.655Z"
                             },
-                            "timestamp": "2023-10-27T19:31:42.418Z"
+                            "timestamp": "2023-11-10T18:25:26.266Z"
                         },
                         "instructions": {
-                            "name": "Proof of delivery",
-                            "images": [
-                                "https://firebasestorage.googleapis.com/v0/b/shopeg-dev.appspot.com/o/orders%2FdeliveryImages%2FrOebEZL96U8iln27G7Fm%2F4342%2Fimg_1698435093478.jpg?alt=media&token=28ab0f01-57ba-4903-b8dd-cb81de969624"
-                            ]
+                            "code": "3",
+                            "name": "ONDC Order",
+                            "long_desc": "No code required."
                         }
                     },
                     "id": "1",
@@ -141,9 +148,9 @@
                 "uri": "https://juspay.in/",
                 "tl_method": "http/get",
                 "params": {
-                    "amount": "55.86",
+                    "amount": "186.92",
                     "currency": "INR",
-                    "transaction_id": "757aa549-96b2-4b8b-8a54-f6f200b623fa"
+                    "transaction_id": "9bd3a22c-31c8-4455-a322-646de566f3cc"
                 },
                 "status": "PAID",
                 "type": "ON-ORDER",
@@ -167,7 +174,7 @@
             "quote": {
                 "breakup": [
                     {
-                        "@ondc/org/item_id": "6ff7768d-66dc-4ad3-a4b9-291c9eadfdb8",
+                        "@ondc/org/item_id": "a208c5d2-0598-4a73-80f6-eb79f0a7f425",
                         "item": {
                             "quantity": {
                                 "available": {
@@ -179,24 +186,50 @@
                             },
                             "price": {
                                 "currency": "INR",
-                                "value": "23.00"
+                                "value": "37.00"
                             }
                         },
                         "price": {
                             "currency": "INR",
-                            "value": "46.00"
+                            "value": "74.00"
                         },
                         "@ondc/org/title_type": "item",
-                        "title": "Aashirvaad Salt,with 4-Step advantage, 1kg\r\n",
+                        "title": "Eastern Coriander Powder - Perfect Colour, Smell & Taste, 100 g Pouch",
                         "@ondc/org/item_quantity": {
                             "count": 2
+                        }
+                    },
+                    {
+                        "@ondc/org/item_id": "a687aab3-df94-4bf1-9639-1414995ff937",
+                        "item": {
+                            "quantity": {
+                                "available": {
+                                    "count": "3"
+                                },
+                                "maximum": {
+                                    "count": "3"
+                                }
+                            },
+                            "price": {
+                                "currency": "INR",
+                                "value": "105.60"
+                            }
+                        },
+                        "price": {
+                            "currency": "INR",
+                            "value": "105.60"
+                        },
+                        "@ondc/org/title_type": "item",
+                        "title": "Britannia Treat Croissant - Vanilla Creme Filling, 100% Veg, Soft, 6x45 g Multipack",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
                         }
                     },
                     {
                         "@ondc/org/item_id": "1",
                         "price": {
                             "currency": "INR",
-                            "value": "7.95"
+                            "value": "0.93"
                         },
                         "@ondc/org/title_type": "delivery",
                         "title": "Delivery charges"
@@ -205,7 +238,7 @@
                         "@ondc/org/item_id": "1",
                         "price": {
                             "currency": "INR",
-                            "value": "1.91"
+                            "value": "6.39"
                         },
                         "@ondc/org/title_type": "misc",
                         "title": "Convenience Fee"
@@ -213,7 +246,7 @@
                 ],
                 "price": {
                     "currency": "INR",
-                    "value": "55.86"
+                    "value": "186.92"
                 },
                 "ttl": "P1D"
             },
@@ -223,7 +256,7 @@
                     "list": [
                         {
                             "code": "tax_number",
-                            "value": "BUYER-APP-GSTN"
+                            "value": "29AAJCB5249A1ZR"
                         }
                     ]
                 },
@@ -232,17 +265,17 @@
                     "list": [
                         {
                             "code": "tax_number",
-                            "value": "BUYER-APP-GSTN"
+                            "value": "BUYER-APP-GSTN-ONDC"
                         }
                     ]
                 }
             ],
-            "created_at": "2023-10-27T19:24:38.758Z",
-            "updated_at": "2023-10-27T19:31:42.418Z",
+            "created_at": "2023-11-10T18:21:58.655Z",
+            "updated_at": "2023-11-10T18:25:26.266Z",
             "documents": [
                 {
                     "label": "Invoice",
-                    "url": "https://dev-api.shopeg.in/api/client/order/ondc/invoice/2023-10-27-564020"
+                    "url": "https://dev-api.shopeg.in/api/client/order/ondc/invoice/2023-11-10-935531"
                 }
             ]
         }

--- a/ShopEG/With buyer-app-preprod-v2.ondc.org/Group A/Flow 3/on_status_out_for_delivery.json
+++ b/ShopEG/With buyer-app-preprod-v2.ondc.org/Group A/Flow 3/on_status_out_for_delivery.json
@@ -8,38 +8,45 @@
         "bap_id": "buyer-app-preprod-v2.ondc.org",
         "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
         "bpp_uri": "https://dev-api.shopeg.in/ondc/bpp",
-        "transaction_id": "757aa549-96b2-4b8b-8a54-f6f200b623fa",
-        "message_id": "c1f77321-3a24-4bcb-bffb-0f6aa97e531a",
-        "timestamp": "2023-10-27T19:30:23.699Z",
+        "transaction_id": "9bd3a22c-31c8-4455-a322-646de566f3cc",
+        "message_id": "407a83b1-0143-49b0-9001-2a78c5c90509",
+        "timestamp": "2023-11-10T18:24:59.448Z",
         "bpp_id": "dev-api.shopeg.in",
         "ttl": "PT30S"
     },
     "message": {
         "order": {
-            "id": "2023-10-27-564020",
+            "id": "2023-11-10-935531",
             "state": "In-progress",
             "billing": {
                 "address": {
-                    "name": "Basanth",
-                    "building": "VHBCS Layout",
-                    "locality": "70 2nd cross road",
+                    "name": "Basanth Home",
+                    "building": "Building name",
+                    "locality": "1st Cross Road",
                     "city": "Bengaluru",
                     "state": "Karnataka",
                     "country": "IND",
-                    "area_code": "560086"
+                    "area_code": "560079"
                 },
-                "phone": "8618563552",
-                "name": "Basanth",
+                "phone": "9900990099",
+                "name": "Basanth Home",
                 "email": "basanth@shopeg.in",
-                "created_at": "2023-10-27T19:24:04.219Z",
-                "updated_at": "2023-10-27T19:24:04.219Z"
+                "created_at": "2023-11-10T18:21:56.124Z",
+                "updated_at": "2023-11-10T18:21:56.124Z"
             },
             "items": [
                 {
                     "quantity": {
                         "count": 2
                     },
-                    "id": "6ff7768d-66dc-4ad3-a4b9-291c9eadfdb8",
+                    "id": "a208c5d2-0598-4a73-80f6-eb79f0a7f425",
+                    "fulfillment_id": "1"
+                },
+                {
+                    "quantity": {
+                        "count": 1
+                    },
+                    "id": "a687aab3-df94-4bf1-9639-1414995ff937",
                     "fulfillment_id": "1"
                 }
             ],
@@ -51,17 +58,18 @@
                     }
                 ],
                 "descriptor": {
-                    "symbol": "https://www.bigbasket.com/media/uploads/p/l/40172087_6-sleepy-owl-cold-brew-coffee-classic.jpg",
-                    "images": [
-                        "https://www.bigbasket.com/media/uploads/p/l/40172087_6-sleepy-owl-cold-brew-coffee-classic.jpg"
-                    ],
                     "name": "B shop",
                     "short_desc": "Fresh Grocery Items updated schedule ",
-                    "long_desc": "Fresh Grocery Items"
+                    "long_desc": "Fresh Grocery Items updated schedule ",
+                    "symbol": "https://shopeg.in/i/eg.png",
+                    "images": [
+                        "https://shopeg.in/i/eg.png"
+                    ]
                 }
             },
             "fulfillments": [
                 {
+                    "@ondc/org/TAT": "PT12H",
                     "start": {
                         "contact": {
                             "phone": "8618563552",
@@ -85,36 +93,36 @@
                         },
                         "time": {
                             "range": {
-                                "start": "2023-10-27T19:24:38.858Z",
-                                "end": "2023-10-28T01:24:38.858Z"
+                                "start": "2023-11-10T18:21:58.747Z",
+                                "end": "2023-11-11T00:21:58.747Z"
                             },
-                            "timestamp": "2023-10-27T19:30:23.699Z"
+                            "timestamp": "2023-11-10T18:24:59.448Z"
                         }
                     },
                     "end": {
                         "person": {
-                            "name": "Basanth"
+                            "name": "Basanth Home"
                         },
                         "contact": {
-                            "phone": "8618563552",
+                            "phone": "9900990099",
                             "email": "basanth@shopeg.in"
                         },
                         "location": {
                             "address": {
                                 "country": "IND",
                                 "city": "Bengaluru",
-                                "area_code": "560086",
-                                "name": "Basanth",
-                                "locality": "70 2nd cross road",
+                                "area_code": "560079",
+                                "name": "Basanth Home",
+                                "locality": "1st Cross Road",
                                 "state": "Karnataka",
-                                "building": "VHBCS Layout"
+                                "building": "Building name"
                             },
-                            "gps": "13.005504, 77.538237"
+                            "gps": "13.000483926941195, 77.5379921271815"
                         },
                         "time": {
                             "range": {
-                                "end": "2023-10-28T07:24:38.758Z",
-                                "start": "2023-10-28T01:24:39.758Z"
+                                "start": "2023-11-11T00:21:59.655Z",
+                                "end": "2023-11-11T06:21:58.655Z"
                             }
                         }
                     },
@@ -134,9 +142,9 @@
                 "uri": "https://juspay.in/",
                 "tl_method": "http/get",
                 "params": {
-                    "amount": "55.86",
+                    "amount": "186.92",
                     "currency": "INR",
-                    "transaction_id": "757aa549-96b2-4b8b-8a54-f6f200b623fa"
+                    "transaction_id": "9bd3a22c-31c8-4455-a322-646de566f3cc"
                 },
                 "status": "PAID",
                 "type": "ON-ORDER",
@@ -160,7 +168,7 @@
             "quote": {
                 "breakup": [
                     {
-                        "@ondc/org/item_id": "6ff7768d-66dc-4ad3-a4b9-291c9eadfdb8",
+                        "@ondc/org/item_id": "a208c5d2-0598-4a73-80f6-eb79f0a7f425",
                         "item": {
                             "quantity": {
                                 "available": {
@@ -172,24 +180,50 @@
                             },
                             "price": {
                                 "currency": "INR",
-                                "value": "23.00"
+                                "value": "37.00"
                             }
                         },
                         "price": {
                             "currency": "INR",
-                            "value": "46.00"
+                            "value": "74.00"
                         },
                         "@ondc/org/title_type": "item",
-                        "title": "Aashirvaad Salt,with 4-Step advantage, 1kg\r\n",
+                        "title": "Eastern Coriander Powder - Perfect Colour, Smell & Taste, 100 g Pouch",
                         "@ondc/org/item_quantity": {
                             "count": 2
+                        }
+                    },
+                    {
+                        "@ondc/org/item_id": "a687aab3-df94-4bf1-9639-1414995ff937",
+                        "item": {
+                            "quantity": {
+                                "available": {
+                                    "count": "3"
+                                },
+                                "maximum": {
+                                    "count": "3"
+                                }
+                            },
+                            "price": {
+                                "currency": "INR",
+                                "value": "105.60"
+                            }
+                        },
+                        "price": {
+                            "currency": "INR",
+                            "value": "105.60"
+                        },
+                        "@ondc/org/title_type": "item",
+                        "title": "Britannia Treat Croissant - Vanilla Creme Filling, 100% Veg, Soft, 6x45 g Multipack",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
                         }
                     },
                     {
                         "@ondc/org/item_id": "1",
                         "price": {
                             "currency": "INR",
-                            "value": "7.95"
+                            "value": "0.93"
                         },
                         "@ondc/org/title_type": "delivery",
                         "title": "Delivery charges"
@@ -198,7 +232,7 @@
                         "@ondc/org/item_id": "1",
                         "price": {
                             "currency": "INR",
-                            "value": "1.91"
+                            "value": "6.39"
                         },
                         "@ondc/org/title_type": "misc",
                         "title": "Convenience Fee"
@@ -206,7 +240,7 @@
                 ],
                 "price": {
                     "currency": "INR",
-                    "value": "55.86"
+                    "value": "186.92"
                 },
                 "ttl": "P1D"
             },
@@ -216,7 +250,7 @@
                     "list": [
                         {
                             "code": "tax_number",
-                            "value": "BUYER-APP-GSTN"
+                            "value": "29AAJCB5249A1ZR"
                         }
                     ]
                 },
@@ -225,17 +259,17 @@
                     "list": [
                         {
                             "code": "tax_number",
-                            "value": "BUYER-APP-GSTN"
+                            "value": "BUYER-APP-GSTN-ONDC"
                         }
                     ]
                 }
             ],
-            "created_at": "2023-10-27T19:24:38.758Z",
-            "updated_at": "2023-10-27T19:30:23.699Z",
+            "created_at": "2023-11-10T18:21:58.655Z",
+            "updated_at": "2023-11-10T18:24:59.448Z",
             "documents": [
                 {
                     "label": "Invoice",
-                    "url": "https://dev-api.shopeg.in/api/client/order/ondc/invoice/2023-10-27-564020"
+                    "url": "https://dev-api.shopeg.in/api/client/order/ondc/invoice/2023-11-10-935531"
                 }
             ]
         }

--- a/ShopEG/With buyer-app-preprod-v2.ondc.org/Group A/Flow 3/on_status_packed.json
+++ b/ShopEG/With buyer-app-preprod-v2.ondc.org/Group A/Flow 3/on_status_packed.json
@@ -8,38 +8,45 @@
         "bap_id": "buyer-app-preprod-v2.ondc.org",
         "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
         "bpp_uri": "https://dev-api.shopeg.in/ondc/bpp",
-        "transaction_id": "757aa549-96b2-4b8b-8a54-f6f200b623fa",
-        "message_id": "b6c9a6d7-72b7-4227-97de-8bf84bb3130c",
-        "timestamp": "2023-10-27T19:30:03.149Z",
+        "transaction_id": "9bd3a22c-31c8-4455-a322-646de566f3cc",
+        "message_id": "312f5a96-6969-4648-9689-5d45af3e256b",
+        "timestamp": "2023-11-10T18:24:48.791Z",
         "bpp_id": "dev-api.shopeg.in",
         "ttl": "PT30S"
     },
     "message": {
         "order": {
-            "id": "2023-10-27-564020",
+            "id": "2023-11-10-935531",
             "state": "In-progress",
             "billing": {
                 "address": {
-                    "name": "Basanth",
-                    "building": "VHBCS Layout",
-                    "locality": "70 2nd cross road",
+                    "name": "Basanth Home",
+                    "building": "Building name",
+                    "locality": "1st Cross Road",
                     "city": "Bengaluru",
                     "state": "Karnataka",
                     "country": "IND",
-                    "area_code": "560086"
+                    "area_code": "560079"
                 },
-                "phone": "8618563552",
-                "name": "Basanth",
+                "phone": "9900990099",
+                "name": "Basanth Home",
                 "email": "basanth@shopeg.in",
-                "created_at": "2023-10-27T19:24:04.219Z",
-                "updated_at": "2023-10-27T19:24:04.219Z"
+                "created_at": "2023-11-10T18:21:56.124Z",
+                "updated_at": "2023-11-10T18:21:56.124Z"
             },
             "items": [
                 {
                     "quantity": {
                         "count": 2
                     },
-                    "id": "6ff7768d-66dc-4ad3-a4b9-291c9eadfdb8",
+                    "id": "a208c5d2-0598-4a73-80f6-eb79f0a7f425",
+                    "fulfillment_id": "1"
+                },
+                {
+                    "quantity": {
+                        "count": 1
+                    },
+                    "id": "a687aab3-df94-4bf1-9639-1414995ff937",
                     "fulfillment_id": "1"
                 }
             ],
@@ -51,17 +58,18 @@
                     }
                 ],
                 "descriptor": {
-                    "symbol": "https://www.bigbasket.com/media/uploads/p/l/40172087_6-sleepy-owl-cold-brew-coffee-classic.jpg",
-                    "images": [
-                        "https://www.bigbasket.com/media/uploads/p/l/40172087_6-sleepy-owl-cold-brew-coffee-classic.jpg"
-                    ],
                     "name": "B shop",
                     "short_desc": "Fresh Grocery Items updated schedule ",
-                    "long_desc": "Fresh Grocery Items"
+                    "long_desc": "Fresh Grocery Items updated schedule ",
+                    "symbol": "https://shopeg.in/i/eg.png",
+                    "images": [
+                        "https://shopeg.in/i/eg.png"
+                    ]
                 }
             },
             "fulfillments": [
                 {
+                    "@ondc/org/TAT": "PT12H",
                     "start": {
                         "contact": {
                             "phone": "8618563552",
@@ -85,30 +93,36 @@
                         },
                         "time": {
                             "range": {
-                                "start": "2023-10-27T19:24:38.858Z",
-                                "end": "2023-10-28T01:24:38.858Z"
+                                "start": "2023-11-10T18:21:58.747Z",
+                                "end": "2023-11-11T00:21:58.747Z"
                             }
                         }
                     },
                     "end": {
                         "person": {
-                            "name": "Basanth"
+                            "name": "Basanth Home"
                         },
                         "contact": {
-                            "phone": "8618563552",
+                            "phone": "9900990099",
                             "email": "basanth@shopeg.in"
                         },
                         "location": {
                             "address": {
                                 "country": "IND",
                                 "city": "Bengaluru",
-                                "area_code": "560086",
-                                "name": "Basanth",
-                                "locality": "70 2nd cross road",
+                                "area_code": "560079",
+                                "name": "Basanth Home",
+                                "locality": "1st Cross Road",
                                 "state": "Karnataka",
-                                "building": "VHBCS Layout"
+                                "building": "Building name"
                             },
-                            "gps": "13.005504, 77.538237"
+                            "gps": "13.000483926941195, 77.5379921271815"
+                        },
+                        "time": {
+                            "range": {
+                                "start": "2023-11-11T00:21:59.655Z",
+                                "end": "2023-11-11T06:21:58.655Z"
+                            }
                         }
                     },
                     "id": "1",
@@ -127,9 +141,9 @@
                 "uri": "https://juspay.in/",
                 "tl_method": "http/get",
                 "params": {
-                    "amount": "55.86",
+                    "amount": "186.92",
                     "currency": "INR",
-                    "transaction_id": "757aa549-96b2-4b8b-8a54-f6f200b623fa"
+                    "transaction_id": "9bd3a22c-31c8-4455-a322-646de566f3cc"
                 },
                 "status": "PAID",
                 "type": "ON-ORDER",
@@ -153,7 +167,7 @@
             "quote": {
                 "breakup": [
                     {
-                        "@ondc/org/item_id": "6ff7768d-66dc-4ad3-a4b9-291c9eadfdb8",
+                        "@ondc/org/item_id": "a208c5d2-0598-4a73-80f6-eb79f0a7f425",
                         "item": {
                             "quantity": {
                                 "available": {
@@ -165,24 +179,50 @@
                             },
                             "price": {
                                 "currency": "INR",
-                                "value": "23.00"
+                                "value": "37.00"
                             }
                         },
                         "price": {
                             "currency": "INR",
-                            "value": "46.00"
+                            "value": "74.00"
                         },
                         "@ondc/org/title_type": "item",
-                        "title": "Aashirvaad Salt,with 4-Step advantage, 1kg\r\n",
+                        "title": "Eastern Coriander Powder - Perfect Colour, Smell & Taste, 100 g Pouch",
                         "@ondc/org/item_quantity": {
                             "count": 2
+                        }
+                    },
+                    {
+                        "@ondc/org/item_id": "a687aab3-df94-4bf1-9639-1414995ff937",
+                        "item": {
+                            "quantity": {
+                                "available": {
+                                    "count": "3"
+                                },
+                                "maximum": {
+                                    "count": "3"
+                                }
+                            },
+                            "price": {
+                                "currency": "INR",
+                                "value": "105.60"
+                            }
+                        },
+                        "price": {
+                            "currency": "INR",
+                            "value": "105.60"
+                        },
+                        "@ondc/org/title_type": "item",
+                        "title": "Britannia Treat Croissant - Vanilla Creme Filling, 100% Veg, Soft, 6x45 g Multipack",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
                         }
                     },
                     {
                         "@ondc/org/item_id": "1",
                         "price": {
                             "currency": "INR",
-                            "value": "7.95"
+                            "value": "0.93"
                         },
                         "@ondc/org/title_type": "delivery",
                         "title": "Delivery charges"
@@ -191,7 +231,7 @@
                         "@ondc/org/item_id": "1",
                         "price": {
                             "currency": "INR",
-                            "value": "1.91"
+                            "value": "6.39"
                         },
                         "@ondc/org/title_type": "misc",
                         "title": "Convenience Fee"
@@ -199,7 +239,7 @@
                 ],
                 "price": {
                     "currency": "INR",
-                    "value": "55.86"
+                    "value": "186.92"
                 },
                 "ttl": "P1D"
             },
@@ -209,7 +249,7 @@
                     "list": [
                         {
                             "code": "tax_number",
-                            "value": "BUYER-APP-GSTN"
+                            "value": "29AAJCB5249A1ZR"
                         }
                     ]
                 },
@@ -218,13 +258,13 @@
                     "list": [
                         {
                             "code": "tax_number",
-                            "value": "BUYER-APP-GSTN"
+                            "value": "BUYER-APP-GSTN-ONDC"
                         }
                     ]
                 }
             ],
-            "created_at": "2023-10-27T19:24:38.758Z",
-            "updated_at": "2023-10-27T19:30:03.149Z"
+            "created_at": "2023-11-10T18:21:58.655Z",
+            "updated_at": "2023-11-10T18:24:48.791Z"
         }
     }
 }

--- a/ShopEG/With buyer-app-preprod-v2.ondc.org/Group A/Flow 3/on_status_pending.json
+++ b/ShopEG/With buyer-app-preprod-v2.ondc.org/Group A/Flow 3/on_status_pending.json
@@ -8,37 +8,44 @@
         "bap_id": "buyer-app-preprod-v2.ondc.org",
         "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
         "bpp_uri": "https://dev-api.shopeg.in/ondc/bpp",
-        "transaction_id": "757aa549-96b2-4b8b-8a54-f6f200b623fa",
-        "message_id": "5062584f-5d8a-4d72-8431-da16d97c3282",
-        "timestamp": "2023-10-27T19:29:35.735Z",
+        "transaction_id": "9bd3a22c-31c8-4455-a322-646de566f3cc",
+        "message_id": "e1c57207-bb09-4319-8592-159924461966",
+        "timestamp": "2023-11-10T18:23:53.093Z",
         "bpp_id": "dev-api.shopeg.in",
         "ttl": "PT30S"
     },
     "message": {
         "order": {
-            "id": "2023-10-27-564020",
+            "id": "2023-11-10-935531",
             "state": "In-progress",
             "billing": {
                 "address": {
-                    "name": "Basanth",
-                    "building": "VHBCS Layout",
-                    "locality": "70 2nd cross road",
+                    "name": "Basanth Home",
+                    "building": "Building name",
+                    "locality": "1st Cross Road",
                     "city": "Bengaluru",
                     "state": "Karnataka",
                     "country": "IND",
-                    "area_code": "560086"
+                    "area_code": "560079"
                 },
-                "phone": "8618563552",
-                "name": "Basanth",
+                "phone": "9900990099",
+                "name": "Basanth Home",
                 "email": "basanth@shopeg.in",
-                "created_at": "2023-10-27T19:24:04.219Z",
-                "updated_at": "2023-10-27T19:24:04.219Z"
+                "created_at": "2023-11-10T18:21:56.124Z",
+                "updated_at": "2023-11-10T18:21:56.124Z"
             },
             "items": [
                 {
-                    "id": "6ff7768d-66dc-4ad3-a4b9-291c9eadfdb8",
+                    "id": "a208c5d2-0598-4a73-80f6-eb79f0a7f425",
                     "quantity": {
                         "count": 2
+                    },
+                    "fulfillment_id": "1"
+                },
+                {
+                    "id": "a687aab3-df94-4bf1-9639-1414995ff937",
+                    "quantity": {
+                        "count": 1
                     },
                     "fulfillment_id": "1"
                 }
@@ -51,17 +58,18 @@
                     }
                 ],
                 "descriptor": {
-                    "symbol": "https://www.bigbasket.com/media/uploads/p/l/40172087_6-sleepy-owl-cold-brew-coffee-classic.jpg",
-                    "images": [
-                        "https://www.bigbasket.com/media/uploads/p/l/40172087_6-sleepy-owl-cold-brew-coffee-classic.jpg"
-                    ],
                     "name": "B shop",
                     "short_desc": "Fresh Grocery Items updated schedule ",
-                    "long_desc": "Fresh Grocery Items"
+                    "long_desc": "Fresh Grocery Items updated schedule ",
+                    "symbol": "https://shopeg.in/i/eg.png",
+                    "images": [
+                        "https://shopeg.in/i/eg.png"
+                    ]
                 }
             },
             "fulfillments": [
                 {
+                    "@ondc/org/TAT": "PT12H",
                     "start": {
                         "contact": {
                             "phone": "8618563552",
@@ -85,30 +93,36 @@
                         },
                         "time": {
                             "range": {
-                                "start": "2023-10-27T19:24:38.858Z",
-                                "end": "2023-10-28T01:24:38.858Z"
+                                "start": "2023-11-10T18:21:58.747Z",
+                                "end": "2023-11-11T00:21:58.747Z"
                             }
                         }
                     },
                     "end": {
                         "person": {
-                            "name": "Basanth"
+                            "name": "Basanth Home"
                         },
                         "contact": {
-                            "phone": "8618563552",
+                            "phone": "9900990099",
                             "email": "basanth@shopeg.in"
                         },
                         "location": {
                             "address": {
                                 "country": "IND",
                                 "city": "Bengaluru",
-                                "area_code": "560086",
-                                "name": "Basanth",
-                                "locality": "70 2nd cross road",
+                                "area_code": "560079",
+                                "name": "Basanth Home",
+                                "locality": "1st Cross Road",
                                 "state": "Karnataka",
-                                "building": "VHBCS Layout"
+                                "building": "Building name"
                             },
-                            "gps": "13.005504, 77.538237"
+                            "gps": "13.000483926941195, 77.5379921271815"
+                        },
+                        "time": {
+                            "range": {
+                                "start": "2023-11-11T00:21:59.655Z",
+                                "end": "2023-11-11T06:21:58.655Z"
+                            }
                         }
                     },
                     "id": "1",
@@ -127,9 +141,9 @@
                 "uri": "https://juspay.in/",
                 "tl_method": "http/get",
                 "params": {
-                    "amount": "55.86",
+                    "amount": "186.92",
                     "currency": "INR",
-                    "transaction_id": "757aa549-96b2-4b8b-8a54-f6f200b623fa"
+                    "transaction_id": "9bd3a22c-31c8-4455-a322-646de566f3cc"
                 },
                 "status": "PAID",
                 "type": "ON-ORDER",
@@ -153,15 +167,15 @@
             "quote": {
                 "breakup": [
                     {
-                        "@ondc/org/item_id": "6ff7768d-66dc-4ad3-a4b9-291c9eadfdb8",
+                        "@ondc/org/item_id": "a208c5d2-0598-4a73-80f6-eb79f0a7f425",
                         "@ondc/org/item_quantity": {
                             "count": 2
                         },
-                        "title": "Aashirvaad Salt,with 4-Step advantage, 1kg\r\n",
+                        "title": "Eastern Coriander Powder - Perfect Colour, Smell & Taste, 100 g Pouch",
                         "@ondc/org/title_type": "item",
                         "price": {
                             "currency": "INR",
-                            "value": "46.00"
+                            "value": "74.00"
                         },
                         "item": {
                             "quantity": {
@@ -174,7 +188,33 @@
                             },
                             "price": {
                                 "currency": "INR",
-                                "value": "23.00"
+                                "value": "37.00"
+                            }
+                        }
+                    },
+                    {
+                        "@ondc/org/item_id": "a687aab3-df94-4bf1-9639-1414995ff937",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
+                        },
+                        "title": "Britannia Treat Croissant - Vanilla Creme Filling, 100% Veg, Soft, 6x45 g Multipack",
+                        "@ondc/org/title_type": "item",
+                        "price": {
+                            "currency": "INR",
+                            "value": "105.60"
+                        },
+                        "item": {
+                            "quantity": {
+                                "available": {
+                                    "count": "3"
+                                },
+                                "maximum": {
+                                    "count": "3"
+                                }
+                            },
+                            "price": {
+                                "currency": "INR",
+                                "value": "105.60"
                             }
                         }
                     },
@@ -184,7 +224,7 @@
                         "@ondc/org/title_type": "delivery",
                         "price": {
                             "currency": "INR",
-                            "value": "7.95"
+                            "value": "0.93"
                         }
                     },
                     {
@@ -193,13 +233,13 @@
                         "@ondc/org/title_type": "misc",
                         "price": {
                             "currency": "INR",
-                            "value": "1.91"
+                            "value": "6.39"
                         }
                     }
                 ],
                 "price": {
                     "currency": "INR",
-                    "value": "55.86"
+                    "value": "186.92"
                 },
                 "ttl": "P1D"
             },
@@ -209,7 +249,7 @@
                     "list": [
                         {
                             "code": "tax_number",
-                            "value": "BUYER-APP-GSTN"
+                            "value": "29AAJCB5249A1ZR"
                         }
                     ]
                 },
@@ -218,13 +258,13 @@
                     "list": [
                         {
                             "code": "tax_number",
-                            "value": "BUYER-APP-GSTN"
+                            "value": "BUYER-APP-GSTN-ONDC"
                         }
                     ]
                 }
             ],
-            "created_at": "2023-10-27T19:24:38.758Z",
-            "updated_at": "2023-10-27T19:29:35.735Z"
+            "created_at": "2023-11-10T18:21:58.655Z",
+            "updated_at": "2023-11-10T18:23:53.093Z"
         }
     }
 }

--- a/ShopEG/With buyer-app-preprod-v2.ondc.org/Group A/Flow 3/select (remove out of stock item from cart).json
+++ b/ShopEG/With buyer-app-preprod-v2.ondc.org/Group A/Flow 3/select (remove out of stock item from cart).json
@@ -8,9 +8,9 @@
         "bap_id": "buyer-app-preprod-v2.ondc.org",
         "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
         "bpp_uri": "https://dev-api.shopeg.in/ondc/bpp",
-        "transaction_id": "757aa549-96b2-4b8b-8a54-f6f200b623fa",
-        "message_id": "a424c1dd-4b51-4d7e-8693-450bdaa3f8e4",
-        "timestamp": "2023-10-27T19:23:56.023Z",
+        "transaction_id": "9bd3a22c-31c8-4455-a322-646de566f3cc",
+        "message_id": "ec9a4379-74ac-486c-87d2-29957d1227db",
+        "timestamp": "2023-11-10T18:21:07.144Z",
         "bpp_id": "dev-api.shopeg.in",
         "ttl": "PT30S"
     },
@@ -18,9 +18,16 @@
         "order": {
             "items": [
                 {
-                    "id": "6ff7768d-66dc-4ad3-a4b9-291c9eadfdb8",
+                    "id": "a208c5d2-0598-4a73-80f6-eb79f0a7f425",
                     "quantity": {
                         "count": 2
+                    },
+                    "location_id": "6271"
+                },
+                {
+                    "id": "a687aab3-df94-4bf1-9639-1414995ff937",
+                    "quantity": {
+                        "count": 1
                     },
                     "location_id": "6271"
                 }
@@ -37,9 +44,9 @@
                 {
                     "end": {
                         "location": {
-                            "gps": "13.005504, 77.538237",
+                            "gps": "12.9937210000001, 77.5390140000001",
                             "address": {
-                                "area_code": "560086"
+                                "area_code": "560079"
                             }
                         }
                     }

--- a/ShopEG/With buyer-app-preprod-v2.ondc.org/Group A/Flow 3/select (with 1 out of stock item).json
+++ b/ShopEG/With buyer-app-preprod-v2.ondc.org/Group A/Flow 3/select (with 1 out of stock item).json
@@ -8,9 +8,9 @@
         "bap_id": "buyer-app-preprod-v2.ondc.org",
         "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
         "bpp_uri": "https://dev-api.shopeg.in/ondc/bpp",
-        "transaction_id": "c40b5bda-e8bc-4b6c-ad93-77be44b9e46f",
-        "message_id": "bea0463e-d767-4603-9234-0ef7c326db08",
-        "timestamp": "2023-10-27T19:23:16.673Z",
+        "transaction_id": "9bd3a22c-31c8-4455-a322-646de566f3cc",
+        "message_id": "4030ca8b-854d-4f43-a8a1-df72cb0dc2c4",
+        "timestamp": "2023-11-10T18:19:53.413Z",
         "bpp_id": "dev-api.shopeg.in",
         "ttl": "PT30S"
     },
@@ -18,16 +18,23 @@
         "order": {
             "items": [
                 {
-                    "id": "8fcb8ccd-0a60-49ad-8c08-cfd5f2c705fd",
+                    "id": "cdd75c83-28c4-4b20-a1f2-7695a04275f0",
                     "quantity": {
-                        "count": 1
+                        "count": 3
                     },
                     "location_id": "6271"
                 },
                 {
-                    "id": "6ff7768d-66dc-4ad3-a4b9-291c9eadfdb8",
+                    "id": "a208c5d2-0598-4a73-80f6-eb79f0a7f425",
                     "quantity": {
                         "count": 2
+                    },
+                    "location_id": "6271"
+                },
+                {
+                    "id": "a687aab3-df94-4bf1-9639-1414995ff937",
+                    "quantity": {
+                        "count": 1
                     },
                     "location_id": "6271"
                 }
@@ -44,9 +51,9 @@
                 {
                     "end": {
                         "location": {
-                            "gps": "13.005504, 77.538237",
+                            "gps": "13.000483926941195, 77.5379921271815",
                             "address": {
-                                "area_code": "560086"
+                                "area_code": "560079"
                             }
                         }
                     }


### PR DESCRIPTION
Re-uploaded all flows as per #92 

Except for the common payment fields, since reference buyer app doesn't send these fields. If buyer app sends them then it's included in our response.

```
/message/order/payment must have required property '@ondc/org/settlement_basis'
/message/order/payment must have required property '@ondc/org/settlement_window'
/message/order/payment must have required property '@ondc/org/withholding_amount'
```