### PR TITLE
corrected timestamp & remove bpp/descriptors from on_search_incremental

### DIFF
--- a/COSTBO/retail-v120-logs/flow1-corrected/on_search_corrected.json
+++ b/COSTBO/retail-v120-logs/flow1-corrected/on_search_corrected.json
@@ -1,0 +1,927 @@
+{
+    "context": {
+        "domain": "ONDC:RET10",
+        "country": "IND",
+        "city": "std:0124",
+        "action": "on_search",
+        "core_version": "1.2.0",
+        "bap_id": "buyer-app-preprod-v2.ondc.org",
+        "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+        "bpp_id": "ondcseller-staging.costbo.com",
+        "bpp_uri": "https://ondcseller-staging.costbo.com/ondc/",
+        "transaction_id": "f9eddac8-06c1-4dc2-8924-4b6eecd908b4",
+        "message_id": "9f09ea7c-f495-476c-a699-0080ffad828d",
+        "timestamp": "2023-12-01T02:00:57.417Z",
+        "ttl": "PT30S"
+    },
+    "message": {
+        "catalog": {
+            "bpp/fulfillments": [
+                {
+                    "id": "F1",
+                    "type": "Delivery"
+                },
+                {
+                    "id": "F2",
+                    "type": "Self-Pickup"
+                },
+                {
+                    "id": "F3",
+                    "type": "Delivery and Self-Pickup"
+                }
+            ],
+            "bpp/descriptor": {
+                "name": "COSTBO SERVICES",
+                "symbol": "https://storage.googleapis.com/bodefaults/ondc/backend/COSTBO-landscape-logo.png",
+                "images": [
+                    "https://storage.googleapis.com/bodefaults/ondc/backend/COSTBO-BOLD-NEW.jpg"
+                ],
+                "short_desc": "Everything you need to make Online & ONDC sales happen",
+                "long_desc": "Effortlessly manage Online and ONDC orders, WebStore, Integrated Logistics, Loyalty programs, CRM, Payments, Influencer marketing and more in one convenient NO-CODE application."
+            },
+            "bpp/providers": [
+                {
+                    "id": "536efe8f78cd45538f1a8b7d333f91fd",
+                    "time": {
+                        "label": "enable",
+                        "timestamp": "2023-12-01T02:00:57.417Z"
+                    },
+                    "fulfillments": [
+                        {
+                            "id": "F1",
+                            "type": "Delivery",
+                            "contact": {
+                                "phone": "9886098860",
+                                "email": "abc@xyz.com"
+                            }
+                        },
+                        {
+                            "id": "F2",
+                            "type": "Self-Pickup",
+                            "contact": {
+                                "phone": "9886098860",
+                                "email": "abc@xyz.com"
+                            }
+                        }
+                    ],
+                    "descriptor": {
+                        "name": "Vishful Creations",
+                        "code": "1:123412341234",
+                        "symbol": "https://storage.googleapis.com/bo3151920215/business/536efe8f78cd45538f1a8b7d333f91fd/logo.jpeg",
+                        "images": [
+                            "https://storage.googleapis.com/bo3151920215/business/536efe8f78cd45538f1a8b7d333f91fd/logo.jpeg"
+                        ],
+                        "short_desc": "Vishful Creations",
+                        "long_desc": "A place for exclusive collection of handmade jewelry for your every occasion. "
+                    },
+                    "ttl": "P1D",
+                    "locations": [
+                        {
+                            "id": "536efe8f78cd45538f1a8b7d333f91fd",
+                            "time": {
+                                "label": "enable",
+                                "timestamp": "2023-12-01T02:00:57.418Z",
+                                "days": "1,2,3,4,5,6,7",
+                                "schedule": {
+                                    "holidays": [
+                                        "2023-11-15",
+                                        "2023-11-16",
+                                        "2023-11-17",
+                                        "2023-11-18"
+                                    ],
+                                    "frequency": "PT18H6M",
+                                    "times": [
+                                        "0527"
+                                    ]
+                                }
+                            },
+                            "gps": "12.9202432632446,77.6953811645508",
+                            "address": {
+                                "locality": "5, Doddakannelli - Kaadubeesanahalli Rd, Adarsh Palm Retreat, Bhoganhalli, Bengaluru, Karnataka 560035, India",
+                                "street": "Bengaluru",
+                                "city": "Bengaluru",
+                                "area_code": "560103",
+                                "state": "KA"
+                            },
+                            "circle": {
+                                "gps": "12.9202432632446,77.6953811645508",
+                                "radius": {
+                                    "unit": "km",
+                                    "value": "3000"
+                                }
+                            }
+                        }
+                    ],
+                    "categories": [
+                        {
+                            "id": "V1",
+                            "descriptor": {
+                                "name": "Variant Group 1"
+                            },
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "variant_group"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ],
+                    "items": [
+                        {
+                            "id": "da1da524af79485eb95893cf5c98cc82",
+                            "time": {
+                                "label": "enable",
+                                "timestamp": "2023-12-01T02:00:57.418135681Z"
+                            },
+                            "descriptor": {
+                                "name": "Rakhi Pair",
+                                "code": "1:EAN",
+                                "symbol": "https://storage.googleapis.com/bo3151920215/business/536efe8f78cd45538f1a8b7d333f91fd/product/da1da524af79485eb95893cf5c98cc82/product1-SBIEwU.jpeg",
+                                "images": [
+                                    "https://storage.googleapis.com/bo3151920215/business/536efe8f78cd45538f1a8b7d333f91fd/product/da1da524af79485eb95893cf5c98cc82/product1-SBIEwU.jpeg"
+                                ],
+                                "short_desc": "Bhaiya-Bhabi Rakhi. Just Bhai Rakhi is also available",
+                                "long_desc": "Bhaiya-Bhabi Rakhi. Just Bhai Rakhi is also available"
+                            },
+                            "quantity": {
+                                "unitized": {
+                                    "measure": {
+                                        "unit": "kilogram",
+                                        "value": "1"
+                                    }
+                                },
+                                "available": {
+                                    "count": "99"
+                                },
+                                "maximum": {
+                                    "count": "99"
+                                }
+                            },
+                            "price": {
+                                "currency": "INR",
+                                "value": "400.0",
+                                "maximum_value": "450.0"
+                            },
+                            "tags": [
+                                {
+                                    "code": "origin",
+                                    "list": [
+                                        {
+                                            "code": "country",
+                                            "value": "IND"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "veg_nonveg",
+                                    "list": [
+                                        {
+                                            "code": "veg",
+                                            "value": "yes"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "parent_item_id": "da1da524af79485eb95893cf5c98cc82",
+                            "category_id": "Foodgrains",
+                            "fulfillment_id": "F1",
+                            "location_id": "536efe8f78cd45538f1a8b7d333f91fd",
+                            "@ondc/org/returnable": true,
+                            "@ondc/org/cancellable": true,
+                            "@ondc/org/return_window": "PT1H",
+                            "@ondc/org/seller_pickup_return": true,
+                            "@ondc/org/time_to_ship": "PT45M",
+                            "@ondc/org/available_on_cod": false,
+                            "@ondc/org/contact_details_consumer_care": "Ramesh,ramesh@abc.com,18004254444",
+                            "@ondc/org/statutory_reqs_packaged_commodities": {
+                                "manufacturer_or_packer_name": "ITC",
+                                "manufacturer_or_packer_address": "ITC Quality Care Cell,P.O Box No.592,Bangalore-560005",
+                                "common_or_generic_name_of_commodity": "Ashirwad Atta",
+                                "month_year_of_manufacture_packing_import": "01/2023"
+                            },
+                            "@ondc/org/statutory_reqs_prepackaged_food": {
+                                "nutritional_info": "Energy(KCal)-(per 100kg) 420,(per serving 50g)250;Protein(g)-(per 100kg) 12,(per serving 50g) 6",
+                                "additives_info": "Preservatives,Artificial Colours",
+                                "brand_owner_FSSAI_license_no": "12345678901234",
+                                "other_FSSAI_license_no": "12345678901234",
+                                "importer_FSSAI_license_no": "12345678901234"
+                            }
+                        },
+                        {
+                            "id": "e5206e0fca32485cac677f4f9eba7e86",
+                            "time": {
+                                "label": "enable",
+                                "timestamp": "2023-12-01T02:00:57.418139729Z"
+                            },
+                            "descriptor": {
+                                "name": "Meena Bead Rakhi....",
+                                "code": "1:EAN",
+                                "symbol": "https://storage.googleapis.com/bo3151920215/business/536efe8f78cd45538f1a8b7d333f91fd/product/e5206e0fca32485cac677f4f9eba7e86/Product1-176497.jpeg",
+                                "images": [
+                                    "https://storage.googleapis.com/bo3151920215/business/536efe8f78cd45538f1a8b7d333f91fd/product/e5206e0fca32485cac677f4f9eba7e86/Product1-176497.jpeg"
+                                ],
+                                "short_desc": "Silk thread hook jhumka",
+                                "long_desc": "Silk thread hook jhumka"
+                            },
+                            "quantity": {
+                                "unitized": {
+                                    "measure": {
+                                        "unit": "kilogram",
+                                        "value": "1"
+                                    }
+                                },
+                                "available": {
+                                    "count": "99"
+                                },
+                                "maximum": {
+                                    "count": "99"
+                                }
+                            },
+                            "price": {
+                                "currency": "INR",
+                                "value": "220.0",
+                                "maximum_value": "225.0"
+                            },
+                            "tags": [
+                                {
+                                    "code": "origin",
+                                    "list": [
+                                        {
+                                            "code": "country",
+                                            "value": "IND"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "veg_nonveg",
+                                    "list": [
+                                        {
+                                            "code": "veg",
+                                            "value": "yes"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "parent_item_id": "e5206e0fca32485cac677f4f9eba7e86",
+                            "category_id": "Foodgrains",
+                            "fulfillment_id": "F1",
+                            "location_id": "536efe8f78cd45538f1a8b7d333f91fd",
+                            "@ondc/org/returnable": true,
+                            "@ondc/org/cancellable": true,
+                            "@ondc/org/return_window": "PT1H",
+                            "@ondc/org/seller_pickup_return": true,
+                            "@ondc/org/time_to_ship": "PT45M",
+                            "@ondc/org/available_on_cod": false,
+                            "@ondc/org/contact_details_consumer_care": "Ramesh,ramesh@abc.com,18004254444",
+                            "@ondc/org/statutory_reqs_packaged_commodities": {
+                                "manufacturer_or_packer_name": "ITC",
+                                "manufacturer_or_packer_address": "ITC Quality Care Cell,P.O Box No.592,Bangalore-560005",
+                                "common_or_generic_name_of_commodity": "Ashirwad Atta",
+                                "month_year_of_manufacture_packing_import": "01/2023"
+                            },
+                            "@ondc/org/statutory_reqs_prepackaged_food": {
+                                "nutritional_info": "Energy(KCal)-(per 100kg) 420,(per serving 50g)250;Protein(g)-(per 100kg) 12,(per serving 50g) 6",
+                                "additives_info": "Preservatives,Artificial Colours",
+                                "brand_owner_FSSAI_license_no": "12345678901234",
+                                "other_FSSAI_license_no": "12345678901234",
+                                "importer_FSSAI_license_no": "12345678901234"
+                            }
+                        },
+                        {
+                            "id": "bedfd446cd984428899ea6757c29ea0d",
+                            "time": {
+                                "label": "enable",
+                                "timestamp": "2023-12-01T02:00:57.418142285Z"
+                            },
+                            "descriptor": {
+                                "name": "Blue Thread Rakhi with pearls",
+                                "code": "1:EAN",
+                                "symbol": "https://storage.googleapis.com/bo3151920215/business/536efe8f78cd45538f1a8b7d333f91fd/product/bedfd446cd984428899ea6757c29ea0d/Product1-880173.jpeg",
+                                "images": [
+                                    "https://storage.googleapis.com/bo3151920215/business/536efe8f78cd45538f1a8b7d333f91fd/product/bedfd446cd984428899ea6757c29ea0d/Product1-880173.jpeg"
+                                ],
+                                "short_desc": "Blue Thread Rakhi with pearls",
+                                "long_desc": "Blue Thread Rakhi with pearls"
+                            },
+                            "quantity": {
+                                "unitized": {
+                                    "measure": {
+                                        "unit": "kilogram",
+                                        "value": "1"
+                                    }
+                                },
+                                "available": {
+                                    "count": "99"
+                                },
+                                "maximum": {
+                                    "count": "99"
+                                }
+                            },
+                            "price": {
+                                "currency": "INR",
+                                "value": "10.0",
+                                "maximum_value": "50.0"
+                            },
+                            "tags": [
+                                {
+                                    "code": "origin",
+                                    "list": [
+                                        {
+                                            "code": "country",
+                                            "value": "IND"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "veg_nonveg",
+                                    "list": [
+                                        {
+                                            "code": "veg",
+                                            "value": "yes"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "parent_item_id": "bedfd446cd984428899ea6757c29ea0d",
+                            "category_id": "Foodgrains",
+                            "fulfillment_id": "F1",
+                            "location_id": "536efe8f78cd45538f1a8b7d333f91fd",
+                            "@ondc/org/returnable": true,
+                            "@ondc/org/cancellable": true,
+                            "@ondc/org/return_window": "PT1H",
+                            "@ondc/org/seller_pickup_return": true,
+                            "@ondc/org/time_to_ship": "PT45M",
+                            "@ondc/org/available_on_cod": false,
+                            "@ondc/org/contact_details_consumer_care": "Ramesh,ramesh@abc.com,18004254444",
+                            "@ondc/org/statutory_reqs_packaged_commodities": {
+                                "manufacturer_or_packer_name": "ITC",
+                                "manufacturer_or_packer_address": "ITC Quality Care Cell,P.O Box No.592,Bangalore-560005",
+                                "common_or_generic_name_of_commodity": "Ashirwad Atta",
+                                "month_year_of_manufacture_packing_import": "01/2023"
+                            },
+                            "@ondc/org/statutory_reqs_prepackaged_food": {
+                                "nutritional_info": "Energy(KCal)-(per 100kg) 420,(per serving 50g)250;Protein(g)-(per 100kg) 12,(per serving 50g) 6",
+                                "additives_info": "Preservatives,Artificial Colours",
+                                "brand_owner_FSSAI_license_no": "12345678901234",
+                                "other_FSSAI_license_no": "12345678901234",
+                                "importer_FSSAI_license_no": "12345678901234"
+                            }
+                        },
+                        {
+                            "id": "c978d75a72c747a1a4469841b2380d4d",
+                            "time": {
+                                "label": "enable",
+                                "timestamp": "2023-12-01T02:00:57.418235820Z"
+                            },
+                            "descriptor": {
+                                "name": "Rakhi a set",
+                                "code": "1:EAN",
+                                "symbol": "https://storage.googleapis.com/bo3151920215/business/536efe8f78cd45538f1a8b7d333f91fd/product/c978d75a72c747a1a4469841b2380d4d/product1-nac2TI.jpeg",
+                                "images": [
+                                    "https://storage.googleapis.com/bo3151920215/business/536efe8f78cd45538f1a8b7d333f91fd/product/c978d75a72c747a1a4469841b2380d4d/product1-nac2TI.jpeg",
+                                    "https://storage.googleapis.com/bo3151920215/business/536efe8f78cd45538f1a8b7d333f91fd/product/c978d75a72c747a1a4469841b2380d4d/Product2-137194.jpeg"
+                                ],
+                                "short_desc": "Rakhi with golden metal beads and agate beads. Customisable colours.2",
+                                "long_desc": "Rakhi with golden metal beads and agate beads. Customisable colours.2"
+                            },
+                            "quantity": {
+                                "unitized": {
+                                    "measure": {
+                                        "unit": "kilogram",
+                                        "value": "1"
+                                    }
+                                },
+                                "available": {
+                                    "count": "99"
+                                },
+                                "maximum": {
+                                    "count": "99"
+                                }
+                            },
+                            "price": {
+                                "currency": "INR",
+                                "value": "300.0",
+                                "maximum_value": "300.0"
+                            },
+                            "tags": [
+                                {
+                                    "code": "origin",
+                                    "list": [
+                                        {
+                                            "code": "country",
+                                            "value": "IND"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "veg_nonveg",
+                                    "list": [
+                                        {
+                                            "code": "veg",
+                                            "value": "yes"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "parent_item_id": "c978d75a72c747a1a4469841b2380d4d",
+                            "category_id": "Foodgrains",
+                            "fulfillment_id": "F1",
+                            "location_id": "536efe8f78cd45538f1a8b7d333f91fd",
+                            "@ondc/org/returnable": true,
+                            "@ondc/org/cancellable": true,
+                            "@ondc/org/return_window": "PT1H",
+                            "@ondc/org/seller_pickup_return": true,
+                            "@ondc/org/time_to_ship": "PT45M",
+                            "@ondc/org/available_on_cod": false,
+                            "@ondc/org/contact_details_consumer_care": "Ramesh,ramesh@abc.com,18004254444",
+                            "@ondc/org/statutory_reqs_packaged_commodities": {
+                                "manufacturer_or_packer_name": "ITC",
+                                "manufacturer_or_packer_address": "ITC Quality Care Cell,P.O Box No.592,Bangalore-560005",
+                                "common_or_generic_name_of_commodity": "Ashirwad Atta",
+                                "month_year_of_manufacture_packing_import": "01/2023"
+                            },
+                            "@ondc/org/statutory_reqs_prepackaged_food": {
+                                "nutritional_info": "Energy(KCal)-(per 100kg) 420,(per serving 50g)250;Protein(g)-(per 100kg) 12,(per serving 50g) 6",
+                                "additives_info": "Preservatives,Artificial Colours",
+                                "brand_owner_FSSAI_license_no": "12345678901234",
+                                "other_FSSAI_license_no": "12345678901234",
+                                "importer_FSSAI_license_no": "12345678901234"
+                            }
+                        },
+                        {
+                            "id": "6842a112bb32424a801a22c4bcd1f62e",
+                            "time": {
+                                "label": "enable",
+                                "timestamp": "2023-12-01T02:00:57.418244189Z"
+                            },
+                            "descriptor": {
+                                "name": "Red Rakhi set.",
+                                "code": "1:EAN",
+                                "symbol": "https://storage.googleapis.com/bo3151920215/business/536efe8f78cd45538f1a8b7d333f91fd/product/02f6e0d65f554f09a05a89d7d11dde5d/product1-6bIS14.jpeg",
+                                "images": [
+                                    "https://storage.googleapis.com/bo3151920215/business/536efe8f78cd45538f1a8b7d333f91fd/product/02f6e0d65f554f09a05a89d7d11dde5d/product1-6bIS14.jpeg",
+                                    "https://storage.googleapis.com/bo3151920215/business/536efe8f78cd45538f1a8b7d333f91fd/product/02f6e0d65f554f09a05a89d7d11dde5d/Product2-427947.jpeg"
+                                ],
+                                "short_desc": "Silk thread hook jhumka",
+                                "long_desc": "Silk thread hook jhumka"
+                            },
+                            "quantity": {
+                                "unitized": {
+                                    "measure": {
+                                        "unit": "kilogram",
+                                        "value": "1"
+                                    }
+                                },
+                                "available": {
+                                    "count": "99"
+                                },
+                                "maximum": {
+                                    "count": "99"
+                                }
+                            },
+                            "price": {
+                                "currency": "INR",
+                                "value": "220.0",
+                                "maximum_value": "225.0"
+                            },
+                            "tags": [
+                                {
+                                    "code": "origin",
+                                    "list": [
+                                        {
+                                            "code": "country",
+                                            "value": "IND"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "veg_nonveg",
+                                    "list": [
+                                        {
+                                            "code": "veg",
+                                            "value": "yes"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "parent_item_id": "6842a112bb32424a801a22c4bcd1f62e",
+                            "category_id": "Foodgrains",
+                            "fulfillment_id": "F1",
+                            "location_id": "536efe8f78cd45538f1a8b7d333f91fd",
+                            "@ondc/org/returnable": true,
+                            "@ondc/org/cancellable": true,
+                            "@ondc/org/return_window": "PT1H",
+                            "@ondc/org/seller_pickup_return": true,
+                            "@ondc/org/time_to_ship": "PT45M",
+                            "@ondc/org/available_on_cod": false,
+                            "@ondc/org/contact_details_consumer_care": "Ramesh,ramesh@abc.com,18004254444",
+                            "@ondc/org/statutory_reqs_packaged_commodities": {
+                                "manufacturer_or_packer_name": "ITC",
+                                "manufacturer_or_packer_address": "ITC Quality Care Cell,P.O Box No.592,Bangalore-560005",
+                                "common_or_generic_name_of_commodity": "Ashirwad Atta",
+                                "month_year_of_manufacture_packing_import": "01/2023"
+                            },
+                            "@ondc/org/statutory_reqs_prepackaged_food": {
+                                "nutritional_info": "Energy(KCal)-(per 100kg) 420,(per serving 50g)250;Protein(g)-(per 100kg) 12,(per serving 50g) 6",
+                                "additives_info": "Preservatives,Artificial Colours",
+                                "brand_owner_FSSAI_license_no": "12345678901234",
+                                "other_FSSAI_license_no": "12345678901234",
+                                "importer_FSSAI_license_no": "12345678901234"
+                            }
+                        },
+                        {
+                            "id": "72a0cf4bde1a4220aa6baf02f350e213",
+                            "time": {
+                                "label": "enable",
+                                "timestamp": "2023-12-01T02:00:57.418246963Z"
+                            },
+                            "descriptor": {
+                                "name": "pearl and blue rakhi",
+                                "code": "1:EAN",
+                                "symbol": "https://storage.googleapis.com/bo3151920215/business/536efe8f78cd45538f1a8b7d333f91fd/product/72a0cf4bde1a4220aa6baf02f350e213/Product1-584128.jpeg",
+                                "images": [
+                                    "https://storage.googleapis.com/bo3151920215/business/536efe8f78cd45538f1a8b7d333f91fd/product/72a0cf4bde1a4220aa6baf02f350e213/Product1-584128.jpeg",
+                                    "https://storage.googleapis.com/bo3151920215/business/536efe8f78cd45538f1a8b7d333f91fd/product/72a0cf4bde1a4220aa6baf02f350e213/product4-45680.jpeg"
+                                ],
+                                "short_desc": "pearl and blue rakhi",
+                                "long_desc": "pearl and blue rakhi"
+                            },
+                            "quantity": {
+                                "unitized": {
+                                    "measure": {
+                                        "unit": "kilogram",
+                                        "value": "1"
+                                    }
+                                },
+                                "available": {
+                                    "count": "99"
+                                },
+                                "maximum": {
+                                    "count": "99"
+                                }
+                            },
+                            "price": {
+                                "currency": "INR",
+                                "value": "45.0",
+                                "maximum_value": "50.0"
+                            },
+                            "tags": [
+                                {
+                                    "code": "origin",
+                                    "list": [
+                                        {
+                                            "code": "country",
+                                            "value": "IND"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "veg_nonveg",
+                                    "list": [
+                                        {
+                                            "code": "veg",
+                                            "value": "yes"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "parent_item_id": "72a0cf4bde1a4220aa6baf02f350e213",
+                            "category_id": "Foodgrains",
+                            "fulfillment_id": "F1",
+                            "location_id": "536efe8f78cd45538f1a8b7d333f91fd",
+                            "@ondc/org/returnable": true,
+                            "@ondc/org/cancellable": true,
+                            "@ondc/org/return_window": "PT1H",
+                            "@ondc/org/seller_pickup_return": true,
+                            "@ondc/org/time_to_ship": "PT45M",
+                            "@ondc/org/available_on_cod": false,
+                            "@ondc/org/contact_details_consumer_care": "Ramesh,ramesh@abc.com,18004254444",
+                            "@ondc/org/statutory_reqs_packaged_commodities": {
+                                "manufacturer_or_packer_name": "ITC",
+                                "manufacturer_or_packer_address": "ITC Quality Care Cell,P.O Box No.592,Bangalore-560005",
+                                "common_or_generic_name_of_commodity": "Ashirwad Atta",
+                                "month_year_of_manufacture_packing_import": "01/2023"
+                            },
+                            "@ondc/org/statutory_reqs_prepackaged_food": {
+                                "nutritional_info": "Energy(KCal)-(per 100kg) 420,(per serving 50g)250;Protein(g)-(per 100kg) 12,(per serving 50g) 6",
+                                "additives_info": "Preservatives,Artificial Colours",
+                                "brand_owner_FSSAI_license_no": "12345678901234",
+                                "other_FSSAI_license_no": "12345678901234",
+                                "importer_FSSAI_license_no": "12345678901234"
+                            }
+                        },
+                        {
+                            "id": "4cbdd9c08c614d39884e40b1dd279341",
+                            "time": {
+                                "label": "enable",
+                                "timestamp": "2023-12-01T02:00:57.418249697Z"
+                            },
+                            "descriptor": {
+                                "name": "Red Rakhi set",
+                                "code": "1:EAN",
+                                "symbol": "https://storage.googleapis.com/bo3151920215/business/536efe8f78cd45538f1a8b7d333f91fd/product/02f6e0d65f554f09a05a89d7d11dde5d/product1-6bIS14.jpeg",
+                                "images": [
+                                    "https://storage.googleapis.com/bo3151920215/business/536efe8f78cd45538f1a8b7d333f91fd/product/02f6e0d65f554f09a05a89d7d11dde5d/product1-6bIS14.jpeg",
+                                    "https://storage.googleapis.com/bo3151920215/business/536efe8f78cd45538f1a8b7d333f91fd/product/02f6e0d65f554f09a05a89d7d11dde5d/Product2-427947.jpeg",
+                                    "https://storage.googleapis.com/bo3151920215/business/536efe8f78cd45538f1a8b7d333f91fd/product/02f6e0d65f554f09a05a89d7d11dde5d/product4-45680.jpeg"
+                                ],
+                                "short_desc": "Silk thread hook jhumka",
+                                "long_desc": "Silk thread hook jhumka"
+                            },
+                            "quantity": {
+                                "unitized": {
+                                    "measure": {
+                                        "unit": "kilogram",
+                                        "value": "1"
+                                    }
+                                },
+                                "available": {
+                                    "count": "99"
+                                },
+                                "maximum": {
+                                    "count": "99"
+                                }
+                            },
+                            "price": {
+                                "currency": "INR",
+                                "value": "220.0",
+                                "maximum_value": "225.0"
+                            },
+                            "tags": [
+                                {
+                                    "code": "origin",
+                                    "list": [
+                                        {
+                                            "code": "country",
+                                            "value": "IND"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "veg_nonveg",
+                                    "list": [
+                                        {
+                                            "code": "veg",
+                                            "value": "yes"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "parent_item_id": "4cbdd9c08c614d39884e40b1dd279341",
+                            "category_id": "Foodgrains",
+                            "fulfillment_id": "F1",
+                            "location_id": "536efe8f78cd45538f1a8b7d333f91fd",
+                            "@ondc/org/returnable": true,
+                            "@ondc/org/cancellable": true,
+                            "@ondc/org/return_window": "PT1H",
+                            "@ondc/org/seller_pickup_return": true,
+                            "@ondc/org/time_to_ship": "PT45M",
+                            "@ondc/org/available_on_cod": false,
+                            "@ondc/org/contact_details_consumer_care": "Ramesh,ramesh@abc.com,18004254444",
+                            "@ondc/org/statutory_reqs_packaged_commodities": {
+                                "manufacturer_or_packer_name": "ITC",
+                                "manufacturer_or_packer_address": "ITC Quality Care Cell,P.O Box No.592,Bangalore-560005",
+                                "common_or_generic_name_of_commodity": "Ashirwad Atta",
+                                "month_year_of_manufacture_packing_import": "01/2023"
+                            },
+                            "@ondc/org/statutory_reqs_prepackaged_food": {
+                                "nutritional_info": "Energy(KCal)-(per 100kg) 420,(per serving 50g)250;Protein(g)-(per 100kg) 12,(per serving 50g) 6",
+                                "additives_info": "Preservatives,Artificial Colours",
+                                "brand_owner_FSSAI_license_no": "12345678901234",
+                                "other_FSSAI_license_no": "12345678901234",
+                                "importer_FSSAI_license_no": "12345678901234"
+                            }
+                        }
+                    ],
+                    "tags": [
+                        {
+                            "code": "serviceability",
+                            "list": [
+                                {
+                                    "code": "location",
+                                    "value": "536efe8f78cd45538f1a8b7d333f91fd"
+                                },
+                                {
+                                    "code": "category",
+                                    "value": "Foodgrains"
+                                },
+                                {
+                                    "code": "type",
+                                    "value": "10"
+                                },
+                                {
+                                    "code": "val",
+                                    "value": "3000"
+                                },
+                                {
+                                    "code": "unit",
+                                    "value": "km"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "id": "7bf9b561199f4a898b3f8a3cef91b6e6",
+                    "time": {
+                        "label": "enable",
+                        "timestamp": "2023-12-01T02:00:57.417Z"
+                    },
+                    "fulfillments": [
+                        {
+                            "id": "F1",
+                            "type": "Delivery",
+                            "contact": {
+                                "phone": "9886098860",
+                                "email": "abc@xyz.com"
+                            }
+                        },
+                        {
+                            "id": "F2",
+                            "type": "Self-Pickup",
+                            "contact": {
+                                "phone": "9886098860",
+                                "email": "abc@xyz.com"
+                            }
+                        }
+                    ],
+                    "descriptor": {
+                        "name": "Himachal Jams",
+                        "code": "1:123412341234",
+                        "symbol": "https://storage.googleapis.com/bo3151920215/business/7bf9b561199f4a898b3f8a3cef91b6e6/logo.jpeg",
+                        "images": [
+                            "https://storage.googleapis.com/bo3151920215/business/7bf9b561199f4a898b3f8a3cef91b6e6/logo.jpeg"
+                        ],
+                        "short_desc": "Himachal Jams",
+                        "long_desc": "Himachal Jams was started up in the year 2010, with the idea of developing fresh, handcrafted jams & jellies filled with the goodness of local fruit in the small village of Himachal Pradesh.\n\nMade by Happy Mountain women who take great pride in their work, we bring the flavour and romance of the mountains to your table. The fruit used is always the freshest and the very best. Wherever possible, our jams are made from organically grown, sometimes even home-grown fruit. Hand -picked, it is carefully sorted and meticulously cut.\n\nThe process used is very labour intensive but this is our USP – Each bottle of our jams is a preservative free, home-made taste, full of fruit and natural goodness.\n"
+                    },
+                    "ttl": "P1D",
+                    "locations": [
+                        {
+                            "id": "7bf9b561199f4a898b3f8a3cef91b6e6",
+                            "time": {
+                                "label": "enable",
+                                "timestamp": "2023-12-01T02:00:57.418Z",
+                                "days": "1,2,3,4,5,6,7",
+                                "range": {
+                                    "start": "0000",
+                                    "end": "2359"
+                                }
+                            },
+                            "gps": "30.8862736,77.3094674",
+                            "address": {
+                                "locality": "Main Bazaar, Sirmour District, Rajgarh",
+                                "street": "",
+                                "city": "Rajgarh",
+                                "area_code": "173101",
+                                "state": "KA"
+                            },
+                            "circle": {
+                                "gps": "30.8862736,77.3094674",
+                                "radius": {
+                                    "unit": "km",
+                                    "value": "3000"
+                                }
+                            }
+                        }
+                    ],
+                    "categories": [
+                        {
+                            "id": "V1",
+                            "descriptor": {
+                                "name": "Variant Group 1"
+                            },
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "variant_group"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ],
+                    "items": [
+                        {
+                            "id": "3a9ae21051844ca28970db24b28cf818",
+                            "time": {
+                                "label": "enable",
+                                "timestamp": "2023-12-01T02:00:57.418343239Z"
+                            },
+                            "descriptor": {
+                                "name": "Bhuira Apple Cinnamon Jelly 470g - With Rakhi as a gift",
+                                "code": "1:EAN",
+                                "symbol": "https://storage.googleapis.com/bo3151920215/business/7bf9b561199f4a898b3f8a3cef91b6e6/product/3a9ae21051844ca28970db24b28cf818/Product1-450146.jpeg",
+                                "images": [
+                                    "https://storage.googleapis.com/bo3151920215/business/7bf9b561199f4a898b3f8a3cef91b6e6/product/3a9ae21051844ca28970db24b28cf818/Product1-450146.jpeg",
+                                    "https://storage.googleapis.com/bo3151920215/business/7bf9b561199f4a898b3f8a3cef91b6e6/product/3a9ae21051844ca28970db24b28cf818/Product2-653421.jpeg",
+                                    "https://storage.googleapis.com/bo3151920215/business/7bf9b561199f4a898b3f8a3cef91b6e6/product/3a9ae21051844ca28970db24b28cf818/Product3-607291.jpeg"
+                                ],
+                                "short_desc": "Jelly is a more sophisticated form which involves a two-step process of first boiling fruit to extract juice and then boiling the pure juice till it sets into a clear jelly. Apple Cinnamon is our favourite spread over Waffles, Scones or Pancakes made from the juice of Himachal Apples. Also serves as an exotic ingredient in Bakes, Apple Cinnamon bars or in a cake. Can be drizzled over muesli or cornflakes to make your breakfast a treat.",
+                                "long_desc": "Jelly is a more sophisticated form which involves a two-step process of first boiling fruit to extract juice and then boiling the pure juice till it sets into a clear jelly. Apple Cinnamon is our favourite spread over Waffles, Scones or Pancakes made from the juice of Himachal Apples. Also serves as an exotic ingredient in Bakes, Apple Cinnamon bars or in a cake. Can be drizzled over muesli or cornflakes to make your breakfast a treat."
+                            },
+                            "quantity": {
+                                "unitized": {
+                                    "measure": {
+                                        "unit": "kilogram",
+                                        "value": "1"
+                                    }
+                                },
+                                "available": {
+                                    "count": "99"
+                                },
+                                "maximum": {
+                                    "count": "99"
+                                }
+                            },
+                            "price": {
+                                "currency": "INR",
+                                "value": "849.0",
+                                "maximum_value": "1300.0"
+                            },
+                            "tags": [
+                                {
+                                    "code": "origin",
+                                    "list": [
+                                        {
+                                            "code": "country",
+                                            "value": "IND"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "veg_nonveg",
+                                    "list": [
+                                        {
+                                            "code": "veg",
+                                            "value": "yes"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "parent_item_id": "3a9ae21051844ca28970db24b28cf818",
+                            "category_id": "Foodgrains",
+                            "fulfillment_id": "F1",
+                            "location_id": "7bf9b561199f4a898b3f8a3cef91b6e6",
+                            "@ondc/org/returnable": true,
+                            "@ondc/org/cancellable": true,
+                            "@ondc/org/return_window": "PT1H",
+                            "@ondc/org/seller_pickup_return": true,
+                            "@ondc/org/time_to_ship": "PT45M",
+                            "@ondc/org/available_on_cod": false,
+                            "@ondc/org/contact_details_consumer_care": "Ramesh,ramesh@abc.com,18004254444",
+                            "@ondc/org/statutory_reqs_packaged_commodities": {
+                                "manufacturer_or_packer_name": "ITC",
+                                "manufacturer_or_packer_address": "ITC Quality Care Cell,P.O Box No.592,Bangalore-560005",
+                                "common_or_generic_name_of_commodity": "Ashirwad Atta",
+                                "month_year_of_manufacture_packing_import": "01/2023"
+                            },
+                            "@ondc/org/statutory_reqs_prepackaged_food": {
+                                "nutritional_info": "Energy(KCal)-(per 100kg) 420,(per serving 50g)250;Protein(g)-(per 100kg) 12,(per serving 50g) 6",
+                                "additives_info": "Preservatives,Artificial Colours",
+                                "brand_owner_FSSAI_license_no": "12345678901234",
+                                "other_FSSAI_license_no": "12345678901234",
+                                "importer_FSSAI_license_no": "12345678901234"
+                            }
+                        }
+                    ],
+                    "tags": [
+                        {
+                            "code": "serviceability",
+                            "list": [
+                                {
+                                    "code": "location",
+                                    "value": "536efe8f78cd45538f1a8b7d333f91fd"
+                                },
+                                {
+                                    "code": "category",
+                                    "value": "Foodgrains"
+                                },
+                                {
+                                    "code": "type",
+                                    "value": "10"
+                                },
+                                {
+                                    "code": "val",
+                                    "value": "3000"
+                                },
+                                {
+                                    "code": "unit",
+                                    "value": "km"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }
+    }
+}

--- a/COSTBO/retail-v120-logs/flow1-corrected/on_search_incremental_corrected.json
+++ b/COSTBO/retail-v120-logs/flow1-corrected/on_search_incremental_corrected.json
@@ -1,0 +1,202 @@
+{
+    "context": {
+        "domain": "ONDC:RET10",
+        "country": "IND",
+        "city": "*",
+        "action": "on_search",
+        "core_version": "1.2.0",
+        "bap_id": "buyer-app-preprod-v2.ondc.org",
+        "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+        "bpp_id": "ondcseller-staging.costbo.com",
+        "bpp_uri": "https://ondcseller-staging.costbo.com/ondc/",
+        "transaction_id": "e0fd9dc5-4e99-4cd2-8c42-987e0cd2fb61",
+        "message_id": "ad9e9dc7-28b0-4275-9d52-f956934547d5",
+        "timestamp": "2023-11-30T19:31:47.077Z",
+        "ttl": "PT30S"
+    },
+    "message": {
+        "catalog": {
+            "bpp/providers": [
+                {
+                    "id": "536efe8f78cd45538f1a8b7d333f91fd",
+                    "fulfillments": [],
+                    "locations": [],
+                    "categories": [],
+                    "items": [
+                        {
+                            "id": "da1da524af79485eb95893cf5c98cc82",
+                            "time": {
+                                "label": "enable",
+                                "timestamp": "2023-11-30T19:31:47.080Z"
+                            },
+                            "descriptor": {
+                                "name": "Rakhi Pair-new",
+                                "code": "1:EAN",
+                                "symbol": "https://storage.googleapis.com/bo3151920215/business/536efe8f78cd45538f1a8b7d333f91fd/product/da1da524af79485eb95893cf5c98cc82/product1-SBIEwU.jpeg",
+                                "images": [
+                                    "https://storage.googleapis.com/bo3151920215/business/536efe8f78cd45538f1a8b7d333f91fd/product/da1da524af79485eb95893cf5c98cc82/product1-SBIEwU.jpeg"
+                                ],
+                                "short_desc": "Bhaiya-Bhabi Rakhi. Just Bhai Rakhi is also available",
+                                "long_desc": "Bhaiya-Bhabi Rakhi. Just Bhai Rakhi is also available"
+                            },
+                            "quantity": {
+                                "unitized": {
+                                    "measure": {
+                                        "unit": "kilogram",
+                                        "value": "1"
+                                    }
+                                },
+                                "available": {
+                                    "count": "99"
+                                },
+                                "maximum": {
+                                    "count": "99"
+                                }
+                            },
+                            "price": {
+                                "currency": "INR",
+                                "value": "401.0",
+                                "maximum_value": "451.0"
+                            },
+                            "tags": [
+                                {
+                                    "code": "origin",
+                                    "list": [
+                                        {
+                                            "code": "country",
+                                            "value": "IND"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "veg_nonveg",
+                                    "list": [
+                                        {
+                                            "code": "veg",
+                                            "value": "yes"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "parent_item_id": "da1da524af79485eb95893cf5c98cc82",
+                            "category_id": "Foodgrains",
+                            "fulfillment_id": "F1",
+                            "location_id": "536efe8f78cd45538f1a8b7d333f91fd",
+                            "@ondc/org/returnable": true,
+                            "@ondc/org/cancellable": true,
+                            "@ondc/org/return_window": "PT1H",
+                            "@ondc/org/seller_pickup_return": true,
+                            "@ondc/org/time_to_ship": "PT45M",
+                            "@ondc/org/available_on_cod": false,
+                            "@ondc/org/contact_details_consumer_care": "Ramesh,ramesh@abc.com,18004254444",
+                            "@ondc/org/statutory_reqs_packaged_commodities": {
+                                "manufacturer_or_packer_name": "ITC",
+                                "manufacturer_or_packer_address": "ITC Quality Care Cell,P.O Box No.592,Bangalore-560005",
+                                "common_or_generic_name_of_commodity": "Ashirwad Atta",
+                                "month_year_of_manufacture_packing_import": "01/2023"
+                            },
+                            "@ondc/org/statutory_reqs_prepackaged_food": {
+                                "nutritional_info": "Energy(KCal)-(per 100kg) 420,(per serving 50g)250;Protein(g)-(per 100kg) 12,(per serving 50g) 6",
+                                "additives_info": "Preservatives,Artificial Colours",
+                                "brand_owner_FSSAI_license_no": "12345678901234",
+                                "other_FSSAI_license_no": "12345678901234",
+                                "importer_FSSAI_license_no": "12345678901234"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "id": "7bf9b561199f4a898b3f8a3cef91b6e6",
+                    "fulfillments": [],
+                    "locations": [],
+                    "categories": [],
+                    "items": [
+                        {
+                            "id": "3a9ae21051844ca28970db24b28cf818",
+                            "time": {
+                                "label": "enable",
+                                "timestamp": "2023-11-30T19:31:47.080Z"
+                            },
+                            "descriptor": {
+                                "name": "Bhuira Apple Cinnamon Jelly 470g - With Rakhi as a gift-new",
+                                "code": "1:EAN",
+                                "symbol": "https://storage.googleapis.com/bo3151920215/business/7bf9b561199f4a898b3f8a3cef91b6e6/product/3a9ae21051844ca28970db24b28cf818/Product1-450146.jpeg",
+                                "images": [
+                                    "https://storage.googleapis.com/bo3151920215/business/7bf9b561199f4a898b3f8a3cef91b6e6/product/3a9ae21051844ca28970db24b28cf818/Product1-450146.jpeg",
+                                    "https://storage.googleapis.com/bo3151920215/business/7bf9b561199f4a898b3f8a3cef91b6e6/product/3a9ae21051844ca28970db24b28cf818/Product2-653421.jpeg",
+                                    "https://storage.googleapis.com/bo3151920215/business/7bf9b561199f4a898b3f8a3cef91b6e6/product/3a9ae21051844ca28970db24b28cf818/Product3-607291.jpeg"
+                                ],
+                                "short_desc": "Jelly is a more sophisticated form which involves a two-step process of first boiling fruit to extract juice and then boiling the pure juice till it sets into a clear jelly. Apple Cinnamon is our favourite spread over Waffles, Scones or Pancakes made from the juice of Himachal Apples. Also serves as an exotic ingredient in Bakes, Apple Cinnamon bars or in a cake. Can be drizzled over muesli or cornflakes to make your breakfast a treat.",
+                                "long_desc": "Jelly is a more sophisticated form which involves a two-step process of first boiling fruit to extract juice and then boiling the pure juice till it sets into a clear jelly. Apple Cinnamon is our favourite spread over Waffles, Scones or Pancakes made from the juice of Himachal Apples. Also serves as an exotic ingredient in Bakes, Apple Cinnamon bars or in a cake. Can be drizzled over muesli or cornflakes to make your breakfast a treat."
+                            },
+                            "quantity": {
+                                "unitized": {
+                                    "measure": {
+                                        "unit": "kilogram",
+                                        "value": "1"
+                                    }
+                                },
+                                "available": {
+                                    "count": "99"
+                                },
+                                "maximum": {
+                                    "count": "99"
+                                }
+                            },
+                            "price": {
+                                "currency": "INR",
+                                "value": "850.0",
+                                "maximum_value": "1301.0"
+                            },
+                            "tags": [
+                                {
+                                    "code": "origin",
+                                    "list": [
+                                        {
+                                            "code": "country",
+                                            "value": "IND"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "veg_nonveg",
+                                    "list": [
+                                        {
+                                            "code": "veg",
+                                            "value": "yes"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "parent_item_id": "3a9ae21051844ca28970db24b28cf818",
+                            "category_id": "Foodgrains",
+                            "fulfillment_id": "F1",
+                            "location_id": "7bf9b561199f4a898b3f8a3cef91b6e6",
+                            "@ondc/org/returnable": true,
+                            "@ondc/org/cancellable": true,
+                            "@ondc/org/return_window": "PT1H",
+                            "@ondc/org/seller_pickup_return": true,
+                            "@ondc/org/time_to_ship": "PT45M",
+                            "@ondc/org/available_on_cod": false,
+                            "@ondc/org/contact_details_consumer_care": "Ramesh,ramesh@abc.com,18004254444",
+                            "@ondc/org/statutory_reqs_packaged_commodities": {
+                                "manufacturer_or_packer_name": "ITC",
+                                "manufacturer_or_packer_address": "ITC Quality Care Cell,P.O Box No.592,Bangalore-560005",
+                                "common_or_generic_name_of_commodity": "Ashirwad Atta",
+                                "month_year_of_manufacture_packing_import": "01/2023"
+                            },
+                            "@ondc/org/statutory_reqs_prepackaged_food": {
+                                "nutritional_info": "Energy(KCal)-(per 100kg) 420,(per serving 50g)250;Protein(g)-(per 100kg) 12,(per serving 50g) 6",
+                                "additives_info": "Preservatives,Artificial Colours",
+                                "brand_owner_FSSAI_license_no": "12345678901234",
+                                "other_FSSAI_license_no": "12345678901234",
+                                "importer_FSSAI_license_no": "12345678901234"
+                            }
+                        }
+                    ],
+                    "tags": []
+                }
+            ]
+        }
+    }
+}

--- a/COSTBO/retail-v120-logs/flow1-corrected/search_corrected.json
+++ b/COSTBO/retail-v120-logs/flow1-corrected/search_corrected.json
@@ -1,0 +1,26 @@
+{
+    "context": {
+        "domain": "ONDC:RET10",
+        "action": "search",
+        "country": "IND",
+        "city": "std:0124",
+        "core_version": "1.2.0",
+        "bap_id": "buyer-app-preprod-v2.ondc.org",
+        "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+        "transaction_id": "f9eddac8-06c1-4dc2-8924-4b6eecd908b4",
+        "message_id": "9f09ea7c-f495-476c-a699-0080ffad828d",
+        "timestamp": "2023-12-01T02:00:01.994Z",
+        "ttl": "PT30S"
+    },
+    "message": {
+        "intent": {
+            "fulfillment": {
+                "type": "Delivery"
+            },
+            "payment": {
+                "@ondc/org/buyer_app_finder_fee_type": "percent",
+                "@ondc/org/buyer_app_finder_fee_amount": "3"
+            }
+        }
+    }
+}

--- a/COSTBO/retail-v120-logs/flow1-corrected/search_incremental_corrected.json
+++ b/COSTBO/retail-v120-logs/flow1-corrected/search_incremental_corrected.json
@@ -1,0 +1,34 @@
+{
+    "context": {
+        "domain": "ONDC:RET10",
+        "action": "search",
+        "country": "IND",
+        "city": "*",
+        "core_version": "1.2.0",
+        "bap_id": "buyer-app-preprod-v2.ondc.org",
+        "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+        "transaction_id": "e0fd9dc5-4e99-4cd2-8c42-987e0cd2fb61",
+        "message_id": "ad9e9dc7-28b0-4275-9d52-f956934547d5",
+        "timestamp": "2023-11-30T19:31:44.287Z",
+        "ttl": "PT30S"
+    },
+    "message": {
+        "intent": {
+            "payment": {
+                "@ondc/org/buyer_app_finder_fee_type": "percent",
+                "@ondc/org/buyer_app_finder_fee_amount": "3"
+            },
+            "tags": [
+                {
+                    "code": "catalog_inc",
+                    "list": [
+                        {
+                            "code": "mode",
+                            "value": "start"
+                        }
+                    ]
+                }
+            ]
+        }
+    }
+}


### PR DESCRIPTION
Received Comments from ONDC team and have fixed for retail .

1). Location time stamp was going nanoseconds,  ONDC requested ms. (3 digits). - fixed
2). Since we are MSN seller,  incremental search related bugs are not applicable (those are from reference buyer app)
3). on_search incremental fixes requested has been fixed. 