### PR TITLE
Chattybao - feedback fixes for retails logs

### DIFF
--- a/Chattybao/Logs_Dec_13/Retail/Flow 1/on_search_full_catalog.json
+++ b/Chattybao/Logs_Dec_13/Retail/Flow 1/on_search_full_catalog.json
@@ -1,0 +1,2699 @@
+{
+  "context": {
+    "domain": "ONDC:RET10",
+    "country": "IND",
+    "city": "std:0522",
+    "action": "on_search",
+    "core_version": "1.2.0",
+    "bap_id": "api.staging.nearshop.in",
+    "bap_uri": "https://api.staging.nearshop.in/bap/api/v1",
+    "transaction_id": "ceb62331-0122-5956-b1eb-834ebe31d363",
+    "message_id": "34f53b10-39e8-5aae-9e26-e41c77307670",
+    "timestamp": "2023-12-13T05:25:44.190Z",
+    "ttl": "PT30S",
+    "bpp_id": "ondc-seller-preprod.chattybao.com/ondc",
+    "bpp_uri": "https://ondc-seller-preprod.chattybao.com/ondc/bpp"
+  },
+  "message": {
+    "catalog": {
+      "bpp/fulfillments": [
+        {
+          "id": "1",
+          "type": "Delivery"
+        }
+      ],
+      "bpp/descriptor": {
+        "name": "chattyBao",
+        "symbol": "https://chattybao.com/static/media/chattybao_logo.f1be2b203f63d9074817.png",
+        "short_desc": "ChattyBao Seller Marketplace",
+        "long_desc": "ChattyBao Seller Marketplace",
+        "images": [
+          "https://chattybao.com/static/media/chattybao_logo.f1be2b203f63d9074817.png"
+        ],
+        "tags": [
+          {
+            "code": "bpp_terms",
+            "list": [
+              {
+                "code": "np_type",
+                "value": "MSN"
+              },
+              {
+                "code": "accept_bap_terms",
+                "value": "Y"
+              }
+            ]
+          }
+        ]
+      },
+      "bpp/providers": [
+        {
+          "id": "MlepomA3E7XUC_7MpLJgjn",
+          "time": {
+            "label": "enable",
+            "timestamp": "2023-12-13T05:25:44.026Z"
+          },
+          "fulfillments": [
+            {
+              "id": "1",
+              "type": "Delivery",
+              "contact": {
+                "phone": "9480323092",
+                "email": "help@chattybao.com"
+              }
+            }
+          ],
+          "descriptor": {
+            "name": "Tester Louis Resto",
+            "symbol": "https://categoryvisitingcards.s3.ap-south-1.amazonaws.com/panelupload_1686915131370_Biryani.png",
+            "long_desc": "Tester Louis Resto",
+            "short_desc": "Tester Louis Resto",
+            "images": [
+              "https://categoryvisitingcards.s3.ap-south-1.amazonaws.com/panelupload_1686915131370_Biryani.png"
+            ]
+          },
+          "ttl": "P1D",
+          "locations": [
+            {
+              "id": "15b5f8a0-29b5-11ed-93b0-8d73fff38901",
+              "gps": "26.854719,80.998035",
+              "time": {
+                "label": "enable",
+                "days": "2,3,4,5,6,7",
+                "timestamp": "2023-12-13T05:25:44.026Z",
+                "range": {
+                  "start": "0800",
+                  "end": "2200"
+                }
+              },
+              "address": {
+                "locality": "4/267, Vivek Khand 4",
+                "street": "Gomti Nagar",
+                "city": "Uttar Pradesh",
+                "area_code": "226010",
+                "state": "Lucknow"
+              },
+              "circle": {
+                "gps": "26.854719,80.998035",
+                "radius": {
+                  "unit": "km",
+                  "value": "5"
+                }
+              }
+            }
+          ],
+          "tags": [
+            {
+              "code": "order_value",
+              "list": [
+                {
+                  "code": "min_value",
+                  "value": "300.00"
+                }
+              ]
+            },
+            {
+              "code": "timing",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "Delivery"
+                },
+                {
+                  "code": "location",
+                  "value": "15b5f8a0-29b5-11ed-93b0-8d73fff38901"
+                },
+                {
+                  "code": "day_from",
+                  "value": "1"
+                },
+                {
+                  "code": "day_to",
+                  "value": "6"
+                },
+                {
+                  "code": "time_from",
+                  "value": "0800"
+                },
+                {
+                  "code": "time_to",
+                  "value": "2200"
+                }
+              ]
+            },
+            {
+              "code": "catalog_link",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "inline"
+                },
+                {
+                  "code": "type_value",
+                  "value": "https://s3.amazon.com/x-1234.zip"
+                },
+                {
+                  "code": "type_validity",
+                  "value": "PT24H"
+                },
+                {
+                  "code": "last_update",
+                  "value": "2023-05-21T00:00:00:000Z"
+                }
+              ]
+            },
+            {
+              "code": "serviceability",
+              "list": [
+                {
+                  "code": "location",
+                  "value": "15b5f8a0-29b5-11ed-93b0-8d73fff38901"
+                },
+                {
+                  "code": "category",
+                  "value": "Foodgrains"
+                },
+                {
+                  "code": "type",
+                  "value": "10"
+                },
+                {
+                  "code": "val",
+                  "value": "5"
+                },
+                {
+                  "code": "unit",
+                  "value": "km"
+                }
+              ]
+            },
+            {
+              "code": "close_timing",
+              "list": [
+                {
+                  "code": "location",
+                  "value": "15b5f8a0-29b5-11ed-93b0-8d73fff38901"
+                },
+                {
+                  "code": "start",
+                  "value": "0800"
+                },
+                {
+                  "code": "end",
+                  "value": "2200"
+                }
+              ]
+            }
+          ],
+          "items": [
+            {
+              "id": "73e9ceb0-f2d2-11ed-94e2-47a1196d3966:MlepomA3E7XUC_7MpLJgjn",
+              "time": {
+                "label": "disable",
+                "timestamp": "2023-12-13T05:25:44.026Z"
+              },
+              "descriptor": {
+                "name": "Butterfruit",
+                "code": "73e9ceb0-f2d2-11ed-94e2-47a1196d3966",
+                "symbol": "https://cdn.chattybao.com/96bcac7b-237f-45f5-b819-c57b807876eb-040a62ff-0240-4b8e-8849-ec03ffc853df.jpg",
+                "short_desc": "Butterfruit",
+                "long_desc": "Butterfruit",
+                "images": [
+                  "https://cdn.chattybao.com/96bcac7b-237f-45f5-b819-c57b807876eb-040a62ff-0240-4b8e-8849-ec03ffc853df.jpg"
+                ]
+              },
+              "quantity": {
+                "unitized": {
+                  "measure": {
+                    "unit": "kilogram",
+                    "value": "5"
+                  }
+                },
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "100",
+                "maximum_value": "200"
+              },
+              "category_id": "Foodgrains",
+              "location_id": "15b5f8a0-29b5-11ed-93b0-8d73fff38901",
+              "fulfillment_id": "1",
+              "@ondc/org/returnable": true,
+              "@ondc/org/cancellable": true,
+              "@ondc/org/seller_pickup_return": false,
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/time_to_ship": "PT60M",
+              "@ondc/org/contact_details_consumer_care": "ChattyBao Help, help@chattybao.com,7353256777",
+              "@ondc/org/return_window": "P1D",
+              "matched": true,
+              "tags": [
+                {
+                  "code": "origin",
+                  "list": [
+                    {
+                      "code": "country",
+                      "value": "IND"
+                    }
+                  ]
+                },
+                {
+                  "code": "image",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "back_image"
+                    },
+                    {
+                      "code": "url",
+                      "value": "https://cdntest.chattybao.com/sendbird_yellow_images/temp_file_20221125_195913.jpg"
+                    }
+                  ]
+                },
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "3f62f160-f4aa-11ed-a622-6dbce6254fee:MlepomA3E7XUC_7MpLJgjn",
+              "time": {
+                "label": "disable",
+                "timestamp": "2023-12-13T05:25:44.026Z"
+              },
+              "descriptor": {
+                "name": "Strawberry",
+                "code": "3f62f160-f4aa-11ed-a622-6dbce6254fee",
+                "symbol": "https://cdn.chattybao.com/999da768-a232-45fe-8d44-26f3b8a11df0-ff62dfac-754f-4142-b74f-4bd8b9544eb9.jpg",
+                "short_desc": "Strawberry",
+                "long_desc": "Strawberry",
+                "images": [
+                  "https://cdn.chattybao.com/999da768-a232-45fe-8d44-26f3b8a11df0-ff62dfac-754f-4142-b74f-4bd8b9544eb9.jpg"
+                ]
+              },
+              "quantity": {
+                "unitized": {
+                  "measure": {
+                    "unit": "kilogram",
+                    "value": "5"
+                  }
+                },
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "30",
+                "maximum_value": "35"
+              },
+              "category_id": "Foodgrains",
+              "location_id": "15b5f8a0-29b5-11ed-93b0-8d73fff38901",
+              "fulfillment_id": "1",
+              "@ondc/org/returnable": true,
+              "@ondc/org/cancellable": true,
+              "@ondc/org/seller_pickup_return": false,
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/time_to_ship": "PT60M",
+              "@ondc/org/contact_details_consumer_care": "ChattyBao Help, help@chattybao.com,7353256777",
+              "@ondc/org/return_window": "P1D",
+              "matched": true,
+              "tags": [
+                {
+                  "code": "origin",
+                  "list": [
+                    {
+                      "code": "country",
+                      "value": "IND"
+                    }
+                  ]
+                },
+                {
+                  "code": "image",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "back_image"
+                    },
+                    {
+                      "code": "url",
+                      "value": "https://cdntest.chattybao.com/sendbird_yellow_images/temp_file_20221125_195913.jpg"
+                    }
+                  ]
+                },
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "6c3b4c00-f4a5-11ed-a622-6dbce6254fee:MlepomA3E7XUC_7MpLJgjn",
+              "time": {
+                "label": "enable",
+                "timestamp": "2023-12-13T05:25:44.026Z"
+              },
+              "descriptor": {
+                "name": "Cake",
+                "code": "6c3b4c00-f4a5-11ed-a622-6dbce6254fee",
+                "symbol": "https://cdn.chattybao.com/dfbd1d2e-13bb-487c-bf88-5bb71d828f76-b99ca043-8318-4553-bbca-c22e00054099.jpg",
+                "short_desc": "Cake",
+                "long_desc": "Cake",
+                "images": [
+                  "https://cdn.chattybao.com/dfbd1d2e-13bb-487c-bf88-5bb71d828f76-b99ca043-8318-4553-bbca-c22e00054099.jpg"
+                ]
+              },
+              "quantity": {
+                "unitized": {
+                  "measure": {
+                    "unit": "kilogram",
+                    "value": "5"
+                  }
+                },
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "30",
+                "maximum_value": "30"
+              },
+              "category_id": "Foodgrains",
+              "location_id": "15b5f8a0-29b5-11ed-93b0-8d73fff38901",
+              "fulfillment_id": "1",
+              "@ondc/org/returnable": true,
+              "@ondc/org/cancellable": true,
+              "@ondc/org/seller_pickup_return": false,
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/time_to_ship": "PT60M",
+              "@ondc/org/contact_details_consumer_care": "ChattyBao Help, help@chattybao.com,7353256777",
+              "@ondc/org/return_window": "P1D",
+              "matched": true,
+              "tags": [
+                {
+                  "code": "origin",
+                  "list": [
+                    {
+                      "code": "country",
+                      "value": "IND"
+                    }
+                  ]
+                },
+                {
+                  "code": "image",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "back_image"
+                    },
+                    {
+                      "code": "url",
+                      "value": "https://cdntest.chattybao.com/sendbird_yellow_images/temp_file_20221125_195913.jpg"
+                    }
+                  ]
+                },
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "2bd34bb0-f6d8-11ed-8532-d7d80552556d:MlepomA3E7XUC_7MpLJgjn",
+              "time": {
+                "label": "enable",
+                "timestamp": "2023-12-13T05:25:44.026Z"
+              },
+              "descriptor": {
+                "name": "Honey",
+                "code": "2bd34bb0-f6d8-11ed-8532-d7d80552556d",
+                "symbol": "https://cdn.chattybao.com/bd6182e5-8595-4037-8005-efa63127fcbd-0f063adf-9fb6-4a3d-a809-c9007bab2a85.jpg",
+                "short_desc": "Honey",
+                "long_desc": "Honey",
+                "images": [
+                  "https://cdn.chattybao.com/bd6182e5-8595-4037-8005-efa63127fcbd-0f063adf-9fb6-4a3d-a809-c9007bab2a85.jpg"
+                ]
+              },
+              "quantity": {
+                "unitized": {
+                  "measure": {
+                    "unit": "kilogram",
+                    "value": "5"
+                  }
+                },
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "2200",
+                "maximum_value": "3000"
+              },
+              "category_id": "Foodgrains",
+              "location_id": "15b5f8a0-29b5-11ed-93b0-8d73fff38901",
+              "fulfillment_id": "1",
+              "@ondc/org/returnable": true,
+              "@ondc/org/cancellable": true,
+              "@ondc/org/seller_pickup_return": false,
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/time_to_ship": "PT60M",
+              "@ondc/org/contact_details_consumer_care": "ChattyBao Help, help@chattybao.com,7353256777",
+              "@ondc/org/return_window": "P1D",
+              "matched": true,
+              "tags": [
+                {
+                  "code": "origin",
+                  "list": [
+                    {
+                      "code": "country",
+                      "value": "IND"
+                    }
+                  ]
+                },
+                {
+                  "code": "image",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "back_image"
+                    },
+                    {
+                      "code": "url",
+                      "value": "https://cdntest.chattybao.com/sendbird_yellow_images/temp_file_20221125_195913.jpg"
+                    }
+                  ]
+                },
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "ae4b0a90-eedd-11ed-8905-f5409c786315:MlepomA3E7XUC_7MpLJgjn",
+              "time": {
+                "label": "enable",
+                "timestamp": "2023-12-13T05:25:44.026Z"
+              },
+              "descriptor": {
+                "name": "Orange",
+                "code": "ae4b0a90-eedd-11ed-8905-f5409c786315",
+                "symbol": "https://cdn.chattybao.com/30cd9141-efcc-4599-bb46-a27086e615bb-8c0b5478-7da3-4382-87cd-536c1b616a74.jpg",
+                "short_desc": "Orange",
+                "long_desc": "Orange",
+                "images": [
+                  "https://cdn.chattybao.com/30cd9141-efcc-4599-bb46-a27086e615bb-8c0b5478-7da3-4382-87cd-536c1b616a74.jpg"
+                ]
+              },
+              "quantity": {
+                "unitized": {
+                  "measure": {
+                    "unit": "kilogram",
+                    "value": "5"
+                  }
+                },
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "200",
+                "maximum_value": "250"
+              },
+              "category_id": "Foodgrains",
+              "location_id": "15b5f8a0-29b5-11ed-93b0-8d73fff38901",
+              "fulfillment_id": "1",
+              "@ondc/org/returnable": true,
+              "@ondc/org/cancellable": true,
+              "@ondc/org/seller_pickup_return": false,
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/time_to_ship": "PT60M",
+              "@ondc/org/contact_details_consumer_care": "ChattyBao Help, help@chattybao.com,7353256777",
+              "@ondc/org/return_window": "P1D",
+              "matched": true,
+              "tags": [
+                {
+                  "code": "origin",
+                  "list": [
+                    {
+                      "code": "country",
+                      "value": "IND"
+                    }
+                  ]
+                },
+                {
+                  "code": "image",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "back_image"
+                    },
+                    {
+                      "code": "url",
+                      "value": "https://cdntest.chattybao.com/sendbird_yellow_images/temp_file_20221125_195913.jpg"
+                    }
+                  ]
+                },
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "167747a0-958c-11ee-a08b-1f1730198de8:MlepomA3E7XUC_7MpLJgjn",
+              "time": {
+                "label": "enable",
+                "timestamp": "2023-12-13T05:25:44.026Z"
+              },
+              "descriptor": {
+                "name": "Apple",
+                "code": "167747a0-958c-11ee-a08b-1f1730198de8",
+                "symbol": "https://menucards.s3.ap-south-1.amazonaws.com/pdf_menu/user_delivery_confirmation/android-CB-Partner-img-Tester-Louis-Resto-1702013936.jpg",
+                "short_desc": "Apple",
+                "long_desc": "Apple",
+                "images": [
+                  "https://menucards.s3.ap-south-1.amazonaws.com/pdf_menu/user_delivery_confirmation/android-CB-Partner-img-Tester-Louis-Resto-1702013936.jpg"
+                ]
+              },
+              "quantity": {
+                "unitized": {
+                  "measure": {
+                    "unit": "kilogram",
+                    "value": "5"
+                  }
+                },
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "1",
+                "maximum_value": "1"
+              },
+              "category_id": "Foodgrains",
+              "location_id": "15b5f8a0-29b5-11ed-93b0-8d73fff38901",
+              "fulfillment_id": "1",
+              "@ondc/org/returnable": true,
+              "@ondc/org/cancellable": true,
+              "@ondc/org/seller_pickup_return": false,
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/time_to_ship": "PT60M",
+              "@ondc/org/contact_details_consumer_care": "ChattyBao Help, help@chattybao.com,7353256777",
+              "@ondc/org/return_window": "P1D",
+              "matched": true,
+              "tags": [
+                {
+                  "code": "origin",
+                  "list": [
+                    {
+                      "code": "country",
+                      "value": "IND"
+                    }
+                  ]
+                },
+                {
+                  "code": "image",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "back_image"
+                    },
+                    {
+                      "code": "url",
+                      "value": "https://cdntest.chattybao.com/sendbird_yellow_images/temp_file_20221125_195913.jpg"
+                    }
+                  ]
+                },
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "13408ac0-a707-11ed-9d0e-4318af7abbba:MlepomA3E7XUC_7MpLJgjn",
+              "time": {
+                "label": "enable",
+                "timestamp": "2023-12-13T05:25:44.026Z"
+              },
+              "descriptor": {
+                "name": "Potato",
+                "code": "13408ac0-a707-11ed-9d0e-4318af7abbba",
+                "symbol": "https://cdn.chattybao.com/catlog-img-temp_file_20230207_221655-4a92901e-4615-43a1-adcf-c01053169f4f.jpg",
+                "short_desc": "Potato",
+                "long_desc": "Potato",
+                "images": [
+                  "https://cdn.chattybao.com/catlog-img-temp_file_20230207_221655-4a92901e-4615-43a1-adcf-c01053169f4f.jpg"
+                ]
+              },
+              "quantity": {
+                "unitized": {
+                  "measure": {
+                    "unit": "kilogram",
+                    "value": "5"
+                  }
+                },
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "21",
+                "maximum_value": "30"
+              },
+              "category_id": "Foodgrains",
+              "location_id": "15b5f8a0-29b5-11ed-93b0-8d73fff38901",
+              "fulfillment_id": "1",
+              "@ondc/org/returnable": true,
+              "@ondc/org/cancellable": true,
+              "@ondc/org/seller_pickup_return": false,
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/time_to_ship": "PT60M",
+              "@ondc/org/contact_details_consumer_care": "ChattyBao Help, help@chattybao.com,7353256777",
+              "@ondc/org/return_window": "P1D",
+              "matched": true,
+              "tags": [
+                {
+                  "code": "origin",
+                  "list": [
+                    {
+                      "code": "country",
+                      "value": "IND"
+                    }
+                  ]
+                },
+                {
+                  "code": "image",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "back_image"
+                    },
+                    {
+                      "code": "url",
+                      "value": "https://cdntest.chattybao.com/sendbird_yellow_images/temp_file_20221125_195913.jpg"
+                    }
+                  ]
+                },
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "56229620-f2d0-11ed-94e2-47a1196d3966:MlepomA3E7XUC_7MpLJgjn",
+              "time": {
+                "label": "enable",
+                "timestamp": "2023-12-13T05:25:44.026Z"
+              },
+              "descriptor": {
+                "name": "Gugh",
+                "code": "56229620-f2d0-11ed-94e2-47a1196d3966",
+                "symbol": "https://menucards.s3.amazonaws.com/67ee8f5e-2a55-42c4-920d-083f6f83f87d-74a71ddb-3cde-4b17-a75e-e38d66795b9f.jpg",
+                "short_desc": "Gugh",
+                "long_desc": "Gugh",
+                "images": [
+                  "https://menucards.s3.amazonaws.com/67ee8f5e-2a55-42c4-920d-083f6f83f87d-74a71ddb-3cde-4b17-a75e-e38d66795b9f.jpg"
+                ]
+              },
+              "quantity": {
+                "unitized": {
+                  "measure": {
+                    "unit": "kilogram",
+                    "value": "5"
+                  }
+                },
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "200",
+                "maximum_value": "200"
+              },
+              "category_id": "Foodgrains",
+              "location_id": "15b5f8a0-29b5-11ed-93b0-8d73fff38901",
+              "fulfillment_id": "1",
+              "@ondc/org/returnable": true,
+              "@ondc/org/cancellable": true,
+              "@ondc/org/seller_pickup_return": false,
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/time_to_ship": "PT60M",
+              "@ondc/org/contact_details_consumer_care": "ChattyBao Help, help@chattybao.com,7353256777",
+              "@ondc/org/return_window": "P1D",
+              "matched": true,
+              "tags": [
+                {
+                  "code": "origin",
+                  "list": [
+                    {
+                      "code": "country",
+                      "value": "IND"
+                    }
+                  ]
+                },
+                {
+                  "code": "image",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "back_image"
+                    },
+                    {
+                      "code": "url",
+                      "value": "https://cdntest.chattybao.com/sendbird_yellow_images/temp_file_20221125_195913.jpg"
+                    }
+                  ]
+                },
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "id": "MR8mcezPPQEA-r8EhP6UN9",
+          "time": {
+            "label": "enable",
+            "timestamp": "2023-12-13T05:25:44.026Z"
+          },
+          "fulfillments": [
+            {
+              "id": "1",
+              "type": "Delivery",
+              "contact": {
+                "phone": "8840019700",
+                "email": "help@chattybao.com"
+              }
+            }
+          ],
+          "descriptor": {
+            "name": "tester shatrughan fru and veg",
+            "symbol": "https://cdn.chattybao.com/shopoutside-temp_file_20230222_093036-0e1d5670-16a2-4a55-abcb-a25aa1711347.jpg",
+            "long_desc": "tester shatrughan fru and veg",
+            "short_desc": "tester shatrughan fru and veg",
+            "images": [
+              "https://cdn.chattybao.com/shopoutside-temp_file_20230222_093036-0e1d5670-16a2-4a55-abcb-a25aa1711347.jpg"
+            ]
+          },
+          "ttl": "P1D",
+          "locations": [
+            {
+              "id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042",
+              "gps": "26.854719,80.998035",
+              "time": {
+                "label": "enable",
+                "days": "1,2,3,4,5,6,7",
+                "timestamp": "2023-12-13T05:25:44.026Z",
+                "range": {
+                  "start": "0801",
+                  "end": "2200"
+                }
+              },
+              "address": {
+                "locality": "4/267, Vivek Khand 4",
+                "street": "Gomti Nagar",
+                "city": "Uttar Pradesh",
+                "area_code": "226010",
+                "state": "Lucknow"
+              },
+              "circle": {
+                "gps": "26.854719,80.998035",
+                "radius": {
+                  "unit": "km",
+                  "value": "5"
+                }
+              }
+            }
+          ],
+          "tags": [
+            {
+              "code": "order_value",
+              "list": [
+                {
+                  "code": "min_value",
+                  "value": "300.00"
+                }
+              ]
+            },
+            {
+              "code": "timing",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "Delivery"
+                },
+                {
+                  "code": "location",
+                  "value": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042"
+                },
+                {
+                  "code": "day_from",
+                  "value": "1"
+                },
+                {
+                  "code": "day_to",
+                  "value": "6"
+                },
+                {
+                  "code": "time_from",
+                  "value": "0801"
+                },
+                {
+                  "code": "time_to",
+                  "value": "2200"
+                }
+              ]
+            },
+            {
+              "code": "catalog_link",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "inline"
+                },
+                {
+                  "code": "type_value",
+                  "value": "https://s3.amazon.com/x-1234.zip"
+                },
+                {
+                  "code": "type_validity",
+                  "value": "PT24H"
+                },
+                {
+                  "code": "last_update",
+                  "value": "2023-05-21T00:00:00:000Z"
+                }
+              ]
+            },
+            {
+              "code": "serviceability",
+              "list": [
+                {
+                  "code": "location",
+                  "value": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042"
+                },
+                {
+                  "code": "category",
+                  "value": "Stationery"
+                },
+                {
+                  "code": "type",
+                  "value": "10"
+                },
+                {
+                  "code": "val",
+                  "value": "5"
+                },
+                {
+                  "code": "unit",
+                  "value": "km"
+                }
+              ]
+            },
+            {
+              "code": "close_timing",
+              "list": [
+                {
+                  "code": "location",
+                  "value": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042"
+                },
+                {
+                  "code": "start",
+                  "value": "0801"
+                },
+                {
+                  "code": "end",
+                  "value": "2200"
+                }
+              ]
+            }
+          ],
+          "items": [
+            {
+              "id": "7f758d50-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+              "time": {
+                "label": "enable",
+                "timestamp": "2023-12-13T05:25:44.026Z"
+              },
+              "descriptor": {
+                "name": "Avocado Hass 1 piece ( 250 - 300 g)",
+                "code": "7f758d50-35e4-11ee-95dc-396fe1db85181",
+                "symbol": "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/949-cfa69c25-beb6-4dc6-8aab-a85cf6578cfc",
+                "short_desc": "Avocado Hass 1 piece ( 250 - 300 g)",
+                "long_desc": "Avocado 2023-12-13T05:25:44.192327797Z Hass 1 piece ( 250 - 300 g)",
+                "images": [
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/949-cfa69c25-beb6-4dc6-8aab-a85cf6578cfc"
+                ]
+              },
+              "quantity": {
+                "unitized": {
+                  "measure": {
+                    "unit": "kilogram",
+                    "value": "5"
+                  }
+                },
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "1500",
+                "maximum_value": "1500"
+              },
+              "category_id": "Stationery",
+              "location_id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042",
+              "fulfillment_id": "1",
+              "@ondc/org/returnable": true,
+              "@ondc/org/cancellable": true,
+              "@ondc/org/seller_pickup_return": false,
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/time_to_ship": "PT60M",
+              "@ondc/org/contact_details_consumer_care": "ChattyBao Help, help@chattybao.com,7353256777",
+              "@ondc/org/return_window": "P1D",
+              "matched": true,
+              "tags": [
+                {
+                  "code": "origin",
+                  "list": [
+                    {
+                      "code": "country",
+                      "value": "IND"
+                    }
+                  ]
+                },
+                {
+                  "code": "image",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "back_image"
+                    },
+                    {
+                      "code": "url",
+                      "value": "https://cdntest.chattybao.com/sendbird_yellow_images/temp_file_20221125_195913.jpg"
+                    }
+                  ]
+                },
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "ded21392-1a41-11ee-8ddd-2bac5af1417f:MR8mcezPPQEA-r8EhP6UN9",
+              "time": {
+                "label": "disable",
+                "timestamp": "2023-12-13T05:25:44.026Z"
+              },
+              "descriptor": {
+                "name": "Aashirvaad Shudh Chakki Atta Whole Wheat 10 Kg",
+                "code": "ded21392-1a41-11ee-8ddd-2bac5af1417f",
+                "symbol": "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196846739_40127505_7-aashirvaad-shudh-chakki-atta.jpg",
+                "short_desc": "Aashirvaad Shudh Chakki Atta Whole Wheat 10 Kg",
+                "long_desc": "Aashirvaad Shudh Chakki Atta Whole Wheat 10 Kg",
+                "images": [
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196846739_40127505_7-aashirvaad-shudh-chakki-atta.jpg",
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196846964_40127505-3_8-aashirvaad-shudh-chakki-atta.jpg",
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196847065_40127506-9_2-aashirvaad-shudh-chakki-atta.jpg",
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196846983_aashirvaad-whole-wheat-atta-10-kg-legal-images-o490000041-p490000041-4-202207051337.jpg",
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196847015_40127506-4_8-aashirvaad-shudh-chakki-atta.jpg"
+                ]
+              },
+              "quantity": {
+                "unitized": {
+                  "measure": {
+                    "unit": "kilogram",
+                    "value": "5"
+                  }
+                },
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "35",
+                "maximum_value": "250"
+              },
+              "category_id": "Stationery",
+              "location_id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042",
+              "fulfillment_id": "1",
+              "@ondc/org/returnable": true,
+              "@ondc/org/cancellable": true,
+              "@ondc/org/seller_pickup_return": false,
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/time_to_ship": "PT60M",
+              "@ondc/org/contact_details_consumer_care": "ChattyBao Help, help@chattybao.com,7353256777",
+              "@ondc/org/return_window": "P1D",
+              "matched": true,
+              "tags": [
+                {
+                  "code": "origin",
+                  "list": [
+                    {
+                      "code": "country",
+                      "value": "IND"
+                    }
+                  ]
+                },
+                {
+                  "code": "image",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "back_image"
+                    },
+                    {
+                      "code": "url",
+                      "value": "https://cdntest.chattybao.com/sendbird_yellow_images/temp_file_20221125_195913.jpg"
+                    }
+                  ]
+                },
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "988d4f70-b340-11ed-b67d-b356d861831b:MR8mcezPPQEA-r8EhP6UN9",
+              "time": {
+                "label": "enable",
+                "timestamp": "2023-12-13T05:25:44.026Z"
+              },
+              "descriptor": {
+                "name": "Item 6",
+                "code": "988d4f70-b340-11ed-b67d-b356d861831b",
+                "symbol": "https://menucards.s3.ap-south-1.amazonaws.com/catlog-img-temp_file_20230223_113900-a093d442-b29a-4c0e-a301-f48bfa2fc66d.jpg",
+                "short_desc": "Item 6",
+                "long_desc": "Item 6",
+                "images": [
+                  "https://menucards.s3.ap-south-1.amazonaws.com/catlog-img-temp_file_20230223_113900-a093d442-b29a-4c0e-a301-f48bfa2fc66d.jpg"
+                ]
+              },
+              "quantity": {
+                "unitized": {
+                  "measure": {
+                    "unit": "kilogram",
+                    "value": "5"
+                  }
+                },
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "60",
+                "maximum_value": "65"
+              },
+              "category_id": "Stationery",
+              "location_id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042",
+              "fulfillment_id": "1",
+              "@ondc/org/returnable": true,
+              "@ondc/org/cancellable": true,
+              "@ondc/org/seller_pickup_return": false,
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/time_to_ship": "PT60M",
+              "@ondc/org/contact_details_consumer_care": "ChattyBao Help, help@chattybao.com,7353256777",
+              "@ondc/org/return_window": "P1D",
+              "matched": true,
+              "tags": [
+                {
+                  "code": "origin",
+                  "list": [
+                    {
+                      "code": "country",
+                      "value": "IND"
+                    }
+                  ]
+                },
+                {
+                  "code": "image",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "back_image"
+                    },
+                    {
+                      "code": "url",
+                      "value": "https://cdntest.chattybao.com/sendbird_yellow_images/temp_file_20221125_195913.jpg"
+                    }
+                  ]
+                },
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "063a93d0-1a42-11ee-8ddd-2bac5af1417f:MR8mcezPPQEA-r8EhP6UN9",
+              "time": {
+                "label": "disable",
+                "timestamp": "2023-12-13T05:25:44.026Z"
+              },
+              "descriptor": {
+                "name": "Golden Sela Rice Loose 1 Kg",
+                "code": "063a93d0-1a42-11ee-8ddd-2bac5af1417f",
+                "symbol": "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196879556_extra-long-grains-jarda-golden-sella-classic-rice-1kg-biryani-rice-553.jpg",
+                "short_desc": "Golden Sela Rice Loose 1 Kg",
+                "long_desc": "Golden Sela Rice Loose 1 Kg",
+                "images": [
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196879556_extra-long-grains-jarda-golden-sella-classic-rice-1kg-biryani-rice-553.jpg"
+                ]
+              },
+              "quantity": {
+                "unitized": {
+                  "measure": {
+                    "unit": "kilogram",
+                    "value": "5"
+                  }
+                },
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "36",
+                "maximum_value": "250"
+              },
+              "category_id": "Stationery",
+              "location_id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042",
+              "fulfillment_id": "1",
+              "@ondc/org/returnable": true,
+              "@ondc/org/cancellable": true,
+              "@ondc/org/seller_pickup_return": false,
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/time_to_ship": "PT60M",
+              "@ondc/org/contact_details_consumer_care": "ChattyBao Help, help@chattybao.com,7353256777",
+              "@ondc/org/return_window": "P1D",
+              "matched": true,
+              "tags": [
+                {
+                  "code": "origin",
+                  "list": [
+                    {
+                      "code": "country",
+                      "value": "IND"
+                    }
+                  ]
+                },
+                {
+                  "code": "image",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "back_image"
+                    },
+                    {
+                      "code": "url",
+                      "value": "https://cdntest.chattybao.com/sendbird_yellow_images/temp_file_20221125_195913.jpg"
+                    }
+                  ]
+                },
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "49d5ca60-b340-11ed-b67d-b356d861831b:MR8mcezPPQEA-r8EhP6UN9",
+              "time": {
+                "label": "disable",
+                "timestamp": "2023-12-13T05:25:44.026Z"
+              },
+              "descriptor": {
+                "name": "Item 2",
+                "code": "49d5ca60-b340-11ed-b67d-b356d861831b",
+                "symbol": "https://menucards.s3.ap-south-1.amazonaws.com/catlog-img-temp_file_20230223_113650-082b41c9-bcc6-41f7-8ddf-6e27964d5d95.jpg",
+                "short_desc": "Item 2",
+                "long_desc": "Item 2",
+                "images": [
+                  "https://menucards.s3.ap-south-1.amazonaws.com/catlog-img-temp_file_20230223_113650-082b41c9-bcc6-41f7-8ddf-6e27964d5d95.jpg"
+                ]
+              },
+              "quantity": {
+                "unitized": {
+                  "measure": {
+                    "unit": "kilogram",
+                    "value": "5"
+                  }
+                },
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "60",
+                "maximum_value": "65"
+              },
+              "category_id": "Stationery",
+              "location_id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042",
+              "fulfillment_id": "1",
+              "@ondc/org/returnable": true,
+              "@ondc/org/cancellable": true,
+              "@ondc/org/seller_pickup_return": false,
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/time_to_ship": "PT60M",
+              "@ondc/org/contact_details_consumer_care": "ChattyBao Help, help@chattybao.com,7353256777",
+              "@ondc/org/return_window": "P1D",
+              "matched": true,
+              "tags": [
+                {
+                  "code": "origin",
+                  "list": [
+                    {
+                      "code": "country",
+                      "value": "IND"
+                    }
+                  ]
+                },
+                {
+                  "code": "image",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "back_image"
+                    },
+                    {
+                      "code": "url",
+                      "value": "https://cdntest.chattybao.com/sendbird_yellow_images/temp_file_20221125_195913.jpg"
+                    }
+                  ]
+                },
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "7efc8cc0-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+              "time": {
+                "label": "enable",
+                "timestamp": "2023-12-13T05:25:44.026Z"
+              },
+              "descriptor": {
+                "name": "Avocado Indian 1 piece (250 - 300 g)",
+                "code": "7efc8cc0-35e4-11ee-95dc-396fe1db85181",
+                "symbol": "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/avocado-indian-1-pc-approx-300-g-600-g-product-images-o590003579-p590144487-0-202203170211",
+                "short_desc": "Avocado Indian 1 piece (250 - 300 g)",
+                "long_desc": "Avocado Indian 1 piece (250 - 300 g)",
+                "images": [
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/avocado-indian-1-pc-approx-300-g-600-g-product-images-o590003579-p590144487-0-202203170211"
+                ]
+              },
+              "quantity": {
+                "unitized": {
+                  "measure": {
+                    "unit": "kilogram",
+                    "value": "5"
+                  }
+                },
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "1000",
+                "maximum_value": "1000"
+              },
+              "category_id": "Stationery",
+              "location_id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042",
+              "fulfillment_id": "1",
+              "@ondc/org/returnable": true,
+              "@ondc/org/cancellable": true,
+              "@ondc/org/seller_pickup_return": false,
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/time_to_ship": "PT60M",
+              "@ondc/org/contact_details_consumer_care": "ChattyBao Help, help@chattybao.com,7353256777",
+              "@ondc/org/return_window": "P1D",
+              "matched": true,
+              "tags": [
+                {
+                  "code": "origin",
+                  "list": [
+                    {
+                      "code": "country",
+                      "value": "IND"
+                    }
+                  ]
+                },
+                {
+                  "code": "image",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "back_image"
+                    },
+                    {
+                      "code": "url",
+                      "value": "https://cdntest.chattybao.com/sendbird_yellow_images/temp_file_20221125_195913.jpg"
+                    }
+                  ]
+                },
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "b05b0f70-b340-11ed-b67d-b356d861831b:MR8mcezPPQEA-r8EhP6UN9",
+              "time": {
+                "label": "disable",
+                "timestamp": "2023-12-13T05:25:44.026Z"
+              },
+              "descriptor": {
+                "name": "Item 8",
+                "code": "b05b0f70-b340-11ed-b67d-b356d861831b",
+                "symbol": "https://menucards.s3.ap-south-1.amazonaws.com/catlog-img-temp_file_20230223_113943-fb1bda7d-32d9-40ab-982f-9ef3ae9df7b5.png",
+                "short_desc": "Item 8",
+                "long_desc": "Item 8",
+                "images": [
+                  "https://menucards.s3.ap-south-1.amazonaws.com/catlog-img-temp_file_20230223_113943-fb1bda7d-32d9-40ab-982f-9ef3ae9df7b5.png"
+                ]
+              },
+              "quantity": {
+                "unitized": {
+                  "measure": {
+                    "unit": "kilogram",
+                    "value": "5"
+                  }
+                },
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "11",
+                "maximum_value": "65"
+              },
+              "category_id": "Stationery",
+              "location_id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042",
+              "fulfillment_id": "1",
+              "@ondc/org/returnable": true,
+              "@ondc/org/cancellable": true,
+              "@ondc/org/seller_pickup_return": false,
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/time_to_ship": "PT60M",
+              "@ondc/org/contact_details_consumer_care": "ChattyBao Help, help@chattybao.com,7353256777",
+              "@ondc/org/return_window": "P1D",
+              "matched": true,
+              "tags": [
+                {
+                  "code": "origin",
+                  "list": [
+                    {
+                      "code": "country",
+                      "value": "IND"
+                    }
+                  ]
+                },
+                {
+                  "code": "image",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "back_image"
+                    },
+                    {
+                      "code": "url",
+                      "value": "https://cdntest.chattybao.com/sendbird_yellow_images/temp_file_20221125_195913.jpg"
+                    }
+                  ]
+                },
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "d76b3680-b340-11ed-b67d-b356d861831b:MR8mcezPPQEA-r8EhP6UN9",
+              "time": {
+                "label": "enable",
+                "timestamp": "2023-12-13T05:25:44.026Z"
+              },
+              "descriptor": {
+                "name": "Item 11",
+                "code": "d76b3680-b340-11ed-b67d-b356d861831b",
+                "symbol": "https://menucards.s3.ap-south-1.amazonaws.com/catlog-img-temp_file_20230223_114048-12eba147-52d8-401e-995a-ce7d8b2706f2.jpg",
+                "short_desc": "Item 11",
+                "long_desc": "Item 11",
+                "images": [
+                  "https://menucards.s3.ap-south-1.amazonaws.com/catlog-img-temp_file_20230223_114048-12eba147-52d8-401e-995a-ce7d8b2706f2.jpg"
+                ]
+              },
+              "quantity": {
+                "unitized": {
+                  "measure": {
+                    "unit": "kilogram",
+                    "value": "5"
+                  }
+                },
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "35",
+                "maximum_value": "65"
+              },
+              "category_id": "Stationery",
+              "location_id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042",
+              "fulfillment_id": "1",
+              "@ondc/org/returnable": true,
+              "@ondc/org/cancellable": true,
+              "@ondc/org/seller_pickup_return": false,
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/time_to_ship": "PT60M",
+              "@ondc/org/contact_details_consumer_care": "ChattyBao Help, help@chattybao.com,7353256777",
+              "@ondc/org/return_window": "P1D",
+              "matched": true,
+              "tags": [
+                {
+                  "code": "origin",
+                  "list": [
+                    {
+                      "code": "country",
+                      "value": "IND"
+                    }
+                  ]
+                },
+                {
+                  "code": "image",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "back_image"
+                    },
+                    {
+                      "code": "url",
+                      "value": "https://cdntest.chattybao.com/sendbird_yellow_images/temp_file_20221125_195913.jpg"
+                    }
+                  ]
+                },
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "7eaee1f0-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+              "time": {
+                "label": "enable",
+                "timestamp": "2023-12-13T05:25:44.026Z"
+              },
+              "descriptor": {
+                "name": "Banana small 6 pc",
+                "code": "7eaee1f0-35e4-11ee-95dc-396fe1db85181",
+                "symbol": "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/Banana-Elaichi",
+                "short_desc": "Banana small 6 pc",
+                "long_desc": "Banana small 6 pc",
+                "images": [
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/Banana-Elaichi"
+                ]
+              },
+              "quantity": {
+                "unitized": {
+                  "measure": {
+                    "unit": "kilogram",
+                    "value": "5"
+                  }
+                },
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "3650",
+                "maximum_value": "3650"
+              },
+              "category_id": "Stationery",
+              "location_id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042",
+              "fulfillment_id": "1",
+              "@ondc/org/returnable": true,
+              "@ondc/org/cancellable": true,
+              "@ondc/org/seller_pickup_return": false,
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/time_to_ship": "PT60M",
+              "@ondc/org/contact_details_consumer_care": "ChattyBao Help, help@chattybao.com,7353256777",
+              "@ondc/org/return_window": "P1D",
+              "matched": true,
+              "tags": [
+                {
+                  "code": "origin",
+                  "list": [
+                    {
+                      "code": "country",
+                      "value": "IND"
+                    }
+                  ]
+                },
+                {
+                  "code": "image",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "back_image"
+                    },
+                    {
+                      "code": "url",
+                      "value": "https://cdntest.chattybao.com/sendbird_yellow_images/temp_file_20221125_195913.jpg"
+                    }
+                  ]
+                },
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "62136330-b340-11ed-b67d-b356d861831b:MR8mcezPPQEA-r8EhP6UN9",
+              "time": {
+                "label": "disable",
+                "timestamp": "2023-12-13T05:25:44.026Z"
+              },
+              "descriptor": {
+                "name": "Item 4",
+                "code": "62136330-b340-11ed-b67d-b356d861831b",
+                "symbol": "https://menucards.s3.ap-south-1.amazonaws.com/catlog-img-temp_file_20230223_113728-db8a2281-993f-4351-b43a-17b255abd579.jpg",
+                "short_desc": "Item 4",
+                "long_desc": "Item 4",
+                "images": [
+                  "https://menucards.s3.ap-south-1.amazonaws.com/catlog-img-temp_file_20230223_113728-db8a2281-993f-4351-b43a-17b255abd579.jpg"
+                ]
+              },
+              "quantity": {
+                "unitized": {
+                  "measure": {
+                    "unit": "kilogram",
+                    "value": "5"
+                  }
+                },
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "56",
+                "maximum_value": "65"
+              },
+              "category_id": "Stationery",
+              "location_id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042",
+              "fulfillment_id": "1",
+              "@ondc/org/returnable": true,
+              "@ondc/org/cancellable": true,
+              "@ondc/org/seller_pickup_return": false,
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/time_to_ship": "PT60M",
+              "@ondc/org/contact_details_consumer_care": "ChattyBao Help, help@chattybao.com,7353256777",
+              "@ondc/org/return_window": "P1D",
+              "matched": true,
+              "tags": [
+                {
+                  "code": "origin",
+                  "list": [
+                    {
+                      "code": "country",
+                      "value": "IND"
+                    }
+                  ]
+                },
+                {
+                  "code": "image",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "back_image"
+                    },
+                    {
+                      "code": "url",
+                      "value": "https://cdntest.chattybao.com/sendbird_yellow_images/temp_file_20221125_195913.jpg"
+                    }
+                  ]
+                },
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "c95122d0-b340-11ed-b67d-b356d861831b:MR8mcezPPQEA-r8EhP6UN9",
+              "time": {
+                "label": "enable",
+                "timestamp": "2023-12-13T05:25:44.026Z"
+              },
+              "descriptor": {
+                "name": "Item 10",
+                "code": "c95122d0-b340-11ed-b67d-b356d861831b",
+                "symbol": "https://menucards.s3.ap-south-1.amazonaws.com/catlog-img-temp_file_20230223_114026-9d5d80dc-a9eb-4a8d-a4e5-9cfb1d17f34e.jpg",
+                "short_desc": "Item 10",
+                "long_desc": "Item 10",
+                "images": [
+                  "https://menucards.s3.ap-south-1.amazonaws.com/catlog-img-temp_file_20230223_114026-9d5d80dc-a9eb-4a8d-a4e5-9cfb1d17f34e.jpg"
+                ]
+              },
+              "quantity": {
+                "unitized": {
+                  "measure": {
+                    "unit": "kilogram",
+                    "value": "5"
+                  }
+                },
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "45",
+                "maximum_value": "65"
+              },
+              "category_id": "Stationery",
+              "location_id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042",
+              "fulfillment_id": "1",
+              "@ondc/org/returnable": true,
+              "@ondc/org/cancellable": true,
+              "@ondc/org/seller_pickup_return": false,
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/time_to_ship": "PT60M",
+              "@ondc/org/contact_details_consumer_care": "ChattyBao Help, help@chattybao.com,7353256777",
+              "@ondc/org/return_window": "P1D",
+              "matched": true,
+              "tags": [
+                {
+                  "code": "origin",
+                  "list": [
+                    {
+                      "code": "country",
+                      "value": "IND"
+                    }
+                  ]
+                },
+                {
+                  "code": "image",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "back_image"
+                    },
+                    {
+                      "code": "url",
+                      "value": "https://cdntest.chattybao.com/sendbird_yellow_images/temp_file_20221125_195913.jpg"
+                    }
+                  ]
+                },
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "a49795f0-b340-11ed-b67d-b356d861831b:MR8mcezPPQEA-r8EhP6UN9",
+              "time": {
+                "label": "enable",
+                "timestamp": "2023-12-13T05:25:44.026Z"
+              },
+              "descriptor": {
+                "name": "Item 7",
+                "code": "a49795f0-b340-11ed-b67d-b356d861831b",
+                "symbol": "https://menucards.s3.ap-south-1.amazonaws.com/catlog-img-temp_file_20230223_113922-dd82da6e-140d-4f05-ada3-a9c7645a391b.jpg",
+                "short_desc": "Item 7",
+                "long_desc": "Item 7",
+                "images": [
+                  "https://menucards.s3.ap-south-1.amazonaws.com/catlog-img-temp_file_20230223_113922-dd82da6e-140d-4f05-ada3-a9c7645a391b.jpg"
+                ]
+              },
+              "quantity": {
+                "unitized": {
+                  "measure": {
+                    "unit": "kilogram",
+                    "value": "5"
+                  }
+                },
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "28",
+                "maximum_value": "65"
+              },
+              "category_id": "Stationery",
+              "location_id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042",
+              "fulfillment_id": "1",
+              "@ondc/org/returnable": true,
+              "@ondc/org/cancellable": true,
+              "@ondc/org/seller_pickup_return": false,
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/time_to_ship": "PT60M",
+              "@ondc/org/contact_details_consumer_care": "ChattyBao Help, help@chattybao.com,7353256777",
+              "@ondc/org/return_window": "P1D",
+              "matched": true,
+              "tags": [
+                {
+                  "code": "origin",
+                  "list": [
+                    {
+                      "code": "country",
+                      "value": "IND"
+                    }
+                  ]
+                },
+                {
+                  "code": "image",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "back_image"
+                    },
+                    {
+                      "code": "url",
+                      "value": "https://cdntest.chattybao.com/sendbird_yellow_images/temp_file_20221125_195913.jpg"
+                    }
+                  ]
+                },
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "7e92f580-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+              "time": {
+                "label": "enable",
+                "timestamp": "2023-12-13T05:25:44.026Z"
+              },
+              "descriptor": {
+                "name": "Banana 1 kg",
+                "code": "7e92f580-35e4-11ee-95dc-396fe1db85181",
+                "symbol": "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/banana",
+                "short_desc": "Banana 1 kg",
+                "long_desc": "Banana 1 kg",
+                "images": [
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/banana"
+                ]
+              },
+              "quantity": {
+                "unitized": {
+                  "measure": {
+                    "unit": "kilogram",
+                    "value": "5"
+                  }
+                },
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "2500",
+                "maximum_value": "2500"
+              },
+              "category_id": "Stationery",
+              "location_id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042",
+              "fulfillment_id": "1",
+              "@ondc/org/returnable": true,
+              "@ondc/org/cancellable": true,
+              "@ondc/org/seller_pickup_return": false,
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/time_to_ship": "PT60M",
+              "@ondc/org/contact_details_consumer_care": "ChattyBao Help, help@chattybao.com,7353256777",
+              "@ondc/org/return_window": "P1D",
+              "matched": true,
+              "tags": [
+                {
+                  "code": "origin",
+                  "list": [
+                    {
+                      "code": "country",
+                      "value": "IND"
+                    }
+                  ]
+                },
+                {
+                  "code": "image",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "back_image"
+                    },
+                    {
+                      "code": "url",
+                      "value": "https://cdntest.chattybao.com/sendbird_yellow_images/temp_file_20221125_195913.jpg"
+                    }
+                  ]
+                },
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "7f0677d0-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+              "time": {
+                "label": "enable",
+                "timestamp": "2023-12-13T05:25:44.026Z"
+              },
+              "descriptor": {
+                "name": "Apple Kinnaur 500 g",
+                "code": "7f0677d0-35e4-11ee-95dc-396fe1db85181",
+                "symbol": "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/40033821-2_1-fresho-apple-kinnaur",
+                "short_desc": "Apple Kinnaur 500 g",
+                "long_desc": "Apple Kinnaur 500 g",
+                "images": [
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/40033821-2_1-fresho-apple-kinnaur"
+                ]
+              },
+              "quantity": {
+                "unitized": {
+                  "measure": {
+                    "unit": "kilogram",
+                    "value": "5"
+                  }
+                },
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "65",
+                "maximum_value": "250"
+              },
+              "category_id": "Stationery",
+              "location_id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042",
+              "fulfillment_id": "1",
+              "@ondc/org/returnable": true,
+              "@ondc/org/cancellable": true,
+              "@ondc/org/seller_pickup_return": false,
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/time_to_ship": "PT60M",
+              "@ondc/org/contact_details_consumer_care": "ChattyBao Help, help@chattybao.com,7353256777",
+              "@ondc/org/return_window": "P1D",
+              "matched": true,
+              "tags": [
+                {
+                  "code": "origin",
+                  "list": [
+                    {
+                      "code": "country",
+                      "value": "IND"
+                    }
+                  ]
+                },
+                {
+                  "code": "image",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "back_image"
+                    },
+                    {
+                      "code": "url",
+                      "value": "https://cdntest.chattybao.com/sendbird_yellow_images/temp_file_20221125_195913.jpg"
+                    }
+                  ]
+                },
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "7eaebae0-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+              "time": {
+                "label": "enable",
+                "timestamp": "2023-12-13T05:25:44.026Z"
+              },
+              "descriptor": {
+                "name": "Banana big 6 pc",
+                "code": "7eaebae0-35e4-11ee-95dc-396fe1db85181",
+                "symbol": "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/banana",
+                "short_desc": "Banana big 6 pc",
+                "long_desc": "Banana big 6 pc",
+                "images": [
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/banana"
+                ]
+              },
+              "quantity": {
+                "unitized": {
+                  "measure": {
+                    "unit": "kilogram",
+                    "value": "5"
+                  }
+                },
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "1400",
+                "maximum_value": "1400"
+              },
+              "category_id": "Stationery",
+              "location_id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042",
+              "fulfillment_id": "1",
+              "@ondc/org/returnable": true,
+              "@ondc/org/cancellable": true,
+              "@ondc/org/seller_pickup_return": false,
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/time_to_ship": "PT60M",
+              "@ondc/org/contact_details_consumer_care": "ChattyBao Help, help@chattybao.com,7353256777",
+              "@ondc/org/return_window": "P1D",
+              "matched": true,
+              "tags": [
+                {
+                  "code": "origin",
+                  "list": [
+                    {
+                      "code": "country",
+                      "value": "IND"
+                    }
+                  ]
+                },
+                {
+                  "code": "image",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "back_image"
+                    },
+                    {
+                      "code": "url",
+                      "value": "https://cdntest.chattybao.com/sendbird_yellow_images/temp_file_20221125_195913.jpg"
+                    }
+                  ]
+                },
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "be497f40-b340-11ed-b67d-b356d861831b:MR8mcezPPQEA-r8EhP6UN9",
+              "time": {
+                "label": "disable",
+                "timestamp": "2023-12-13T05:25:44.026Z"
+              },
+              "descriptor": {
+                "name": "Item 9",
+                "code": "be497f40-b340-11ed-b67d-b356d861831b",
+                "symbol": "https://menucards.s3.ap-south-1.amazonaws.com/catlog-img-temp_file_20230223_114006-a8f2500e-cc0e-43b9-b808-1d33a7b1dab0.jpg",
+                "short_desc": "Item 9",
+                "long_desc": "Item 9",
+                "images": [
+                  "https://menucards.s3.ap-south-1.amazonaws.com/catlog-img-temp_file_20230223_114006-a8f2500e-cc0e-43b9-b808-1d33a7b1dab0.jpg"
+                ]
+              },
+              "quantity": {
+                "unitized": {
+                  "measure": {
+                    "unit": "kilogram",
+                    "value": "5"
+                  }
+                },
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "59",
+                "maximum_value": "65"
+              },
+              "category_id": "Stationery",
+              "location_id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042",
+              "fulfillment_id": "1",
+              "@ondc/org/returnable": true,
+              "@ondc/org/cancellable": true,
+              "@ondc/org/seller_pickup_return": false,
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/time_to_ship": "PT60M",
+              "@ondc/org/contact_details_consumer_care": "ChattyBao Help, help@chattybao.com,7353256777",
+              "@ondc/org/return_window": "P1D",
+              "matched": true,
+              "tags": [
+                {
+                  "code": "origin",
+                  "list": [
+                    {
+                      "code": "country",
+                      "value": "IND"
+                    }
+                  ]
+                },
+                {
+                  "code": "image",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "back_image"
+                    },
+                    {
+                      "code": "url",
+                      "value": "https://cdntest.chattybao.com/sendbird_yellow_images/temp_file_20221125_195913.jpg"
+                    }
+                  ]
+                },
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "7fbdd6c0-fb95-11ed-a974-f364c597eb2b:MR8mcezPPQEA-r8EhP6UN9",
+              "time": {
+                "label": "enable",
+                "timestamp": "2023-12-13T05:25:44.026Z"
+              },
+              "descriptor": {
+                "name": "Angur",
+                "code": "7fbdd6c0-fb95-11ed-a974-f364c597eb2b",
+                "symbol": "https://cdn.chattybao.com/51c7dd64-3401-4bdd-bf27-c0833c335763-7a0251df-9dac-4d66-8929-d2acaaa66152.jpg",
+                "short_desc": "Angur",
+                "long_desc": "Angur",
+                "images": [
+                  "https://cdn.chattybao.com/51c7dd64-3401-4bdd-bf27-c0833c335763-7a0251df-9dac-4d66-8929-d2acaaa66152.jpg"
+                ]
+              },
+              "quantity": {
+                "unitized": {
+                  "measure": {
+                    "unit": "kilogram",
+                    "value": "5"
+                  }
+                },
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "124",
+                "maximum_value": "124"
+              },
+              "category_id": "Stationery",
+              "location_id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042",
+              "fulfillment_id": "1",
+              "@ondc/org/returnable": true,
+              "@ondc/org/cancellable": true,
+              "@ondc/org/seller_pickup_return": false,
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/time_to_ship": "PT60M",
+              "@ondc/org/contact_details_consumer_care": "ChattyBao Help, help@chattybao.com,7353256777",
+              "@ondc/org/return_window": "P1D",
+              "matched": true,
+              "tags": [
+                {
+                  "code": "origin",
+                  "list": [
+                    {
+                      "code": "country",
+                      "value": "IND"
+                    }
+                  ]
+                },
+                {
+                  "code": "image",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "back_image"
+                    },
+                    {
+                      "code": "url",
+                      "value": "https://cdntest.chattybao.com/sendbird_yellow_images/temp_file_20221125_195913.jpg"
+                    }
+                  ]
+                },
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "70b0fec0-b340-11ed-b67d-b356d861831b:MR8mcezPPQEA-r8EhP6UN9",
+              "time": {
+                "label": "enable",
+                "timestamp": "2023-12-13T05:25:44.026Z"
+              },
+              "descriptor": {
+                "name": "Item 5",
+                "code": "70b0fec0-b340-11ed-b67d-b356d861831b",
+                "symbol": "https://menucards.s3.ap-south-1.amazonaws.com/catlog-img-temp_file_20230223_113750-ca305d07-31d7-48e0-add0-b77247a68234.jpg",
+                "short_desc": "Item 5",
+                "long_desc": "Item 5",
+                "images": [
+                  "https://menucards.s3.ap-south-1.amazonaws.com/catlog-img-temp_file_20230223_113750-ca305d07-31d7-48e0-add0-b77247a68234.jpg"
+                ]
+              },
+              "quantity": {
+                "unitized": {
+                  "measure": {
+                    "unit": "kilogram",
+                    "value": "5"
+                  }
+                },
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "38",
+                "maximum_value": "65"
+              },
+              "category_id": "Stationery",
+              "location_id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042",
+              "fulfillment_id": "1",
+              "@ondc/org/returnable": true,
+              "@ondc/org/cancellable": true,
+              "@ondc/org/seller_pickup_return": false,
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/time_to_ship": "PT60M",
+              "@ondc/org/contact_details_consumer_care": "ChattyBao Help, help@chattybao.com,7353256777",
+              "@ondc/org/return_window": "P1D",
+              "matched": true,
+              "tags": [
+                {
+                  "code": "origin",
+                  "list": [
+                    {
+                      "code": "country",
+                      "value": "IND"
+                    }
+                  ]
+                },
+                {
+                  "code": "image",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "back_image"
+                    },
+                    {
+                      "code": "url",
+                      "value": "https://cdntest.chattybao.com/sendbird_yellow_images/temp_file_20221125_195913.jpg"
+                    }
+                  ]
+                },
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "7ef33df0-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+              "time": {
+                "label": "enable",
+                "timestamp": "2023-12-13T05:25:44.026Z"
+              },
+              "descriptor": {
+                "name": "Banana 500 g",
+                "code": "7ef33df0-35e4-11ee-95dc-396fe1db85181",
+                "symbol": "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/banana",
+                "short_desc": "Banana 500 g",
+                "long_desc": "Banana 500 g",
+                "images": [
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/banana"
+                ]
+              },
+              "quantity": {
+                "unitized": {
+                  "measure": {
+                    "unit": "kilogram",
+                    "value": "5"
+                  }
+                },
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "3000",
+                "maximum_value": "3000"
+              },
+              "category_id": "Stationery",
+              "location_id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042",
+              "fulfillment_id": "1",
+              "@ondc/org/returnable": true,
+              "@ondc/org/cancellable": true,
+              "@ondc/org/seller_pickup_return": false,
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/time_to_ship": "PT60M",
+              "@ondc/org/contact_details_consumer_care": "ChattyBao Help, help@chattybao.com,7353256777",
+              "@ondc/org/return_window": "P1D",
+              "matched": true,
+              "tags": [
+                {
+                  "code": "origin",
+                  "list": [
+                    {
+                      "code": "country",
+                      "value": "IND"
+                    }
+                  ]
+                },
+                {
+                  "code": "image",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "back_image"
+                    },
+                    {
+                      "code": "url",
+                      "value": "https://cdntest.chattybao.com/sendbird_yellow_images/temp_file_20221125_195913.jpg"
+                    }
+                  ]
+                },
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "54eb9ec0-b340-11ed-b67d-b356d861831b:MR8mcezPPQEA-r8EhP6UN9",
+              "time": {
+                "label": "disable",
+                "timestamp": "2023-12-13T05:25:44.026Z"
+              },
+              "descriptor": {
+                "name": "Item 3",
+                "code": "54eb9ec0-b340-11ed-b67d-b356d861831b",
+                "symbol": "https://cdn.chattybao.com/catlog-img-temp_file_20230223_113710-9892f1fb-ade6-43ae-996c-3dea81059f6a.png",
+                "short_desc": "Item 3",
+                "long_desc": "Item 3",
+                "images": [
+                  "https://cdn.chattybao.com/catlog-img-temp_file_20230223_113710-9892f1fb-ade6-43ae-996c-3dea81059f6a.png"
+                ]
+              },
+              "quantity": {
+                "unitized": {
+                  "measure": {
+                    "unit": "kilogram",
+                    "value": "5"
+                  }
+                },
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "60",
+                "maximum_value": "65"
+              },
+              "category_id": "Stationery",
+              "location_id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042",
+              "fulfillment_id": "1",
+              "@ondc/org/returnable": true,
+              "@ondc/org/cancellable": true,
+              "@ondc/org/seller_pickup_return": false,
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/time_to_ship": "PT60M",
+              "@ondc/org/contact_details_consumer_care": "ChattyBao Help, help@chattybao.com,7353256777",
+              "@ondc/org/return_window": "P1D",
+              "matched": true,
+              "tags": [
+                {
+                  "code": "origin",
+                  "list": [
+                    {
+                      "code": "country",
+                      "value": "IND"
+                    }
+                  ]
+                },
+                {
+                  "code": "image",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "back_image"
+                    },
+                    {
+                      "code": "url",
+                      "value": "https://cdntest.chattybao.com/sendbird_yellow_images/temp_file_20221125_195913.jpg"
+                    }
+                  ]
+                },
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "82479910-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+              "time": {
+                "label": "enable",
+                "timestamp": "2023-12-13T05:25:44.026Z"
+              },
+              "descriptor": {
+                "name": "Bel (wood apple) 1 piece (400 - 600 g)",
+                "code": "82479910-35e4-11ee-95dc-396fe1db85181",
+                "symbol": "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/305323a",
+                "short_desc": "Bel (wood apple) 1 piece (400 - 600 g)",
+                "long_desc": "Bel (wood apple) 1 piece (400 - 600 g)",
+                "images": [
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/305323a"
+                ]
+              },
+              "quantity": {
+                "unitized": {
+                  "measure": {
+                    "unit": "kilogram",
+                    "value": "5"
+                  }
+                },
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "1778",
+                "maximum_value": "1778"
+              },
+              "category_id": "Stationery",
+              "location_id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042",
+              "fulfillment_id": "1",
+              "@ondc/org/returnable": true,
+              "@ondc/org/cancellable": true,
+              "@ondc/org/seller_pickup_return": false,
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/time_to_ship": "PT60M",
+              "@ondc/org/contact_details_consumer_care": "ChattyBao Help, help@chattybao.com,7353256777",
+              "@ondc/org/return_window": "P1D",
+              "matched": true,
+              "tags": [
+                {
+                  "code": "origin",
+                  "list": [
+                    {
+                      "code": "country",
+                      "value": "IND"
+                    }
+                  ]
+                },
+                {
+                  "code": "image",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "back_image"
+                    },
+                    {
+                      "code": "url",
+                      "value": "https://cdntest.chattybao.com/sendbird_yellow_images/temp_file_20221125_195913.jpg"
+                    }
+                  ]
+                },
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/Chattybao/Logs_Dec_13/Retail/Flow 1/on_search_incremental.json
+++ b/Chattybao/Logs_Dec_13/Retail/Flow 1/on_search_incremental.json
@@ -1,0 +1,360 @@
+{
+  "context": {
+    "domain": "ONDC:RET10",
+    "country": "IND",
+    "city": "std:0522",
+    "action": "on_search",
+    "core_version": "1.2.0",
+    "bap_id": "api.staging.nearshop.in",
+    "bap_uri": "https://api.staging.nearshop.in/bap/api/v1",
+    "bpp_id": "ondc-seller-preprod.chattybao.com/ondc",
+    "bpp_uri": "https://ondc-seller-preprod.chattybao.com/ondc/bpp",
+    "transaction_id": "3a67b803-44a4-5790-9bcf-3f2bf73dd750",
+    "message_id": "89bd4c29-afb1-5482-b3a0-208992188ed4",
+    "timestamp": "2023-12-13T04:19:45.036Z",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "catalog": {
+      "bpp/providers": [
+        {
+          "id": "MlepomA3E7XUC_7MpLJgjn",
+          "locations": [
+            {
+              "id": "15b5f8a0-29b5-11ed-93b0-8d73fff38901",
+              "time": {
+                "label": "open",
+                "timestamp": "2023-12-06T06:39:00.437Z"
+              }
+            }
+          ]
+        },
+        {
+          "id": "MR8mcezPPQEA-r8EhP6UN9",
+          "items": [
+            {
+              "id": "49d5ca60-b340-11ed-b67d-b356d861831b:MR8mcezPPQEA-r8EhP6UN9",
+              "time": {
+                "label": "enable",
+                "timestamp": "2023-12-06T05:49:08.889Z"
+              },
+              "descriptor": {
+                "name": "Item 2",
+                "code": "49d5ca60-b340-11ed-b67d-b356d861831b",
+                "symbol": "https://menucards.s3.ap-south-1.amazonaws.com/catlog-img-temp_file_20230223_113650-082b41c9-bcc6-41f7-8ddf-6e27964d5d95.jpg",
+                "short_desc": "Item 2",
+                "long_desc": "Item 2",
+                "images": [
+                  "https://menucards.s3.ap-south-1.amazonaws.com/catlog-img-temp_file_20230223_113650-082b41c9-bcc6-41f7-8ddf-6e27964d5d95.jpg"
+                ]
+              },
+              "quantity": {
+                "unitized": {
+                  "measure": {
+                    "unit": "kilogram",
+                    "value": "5"
+                  }
+                },
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "60",
+                "maximum_value": "65"
+              },
+              "category_id": "Stationery",
+              "location_id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042",
+              "fulfillment_id": "1",
+              "@ondc/org/returnable": true,
+              "@ondc/org/cancellable": true,
+              "@ondc/org/seller_pickup_return": false,
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/time_to_ship": "PT45M",
+              "@ondc/org/contact_details_consumer_care": "ChattyBao Help, help@chattybao.com,7353256777",
+              "@ondc/org/return_window": "P1D",
+              "matched": true,
+              "tags": [
+                {
+                  "code": "origin",
+                  "list": [
+                    {
+                      "code": "country",
+                      "value": "IND"
+                    }
+                  ]
+                },
+                {
+                  "code": "image",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "back_image"
+                    },
+                    {
+                      "code": "url",
+                      "value": "https://cdntest.chattybao.com/sendbird_yellow_images/temp_file_20221125_195913.jpg"
+                    }
+                  ]
+                },
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "b05b0f70-b340-11ed-b67d-b356d861831b:MR8mcezPPQEA-r8EhP6UN9",
+              "time": {
+                "label": "enable",
+                "timestamp": "2023-12-06T05:49:08.889Z"
+              },
+              "descriptor": {
+                "name": "Item 8",
+                "code": "b05b0f70-b340-11ed-b67d-b356d861831b",
+                "symbol": "https://menucards.s3.ap-south-1.amazonaws.com/catlog-img-temp_file_20230223_113943-fb1bda7d-32d9-40ab-982f-9ef3ae9df7b5.png",
+                "short_desc": "Item 8",
+                "long_desc": "Item 8",
+                "images": [
+                  "https://menucards.s3.ap-south-1.amazonaws.com/catlog-img-temp_file_20230223_113943-fb1bda7d-32d9-40ab-982f-9ef3ae9df7b5.png"
+                ]
+              },
+              "quantity": {
+                "unitized": {
+                  "measure": {
+                    "unit": "kilogram",
+                    "value": "5"
+                  }
+                },
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "11",
+                "maximum_value": "65"
+              },
+              "category_id": "Stationery",
+              "location_id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042",
+              "fulfillment_id": "1",
+              "@ondc/org/returnable": true,
+              "@ondc/org/cancellable": true,
+              "@ondc/org/seller_pickup_return": false,
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/time_to_ship": "PT45M",
+              "@ondc/org/contact_details_consumer_care": "ChattyBao Help, help@chattybao.com,7353256777",
+              "@ondc/org/return_window": "P1D",
+              "matched": true,
+              "tags": [
+                {
+                  "code": "origin",
+                  "list": [
+                    {
+                      "code": "country",
+                      "value": "IND"
+                    }
+                  ]
+                },
+                {
+                  "code": "image",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "back_image"
+                    },
+                    {
+                      "code": "url",
+                      "value": "https://cdntest.chattybao.com/sendbird_yellow_images/temp_file_20221125_195913.jpg"
+                    }
+                  ]
+                },
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "a49795f0-b340-11ed-b67d-b356d861831b:MR8mcezPPQEA-r8EhP6UN9",
+              "time": {
+                "label": "disable",
+                "timestamp": "2023-12-06T05:49:08.889Z"
+              },
+              "descriptor": {
+                "name": "Item 7",
+                "code": "a49795f0-b340-11ed-b67d-b356d861831b",
+                "symbol": "https://menucards.s3.ap-south-1.amazonaws.com/catlog-img-temp_file_20230223_113922-dd82da6e-140d-4f05-ada3-a9c7645a391b.jpg",
+                "short_desc": "Item 7",
+                "long_desc": "Item 7",
+                "images": [
+                  "https://menucards.s3.ap-south-1.amazonaws.com/catlog-img-temp_file_20230223_113922-dd82da6e-140d-4f05-ada3-a9c7645a391b.jpg"
+                ]
+              },
+              "quantity": {
+                "unitized": {
+                  "measure": {
+                    "unit": "kilogram",
+                    "value": "5"
+                  }
+                },
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "28",
+                "maximum_value": "65"
+              },
+              "category_id": "Stationery",
+              "location_id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042",
+              "fulfillment_id": "1",
+              "@ondc/org/returnable": true,
+              "@ondc/org/cancellable": true,
+              "@ondc/org/seller_pickup_return": false,
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/time_to_ship": "PT45M",
+              "@ondc/org/contact_details_consumer_care": "ChattyBao Help, help@chattybao.com,7353256777",
+              "@ondc/org/return_window": "P1D",
+              "matched": true,
+              "tags": [
+                {
+                  "code": "origin",
+                  "list": [
+                    {
+                      "code": "country",
+                      "value": "IND"
+                    }
+                  ]
+                },
+                {
+                  "code": "image",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "back_image"
+                    },
+                    {
+                      "code": "url",
+                      "value": "https://cdntest.chattybao.com/sendbird_yellow_images/temp_file_20221125_195913.jpg"
+                    }
+                  ]
+                },
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "70b0fec0-b340-11ed-b67d-b356d861831b:MR8mcezPPQEA-r8EhP6UN9",
+              "time": {
+                "label": "disable",
+                "timestamp": "2023-12-06T05:49:08.889Z"
+              },
+              "descriptor": {
+                "name": "Item 5",
+                "code": "70b0fec0-b340-11ed-b67d-b356d861831b",
+                "symbol": "https://menucards.s3.ap-south-1.amazonaws.com/catlog-img-temp_file_20230223_113750-ca305d07-31d7-48e0-add0-b77247a68234.jpg",
+                "short_desc": "Item 5",
+                "long_desc": "Item 5",
+                "images": [
+                  "https://menucards.s3.ap-south-1.amazonaws.com/catlog-img-temp_file_20230223_113750-ca305d07-31d7-48e0-add0-b77247a68234.jpg"
+                ]
+              },
+              "quantity": {
+                "unitized": {
+                  "measure": {
+                    "unit": "kilogram",
+                    "value": "5"
+                  }
+                },
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "38",
+                "maximum_value": "65"
+              },
+              "category_id": "Stationery",
+              "location_id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042",
+              "fulfillment_id": "1",
+              "@ondc/org/returnable": true,
+              "@ondc/org/cancellable": true,
+              "@ondc/org/seller_pickup_return": false,
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/time_to_ship": "PT45M",
+              "@ondc/org/contact_details_consumer_care": "ChattyBao Help, help@chattybao.com,7353256777",
+              "@ondc/org/return_window": "P1D",
+              "matched": true,
+              "tags": [
+                {
+                  "code": "origin",
+                  "list": [
+                    {
+                      "code": "country",
+                      "value": "IND"
+                    }
+                  ]
+                },
+                {
+                  "code": "image",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "back_image"
+                    },
+                    {
+                      "code": "url",
+                      "value": "https://cdntest.chattybao.com/sendbird_yellow_images/temp_file_20221125_195913.jpg"
+                    }
+                  ]
+                },
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/Chattybao/Logs_Dec_13/Retail/Flow 1/search_full_catalog.json
+++ b/Chattybao/Logs_Dec_13/Retail/Flow 1/search_full_catalog.json
@@ -1,0 +1,53 @@
+{
+  "context": {
+    "domain": "ONDC:RET10",
+    "country": "IND",
+    "city": "std:0522",
+    "action": "search",
+    "core_version": "1.2.0",
+    "bap_id": "api.staging.nearshop.in",
+    "bap_uri": "https://api.staging.nearshop.in/bap/api/v1",
+    "transaction_id": "ceb62331-0122-5956-b1eb-834ebe31d363",
+    "message_id": "34f53b10-39e8-5aae-9e26-e41c77307670",
+    "timestamp": "2023-12-13T05:25:43.314Z",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "intent": {
+      "fulfillment": {
+        "type": "Delivery",
+        "end": {
+          "location": {
+            "gps": "26.846212,80.949018",
+            "address": {
+              "area_code": "226001"
+            }
+          }
+        }
+      },
+      "tags": [
+        {
+          "code": "bap_terms",
+          "list": [
+            {
+              "code": "static_terms",
+              "value": ""
+            },
+            {
+              "code": "static_terms_new",
+              "value": "https://github.com/ONDC-Official/NP-Static-Terms/buyerNP_BNP/1.0/tc.pdf"
+            },
+            {
+              "code": "effective_date",
+              "value": "2023-12-13T05:25:43.312Z"
+            }
+          ]
+        }
+      ],
+      "payment": {
+        "@ondc/org/buyer_app_finder_fee_type": "percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "3"
+      }
+    }
+  }
+}

--- a/Chattybao/Logs_Dec_13/Retail/Flow 1/search_incremental.json
+++ b/Chattybao/Logs_Dec_13/Retail/Flow 1/search_incremental.json
@@ -1,0 +1,62 @@
+{
+  "context": {
+    "domain": "ONDC:RET10",
+    "country": "IND",
+    "city": "std:0522",
+    "action": "search",
+    "core_version": "1.2.0",
+    "bap_id": "api.staging.nearshop.in",
+    "bap_uri": "https://api.staging.nearshop.in/bap/api/v1",
+    "transaction_id": "3a67b803-44a4-5790-9bcf-3f2bf73dd750",
+    "message_id": "89bd4c29-afb1-5482-b3a0-208992188aa4",
+    "timestamp": "2023-12-13T06:43:38.137Z",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "intent": {
+      "fulfillment": {
+        "type": "Delivery",
+        "end": {
+          "location": {
+            "gps": "26.846212,80.949018",
+            "address": {
+              "area_code": "226001"
+            }
+          }
+        }
+      },
+      "tags": [
+        {
+          "code": "catalog_inc",
+          "list": [
+            {
+              "code": "mode",
+              "value": "start"
+            }
+          ]
+        },
+        {
+          "code": "bap_terms",
+          "list": [
+            {
+              "code": "static_terms",
+              "value": ""
+            },
+            {
+              "code": "static_terms_new",
+              "value": "https://github.com/ONDC-Official/NP-Static-Terms/buyerNP_BNP/1.0/tc.pdf"
+            },
+            {
+              "code": "effective_date",
+              "value": "2023-12-13T05:34:28.135Z"
+            }
+          ]
+        }
+      ],
+      "payment": {
+        "@ondc/org/buyer_app_finder_fee_type": "percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "3"
+      }
+    }
+  }
+}

--- a/Chattybao/Logs_Dec_13/Retail/Flow 2/confirm.json
+++ b/Chattybao/Logs_Dec_13/Retail/Flow 2/confirm.json
@@ -1,0 +1,216 @@
+{
+  "context": {
+    "domain": "ONDC:RET10",
+    "country": "IND",
+    "city": "std:0522",
+    "action": "confirm",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_uri": "https://ondc-seller-preprod.chattybao.com/ondc/bpp",
+    "transaction_id": "3f8a2bbe-b293-44e0-a91b-b9806241d1f5",
+    "message_id": "0565a851-4c83-4ce8-94ef-107ca94a34ca",
+    "timestamp": "2023-12-13T06:59:03.897Z",
+    "bpp_id": "ondc-seller-preprod.chattybao.com/ondc",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "id": "2023-12-13-811516",
+      "state": "Created",
+      "billing": {
+        "address": {
+          "name": "Venkat",
+          "building": "4-32",
+          "locality": "Shankar Chauraha Road",
+          "city": "Lucknow",
+          "state": "Uttar Pradesh",
+          "country": "IND",
+          "area_code": "226010"
+        },
+        "phone": "9739374094",
+        "name": "Venkat",
+        "email": "venkyuvr@gmail.com",
+        "created_at": "2023-12-13T06:58:05.708Z",
+        "updated_at": "2023-12-13T06:58:05.708Z"
+      },
+      "items": [
+        {
+          "id": "7f0677d0-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 3
+          },
+          "fulfillment_id": "1"
+        },
+        {
+          "id": "7e92f580-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "1"
+        }
+      ],
+      "provider": {
+        "id": "MR8mcezPPQEA-r8EhP6UN9",
+        "locations": [
+          {
+            "id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042"
+          }
+        ]
+      },
+      "fulfillments": [
+        {
+          "id": "1",
+          "tracking": true,
+          "end": {
+            "contact": {
+              "email": "venkyuvr@gmail.com",
+              "phone": "9739374094"
+            },
+            "person": {
+              "name": "Venkat"
+            },
+            "location": {
+              "gps": "26.849441465615914, 80.99205368752338",
+              "address": {
+                "name": "Venkat",
+                "building": "4-32",
+                "locality": "Shankar Chauraha Road",
+                "city": "Lucknow",
+                "state": "Uttar Pradesh",
+                "country": "IND",
+                "area_code": "226010"
+              }
+            }
+          },
+          "type": "Delivery"
+        }
+      ],
+      "payment": {
+        "uri": "https://juspay.in/",
+        "tl_method": "http/get",
+        "params": {
+          "amount": "5245",
+          "currency": "INR",
+          "transaction_id": "b9517167-bfd0-44c9-9092-cf8b82969cba"
+        },
+        "status": "PAID",
+        "type": "ON-ORDER",
+        "collected_by": "BAP",
+        "@ondc/org/buyer_app_finder_fee_type": "percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "seller-app",
+            "settlement_phase": "sale-amount",
+            "settlement_type": "neft",
+            "beneficiary_name": "CHATTYBAO TECHNOLOGIES PRIVATE LIMITED NODAL ACCOUNT",
+            "upi_address": "",
+            "settlement_bank_account_no": "661505602069",
+            "settlement_ifsc_code": "ICIC0006615",
+            "bank_name": "ICICI\",",
+            "branch_name": "Sco 31, Sector 18, Udyog Vihar, Gurgaon - 122016, Haryana"
+          }
+        ]
+      },
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "5245"
+        },
+        "breakup": [
+          {
+            "title": "Apple Kinnaur 500 g",
+            "@ondc/org/item_id": "7f0677d0-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/title_type": "item",
+            "@ondc/org/item_quantity": {
+              "count": 3
+            },
+            "price": {
+              "currency": "INR",
+              "value": "195"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "65"
+              }
+            }
+          },
+          {
+            "title": "Banana 1 kg",
+            "@ondc/org/item_id": "7e92f580-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/title_type": "item",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "price": {
+              "currency": "INR",
+              "value": "5000"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "2500"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "1",
+            "title": "Delivery Charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "42"
+            }
+          },
+          {
+            "@ondc/org/item_id": "1",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "8"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "quote",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "fulfillment"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "ttl": "P4D"
+      },
+      "tags": [
+        {
+          "code": "bpp_terms",
+          "list": [
+            {
+              "code": "tax_number",
+              "value": "07AAJCC8423B1ZW"
+            }
+          ]
+        },
+        {
+          "code": "bap_terms",
+          "list": [
+            {
+              "code": "tax_number",
+              "value": "BUYER-APP-GSTN-ONDC"
+            }
+          ]
+        }
+      ],
+      "created_at": "2023-12-13T06:59:03.897Z",
+      "updated_at": "2023-12-13T06:59:03.897Z"
+    }
+  }
+}

--- a/Chattybao/Logs_Dec_13/Retail/Flow 2/init.json
+++ b/Chattybao/Logs_Dec_13/Retail/Flow 2/init.json
@@ -1,0 +1,87 @@
+{
+  "context": {
+    "domain": "ONDC:RET10",
+    "country": "IND",
+    "city": "std:0522",
+    "action": "init",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_uri": "https://ondc-seller-preprod.chattybao.com/ondc/bpp",
+    "transaction_id": "3f8a2bbe-b293-44e0-a91b-b9806241d1f5",
+    "message_id": "ac25c814-0e87-4e89-aa07-d0df1e65b8f8",
+    "timestamp": "2023-12-13T06:58:05.708Z",
+    "bpp_id": "ondc-seller-preprod.chattybao.com/ondc",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "provider": {
+        "id": "MR8mcezPPQEA-r8EhP6UN9",
+        "locations": [
+          {
+            "id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042"
+          }
+        ]
+      },
+      "items": [
+        {
+          "id": "7f0677d0-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 3
+          },
+          "location_id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042",
+          "fulfillment_id": "1"
+        },
+        {
+          "id": "7e92f580-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 2
+          },
+          "location_id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042",
+          "fulfillment_id": "1"
+        }
+      ],
+      "billing": {
+        "address": {
+          "building": "4-32",
+          "city": "Lucknow",
+          "state": "Uttar Pradesh",
+          "country": "IND",
+          "area_code": "226010",
+          "locality": "Shankar Chauraha Road",
+          "name": "Venkat"
+        },
+        "phone": "9739374094",
+        "name": "Venkat",
+        "email": "venkyuvr@gmail.com",
+        "created_at": "2023-12-13T06:58:05.708Z",
+        "updated_at": "2023-12-13T06:58:05.708Z"
+      },
+      "fulfillments": [
+        {
+          "id": "1",
+          "type": "Delivery",
+          "end": {
+            "contact": {
+              "email": "venkyuvr@gmail.com",
+              "phone": "9739374094"
+            },
+            "location": {
+              "gps": "26.849441465615914, 80.99205368752338",
+              "address": {
+                "building": "4-32",
+                "city": "Lucknow",
+                "state": "Uttar Pradesh",
+                "country": "IND",
+                "area_code": "226010",
+                "locality": "Shankar Chauraha Road",
+                "name": "Venkat"
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/Chattybao/Logs_Dec_13/Retail/Flow 2/on_confirm.json
+++ b/Chattybao/Logs_Dec_13/Retail/Flow 2/on_confirm.json
@@ -1,0 +1,263 @@
+{
+  "context": {
+    "domain": "ONDC:RET10",
+    "country": "IND",
+    "city": "std:0522",
+    "action": "on_confirm",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_uri": "https://ondc-seller-preprod.chattybao.com/ondc/bpp",
+    "transaction_id": "3f8a2bbe-b293-44e0-a91b-b9806241d1f5",
+    "message_id": "0565a851-4c83-4ce8-94ef-107ca94a34ca",
+    "timestamp": "2023-12-13T06:59:04.084Z",
+    "bpp_id": "ondc-seller-preprod.chattybao.com/ondc",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "id": "2023-12-13-811516",
+      "state": "Accepted",
+      "billing": {
+        "address": {
+          "name": "Venkat",
+          "building": "4-32",
+          "locality": "Shankar Chauraha Road",
+          "city": "Lucknow",
+          "state": "Uttar Pradesh",
+          "country": "IND",
+          "area_code": "226010"
+        },
+        "phone": "9739374094",
+        "name": "Venkat",
+        "email": "venkyuvr@gmail.com",
+        "created_at": "2023-12-13T06:58:05.708Z",
+        "updated_at": "2023-12-13T06:58:05.708Z"
+      },
+      "items": [
+        {
+          "id": "7f0677d0-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 3
+          },
+          "fulfillment_id": "1"
+        },
+        {
+          "id": "7e92f580-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "1"
+        }
+      ],
+      "provider": {
+        "id": "MR8mcezPPQEA-r8EhP6UN9",
+        "locations": [
+          {
+            "id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042"
+          }
+        ]
+      },
+      "fulfillments": [
+        {
+          "@ondc/org/provider_name": "tester shatrughan fru and veg",
+          "state": {
+            "descriptor": {
+              "code": "Pending"
+            }
+          },
+          "start": {
+            "location": {
+              "id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042",
+              "descriptor": {
+                "name": "tester shatrughan fru and veg"
+              },
+              "gps": "26.854719,80.998035",
+              "address": {
+                "locality": "4/267, Vivek Khand 4 Gomti Nagar",
+                "city": "Uttar Pradesh",
+                "area_code": "226010",
+                "state": "lucknow"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2023-12-13T06:59:04.076Z",
+                "end": "2023-12-13T07:29:04.076Z"
+              }
+            },
+            "instructions": {
+              "code": "2",
+              "name": "ONDC order",
+              "short_desc": "ONDC order",
+              "long_desc": "ONDC order"
+            },
+            "contact": {
+              "phone": "8840019700",
+              "email": "help@chattybao.com"
+            }
+          },
+          "id": "1",
+          "tracking": true,
+          "end": {
+            "contact": {
+              "email": "venkyuvr@gmail.com",
+              "phone": "9739374094"
+            },
+            "person": {
+              "name": "Venkat"
+            },
+            "location": {
+              "gps": "26.849441465615914, 80.99205368752338",
+              "address": {
+                "name": "Venkat",
+                "building": "4-32",
+                "locality": "Shankar Chauraha Road",
+                "city": "Lucknow",
+                "state": "Uttar Pradesh",
+                "country": "IND",
+                "area_code": "226010"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2023-12-13T06:59:04.079Z",
+                "end": "2023-12-13T07:59:04.079Z"
+              }
+            }
+          },
+          "type": "Delivery"
+        }
+      ],
+      "payment": {
+        "uri": "https://juspay.in/",
+        "tl_method": "http/get",
+        "params": {
+          "amount": "5245",
+          "currency": "INR",
+          "transaction_id": "b9517167-bfd0-44c9-9092-cf8b82969cba"
+        },
+        "status": "PAID",
+        "type": "ON-ORDER",
+        "collected_by": "BAP",
+        "@ondc/org/buyer_app_finder_fee_type": "percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "seller-app",
+            "settlement_phase": "sale-amount",
+            "settlement_type": "neft",
+            "beneficiary_name": "CHATTYBAO TECHNOLOGIES PRIVATE LIMITED NODAL ACCOUNT",
+            "upi_address": "",
+            "settlement_bank_account_no": "661505602069",
+            "settlement_ifsc_code": "ICIC0006615",
+            "bank_name": "ICICI\",",
+            "branch_name": "Sco 31, Sector 18, Udyog Vihar, Gurgaon - 122016, Haryana"
+          }
+        ],
+        "@ondc/org/settlement_basis": "delivery",
+        "@ondc/org/settlement_window": "P1D",
+        "@ondc/org/withholding_amount": "10.00"
+      },
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "5245"
+        },
+        "breakup": [
+          {
+            "title": "Apple Kinnaur 500 g",
+            "@ondc/org/item_id": "7f0677d0-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/title_type": "item",
+            "@ondc/org/item_quantity": {
+              "count": 3
+            },
+            "price": {
+              "currency": "INR",
+              "value": "195"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "65"
+              }
+            }
+          },
+          {
+            "title": "Banana 1 kg",
+            "@ondc/org/item_id": "7e92f580-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/title_type": "item",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "price": {
+              "currency": "INR",
+              "value": "5000"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "2500"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "1",
+            "title": "Delivery Charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "42"
+            }
+          },
+          {
+            "@ondc/org/item_id": "1",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "8"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "quote",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "fulfillment"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "ttl": "P4D"
+      },
+      "tags": [
+        {
+          "code": "bpp_terms",
+          "list": [
+            {
+              "code": "tax_number",
+              "value": "07AAJCC8423B1ZW"
+            }
+          ]
+        },
+        {
+          "code": "bap_terms",
+          "list": [
+            {
+              "code": "tax_number",
+              "value": "BUYER-APP-GSTN-ONDC"
+            }
+          ]
+        }
+      ],
+      "created_at": "2023-12-13T06:59:03.897Z",
+      "updated_at": "2023-12-13T06:59:04.084Z",
+      "rateable": true
+    }
+  }
+}

--- a/Chattybao/Logs_Dec_13/Retail/Flow 2/on_init.json
+++ b/Chattybao/Logs_Dec_13/Retail/Flow 2/on_init.json
@@ -1,0 +1,299 @@
+{
+  "context": {
+    "domain": "ONDC:RET10",
+    "country": "IND",
+    "city": "std:0522",
+    "action": "on_init",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_uri": "https://ondc-seller-preprod.chattybao.com/ondc/bpp",
+    "transaction_id": "3f8a2bbe-b293-44e0-a91b-b9806241d1f5",
+    "message_id": "ac25c814-0e87-4e89-aa07-d0df1e65b8f8",
+    "timestamp": "2023-12-13T06:58:06.788Z",
+    "bpp_id": "ondc-seller-preprod.chattybao.com/ondc",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "items": [
+        {
+          "id": "7f0677d0-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 3
+          },
+          "location_id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042",
+          "fulfillment_id": "1"
+        },
+        {
+          "id": "7e92f580-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 2
+          },
+          "location_id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042",
+          "fulfillment_id": "1"
+        }
+      ],
+      "billing": {
+        "address": {
+          "building": "4-32",
+          "city": "Lucknow",
+          "state": "Uttar Pradesh",
+          "country": "IND",
+          "area_code": "226010",
+          "locality": "Shankar Chauraha Road",
+          "name": "Venkat"
+        },
+        "phone": "9739374094",
+        "name": "Venkat",
+        "email": "venkyuvr@gmail.com",
+        "created_at": "2023-12-13T06:58:05.708Z",
+        "updated_at": "2023-12-13T06:58:05.708Z"
+      },
+      "fulfillments": [
+        {
+          "id": "1",
+          "type": "Delivery",
+          "end": {
+            "contact": {
+              "email": "venkyuvr@gmail.com",
+              "phone": "9739374094"
+            },
+            "location": {
+              "gps": "26.849441465615914, 80.99205368752338",
+              "address": {
+                "building": "4-32",
+                "city": "Lucknow",
+                "state": "Uttar Pradesh",
+                "country": "IND",
+                "area_code": "226010",
+                "locality": "Shankar Chauraha Road",
+                "name": "Venkat"
+              }
+            }
+          },
+          "tracking": true
+        }
+      ],
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "5245"
+        },
+        "breakup": [
+          {
+            "title": "Apple Kinnaur 500 g",
+            "@ondc/org/item_id": "7f0677d0-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/title_type": "item",
+            "@ondc/org/item_quantity": {
+              "count": 3
+            },
+            "price": {
+              "currency": "INR",
+              "value": "195"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "65"
+              }
+            }
+          },
+          {
+            "title": "Banana 1 kg",
+            "@ondc/org/item_id": "7e92f580-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/title_type": "item",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "price": {
+              "currency": "INR",
+              "value": "5000"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "2500"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "1",
+            "title": "Delivery Charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "42"
+            }
+          },
+          {
+            "@ondc/org/item_id": "1",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "8"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "quote",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "fulfillment"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "ttl": "P4D"
+      },
+      "provider": {
+        "id": "MR8mcezPPQEA-r8EhP6UN9",
+        "locations": [
+          {
+            "id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042"
+          }
+        ]
+      },
+      "provider_location": {
+        "id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042"
+      },
+      "payment": {
+        "type": "ON-ORDER",
+        "collected_by": "BAP",
+        "status": "NOT-PAID",
+        "@ondc/org/settlement_basis": "delivery",
+        "@ondc/org/settlement_window": "P1D",
+        "@ondc/org/withholding_amount": "10.00",
+        "@ondc/org/buyer_app_finder_fee_type": "percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "3",
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "seller-app",
+            "settlement_phase": "sale-amount",
+            "settlement_type": "neft",
+            "beneficiary_name": "CHATTYBAO TECHNOLOGIES PRIVATE LIMITED NODAL ACCOUNT",
+            "upi_address": "",
+            "settlement_bank_account_no": "661505602069",
+            "settlement_ifsc_code": "ICIC0006615",
+            "bank_name": "ICICI\",",
+            "branch_name": "Sco 31, Sector 18, Udyog Vihar, Gurgaon - 122016, Haryana"
+          }
+        ]
+      },
+      "cancellation_terms": [
+        {
+          "fulfillment_state": {
+            "descriptor": {
+              "code": "Pending",
+              "short_desc": ""
+            }
+          },
+          "refund_eligible": true,
+          "reason_required": false,
+          "cancellation_fee": {
+            "percentage": "0.00",
+            "amount": {
+              "currency": "INR",
+              "value": "0.00"
+            }
+          }
+        },
+        {
+          "fulfillment_state": {
+            "descriptor": {
+              "code": "Packed",
+              "short_desc": "001,003"
+            }
+          },
+          "refund_eligible": true,
+          "reason_required": true,
+          "cancellation_fee": {
+            "percentage": "0.00",
+            "amount": {
+              "currency": "INR",
+              "value": "0.00"
+            }
+          }
+        },
+        {
+          "fulfillment_state": {
+            "descriptor": {
+              "code": "Order-picked-up",
+              "short_desc": "001,003"
+            }
+          },
+          "refund_eligible": true,
+          "reason_required": true,
+          "cancellation_fee": {
+            "amount": {
+              "currency": "INR",
+              "value": "50.00"
+            }
+          }
+        },
+        {
+          "fulfillment_state": {
+            "descriptor": {
+              "code": "Out-for-delivery",
+              "short_desc": "009"
+            }
+          },
+          "refund_eligible": false,
+          "reason_required": true,
+          "cancellation_fee": {
+            "percentage": "100.00"
+          }
+        },
+        {
+          "fulfillment_state": {
+            "descriptor": {
+              "code": "Out-for-delivery",
+              "short_desc": "010,011,012,013,014,015"
+            }
+          },
+          "refund_eligible": false,
+          "reason_required": true,
+          "cancellation_fee": {
+            "percentage": "100.00"
+          }
+        }
+      ],
+      "tags": [
+        {
+          "code": "bpp_terms",
+          "list": [
+            {
+              "code": "max_liability",
+              "value": "2"
+            },
+            {
+              "code": "max_liability_cap",
+              "value": "10000.00"
+            },
+            {
+              "code": "mandatory_arbitration",
+              "value": "false"
+            },
+            {
+              "code": "court_jurisdiction",
+              "value": "Delhi"
+            },
+            {
+              "code": "delay_interest",
+              "value": "1000.00"
+            },
+            {
+              "code": "tax_number",
+              "value": "07AAJCC8423B1ZW"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/Chattybao/Logs_Dec_13/Retail/Flow 2/on_select.json
+++ b/Chattybao/Logs_Dec_13/Retail/Flow 2/on_select.json
@@ -1,0 +1,186 @@
+{
+  "context": {
+    "domain": "ONDC:RET10",
+    "country": "IND",
+    "city": "std:0522",
+    "action": "on_select",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_uri": "https://ondc-seller-preprod.chattybao.com/ondc/bpp",
+    "transaction_id": "3f8a2bbe-b293-44e0-a91b-b9806241d1f5",
+    "message_id": "889d2b93-e52d-4b28-9eca-fae4d103764f",
+    "timestamp": "2023-12-13T06:57:20.214Z",
+    "bpp_id": "ondc-seller-preprod.chattybao.com/ondc",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "provider": {
+        "id": "MR8mcezPPQEA-r8EhP6UN9",
+        "locations": [
+          {
+            "id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042"
+          }
+        ]
+      },
+      "items": [
+        {
+          "@ondc/org/available_on_cod": false,
+          "@ondc/org/cancellable": true,
+          "@ondc/org/contact_details_consumer_care": "ChattyBao Help, help@chattybao.com,7353256777",
+          "@ondc/org/mandatory_reqs_veggies_fruits": {},
+          "@ondc/org/returnable": true,
+          "@ondc/org/seller_pickup_return": true,
+          "@ondc/org/statutory_reqs_packaged_commodities": {},
+          "@ondc/org/statutory_reqs_prepackaged_food": {},
+          "matched": true,
+          "rateable": true,
+          "recommended": true,
+          "fulfillment_id": "1",
+          "id": "7f0677d0-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+          "price": {
+            "currency": "INR",
+            "value": "65"
+          },
+          "quantity": {
+            "selected": {
+              "count": 3
+            }
+          }
+        },
+        {
+          "@ondc/org/available_on_cod": false,
+          "@ondc/org/cancellable": true,
+          "@ondc/org/contact_details_consumer_care": "ChattyBao Help, help@chattybao.com,7353256777",
+          "@ondc/org/mandatory_reqs_veggies_fruits": {},
+          "@ondc/org/returnable": true,
+          "@ondc/org/seller_pickup_return": true,
+          "@ondc/org/statutory_reqs_packaged_commodities": {},
+          "@ondc/org/statutory_reqs_prepackaged_food": {},
+          "matched": true,
+          "rateable": true,
+          "recommended": true,
+          "fulfillment_id": "1",
+          "id": "7e92f580-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+          "price": {
+            "currency": "INR",
+            "value": "2500"
+          },
+          "quantity": {
+            "selected": {
+              "count": 2
+            }
+          }
+        }
+      ],
+      "fulfillments": [
+        {
+          "id": "1",
+          "type": "Delivery",
+          "@ondc/org/provider_name": "Chattybao Logistics",
+          "tracking": true,
+          "@ondc/org/category": "Immediate Delivery",
+          "@ondc/org/TAT": "PT60M",
+          "state": {
+            "descriptor": {
+              "code": "Serviceable"
+            }
+          }
+        }
+      ],
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "5245"
+        },
+        "breakup": [
+          {
+            "@ondc/org/item_id": "7f0677d0-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/item_quantity": {
+              "count": 3
+            },
+            "@ondc/org/title_type": "item",
+            "title": "Apple Kinnaur 500 g",
+            "price": {
+              "currency": "INR",
+              "value": "195"
+            },
+            "item": {
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "65"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "7e92f580-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "@ondc/org/title_type": "item",
+            "title": "Banana 1 kg",
+            "price": {
+              "currency": "INR",
+              "value": "5000"
+            },
+            "item": {
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "2500"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "1",
+            "title": "Delivery Charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "42"
+            }
+          },
+          {
+            "@ondc/org/item_id": "1",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "8"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "quote",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "fulfillment"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "ttl": "P4D"
+      }
+    }
+  }
+}

--- a/Chattybao/Logs_Dec_13/Retail/Flow 2/on_status_delivered.json
+++ b/Chattybao/Logs_Dec_13/Retail/Flow 2/on_status_delivered.json
@@ -1,0 +1,251 @@
+{
+  "context": {
+    "domain": "ONDC:RET10",
+    "country": "IND",
+    "city": "std:0522",
+    "action": "on_status",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_uri": "https://ondc-seller-preprod.chattybao.com/ondc/bpp",
+    "transaction_id": "3f8a2bbe-b293-44e0-a91b-b9806241d1f5",
+    "message_id": "7b9a8b90-9985-11ee-a063-913f64757eea",
+    "timestamp": "2023-12-13T07:01:47.849Z",
+    "bpp_id": "ondc-seller-preprod.chattybao.com/ondc",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "id": "2023-12-13-811516",
+      "state": "Completed",
+      "provider": {
+        "id": "MR8mcezPPQEA-r8EhP6UN9",
+        "locations": [
+          {
+            "id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042"
+          }
+        ]
+      },
+      "items": [
+        {
+          "id": "7f0677d0-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 3
+          },
+          "fulfillment_id": "1",
+          "@ondc/org/returnable": true,
+          "@ondc/org/cancellable": true
+        },
+        {
+          "id": "7e92f580-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "1",
+          "@ondc/org/returnable": true,
+          "@ondc/org/cancellable": true
+        }
+      ],
+      "billing": {
+        "address": {
+          "name": "Venkat",
+          "building": "4-32",
+          "locality": "Shankar Chauraha Road",
+          "city": "Lucknow",
+          "state": "Uttar Pradesh",
+          "country": "IND",
+          "area_code": "226010"
+        },
+        "phone": "9739374094",
+        "name": "Venkat",
+        "email": "help@chattybao.com",
+        "created_at": "2023-12-13T06:58:05.708Z",
+        "updated_at": "2023-12-13T06:58:05.708Z"
+      },
+      "fulfillments": [
+        {
+          "@ondc/org/provider_name": "tester shatrughan fru and veg",
+          "state": {
+            "descriptor": {
+              "code": "Order-delivered",
+              "name": "Order delivered"
+            }
+          },
+          "start": {
+            "location": {
+              "id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042",
+              "descriptor": {
+                "name": "tester shatrughan fru and veg"
+              },
+              "gps": "26.854719,80.998035",
+              "address": {
+                "locality": "4/267, Vivek Khand 4 Gomti Nagar",
+                "city": "Uttar Pradesh",
+                "area_code": "226010",
+                "state": "lucknow"
+              }
+            },
+            "time": {
+              "timestamp": "2023-12-13T07:00:50.821Z",
+              "range": {
+                "start": "2023-12-13T06:59:04.076Z",
+                "end": "2023-12-13T07:29:04.076Z"
+              }
+            },
+            "instructions": {
+              "code": "2",
+              "name": "ONDC order",
+              "short_desc": "ONDC order",
+              "long_desc": "ONDC order"
+            },
+            "contact": {
+              "phone": "8840019700",
+              "email": "help@chattybao.com"
+            }
+          },
+          "id": "1",
+          "tracking": true,
+          "end": {
+            "contact": {
+              "email": "venkyuvr@gmail.com",
+              "phone": "9739374094"
+            },
+            "person": {
+              "name": "Venkat"
+            },
+            "location": {
+              "gps": "26.849441465615914, 80.99205368752338",
+              "address": {
+                "name": "Venkat",
+                "building": "4-32",
+                "locality": "Shankar Chauraha Road",
+                "city": "Lucknow",
+                "state": "Uttar Pradesh",
+                "country": "IND",
+                "area_code": "226010"
+              }
+            },
+            "time": {
+              "timestamp": "2023-12-13T07:01:47.846Z",
+              "range": {
+                "start": "2023-12-13T06:59:04.079Z",
+                "end": "2023-12-13T07:59:04.079Z"
+              }
+            }
+          },
+          "type": "Delivery",
+          "@ondc/org/TAT": "PT60M"
+        }
+      ],
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "5245"
+        },
+        "breakup": [
+          {
+            "title": "Apple Kinnaur 500 g",
+            "@ondc/org/item_id": "7f0677d0-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/title_type": "item",
+            "@ondc/org/item_quantity": {
+              "count": 3
+            },
+            "price": {
+              "currency": "INR",
+              "value": "195"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "65"
+              }
+            }
+          },
+          {
+            "title": "Banana 1 kg",
+            "@ondc/org/item_id": "7e92f580-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/title_type": "item",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "price": {
+              "currency": "INR",
+              "value": "5000"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "2500"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "1",
+            "title": "Delivery Charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "42"
+            }
+          },
+          {
+            "@ondc/org/item_id": "1",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "8"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "quote",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "fulfillment"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "ttl": "P4D"
+      },
+      "payment": {
+        "uri": "https://juspay.in/",
+        "tl_method": "http/get",
+        "params": {
+          "amount": "5245",
+          "currency": "INR",
+          "transaction_id": "b9517167-bfd0-44c9-9092-cf8b82969cba"
+        },
+        "status": "PAID",
+        "type": "ON-ORDER",
+        "collected_by": "BAP",
+        "@ondc/org/buyer_app_finder_fee_type": "percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "seller-app",
+            "settlement_phase": "sale-amount",
+            "settlement_type": "neft",
+            "beneficiary_name": "CHATTYBAO TECHNOLOGIES PRIVATE LIMITED NODAL ACCOUNT",
+            "upi_address": "",
+            "settlement_bank_account_no": "661505602069",
+            "settlement_ifsc_code": "ICIC0006615",
+            "bank_name": "ICICI\",",
+            "branch_name": "Sco 31, Sector 18, Udyog Vihar, Gurgaon - 122016, Haryana",
+            "settlement_timestamp": "2023-12-14T07:29:04.076Z"
+          }
+        ],
+        "@ondc/org/settlement_basis": "delivery",
+        "@ondc/org/settlement_window": "P1D",
+        "@ondc/org/withholding_amount": "10.00"
+      },
+      "created_at": "2023-12-13T06:59:03.897Z",
+      "updated_at": "2023-12-13T07:01:47.849Z"
+    }
+  }
+}

--- a/Chattybao/Logs_Dec_13/Retail/Flow 2/on_status_out_for_delivery.json
+++ b/Chattybao/Logs_Dec_13/Retail/Flow 2/on_status_out_for_delivery.json
@@ -1,0 +1,250 @@
+{
+  "context": {
+    "domain": "ONDC:RET10",
+    "country": "IND",
+    "city": "std:0522",
+    "action": "on_status",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_uri": "https://ondc-seller-preprod.chattybao.com/ondc/bpp",
+    "transaction_id": "3f8a2bbe-b293-44e0-a91b-b9806241d1f5",
+    "message_id": "613a12c0-9985-11ee-a063-913f64757eea",
+    "timestamp": "2023-12-13T07:01:03.596Z",
+    "bpp_id": "ondc-seller-preprod.chattybao.com/ondc",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "id": "2023-12-13-811516",
+      "state": "In-progress",
+      "provider": {
+        "id": "MR8mcezPPQEA-r8EhP6UN9",
+        "locations": [
+          {
+            "id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042"
+          }
+        ]
+      },
+      "items": [
+        {
+          "id": "7f0677d0-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 3
+          },
+          "fulfillment_id": "1",
+          "@ondc/org/returnable": true,
+          "@ondc/org/cancellable": true
+        },
+        {
+          "id": "7e92f580-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "1",
+          "@ondc/org/returnable": true,
+          "@ondc/org/cancellable": true
+        }
+      ],
+      "billing": {
+        "address": {
+          "name": "Venkat",
+          "building": "4-32",
+          "locality": "Shankar Chauraha Road",
+          "city": "Lucknow",
+          "state": "Uttar Pradesh",
+          "country": "IND",
+          "area_code": "226010"
+        },
+        "phone": "9739374094",
+        "name": "Venkat",
+        "email": "help@chattybao.com",
+        "created_at": "2023-12-13T06:58:05.708Z",
+        "updated_at": "2023-12-13T06:58:05.708Z"
+      },
+      "fulfillments": [
+        {
+          "@ondc/org/provider_name": "tester shatrughan fru and veg",
+          "state": {
+            "descriptor": {
+              "code": "Out-for-delivery",
+              "name": "Out for delivery"
+            }
+          },
+          "start": {
+            "location": {
+              "id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042",
+              "descriptor": {
+                "name": "tester shatrughan fru and veg"
+              },
+              "gps": "26.854719,80.998035",
+              "address": {
+                "locality": "4/267, Vivek Khand 4 Gomti Nagar",
+                "city": "Uttar Pradesh",
+                "area_code": "226010",
+                "state": "lucknow"
+              }
+            },
+            "time": {
+              "timestamp": "2023-12-13T07:00:50.821Z",
+              "range": {
+                "start": "2023-12-13T06:59:04.076Z",
+                "end": "2023-12-13T07:29:04.076Z"
+              }
+            },
+            "instructions": {
+              "code": "2",
+              "name": "ONDC order",
+              "short_desc": "ONDC order",
+              "long_desc": "ONDC order"
+            },
+            "contact": {
+              "phone": "8840019700",
+              "email": "help@chattybao.com"
+            }
+          },
+          "id": "1",
+          "tracking": true,
+          "end": {
+            "contact": {
+              "email": "venkyuvr@gmail.com",
+              "phone": "9739374094"
+            },
+            "person": {
+              "name": "Venkat"
+            },
+            "location": {
+              "gps": "26.849441465615914, 80.99205368752338",
+              "address": {
+                "name": "Venkat",
+                "building": "4-32",
+                "locality": "Shankar Chauraha Road",
+                "city": "Lucknow",
+                "state": "Uttar Pradesh",
+                "country": "IND",
+                "area_code": "226010"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2023-12-13T06:59:04.079Z",
+                "end": "2023-12-13T07:59:04.079Z"
+              }
+            }
+          },
+          "type": "Delivery",
+          "@ondc/org/TAT": "PT60M"
+        }
+      ],
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "5245"
+        },
+        "breakup": [
+          {
+            "title": "Apple Kinnaur 500 g",
+            "@ondc/org/item_id": "7f0677d0-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/title_type": "item",
+            "@ondc/org/item_quantity": {
+              "count": 3
+            },
+            "price": {
+              "currency": "INR",
+              "value": "195"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "65"
+              }
+            }
+          },
+          {
+            "title": "Banana 1 kg",
+            "@ondc/org/item_id": "7e92f580-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/title_type": "item",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "price": {
+              "currency": "INR",
+              "value": "5000"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "2500"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "1",
+            "title": "Delivery Charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "42"
+            }
+          },
+          {
+            "@ondc/org/item_id": "1",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "8"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "quote",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "fulfillment"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "ttl": "P4D"
+      },
+      "payment": {
+        "uri": "https://juspay.in/",
+        "tl_method": "http/get",
+        "params": {
+          "amount": "5245",
+          "currency": "INR",
+          "transaction_id": "b9517167-bfd0-44c9-9092-cf8b82969cba"
+        },
+        "status": "PAID",
+        "type": "ON-ORDER",
+        "collected_by": "BAP",
+        "@ondc/org/buyer_app_finder_fee_type": "percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "seller-app",
+            "settlement_phase": "sale-amount",
+            "settlement_type": "neft",
+            "beneficiary_name": "CHATTYBAO TECHNOLOGIES PRIVATE LIMITED NODAL ACCOUNT",
+            "upi_address": "",
+            "settlement_bank_account_no": "661505602069",
+            "settlement_ifsc_code": "ICIC0006615",
+            "bank_name": "ICICI\",",
+            "branch_name": "Sco 31, Sector 18, Udyog Vihar, Gurgaon - 122016, Haryana",
+            "settlement_timestamp": "2023-12-14T07:29:04.076Z"
+          }
+        ],
+        "@ondc/org/settlement_basis": "delivery",
+        "@ondc/org/settlement_window": "P1D",
+        "@ondc/org/withholding_amount": "10.00"
+      },
+      "created_at": "2023-12-13T06:59:03.897Z",
+      "updated_at": "2023-12-13T07:01:03.596Z"
+    }
+  }
+}

--- a/Chattybao/Logs_Dec_13/Retail/Flow 2/on_status_pending(packed).json
+++ b/Chattybao/Logs_Dec_13/Retail/Flow 2/on_status_pending(packed).json
@@ -1,0 +1,249 @@
+{
+  "context": {
+    "domain": "ONDC:RET10",
+    "country": "IND",
+    "city": "std:0522",
+    "action": "on_status",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_uri": "https://ondc-seller-preprod.chattybao.com/ondc/bpp",
+    "transaction_id": "3f8a2bbe-b293-44e0-a91b-b9806241d1f5",
+    "message_id": "2bf216d0-9985-11ee-a063-913f64757eea",
+    "timestamp": "2023-12-13T06:59:34.205Z",
+    "bpp_id": "ondc-seller-preprod.chattybao.com/ondc",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "id": "2023-12-13-811516",
+      "state": "In-progress",
+      "provider": {
+        "id": "MR8mcezPPQEA-r8EhP6UN9",
+        "locations": [
+          {
+            "id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042"
+          }
+        ]
+      },
+      "items": [
+        {
+          "id": "7f0677d0-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 3
+          },
+          "fulfillment_id": "1",
+          "@ondc/org/returnable": true,
+          "@ondc/org/cancellable": true
+        },
+        {
+          "id": "7e92f580-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "1",
+          "@ondc/org/returnable": true,
+          "@ondc/org/cancellable": true
+        }
+      ],
+      "billing": {
+        "address": {
+          "name": "Venkat",
+          "building": "4-32",
+          "locality": "Shankar Chauraha Road",
+          "city": "Lucknow",
+          "state": "Uttar Pradesh",
+          "country": "IND",
+          "area_code": "226010"
+        },
+        "phone": "9739374094",
+        "name": "Venkat",
+        "email": "help@chattybao.com",
+        "created_at": "2023-12-13T06:58:05.708Z",
+        "updated_at": "2023-12-13T06:58:05.708Z"
+      },
+      "fulfillments": [
+        {
+          "@ondc/org/provider_name": "tester shatrughan fru and veg",
+          "state": {
+            "descriptor": {
+              "code": "Packed",
+              "name": "Packed"
+            }
+          },
+          "start": {
+            "location": {
+              "id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042",
+              "descriptor": {
+                "name": "tester shatrughan fru and veg"
+              },
+              "gps": "26.854719,80.998035",
+              "address": {
+                "locality": "4/267, Vivek Khand 4 Gomti Nagar",
+                "city": "Uttar Pradesh",
+                "area_code": "226010",
+                "state": "lucknow"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2023-12-13T06:59:04.076Z",
+                "end": "2023-12-13T07:29:04.076Z"
+              }
+            },
+            "instructions": {
+              "code": "2",
+              "name": "ONDC order",
+              "short_desc": "ONDC order",
+              "long_desc": "ONDC order"
+            },
+            "contact": {
+              "phone": "8840019700",
+              "email": "help@chattybao.com"
+            }
+          },
+          "id": "1",
+          "tracking": true,
+          "end": {
+            "contact": {
+              "email": "venkyuvr@gmail.com",
+              "phone": "9739374094"
+            },
+            "person": {
+              "name": "Venkat"
+            },
+            "location": {
+              "gps": "26.849441465615914, 80.99205368752338",
+              "address": {
+                "name": "Venkat",
+                "building": "4-32",
+                "locality": "Shankar Chauraha Road",
+                "city": "Lucknow",
+                "state": "Uttar Pradesh",
+                "country": "IND",
+                "area_code": "226010"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2023-12-13T06:59:04.079Z",
+                "end": "2023-12-13T07:59:04.079Z"
+              }
+            }
+          },
+          "type": "Delivery",
+          "@ondc/org/TAT": "PT60M"
+        }
+      ],
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "5245"
+        },
+        "breakup": [
+          {
+            "title": "Apple Kinnaur 500 g",
+            "@ondc/org/item_id": "7f0677d0-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/title_type": "item",
+            "@ondc/org/item_quantity": {
+              "count": 3
+            },
+            "price": {
+              "currency": "INR",
+              "value": "195"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "65"
+              }
+            }
+          },
+          {
+            "title": "Banana 1 kg",
+            "@ondc/org/item_id": "7e92f580-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/title_type": "item",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "price": {
+              "currency": "INR",
+              "value": "5000"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "2500"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "1",
+            "title": "Delivery Charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "42"
+            }
+          },
+          {
+            "@ondc/org/item_id": "1",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "8"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "quote",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "fulfillment"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "ttl": "P4D"
+      },
+      "payment": {
+        "uri": "https://juspay.in/",
+        "tl_method": "http/get",
+        "params": {
+          "amount": "5245",
+          "currency": "INR",
+          "transaction_id": "b9517167-bfd0-44c9-9092-cf8b82969cba"
+        },
+        "status": "PAID",
+        "type": "ON-ORDER",
+        "collected_by": "BAP",
+        "@ondc/org/buyer_app_finder_fee_type": "percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "seller-app",
+            "settlement_phase": "sale-amount",
+            "settlement_type": "neft",
+            "beneficiary_name": "CHATTYBAO TECHNOLOGIES PRIVATE LIMITED NODAL ACCOUNT",
+            "upi_address": "",
+            "settlement_bank_account_no": "661505602069",
+            "settlement_ifsc_code": "ICIC0006615",
+            "bank_name": "ICICI\",",
+            "branch_name": "Sco 31, Sector 18, Udyog Vihar, Gurgaon - 122016, Haryana",
+            "settlement_timestamp": "2023-12-14T07:29:04.076Z"
+          }
+        ],
+        "@ondc/org/settlement_basis": "delivery",
+        "@ondc/org/settlement_window": "P1D",
+        "@ondc/org/withholding_amount": "10.00"
+      },
+      "created_at": "2023-12-13T06:59:03.897Z",
+      "updated_at": "2023-12-13T06:59:34.205Z"
+    }
+  }
+}

--- a/Chattybao/Logs_Dec_13/Retail/Flow 2/on_status_picked.json
+++ b/Chattybao/Logs_Dec_13/Retail/Flow 2/on_status_picked.json
@@ -1,0 +1,250 @@
+{
+  "context": {
+    "domain": "ONDC:RET10",
+    "country": "IND",
+    "city": "std:0522",
+    "action": "on_status",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_uri": "https://ondc-seller-preprod.chattybao.com/ondc/bpp",
+    "transaction_id": "3f8a2bbe-b293-44e0-a91b-b9806241d1f5",
+    "message_id": "599cea60-9985-11ee-a063-913f64757eea",
+    "timestamp": "2023-12-13T07:00:50.821Z",
+    "bpp_id": "ondc-seller-preprod.chattybao.com/ondc",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "id": "2023-12-13-811516",
+      "state": "In-progress",
+      "provider": {
+        "id": "MR8mcezPPQEA-r8EhP6UN9",
+        "locations": [
+          {
+            "id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042"
+          }
+        ]
+      },
+      "items": [
+        {
+          "id": "7f0677d0-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 3
+          },
+          "fulfillment_id": "1",
+          "@ondc/org/returnable": true,
+          "@ondc/org/cancellable": true
+        },
+        {
+          "id": "7e92f580-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "1",
+          "@ondc/org/returnable": true,
+          "@ondc/org/cancellable": true
+        }
+      ],
+      "billing": {
+        "address": {
+          "name": "Venkat",
+          "building": "4-32",
+          "locality": "Shankar Chauraha Road",
+          "city": "Lucknow",
+          "state": "Uttar Pradesh",
+          "country": "IND",
+          "area_code": "226010"
+        },
+        "phone": "9739374094",
+        "name": "Venkat",
+        "email": "help@chattybao.com",
+        "created_at": "2023-12-13T06:58:05.708Z",
+        "updated_at": "2023-12-13T06:58:05.708Z"
+      },
+      "fulfillments": [
+        {
+          "@ondc/org/provider_name": "tester shatrughan fru and veg",
+          "state": {
+            "descriptor": {
+              "code": "Order-picked-up",
+              "name": "Order picked up"
+            }
+          },
+          "start": {
+            "location": {
+              "id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042",
+              "descriptor": {
+                "name": "tester shatrughan fru and veg"
+              },
+              "gps": "26.854719,80.998035",
+              "address": {
+                "locality": "4/267, Vivek Khand 4 Gomti Nagar",
+                "city": "Uttar Pradesh",
+                "area_code": "226010",
+                "state": "lucknow"
+              }
+            },
+            "time": {
+              "timestamp": "2023-12-13T07:00:50.821Z",
+              "range": {
+                "start": "2023-12-13T06:59:04.076Z",
+                "end": "2023-12-13T07:29:04.076Z"
+              }
+            },
+            "instructions": {
+              "code": "2",
+              "name": "ONDC order",
+              "short_desc": "ONDC order",
+              "long_desc": "ONDC order"
+            },
+            "contact": {
+              "phone": "8840019700",
+              "email": "help@chattybao.com"
+            }
+          },
+          "id": "1",
+          "tracking": true,
+          "end": {
+            "contact": {
+              "email": "venkyuvr@gmail.com",
+              "phone": "9739374094"
+            },
+            "person": {
+              "name": "Venkat"
+            },
+            "location": {
+              "gps": "26.849441465615914, 80.99205368752338",
+              "address": {
+                "name": "Venkat",
+                "building": "4-32",
+                "locality": "Shankar Chauraha Road",
+                "city": "Lucknow",
+                "state": "Uttar Pradesh",
+                "country": "IND",
+                "area_code": "226010"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2023-12-13T06:59:04.079Z",
+                "end": "2023-12-13T07:59:04.079Z"
+              }
+            }
+          },
+          "type": "Delivery",
+          "@ondc/org/TAT": "PT60M"
+        }
+      ],
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "5245"
+        },
+        "breakup": [
+          {
+            "title": "Apple Kinnaur 500 g",
+            "@ondc/org/item_id": "7f0677d0-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/title_type": "item",
+            "@ondc/org/item_quantity": {
+              "count": 3
+            },
+            "price": {
+              "currency": "INR",
+              "value": "195"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "65"
+              }
+            }
+          },
+          {
+            "title": "Banana 1 kg",
+            "@ondc/org/item_id": "7e92f580-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/title_type": "item",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "price": {
+              "currency": "INR",
+              "value": "5000"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "2500"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "1",
+            "title": "Delivery Charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "42"
+            }
+          },
+          {
+            "@ondc/org/item_id": "1",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "8"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "quote",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "fulfillment"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "ttl": "P4D"
+      },
+      "payment": {
+        "uri": "https://juspay.in/",
+        "tl_method": "http/get",
+        "params": {
+          "amount": "5245",
+          "currency": "INR",
+          "transaction_id": "b9517167-bfd0-44c9-9092-cf8b82969cba"
+        },
+        "status": "PAID",
+        "type": "ON-ORDER",
+        "collected_by": "BAP",
+        "@ondc/org/buyer_app_finder_fee_type": "percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "seller-app",
+            "settlement_phase": "sale-amount",
+            "settlement_type": "neft",
+            "beneficiary_name": "CHATTYBAO TECHNOLOGIES PRIVATE LIMITED NODAL ACCOUNT",
+            "upi_address": "",
+            "settlement_bank_account_no": "661505602069",
+            "settlement_ifsc_code": "ICIC0006615",
+            "bank_name": "ICICI\",",
+            "branch_name": "Sco 31, Sector 18, Udyog Vihar, Gurgaon - 122016, Haryana",
+            "settlement_timestamp": "2023-12-14T07:29:04.076Z"
+          }
+        ],
+        "@ondc/org/settlement_basis": "delivery",
+        "@ondc/org/settlement_window": "P1D",
+        "@ondc/org/withholding_amount": "10.00"
+      },
+      "created_at": "2023-12-13T06:59:03.897Z",
+      "updated_at": "2023-12-13T07:00:50.821Z"
+    }
+  }
+}

--- a/Chattybao/Logs_Dec_13/Retail/Flow 2/select.json
+++ b/Chattybao/Logs_Dec_13/Retail/Flow 2/select.json
@@ -1,0 +1,57 @@
+{
+  "context": {
+    "domain": "ONDC:RET10",
+    "country": "IND",
+    "city": "std:0522",
+    "action": "select",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_uri": "https://ondc-seller-preprod.chattybao.com/ondc/bpp",
+    "transaction_id": "3f8a2bbe-b293-44e0-a91b-b9806241d1f5",
+    "message_id": "889d2b93-e52d-4b28-9eca-fae4d103764f",
+    "timestamp": "2023-12-13T06:57:19.829Z",
+    "bpp_id": "ondc-seller-preprod.chattybao.com/ondc",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "items": [
+        {
+          "id": "7f0677d0-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 3
+          },
+          "location_id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042"
+        },
+        {
+          "id": "7e92f580-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 2
+          },
+          "location_id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042"
+        }
+      ],
+      "provider": {
+        "id": "MR8mcezPPQEA-r8EhP6UN9",
+        "locations": [
+          {
+            "id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042"
+          }
+        ]
+      },
+      "fulfillments": [
+        {
+          "end": {
+            "location": {
+              "gps": "26.849441465615914,80.99205368752338",
+              "address": {
+                "area_code": "226010"
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/Chattybao/Logs_Dec_13/Retail/Flow 3/confirm.json
+++ b/Chattybao/Logs_Dec_13/Retail/Flow 3/confirm.json
@@ -1,0 +1,241 @@
+{
+  "context": {
+    "domain": "ONDC:RET10",
+    "country": "IND",
+    "city": "std:0522",
+    "action": "confirm",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_uri": "https://ondc-seller-preprod.chattybao.com/ondc/bpp",
+    "transaction_id": "0af31cfc-670b-43d8-bc62-40b16af18a32",
+    "message_id": "d97b9d98-4663-4a7f-8ebc-b4979bedb40d",
+    "timestamp": "2023-12-13T07:09:04.657Z",
+    "bpp_id": "ondc-seller-preprod.chattybao.com/ondc",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "id": "2023-12-13-390822",
+      "state": "Created",
+      "billing": {
+        "address": {
+          "name": "Venkat",
+          "building": "4-32",
+          "locality": "Shankar Chauraha Road",
+          "city": "Lucknow",
+          "state": "Uttar Pradesh",
+          "country": "IND",
+          "area_code": "226010"
+        },
+        "phone": "9739374094",
+        "name": "Venkat",
+        "email": "venkyuvr@gmail.com",
+        "created_at": "2023-12-13T07:08:17.436Z",
+        "updated_at": "2023-12-13T07:08:17.436Z"
+      },
+      "items": [
+        {
+          "id": "988d4f70-b340-11ed-b67d-b356d861831b:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 1
+          },
+          "fulfillment_id": "1"
+        },
+        {
+          "id": "7f0677d0-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 1
+          },
+          "fulfillment_id": "1"
+        },
+        {
+          "id": "7eaebae0-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 1
+          },
+          "fulfillment_id": "1"
+        }
+      ],
+      "provider": {
+        "id": "MR8mcezPPQEA-r8EhP6UN9",
+        "locations": [
+          {
+            "id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042"
+          }
+        ]
+      },
+      "fulfillments": [
+        {
+          "id": "1",
+          "tracking": true,
+          "end": {
+            "contact": {
+              "email": "venkyuvr@gmail.com",
+              "phone": "9739374094"
+            },
+            "person": {
+              "name": "Venkat"
+            },
+            "location": {
+              "gps": "26.849441465615914, 80.99205368752338",
+              "address": {
+                "name": "Venkat",
+                "building": "4-32",
+                "locality": "Shankar Chauraha Road",
+                "city": "Lucknow",
+                "state": "Uttar Pradesh",
+                "country": "IND",
+                "area_code": "226010"
+              }
+            }
+          },
+          "type": "Delivery"
+        }
+      ],
+      "payment": {
+        "uri": "https://juspay.in/",
+        "tl_method": "http/get",
+        "params": {
+          "amount": "1575",
+          "currency": "INR",
+          "transaction_id": "e116a0ad-0d7d-454b-9acb-47724309638b"
+        },
+        "status": "PAID",
+        "type": "ON-ORDER",
+        "collected_by": "BAP",
+        "@ondc/org/buyer_app_finder_fee_type": "percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "seller-app",
+            "settlement_phase": "sale-amount",
+            "settlement_type": "neft",
+            "beneficiary_name": "CHATTYBAO TECHNOLOGIES PRIVATE LIMITED NODAL ACCOUNT",
+            "upi_address": "",
+            "settlement_bank_account_no": "661505602069",
+            "settlement_ifsc_code": "ICIC0006615",
+            "bank_name": "ICICI\",",
+            "branch_name": "Sco 31, Sector 18, Udyog Vihar, Gurgaon - 122016, Haryana"
+          }
+        ]
+      },
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "1575"
+        },
+        "breakup": [
+          {
+            "title": "Item 6",
+            "@ondc/org/item_id": "988d4f70-b340-11ed-b67d-b356d861831b:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/title_type": "item",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "price": {
+              "currency": "INR",
+              "value": "60"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "60"
+              }
+            }
+          },
+          {
+            "title": "Apple Kinnaur 500 g",
+            "@ondc/org/item_id": "7f0677d0-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/title_type": "item",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "price": {
+              "currency": "INR",
+              "value": "65"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "65"
+              }
+            }
+          },
+          {
+            "title": "Banana big 6 pc",
+            "@ondc/org/item_id": "7eaebae0-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/title_type": "item",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "price": {
+              "currency": "INR",
+              "value": "1400"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "1400"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "1",
+            "title": "Delivery Charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "42"
+            }
+          },
+          {
+            "@ondc/org/item_id": "1",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "8"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "quote",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "fulfillment"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "ttl": "P4D"
+      },
+      "tags": [
+        {
+          "code": "bpp_terms",
+          "list": [
+            {
+              "code": "tax_number",
+              "value": "07AAJCC8423B1ZW"
+            }
+          ]
+        },
+        {
+          "code": "bap_terms",
+          "list": [
+            {
+              "code": "tax_number",
+              "value": "BUYER-APP-GSTN-ONDC"
+            }
+          ]
+        }
+      ],
+      "created_at": "2023-12-13T07:09:04.657Z",
+      "updated_at": "2023-12-13T07:09:04.657Z"
+    }
+  }
+}

--- a/Chattybao/Logs_Dec_13/Retail/Flow 3/init.json
+++ b/Chattybao/Logs_Dec_13/Retail/Flow 3/init.json
@@ -1,0 +1,95 @@
+{
+  "context": {
+    "domain": "ONDC:RET10",
+    "country": "IND",
+    "city": "std:0522",
+    "action": "init",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_uri": "https://ondc-seller-preprod.chattybao.com/ondc/bpp",
+    "transaction_id": "0af31cfc-670b-43d8-bc62-40b16af18a32",
+    "message_id": "5e61d7c8-dcaf-4aaf-bff7-d292790b5dac",
+    "timestamp": "2023-12-13T07:08:17.436Z",
+    "bpp_id": "ondc-seller-preprod.chattybao.com/ondc",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "provider": {
+        "id": "MR8mcezPPQEA-r8EhP6UN9",
+        "locations": [
+          {
+            "id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042"
+          }
+        ]
+      },
+      "items": [
+        {
+          "id": "988d4f70-b340-11ed-b67d-b356d861831b:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 1
+          },
+          "location_id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042",
+          "fulfillment_id": "1"
+        },
+        {
+          "id": "7f0677d0-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 1
+          },
+          "location_id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042",
+          "fulfillment_id": "1"
+        },
+        {
+          "id": "7eaebae0-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 1
+          },
+          "location_id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042",
+          "fulfillment_id": "1"
+        }
+      ],
+      "billing": {
+        "address": {
+          "building": "4-32",
+          "city": "Lucknow",
+          "state": "Uttar Pradesh",
+          "country": "IND",
+          "area_code": "226010",
+          "locality": "Shankar Chauraha Road",
+          "name": "Venkat"
+        },
+        "phone": "9739374094",
+        "name": "Venkat",
+        "email": "venkyuvr@gmail.com",
+        "created_at": "2023-12-13T07:08:17.436Z",
+        "updated_at": "2023-12-13T07:08:17.436Z"
+      },
+      "fulfillments": [
+        {
+          "id": "1",
+          "type": "Delivery",
+          "end": {
+            "contact": {
+              "email": "venkyuvr@gmail.com",
+              "phone": "9739374094"
+            },
+            "location": {
+              "gps": "26.849441465615914, 80.99205368752338",
+              "address": {
+                "building": "4-32",
+                "city": "Lucknow",
+                "state": "Uttar Pradesh",
+                "country": "IND",
+                "area_code": "226010",
+                "locality": "Shankar Chauraha Road",
+                "name": "Venkat"
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/Chattybao/Logs_Dec_13/Retail/Flow 3/on_confirm.json
+++ b/Chattybao/Logs_Dec_13/Retail/Flow 3/on_confirm.json
@@ -1,0 +1,288 @@
+{
+  "context": {
+    "domain": "ONDC:RET10",
+    "country": "IND",
+    "city": "std:0522",
+    "action": "on_confirm",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_uri": "https://ondc-seller-preprod.chattybao.com/ondc/bpp",
+    "transaction_id": "0af31cfc-670b-43d8-bc62-40b16af18a32",
+    "message_id": "d97b9d98-4663-4a7f-8ebc-b4979bedb40d",
+    "timestamp": "2023-12-13T07:09:04.737Z",
+    "bpp_id": "ondc-seller-preprod.chattybao.com/ondc",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "id": "2023-12-13-390822",
+      "state": "Accepted",
+      "billing": {
+        "address": {
+          "name": "Venkat",
+          "building": "4-32",
+          "locality": "Shankar Chauraha Road",
+          "city": "Lucknow",
+          "state": "Uttar Pradesh",
+          "country": "IND",
+          "area_code": "226010"
+        },
+        "phone": "9739374094",
+        "name": "Venkat",
+        "email": "venkyuvr@gmail.com",
+        "created_at": "2023-12-13T07:08:17.436Z",
+        "updated_at": "2023-12-13T07:08:17.436Z"
+      },
+      "items": [
+        {
+          "id": "988d4f70-b340-11ed-b67d-b356d861831b:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 1
+          },
+          "fulfillment_id": "1"
+        },
+        {
+          "id": "7f0677d0-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 1
+          },
+          "fulfillment_id": "1"
+        },
+        {
+          "id": "7eaebae0-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 1
+          },
+          "fulfillment_id": "1"
+        }
+      ],
+      "provider": {
+        "id": "MR8mcezPPQEA-r8EhP6UN9",
+        "locations": [
+          {
+            "id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042"
+          }
+        ]
+      },
+      "fulfillments": [
+        {
+          "@ondc/org/provider_name": "tester shatrughan fru and veg",
+          "state": {
+            "descriptor": {
+              "code": "Pending"
+            }
+          },
+          "start": {
+            "location": {
+              "id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042",
+              "descriptor": {
+                "name": "tester shatrughan fru and veg"
+              },
+              "gps": "26.854719,80.998035",
+              "address": {
+                "locality": "4/267, Vivek Khand 4 Gomti Nagar",
+                "city": "Uttar Pradesh",
+                "area_code": "226010",
+                "state": "lucknow"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2023-12-13T07:09:04.735Z",
+                "end": "2023-12-13T07:39:04.735Z"
+              }
+            },
+            "instructions": {
+              "code": "2",
+              "name": "ONDC order",
+              "short_desc": "ONDC order",
+              "long_desc": "ONDC order"
+            },
+            "contact": {
+              "phone": "8840019700",
+              "email": "help@chattybao.com"
+            }
+          },
+          "id": "1",
+          "tracking": true,
+          "end": {
+            "contact": {
+              "email": "venkyuvr@gmail.com",
+              "phone": "9739374094"
+            },
+            "person": {
+              "name": "Venkat"
+            },
+            "location": {
+              "gps": "26.849441465615914, 80.99205368752338",
+              "address": {
+                "name": "Venkat",
+                "building": "4-32",
+                "locality": "Shankar Chauraha Road",
+                "city": "Lucknow",
+                "state": "Uttar Pradesh",
+                "country": "IND",
+                "area_code": "226010"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2023-12-13T07:09:04.736Z",
+                "end": "2023-12-13T08:09:04.736Z"
+              }
+            }
+          },
+          "type": "Delivery"
+        }
+      ],
+      "payment": {
+        "uri": "https://juspay.in/",
+        "tl_method": "http/get",
+        "params": {
+          "amount": "1575",
+          "currency": "INR",
+          "transaction_id": "e116a0ad-0d7d-454b-9acb-47724309638b"
+        },
+        "status": "PAID",
+        "type": "ON-ORDER",
+        "collected_by": "BAP",
+        "@ondc/org/buyer_app_finder_fee_type": "percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "seller-app",
+            "settlement_phase": "sale-amount",
+            "settlement_type": "neft",
+            "beneficiary_name": "CHATTYBAO TECHNOLOGIES PRIVATE LIMITED NODAL ACCOUNT",
+            "upi_address": "",
+            "settlement_bank_account_no": "661505602069",
+            "settlement_ifsc_code": "ICIC0006615",
+            "bank_name": "ICICI\",",
+            "branch_name": "Sco 31, Sector 18, Udyog Vihar, Gurgaon - 122016, Haryana"
+          }
+        ],
+        "@ondc/org/settlement_basis": "delivery",
+        "@ondc/org/settlement_window": "P1D",
+        "@ondc/org/withholding_amount": "10.00"
+      },
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "1575"
+        },
+        "breakup": [
+          {
+            "title": "Item 6",
+            "@ondc/org/item_id": "988d4f70-b340-11ed-b67d-b356d861831b:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/title_type": "item",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "price": {
+              "currency": "INR",
+              "value": "60"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "60"
+              }
+            }
+          },
+          {
+            "title": "Apple Kinnaur 500 g",
+            "@ondc/org/item_id": "7f0677d0-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/title_type": "item",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "price": {
+              "currency": "INR",
+              "value": "65"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "65"
+              }
+            }
+          },
+          {
+            "title": "Banana big 6 pc",
+            "@ondc/org/item_id": "7eaebae0-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/title_type": "item",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "price": {
+              "currency": "INR",
+              "value": "1400"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "1400"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "1",
+            "title": "Delivery Charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "42"
+            }
+          },
+          {
+            "@ondc/org/item_id": "1",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "8"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "quote",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "fulfillment"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "ttl": "P4D"
+      },
+      "tags": [
+        {
+          "code": "bpp_terms",
+          "list": [
+            {
+              "code": "tax_number",
+              "value": "07AAJCC8423B1ZW"
+            }
+          ]
+        },
+        {
+          "code": "bap_terms",
+          "list": [
+            {
+              "code": "tax_number",
+              "value": "BUYER-APP-GSTN-ONDC"
+            }
+          ]
+        }
+      ],
+      "created_at": "2023-12-13T07:09:04.657Z",
+      "updated_at": "2023-12-13T07:09:04.737Z",
+      "rateable": true
+    }
+  }
+}

--- a/Chattybao/Logs_Dec_13/Retail/Flow 3/on_init.json
+++ b/Chattybao/Logs_Dec_13/Retail/Flow 3/on_init.json
@@ -1,0 +1,325 @@
+{
+  "context": {
+    "domain": "ONDC:RET10",
+    "country": "IND",
+    "city": "std:0522",
+    "action": "on_init",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_uri": "https://ondc-seller-preprod.chattybao.com/ondc/bpp",
+    "transaction_id": "0af31cfc-670b-43d8-bc62-40b16af18a32",
+    "message_id": "5e61d7c8-dcaf-4aaf-bff7-d292790b5dac",
+    "timestamp": "2023-12-13T07:08:18.445Z",
+    "bpp_id": "ondc-seller-preprod.chattybao.com/ondc",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "items": [
+        {
+          "id": "988d4f70-b340-11ed-b67d-b356d861831b:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 1
+          },
+          "location_id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042",
+          "fulfillment_id": "1"
+        },
+        {
+          "id": "7f0677d0-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 1
+          },
+          "location_id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042",
+          "fulfillment_id": "1"
+        },
+        {
+          "id": "7eaebae0-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 1
+          },
+          "location_id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042",
+          "fulfillment_id": "1"
+        }
+      ],
+      "billing": {
+        "address": {
+          "building": "4-32",
+          "city": "Lucknow",
+          "state": "Uttar Pradesh",
+          "country": "IND",
+          "area_code": "226010",
+          "locality": "Shankar Chauraha Road",
+          "name": "Venkat"
+        },
+        "phone": "9739374094",
+        "name": "Venkat",
+        "email": "venkyuvr@gmail.com",
+        "created_at": "2023-12-13T07:08:17.436Z",
+        "updated_at": "2023-12-13T07:08:17.436Z"
+      },
+      "fulfillments": [
+        {
+          "id": "1",
+          "type": "Delivery",
+          "end": {
+            "contact": {
+              "email": "venkyuvr@gmail.com",
+              "phone": "9739374094"
+            },
+            "location": {
+              "gps": "26.849441465615914, 80.99205368752338",
+              "address": {
+                "building": "4-32",
+                "city": "Lucknow",
+                "state": "Uttar Pradesh",
+                "country": "IND",
+                "area_code": "226010",
+                "locality": "Shankar Chauraha Road",
+                "name": "Venkat"
+              }
+            }
+          },
+          "tracking": true
+        }
+      ],
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "1575"
+        },
+        "breakup": [
+          {
+            "title": "Item 6",
+            "@ondc/org/item_id": "988d4f70-b340-11ed-b67d-b356d861831b:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/title_type": "item",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "price": {
+              "currency": "INR",
+              "value": "60"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "60"
+              }
+            }
+          },
+          {
+            "title": "Apple Kinnaur 500 g",
+            "@ondc/org/item_id": "7f0677d0-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/title_type": "item",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "price": {
+              "currency": "INR",
+              "value": "65"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "65"
+              }
+            }
+          },
+          {
+            "title": "Banana big 6 pc",
+            "@ondc/org/item_id": "7eaebae0-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/title_type": "item",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "price": {
+              "currency": "INR",
+              "value": "1400"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "1400"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "1",
+            "title": "Delivery Charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "42"
+            }
+          },
+          {
+            "@ondc/org/item_id": "1",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "8"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "quote",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "fulfillment"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "ttl": "P4D"
+      },
+      "provider": {
+        "id": "MR8mcezPPQEA-r8EhP6UN9",
+        "locations": [
+          {
+            "id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042"
+          }
+        ]
+      },
+      "provider_location": {
+        "id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042"
+      },
+      "payment": {
+        "type": "ON-ORDER",
+        "collected_by": "BAP",
+        "status": "NOT-PAID",
+        "@ondc/org/settlement_basis": "delivery",
+        "@ondc/org/settlement_window": "P1D",
+        "@ondc/org/withholding_amount": "10.00",
+        "@ondc/org/buyer_app_finder_fee_type": "percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "3",
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "seller-app",
+            "settlement_phase": "sale-amount",
+            "settlement_type": "neft",
+            "beneficiary_name": "CHATTYBAO TECHNOLOGIES PRIVATE LIMITED NODAL ACCOUNT",
+            "upi_address": "",
+            "settlement_bank_account_no": "661505602069",
+            "settlement_ifsc_code": "ICIC0006615",
+            "bank_name": "ICICI\",",
+            "branch_name": "Sco 31, Sector 18, Udyog Vihar, Gurgaon - 122016, Haryana"
+          }
+        ]
+      },
+      "cancellation_terms": [
+        {
+          "fulfillment_state": {
+            "descriptor": {
+              "code": "Pending",
+              "short_desc": ""
+            }
+          },
+          "refund_eligible": true,
+          "reason_required": false,
+          "cancellation_fee": {
+            "percentage": "0.00",
+            "amount": {
+              "currency": "INR",
+              "value": "0.00"
+            }
+          }
+        },
+        {
+          "fulfillment_state": {
+            "descriptor": {
+              "code": "Packed",
+              "short_desc": "001,003"
+            }
+          },
+          "refund_eligible": true,
+          "reason_required": true,
+          "cancellation_fee": {
+            "percentage": "0.00",
+            "amount": {
+              "currency": "INR",
+              "value": "0.00"
+            }
+          }
+        },
+        {
+          "fulfillment_state": {
+            "descriptor": {
+              "code": "Order-picked-up",
+              "short_desc": "001,003"
+            }
+          },
+          "refund_eligible": true,
+          "reason_required": true,
+          "cancellation_fee": {
+            "amount": {
+              "currency": "INR",
+              "value": "50.00"
+            }
+          }
+        },
+        {
+          "fulfillment_state": {
+            "descriptor": {
+              "code": "Out-for-delivery",
+              "short_desc": "009"
+            }
+          },
+          "refund_eligible": false,
+          "reason_required": true,
+          "cancellation_fee": {
+            "percentage": "100.00"
+          }
+        },
+        {
+          "fulfillment_state": {
+            "descriptor": {
+              "code": "Out-for-delivery",
+              "short_desc": "010,011,012,013,014,015"
+            }
+          },
+          "refund_eligible": false,
+          "reason_required": true,
+          "cancellation_fee": {
+            "percentage": "100.00"
+          }
+        }
+      ],
+      "tags": [
+        {
+          "code": "bpp_terms",
+          "list": [
+            {
+              "code": "max_liability",
+              "value": "2"
+            },
+            {
+              "code": "max_liability_cap",
+              "value": "10000.00"
+            },
+            {
+              "code": "mandatory_arbitration",
+              "value": "false"
+            },
+            {
+              "code": "court_jurisdiction",
+              "value": "Delhi"
+            },
+            {
+              "code": "delay_interest",
+              "value": "1000.00"
+            },
+            {
+              "code": "tax_number",
+              "value": "07AAJCC8423B1ZW"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/Chattybao/Logs_Dec_13/Retail/Flow 3/on_select_out_of_stock.json
+++ b/Chattybao/Logs_Dec_13/Retail/Flow 3/on_select_out_of_stock.json
@@ -1,0 +1,291 @@
+{
+  "context": {
+    "domain": "ONDC:RET10",
+    "country": "IND",
+    "city": "std:0522",
+    "action": "on_select",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_uri": "https://ondc-seller-preprod.chattybao.com/ondc/bpp",
+    "transaction_id": "0af31cfc-670b-43d8-bc62-40b16af18a32",
+    "message_id": "b2a47e9c-3e39-48b3-b57e-8e995618e2a3",
+    "timestamp": "2023-12-13T07:06:29.026Z",
+    "bpp_id": "ondc-seller-preprod.chattybao.com/ondc",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "provider": {
+        "id": "MR8mcezPPQEA-r8EhP6UN9",
+        "locations": [
+          {
+            "id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042"
+          }
+        ]
+      },
+      "items": [
+        {
+          "@ondc/org/available_on_cod": false,
+          "@ondc/org/cancellable": true,
+          "@ondc/org/contact_details_consumer_care": "ChattyBao Help, help@chattybao.com,7353256777",
+          "@ondc/org/mandatory_reqs_veggies_fruits": {},
+          "@ondc/org/returnable": true,
+          "@ondc/org/seller_pickup_return": true,
+          "@ondc/org/statutory_reqs_packaged_commodities": {},
+          "@ondc/org/statutory_reqs_prepackaged_food": {},
+          "matched": true,
+          "rateable": true,
+          "recommended": true,
+          "fulfillment_id": "1",
+          "id": "988d4f70-b340-11ed-b67d-b356d861831b:MR8mcezPPQEA-r8EhP6UN9",
+          "price": {
+            "currency": "INR",
+            "value": "60"
+          },
+          "quantity": {
+            "selected": {
+              "count": 1
+            }
+          }
+        },
+        {
+          "@ondc/org/available_on_cod": false,
+          "@ondc/org/cancellable": true,
+          "@ondc/org/contact_details_consumer_care": "ChattyBao Help, help@chattybao.com,7353256777",
+          "@ondc/org/mandatory_reqs_veggies_fruits": {},
+          "@ondc/org/returnable": true,
+          "@ondc/org/seller_pickup_return": true,
+          "@ondc/org/statutory_reqs_packaged_commodities": {},
+          "@ondc/org/statutory_reqs_prepackaged_food": {},
+          "matched": true,
+          "rateable": true,
+          "recommended": true,
+          "fulfillment_id": "1",
+          "id": "7eaebae0-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+          "price": {
+            "currency": "INR",
+            "value": "1400"
+          },
+          "quantity": {
+            "selected": {
+              "count": 1
+            }
+          }
+        },
+        {
+          "@ondc/org/available_on_cod": false,
+          "@ondc/org/cancellable": true,
+          "@ondc/org/contact_details_consumer_care": "ChattyBao Help, help@chattybao.com,7353256777",
+          "@ondc/org/mandatory_reqs_veggies_fruits": {},
+          "@ondc/org/returnable": true,
+          "@ondc/org/seller_pickup_return": true,
+          "@ondc/org/statutory_reqs_packaged_commodities": {},
+          "@ondc/org/statutory_reqs_prepackaged_food": {},
+          "matched": true,
+          "rateable": true,
+          "recommended": true,
+          "fulfillment_id": "1",
+          "id": "7f0677d0-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+          "price": {
+            "currency": "INR",
+            "value": "65"
+          },
+          "quantity": {
+            "selected": {
+              "count": 1
+            }
+          }
+        },
+        {
+          "@ondc/org/available_on_cod": false,
+          "@ondc/org/cancellable": true,
+          "@ondc/org/contact_details_consumer_care": "ChattyBao Help, help@chattybao.com,7353256777",
+          "@ondc/org/mandatory_reqs_veggies_fruits": {},
+          "@ondc/org/returnable": true,
+          "@ondc/org/seller_pickup_return": true,
+          "@ondc/org/statutory_reqs_packaged_commodities": {},
+          "@ondc/org/statutory_reqs_prepackaged_food": {},
+          "matched": true,
+          "rateable": true,
+          "recommended": true,
+          "fulfillment_id": "1",
+          "id": "063a93d0-1a42-11ee-8ddd-2bac5af1417f:MR8mcezPPQEA-r8EhP6UN9",
+          "price": {
+            "currency": "INR",
+            "value": "36"
+          },
+          "quantity": {
+            "selected": {
+              "count": 1
+            }
+          }
+        }
+      ],
+      "fulfillments": [
+        {
+          "id": "1",
+          "type": "Delivery",
+          "@ondc/org/provider_name": "Chattybao Logistics",
+          "tracking": true,
+          "@ondc/org/category": "Immediate Delivery",
+          "@ondc/org/TAT": "PT60M",
+          "state": {
+            "descriptor": {
+              "code": "Serviceable"
+            }
+          }
+        }
+      ],
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "1575"
+        },
+        "breakup": [
+          {
+            "@ondc/org/item_id": "988d4f70-b340-11ed-b67d-b356d861831b:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "@ondc/org/title_type": "item",
+            "title": "Item 6",
+            "price": {
+              "currency": "INR",
+              "value": "60"
+            },
+            "item": {
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "60"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "7eaebae0-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "@ondc/org/title_type": "item",
+            "title": "Banana big 6 pc",
+            "price": {
+              "currency": "INR",
+              "value": "1400"
+            },
+            "item": {
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "1400"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "7f0677d0-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "@ondc/org/title_type": "item",
+            "title": "Apple Kinnaur 500 g",
+            "price": {
+              "currency": "INR",
+              "value": "65"
+            },
+            "item": {
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "65"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "063a93d0-1a42-11ee-8ddd-2bac5af1417f:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/item_quantity": {
+              "count": 0
+            },
+            "@ondc/org/title_type": "item",
+            "title": "Golden Sela Rice Loose 1 Kg",
+            "price": {
+              "currency": "INR",
+              "value": "0.00"
+            },
+            "item": {
+              "quantity": {
+                "available": {
+                  "count": "0"
+                },
+                "maximum": {
+                  "count": "0"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "36"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "1",
+            "title": "Delivery Charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "42"
+            }
+          },
+          {
+            "@ondc/org/item_id": "1",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "8"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "quote",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "fulfillment"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "ttl": "P4D"
+      }
+    }
+  },
+  "error": {
+    "type": "DOMAIN-ERROR",
+    "code": "40002",
+    "message": "063a93d0-1a42-11ee-8ddd-2bac5af1417f:MR8mcezPPQEA-r8EhP6UN9"
+  }
+}

--- a/Chattybao/Logs_Dec_13/Retail/Flow 3/on_select_updated.json
+++ b/Chattybao/Logs_Dec_13/Retail/Flow 3/on_select_updated.json
@@ -1,0 +1,236 @@
+{
+  "context": {
+    "domain": "ONDC:RET10",
+    "country": "IND",
+    "city": "std:0522",
+    "action": "on_select",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_uri": "https://ondc-seller-preprod.chattybao.com/ondc/bpp",
+    "transaction_id": "0af31cfc-670b-43d8-bc62-40b16af18a32",
+    "message_id": "4b72476c-cd73-4d27-ba71-2cfbb116a06b",
+    "timestamp": "2023-12-13T07:07:31.148Z",
+    "bpp_id": "ondc-seller-preprod.chattybao.com/ondc",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "provider": {
+        "id": "MR8mcezPPQEA-r8EhP6UN9",
+        "locations": [
+          {
+            "id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042"
+          }
+        ]
+      },
+      "items": [
+        {
+          "@ondc/org/available_on_cod": false,
+          "@ondc/org/cancellable": true,
+          "@ondc/org/contact_details_consumer_care": "ChattyBao Help, help@chattybao.com,7353256777",
+          "@ondc/org/mandatory_reqs_veggies_fruits": {},
+          "@ondc/org/returnable": true,
+          "@ondc/org/seller_pickup_return": true,
+          "@ondc/org/statutory_reqs_packaged_commodities": {},
+          "@ondc/org/statutory_reqs_prepackaged_food": {},
+          "matched": true,
+          "rateable": true,
+          "recommended": true,
+          "fulfillment_id": "1",
+          "id": "7f0677d0-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+          "price": {
+            "currency": "INR",
+            "value": "65"
+          },
+          "quantity": {
+            "selected": {
+              "count": 1
+            }
+          }
+        },
+        {
+          "@ondc/org/available_on_cod": false,
+          "@ondc/org/cancellable": true,
+          "@ondc/org/contact_details_consumer_care": "ChattyBao Help, help@chattybao.com,7353256777",
+          "@ondc/org/mandatory_reqs_veggies_fruits": {},
+          "@ondc/org/returnable": true,
+          "@ondc/org/seller_pickup_return": true,
+          "@ondc/org/statutory_reqs_packaged_commodities": {},
+          "@ondc/org/statutory_reqs_prepackaged_food": {},
+          "matched": true,
+          "rateable": true,
+          "recommended": true,
+          "fulfillment_id": "1",
+          "id": "7eaebae0-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+          "price": {
+            "currency": "INR",
+            "value": "1400"
+          },
+          "quantity": {
+            "selected": {
+              "count": 1
+            }
+          }
+        },
+        {
+          "@ondc/org/available_on_cod": false,
+          "@ondc/org/cancellable": true,
+          "@ondc/org/contact_details_consumer_care": "ChattyBao Help, help@chattybao.com,7353256777",
+          "@ondc/org/mandatory_reqs_veggies_fruits": {},
+          "@ondc/org/returnable": true,
+          "@ondc/org/seller_pickup_return": true,
+          "@ondc/org/statutory_reqs_packaged_commodities": {},
+          "@ondc/org/statutory_reqs_prepackaged_food": {},
+          "matched": true,
+          "rateable": true,
+          "recommended": true,
+          "fulfillment_id": "1",
+          "id": "988d4f70-b340-11ed-b67d-b356d861831b:MR8mcezPPQEA-r8EhP6UN9",
+          "price": {
+            "currency": "INR",
+            "value": "60"
+          },
+          "quantity": {
+            "selected": {
+              "count": 1
+            }
+          }
+        }
+      ],
+      "fulfillments": [
+        {
+          "id": "1",
+          "type": "Delivery",
+          "@ondc/org/provider_name": "Chattybao Logistics",
+          "tracking": true,
+          "@ondc/org/category": "Immediate Delivery",
+          "@ondc/org/TAT": "PT60M",
+          "state": {
+            "descriptor": {
+              "code": "Serviceable"
+            }
+          }
+        }
+      ],
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "1575"
+        },
+        "breakup": [
+          {
+            "@ondc/org/item_id": "7f0677d0-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "@ondc/org/title_type": "item",
+            "title": "Apple Kinnaur 500 g",
+            "price": {
+              "currency": "INR",
+              "value": "65"
+            },
+            "item": {
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "65"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "7eaebae0-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "@ondc/org/title_type": "item",
+            "title": "Banana big 6 pc",
+            "price": {
+              "currency": "INR",
+              "value": "1400"
+            },
+            "item": {
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "1400"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "988d4f70-b340-11ed-b67d-b356d861831b:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "@ondc/org/title_type": "item",
+            "title": "Item 6",
+            "price": {
+              "currency": "INR",
+              "value": "60"
+            },
+            "item": {
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "60"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "1",
+            "title": "Delivery Charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "42"
+            }
+          },
+          {
+            "@ondc/org/item_id": "1",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "8"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "quote",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "fulfillment"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "ttl": "P4D"
+      }
+    }
+  }
+}

--- a/Chattybao/Logs_Dec_13/Retail/Flow 3/on_status_delivered.json
+++ b/Chattybao/Logs_Dec_13/Retail/Flow 3/on_status_delivered.json
@@ -1,0 +1,278 @@
+{
+  "context": {
+    "domain": "ONDC:RET10",
+    "country": "IND",
+    "city": "std:0522",
+    "action": "on_status",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_uri": "https://ondc-seller-preprod.chattybao.com/ondc/bpp",
+    "transaction_id": "0af31cfc-670b-43d8-bc62-40b16af18a32",
+    "message_id": "7da87210-9987-11ee-a063-913f64757eea",
+    "timestamp": "2023-12-13T07:16:10.289Z",
+    "bpp_id": "ondc-seller-preprod.chattybao.com/ondc",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "id": "2023-12-13-390822",
+      "state": "Completed",
+      "provider": {
+        "id": "MR8mcezPPQEA-r8EhP6UN9",
+        "locations": [
+          {
+            "id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042"
+          }
+        ]
+      },
+      "items": [
+        {
+          "id": "988d4f70-b340-11ed-b67d-b356d861831b:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 1
+          },
+          "fulfillment_id": "1",
+          "@ondc/org/returnable": true,
+          "@ondc/org/cancellable": true
+        },
+        {
+          "id": "7f0677d0-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 1
+          },
+          "fulfillment_id": "1",
+          "@ondc/org/returnable": true,
+          "@ondc/org/cancellable": true
+        },
+        {
+          "id": "7eaebae0-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 1
+          },
+          "fulfillment_id": "1",
+          "@ondc/org/returnable": true,
+          "@ondc/org/cancellable": true
+        }
+      ],
+      "billing": {
+        "address": {
+          "name": "Venkat",
+          "building": "4-32",
+          "locality": "Shankar Chauraha Road",
+          "city": "Lucknow",
+          "state": "Uttar Pradesh",
+          "country": "IND",
+          "area_code": "226010"
+        },
+        "phone": "9739374094",
+        "name": "Venkat",
+        "email": "help@chattybao.com",
+        "created_at": "2023-12-13T07:08:17.436Z",
+        "updated_at": "2023-12-13T07:08:17.436Z"
+      },
+      "fulfillments": [
+        {
+          "@ondc/org/provider_name": "tester shatrughan fru and veg",
+          "state": {
+            "descriptor": {
+              "code": "Order-delivered",
+              "name": "Order delivered"
+            }
+          },
+          "start": {
+            "location": {
+              "id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042",
+              "descriptor": {
+                "name": "tester shatrughan fru and veg"
+              },
+              "gps": "26.854719,80.998035",
+              "address": {
+                "locality": "4/267, Vivek Khand 4 Gomti Nagar",
+                "city": "Uttar Pradesh",
+                "area_code": "226010",
+                "state": "lucknow"
+              }
+            },
+            "time": {
+              "timestamp": "2023-12-13T07:13:29.586Z",
+              "range": {
+                "start": "2023-12-13T07:09:04.735Z",
+                "end": "2023-12-13T07:39:04.735Z"
+              }
+            },
+            "instructions": {
+              "code": "2",
+              "name": "ONDC order",
+              "short_desc": "ONDC order",
+              "long_desc": "ONDC order"
+            },
+            "contact": {
+              "phone": "8840019700",
+              "email": "help@chattybao.com"
+            }
+          },
+          "id": "1",
+          "tracking": true,
+          "end": {
+            "contact": {
+              "email": "venkyuvr@gmail.com",
+              "phone": "9739374094"
+            },
+            "person": {
+              "name": "Venkat"
+            },
+            "location": {
+              "gps": "26.849441465615914, 80.99205368752338",
+              "address": {
+                "name": "Venkat",
+                "building": "4-32",
+                "locality": "Shankar Chauraha Road",
+                "city": "Lucknow",
+                "state": "Uttar Pradesh",
+                "country": "IND",
+                "area_code": "226010"
+              }
+            },
+            "time": {
+              "timestamp": "2023-12-13T07:16:10.286Z",
+              "range": {
+                "start": "2023-12-13T07:09:04.736Z",
+                "end": "2023-12-13T08:09:04.736Z"
+              }
+            }
+          },
+          "type": "Delivery",
+          "@ondc/org/TAT": "PT60M"
+        }
+      ],
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "1575"
+        },
+        "breakup": [
+          {
+            "title": "Item 6",
+            "@ondc/org/item_id": "988d4f70-b340-11ed-b67d-b356d861831b:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/title_type": "item",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "price": {
+              "currency": "INR",
+              "value": "60"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "60"
+              }
+            }
+          },
+          {
+            "title": "Apple Kinnaur 500 g",
+            "@ondc/org/item_id": "7f0677d0-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/title_type": "item",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "price": {
+              "currency": "INR",
+              "value": "65"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "65"
+              }
+            }
+          },
+          {
+            "title": "Banana big 6 pc",
+            "@ondc/org/item_id": "7eaebae0-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/title_type": "item",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "price": {
+              "currency": "INR",
+              "value": "1400"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "1400"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "1",
+            "title": "Delivery Charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "42"
+            }
+          },
+          {
+            "@ondc/org/item_id": "1",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "8"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "quote",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "fulfillment"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "ttl": "P4D"
+      },
+      "payment": {
+        "uri": "https://juspay.in/",
+        "tl_method": "http/get",
+        "params": {
+          "amount": "1575",
+          "currency": "INR",
+          "transaction_id": "e116a0ad-0d7d-454b-9acb-47724309638b"
+        },
+        "status": "PAID",
+        "type": "ON-ORDER",
+        "collected_by": "BAP",
+        "@ondc/org/buyer_app_finder_fee_type": "percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "seller-app",
+            "settlement_phase": "sale-amount",
+            "settlement_type": "neft",
+            "beneficiary_name": "CHATTYBAO TECHNOLOGIES PRIVATE LIMITED NODAL ACCOUNT",
+            "upi_address": "",
+            "settlement_bank_account_no": "661505602069",
+            "settlement_ifsc_code": "ICIC0006615",
+            "bank_name": "ICICI\",",
+            "branch_name": "Sco 31, Sector 18, Udyog Vihar, Gurgaon - 122016, Haryana",
+            "settlement_timestamp": "2023-12-14T07:39:04.735Z"
+          }
+        ],
+        "@ondc/org/settlement_basis": "delivery",
+        "@ondc/org/settlement_window": "P1D",
+        "@ondc/org/withholding_amount": "10.00"
+      },
+      "created_at": "2023-12-13T07:09:04.657Z",
+      "updated_at": "2023-12-13T07:16:10.289Z"
+    }
+  }
+}

--- a/Chattybao/Logs_Dec_13/Retail/Flow 3/on_status_out_for_delivery.json
+++ b/Chattybao/Logs_Dec_13/Retail/Flow 3/on_status_out_for_delivery.json
@@ -1,0 +1,277 @@
+{
+  "context": {
+    "domain": "ONDC:RET10",
+    "country": "IND",
+    "city": "std:0522",
+    "action": "on_status",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_uri": "https://ondc-seller-preprod.chattybao.com/ondc/bpp",
+    "transaction_id": "0af31cfc-670b-43d8-bc62-40b16af18a32",
+    "message_id": "73393df0-9987-11ee-a063-913f64757eea",
+    "timestamp": "2023-12-13T07:15:52.782Z",
+    "bpp_id": "ondc-seller-preprod.chattybao.com/ondc",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "id": "2023-12-13-390822",
+      "state": "In-progress",
+      "provider": {
+        "id": "MR8mcezPPQEA-r8EhP6UN9",
+        "locations": [
+          {
+            "id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042"
+          }
+        ]
+      },
+      "items": [
+        {
+          "id": "988d4f70-b340-11ed-b67d-b356d861831b:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 1
+          },
+          "fulfillment_id": "1",
+          "@ondc/org/returnable": true,
+          "@ondc/org/cancellable": true
+        },
+        {
+          "id": "7f0677d0-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 1
+          },
+          "fulfillment_id": "1",
+          "@ondc/org/returnable": true,
+          "@ondc/org/cancellable": true
+        },
+        {
+          "id": "7eaebae0-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 1
+          },
+          "fulfillment_id": "1",
+          "@ondc/org/returnable": true,
+          "@ondc/org/cancellable": true
+        }
+      ],
+      "billing": {
+        "address": {
+          "name": "Venkat",
+          "building": "4-32",
+          "locality": "Shankar Chauraha Road",
+          "city": "Lucknow",
+          "state": "Uttar Pradesh",
+          "country": "IND",
+          "area_code": "226010"
+        },
+        "phone": "9739374094",
+        "name": "Venkat",
+        "email": "help@chattybao.com",
+        "created_at": "2023-12-13T07:08:17.436Z",
+        "updated_at": "2023-12-13T07:08:17.436Z"
+      },
+      "fulfillments": [
+        {
+          "@ondc/org/provider_name": "tester shatrughan fru and veg",
+          "state": {
+            "descriptor": {
+              "code": "Out-for-delivery",
+              "name": "Out for delivery"
+            }
+          },
+          "start": {
+            "location": {
+              "id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042",
+              "descriptor": {
+                "name": "tester shatrughan fru and veg"
+              },
+              "gps": "26.854719,80.998035",
+              "address": {
+                "locality": "4/267, Vivek Khand 4 Gomti Nagar",
+                "city": "Uttar Pradesh",
+                "area_code": "226010",
+                "state": "lucknow"
+              }
+            },
+            "time": {
+              "timestamp": "2023-12-13T07:13:29.586Z",
+              "range": {
+                "start": "2023-12-13T07:09:04.735Z",
+                "end": "2023-12-13T07:39:04.735Z"
+              }
+            },
+            "instructions": {
+              "code": "2",
+              "name": "ONDC order",
+              "short_desc": "ONDC order",
+              "long_desc": "ONDC order"
+            },
+            "contact": {
+              "phone": "8840019700",
+              "email": "help@chattybao.com"
+            }
+          },
+          "id": "1",
+          "tracking": true,
+          "end": {
+            "contact": {
+              "email": "venkyuvr@gmail.com",
+              "phone": "9739374094"
+            },
+            "person": {
+              "name": "Venkat"
+            },
+            "location": {
+              "gps": "26.849441465615914, 80.99205368752338",
+              "address": {
+                "name": "Venkat",
+                "building": "4-32",
+                "locality": "Shankar Chauraha Road",
+                "city": "Lucknow",
+                "state": "Uttar Pradesh",
+                "country": "IND",
+                "area_code": "226010"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2023-12-13T07:09:04.736Z",
+                "end": "2023-12-13T08:09:04.736Z"
+              }
+            }
+          },
+          "type": "Delivery",
+          "@ondc/org/TAT": "PT60M"
+        }
+      ],
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "1575"
+        },
+        "breakup": [
+          {
+            "title": "Item 6",
+            "@ondc/org/item_id": "988d4f70-b340-11ed-b67d-b356d861831b:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/title_type": "item",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "price": {
+              "currency": "INR",
+              "value": "60"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "60"
+              }
+            }
+          },
+          {
+            "title": "Apple Kinnaur 500 g",
+            "@ondc/org/item_id": "7f0677d0-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/title_type": "item",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "price": {
+              "currency": "INR",
+              "value": "65"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "65"
+              }
+            }
+          },
+          {
+            "title": "Banana big 6 pc",
+            "@ondc/org/item_id": "7eaebae0-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/title_type": "item",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "price": {
+              "currency": "INR",
+              "value": "1400"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "1400"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "1",
+            "title": "Delivery Charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "42"
+            }
+          },
+          {
+            "@ondc/org/item_id": "1",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "8"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "quote",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "fulfillment"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "ttl": "P4D"
+      },
+      "payment": {
+        "uri": "https://juspay.in/",
+        "tl_method": "http/get",
+        "params": {
+          "amount": "1575",
+          "currency": "INR",
+          "transaction_id": "e116a0ad-0d7d-454b-9acb-47724309638b"
+        },
+        "status": "PAID",
+        "type": "ON-ORDER",
+        "collected_by": "BAP",
+        "@ondc/org/buyer_app_finder_fee_type": "percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "seller-app",
+            "settlement_phase": "sale-amount",
+            "settlement_type": "neft",
+            "beneficiary_name": "CHATTYBAO TECHNOLOGIES PRIVATE LIMITED NODAL ACCOUNT",
+            "upi_address": "",
+            "settlement_bank_account_no": "661505602069",
+            "settlement_ifsc_code": "ICIC0006615",
+            "bank_name": "ICICI\",",
+            "branch_name": "Sco 31, Sector 18, Udyog Vihar, Gurgaon - 122016, Haryana",
+            "settlement_timestamp": "2023-12-14T07:39:04.735Z"
+          }
+        ],
+        "@ondc/org/settlement_basis": "delivery",
+        "@ondc/org/settlement_window": "P1D",
+        "@ondc/org/withholding_amount": "10.00"
+      },
+      "created_at": "2023-12-13T07:09:04.657Z",
+      "updated_at": "2023-12-13T07:15:52.782Z"
+    }
+  }
+}

--- a/Chattybao/Logs_Dec_13/Retail/Flow 3/on_status_packed.json
+++ b/Chattybao/Logs_Dec_13/Retail/Flow 3/on_status_packed.json
@@ -1,0 +1,276 @@
+{
+  "context": {
+    "domain": "ONDC:RET10",
+    "country": "IND",
+    "city": "std:0522",
+    "action": "on_status",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_uri": "https://ondc-seller-preprod.chattybao.com/ondc/bpp",
+    "transaction_id": "0af31cfc-670b-43d8-bc62-40b16af18a32",
+    "message_id": "96c38f10-9986-11ee-a063-913f64757eea",
+    "timestamp": "2023-12-13T07:09:42.913Z",
+    "bpp_id": "ondc-seller-preprod.chattybao.com/ondc",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "id": "2023-12-13-390822",
+      "state": "In-progress",
+      "provider": {
+        "id": "MR8mcezPPQEA-r8EhP6UN9",
+        "locations": [
+          {
+            "id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042"
+          }
+        ]
+      },
+      "items": [
+        {
+          "id": "988d4f70-b340-11ed-b67d-b356d861831b:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 1
+          },
+          "fulfillment_id": "1",
+          "@ondc/org/returnable": true,
+          "@ondc/org/cancellable": true
+        },
+        {
+          "id": "7f0677d0-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 1
+          },
+          "fulfillment_id": "1",
+          "@ondc/org/returnable": true,
+          "@ondc/org/cancellable": true
+        },
+        {
+          "id": "7eaebae0-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 1
+          },
+          "fulfillment_id": "1",
+          "@ondc/org/returnable": true,
+          "@ondc/org/cancellable": true
+        }
+      ],
+      "billing": {
+        "address": {
+          "name": "Venkat",
+          "building": "4-32",
+          "locality": "Shankar Chauraha Road",
+          "city": "Lucknow",
+          "state": "Uttar Pradesh",
+          "country": "IND",
+          "area_code": "226010"
+        },
+        "phone": "9739374094",
+        "name": "Venkat",
+        "email": "help@chattybao.com",
+        "created_at": "2023-12-13T07:08:17.436Z",
+        "updated_at": "2023-12-13T07:08:17.436Z"
+      },
+      "fulfillments": [
+        {
+          "@ondc/org/provider_name": "tester shatrughan fru and veg",
+          "state": {
+            "descriptor": {
+              "code": "Packed",
+              "name": "Packed"
+            }
+          },
+          "start": {
+            "location": {
+              "id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042",
+              "descriptor": {
+                "name": "tester shatrughan fru and veg"
+              },
+              "gps": "26.854719,80.998035",
+              "address": {
+                "locality": "4/267, Vivek Khand 4 Gomti Nagar",
+                "city": "Uttar Pradesh",
+                "area_code": "226010",
+                "state": "lucknow"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2023-12-13T07:09:04.735Z",
+                "end": "2023-12-13T07:39:04.735Z"
+              }
+            },
+            "instructions": {
+              "code": "2",
+              "name": "ONDC order",
+              "short_desc": "ONDC order",
+              "long_desc": "ONDC order"
+            },
+            "contact": {
+              "phone": "8840019700",
+              "email": "help@chattybao.com"
+            }
+          },
+          "id": "1",
+          "tracking": true,
+          "end": {
+            "contact": {
+              "email": "venkyuvr@gmail.com",
+              "phone": "9739374094"
+            },
+            "person": {
+              "name": "Venkat"
+            },
+            "location": {
+              "gps": "26.849441465615914, 80.99205368752338",
+              "address": {
+                "name": "Venkat",
+                "building": "4-32",
+                "locality": "Shankar Chauraha Road",
+                "city": "Lucknow",
+                "state": "Uttar Pradesh",
+                "country": "IND",
+                "area_code": "226010"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2023-12-13T07:09:04.736Z",
+                "end": "2023-12-13T08:09:04.736Z"
+              }
+            }
+          },
+          "type": "Delivery",
+          "@ondc/org/TAT": "PT60M"
+        }
+      ],
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "1575"
+        },
+        "breakup": [
+          {
+            "title": "Item 6",
+            "@ondc/org/item_id": "988d4f70-b340-11ed-b67d-b356d861831b:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/title_type": "item",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "price": {
+              "currency": "INR",
+              "value": "60"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "60"
+              }
+            }
+          },
+          {
+            "title": "Apple Kinnaur 500 g",
+            "@ondc/org/item_id": "7f0677d0-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/title_type": "item",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "price": {
+              "currency": "INR",
+              "value": "65"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "65"
+              }
+            }
+          },
+          {
+            "title": "Banana big 6 pc",
+            "@ondc/org/item_id": "7eaebae0-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/title_type": "item",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "price": {
+              "currency": "INR",
+              "value": "1400"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "1400"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "1",
+            "title": "Delivery Charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "42"
+            }
+          },
+          {
+            "@ondc/org/item_id": "1",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "8"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "quote",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "fulfillment"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "ttl": "P4D"
+      },
+      "payment": {
+        "uri": "https://juspay.in/",
+        "tl_method": "http/get",
+        "params": {
+          "amount": "1575",
+          "currency": "INR",
+          "transaction_id": "e116a0ad-0d7d-454b-9acb-47724309638b"
+        },
+        "status": "PAID",
+        "type": "ON-ORDER",
+        "collected_by": "BAP",
+        "@ondc/org/buyer_app_finder_fee_type": "percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "seller-app",
+            "settlement_phase": "sale-amount",
+            "settlement_type": "neft",
+            "beneficiary_name": "CHATTYBAO TECHNOLOGIES PRIVATE LIMITED NODAL ACCOUNT",
+            "upi_address": "",
+            "settlement_bank_account_no": "661505602069",
+            "settlement_ifsc_code": "ICIC0006615",
+            "bank_name": "ICICI\",",
+            "branch_name": "Sco 31, Sector 18, Udyog Vihar, Gurgaon - 122016, Haryana",
+            "settlement_timestamp": "2023-12-14T07:39:04.735Z"
+          }
+        ],
+        "@ondc/org/settlement_basis": "delivery",
+        "@ondc/org/settlement_window": "P1D",
+        "@ondc/org/withholding_amount": "10.00"
+      },
+      "created_at": "2023-12-13T07:09:04.657Z",
+      "updated_at": "2023-12-13T07:09:42.913Z"
+    }
+  }
+}

--- a/Chattybao/Logs_Dec_13/Retail/Flow 3/on_status_pending.json
+++ b/Chattybao/Logs_Dec_13/Retail/Flow 3/on_status_pending.json
@@ -1,0 +1,276 @@
+{
+  "context": {
+    "domain": "ONDC:RET10",
+    "country": "IND",
+    "city": "std:0522",
+    "action": "on_status",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_uri": "https://ondc-seller-preprod.chattybao.com/ondc/bpp",
+    "transaction_id": "0af31cfc-670b-43d8-bc62-40b16af18a32",
+    "message_id": "81048ad0-9986-11ee-a063-913f64757eea",
+    "timestamp": "2023-12-13T07:09:06.429Z",
+    "bpp_id": "ondc-seller-preprod.chattybao.com/ondc",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "id": "2023-12-13-390822",
+      "state": "Accepted",
+      "provider": {
+        "id": "MR8mcezPPQEA-r8EhP6UN9",
+        "locations": [
+          {
+            "id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042"
+          }
+        ]
+      },
+      "items": [
+        {
+          "id": "988d4f70-b340-11ed-b67d-b356d861831b:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 1
+          },
+          "fulfillment_id": "1",
+          "@ondc/org/returnable": true,
+          "@ondc/org/cancellable": true
+        },
+        {
+          "id": "7f0677d0-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 1
+          },
+          "fulfillment_id": "1",
+          "@ondc/org/returnable": true,
+          "@ondc/org/cancellable": true
+        },
+        {
+          "id": "7eaebae0-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 1
+          },
+          "fulfillment_id": "1",
+          "@ondc/org/returnable": true,
+          "@ondc/org/cancellable": true
+        }
+      ],
+      "billing": {
+        "address": {
+          "name": "Venkat",
+          "building": "4-32",
+          "locality": "Shankar Chauraha Road",
+          "city": "Lucknow",
+          "state": "Uttar Pradesh",
+          "country": "IND",
+          "area_code": "226010"
+        },
+        "phone": "9739374094",
+        "name": "Venkat",
+        "email": "help@chattybao.com",
+        "created_at": "2023-12-13T07:08:17.436Z",
+        "updated_at": "2023-12-13T07:08:17.436Z"
+      },
+      "fulfillments": [
+        {
+          "@ondc/org/provider_name": "tester shatrughan fru and veg",
+          "state": {
+            "descriptor": {
+              "code": "Pending",
+              "name": "Pending"
+            }
+          },
+          "start": {
+            "location": {
+              "id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042",
+              "descriptor": {
+                "name": "tester shatrughan fru and veg"
+              },
+              "gps": "26.854719,80.998035",
+              "address": {
+                "locality": "4/267, Vivek Khand 4 Gomti Nagar",
+                "city": "Uttar Pradesh",
+                "area_code": "226010",
+                "state": "lucknow"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2023-12-13T07:09:04.735Z",
+                "end": "2023-12-13T07:39:04.735Z"
+              }
+            },
+            "instructions": {
+              "code": "2",
+              "name": "ONDC order",
+              "short_desc": "ONDC order",
+              "long_desc": "ONDC order"
+            },
+            "contact": {
+              "phone": "8840019700",
+              "email": "help@chattybao.com"
+            }
+          },
+          "id": "1",
+          "tracking": true,
+          "end": {
+            "contact": {
+              "email": "venkyuvr@gmail.com",
+              "phone": "9739374094"
+            },
+            "person": {
+              "name": "Venkat"
+            },
+            "location": {
+              "gps": "26.849441465615914, 80.99205368752338",
+              "address": {
+                "name": "Venkat",
+                "building": "4-32",
+                "locality": "Shankar Chauraha Road",
+                "city": "Lucknow",
+                "state": "Uttar Pradesh",
+                "country": "IND",
+                "area_code": "226010"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2023-12-13T07:09:04.736Z",
+                "end": "2023-12-13T08:09:04.736Z"
+              }
+            }
+          },
+          "type": "Delivery",
+          "@ondc/org/TAT": "PT60M"
+        }
+      ],
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "1575"
+        },
+        "breakup": [
+          {
+            "title": "Item 6",
+            "@ondc/org/item_id": "988d4f70-b340-11ed-b67d-b356d861831b:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/title_type": "item",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "price": {
+              "currency": "INR",
+              "value": "60"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "60"
+              }
+            }
+          },
+          {
+            "title": "Apple Kinnaur 500 g",
+            "@ondc/org/item_id": "7f0677d0-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/title_type": "item",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "price": {
+              "currency": "INR",
+              "value": "65"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "65"
+              }
+            }
+          },
+          {
+            "title": "Banana big 6 pc",
+            "@ondc/org/item_id": "7eaebae0-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/title_type": "item",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "price": {
+              "currency": "INR",
+              "value": "1400"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "1400"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "1",
+            "title": "Delivery Charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "42"
+            }
+          },
+          {
+            "@ondc/org/item_id": "1",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "8"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "quote",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "fulfillment"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "ttl": "P4D"
+      },
+      "payment": {
+        "uri": "https://juspay.in/",
+        "tl_method": "http/get",
+        "params": {
+          "amount": "1575",
+          "currency": "INR",
+          "transaction_id": "e116a0ad-0d7d-454b-9acb-47724309638b"
+        },
+        "status": "PAID",
+        "type": "ON-ORDER",
+        "collected_by": "BAP",
+        "@ondc/org/buyer_app_finder_fee_type": "percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "seller-app",
+            "settlement_phase": "sale-amount",
+            "settlement_type": "neft",
+            "beneficiary_name": "CHATTYBAO TECHNOLOGIES PRIVATE LIMITED NODAL ACCOUNT",
+            "upi_address": "",
+            "settlement_bank_account_no": "661505602069",
+            "settlement_ifsc_code": "ICIC0006615",
+            "bank_name": "ICICI\",",
+            "branch_name": "Sco 31, Sector 18, Udyog Vihar, Gurgaon - 122016, Haryana",
+            "settlement_timestamp": "2023-12-14T07:39:04.735Z"
+          }
+        ],
+        "@ondc/org/settlement_basis": "delivery",
+        "@ondc/org/settlement_window": "P1D",
+        "@ondc/org/withholding_amount": "10.00"
+      },
+      "created_at": "2023-12-13T07:09:04.657Z",
+      "updated_at": "2023-12-13T07:09:06.429Z"
+    }
+  }
+}

--- a/Chattybao/Logs_Dec_13/Retail/Flow 3/on_status_picked.json
+++ b/Chattybao/Logs_Dec_13/Retail/Flow 3/on_status_picked.json
@@ -1,0 +1,277 @@
+{
+  "context": {
+    "domain": "ONDC:RET10",
+    "country": "IND",
+    "city": "std:0522",
+    "action": "on_status",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_uri": "https://ondc-seller-preprod.chattybao.com/ondc/bpp",
+    "transaction_id": "0af31cfc-670b-43d8-bc62-40b16af18a32",
+    "message_id": "1ddf4430-9987-11ee-a063-913f64757eea",
+    "timestamp": "2023-12-13T07:13:29.587Z",
+    "bpp_id": "ondc-seller-preprod.chattybao.com/ondc",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "id": "2023-12-13-390822",
+      "state": "In-progress",
+      "provider": {
+        "id": "MR8mcezPPQEA-r8EhP6UN9",
+        "locations": [
+          {
+            "id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042"
+          }
+        ]
+      },
+      "items": [
+        {
+          "id": "988d4f70-b340-11ed-b67d-b356d861831b:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 1
+          },
+          "fulfillment_id": "1",
+          "@ondc/org/returnable": true,
+          "@ondc/org/cancellable": true
+        },
+        {
+          "id": "7f0677d0-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 1
+          },
+          "fulfillment_id": "1",
+          "@ondc/org/returnable": true,
+          "@ondc/org/cancellable": true
+        },
+        {
+          "id": "7eaebae0-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 1
+          },
+          "fulfillment_id": "1",
+          "@ondc/org/returnable": true,
+          "@ondc/org/cancellable": true
+        }
+      ],
+      "billing": {
+        "address": {
+          "name": "Venkat",
+          "building": "4-32",
+          "locality": "Shankar Chauraha Road",
+          "city": "Lucknow",
+          "state": "Uttar Pradesh",
+          "country": "IND",
+          "area_code": "226010"
+        },
+        "phone": "9739374094",
+        "name": "Venkat",
+        "email": "help@chattybao.com",
+        "created_at": "2023-12-13T07:08:17.436Z",
+        "updated_at": "2023-12-13T07:08:17.436Z"
+      },
+      "fulfillments": [
+        {
+          "@ondc/org/provider_name": "tester shatrughan fru and veg",
+          "state": {
+            "descriptor": {
+              "code": "Order-picked-up",
+              "name": "Order picked up"
+            }
+          },
+          "start": {
+            "location": {
+              "id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042",
+              "descriptor": {
+                "name": "tester shatrughan fru and veg"
+              },
+              "gps": "26.854719,80.998035",
+              "address": {
+                "locality": "4/267, Vivek Khand 4 Gomti Nagar",
+                "city": "Uttar Pradesh",
+                "area_code": "226010",
+                "state": "lucknow"
+              }
+            },
+            "time": {
+              "timestamp": "2023-12-13T07:13:29.586Z",
+              "range": {
+                "start": "2023-12-13T07:09:04.735Z",
+                "end": "2023-12-13T07:39:04.735Z"
+              }
+            },
+            "instructions": {
+              "code": "2",
+              "name": "ONDC order",
+              "short_desc": "ONDC order",
+              "long_desc": "ONDC order"
+            },
+            "contact": {
+              "phone": "8840019700",
+              "email": "help@chattybao.com"
+            }
+          },
+          "id": "1",
+          "tracking": true,
+          "end": {
+            "contact": {
+              "email": "venkyuvr@gmail.com",
+              "phone": "9739374094"
+            },
+            "person": {
+              "name": "Venkat"
+            },
+            "location": {
+              "gps": "26.849441465615914, 80.99205368752338",
+              "address": {
+                "name": "Venkat",
+                "building": "4-32",
+                "locality": "Shankar Chauraha Road",
+                "city": "Lucknow",
+                "state": "Uttar Pradesh",
+                "country": "IND",
+                "area_code": "226010"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2023-12-13T07:09:04.736Z",
+                "end": "2023-12-13T08:09:04.736Z"
+              }
+            }
+          },
+          "type": "Delivery",
+          "@ondc/org/TAT": "PT60M"
+        }
+      ],
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "1575"
+        },
+        "breakup": [
+          {
+            "title": "Item 6",
+            "@ondc/org/item_id": "988d4f70-b340-11ed-b67d-b356d861831b:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/title_type": "item",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "price": {
+              "currency": "INR",
+              "value": "60"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "60"
+              }
+            }
+          },
+          {
+            "title": "Apple Kinnaur 500 g",
+            "@ondc/org/item_id": "7f0677d0-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/title_type": "item",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "price": {
+              "currency": "INR",
+              "value": "65"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "65"
+              }
+            }
+          },
+          {
+            "title": "Banana big 6 pc",
+            "@ondc/org/item_id": "7eaebae0-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/title_type": "item",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "price": {
+              "currency": "INR",
+              "value": "1400"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "1400"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "1",
+            "title": "Delivery Charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "42"
+            }
+          },
+          {
+            "@ondc/org/item_id": "1",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "8"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "quote",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "fulfillment"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "ttl": "P4D"
+      },
+      "payment": {
+        "uri": "https://juspay.in/",
+        "tl_method": "http/get",
+        "params": {
+          "amount": "1575",
+          "currency": "INR",
+          "transaction_id": "e116a0ad-0d7d-454b-9acb-47724309638b"
+        },
+        "status": "PAID",
+        "type": "ON-ORDER",
+        "collected_by": "BAP",
+        "@ondc/org/buyer_app_finder_fee_type": "percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "seller-app",
+            "settlement_phase": "sale-amount",
+            "settlement_type": "neft",
+            "beneficiary_name": "CHATTYBAO TECHNOLOGIES PRIVATE LIMITED NODAL ACCOUNT",
+            "upi_address": "",
+            "settlement_bank_account_no": "661505602069",
+            "settlement_ifsc_code": "ICIC0006615",
+            "bank_name": "ICICI\",",
+            "branch_name": "Sco 31, Sector 18, Udyog Vihar, Gurgaon - 122016, Haryana",
+            "settlement_timestamp": "2023-12-14T07:39:04.735Z"
+          }
+        ],
+        "@ondc/org/settlement_basis": "delivery",
+        "@ondc/org/settlement_window": "P1D",
+        "@ondc/org/withholding_amount": "10.00"
+      },
+      "created_at": "2023-12-13T07:09:04.657Z",
+      "updated_at": "2023-12-13T07:13:29.587Z"
+    }
+  }
+}

--- a/Chattybao/Logs_Dec_13/Retail/Flow 3/select_out_of_stock.json
+++ b/Chattybao/Logs_Dec_13/Retail/Flow 3/select_out_of_stock.json
@@ -1,0 +1,71 @@
+{
+  "context": {
+    "domain": "ONDC:RET10",
+    "country": "IND",
+    "city": "std:0522",
+    "action": "select",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_uri": "https://ondc-seller-preprod.chattybao.com/ondc/bpp",
+    "transaction_id": "0af31cfc-670b-43d8-bc62-40b16af18a32",
+    "message_id": "b2a47e9c-3e39-48b3-b57e-8e995618e2a3",
+    "timestamp": "2023-12-13T07:06:28.546Z",
+    "bpp_id": "ondc-seller-preprod.chattybao.com/ondc",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "items": [
+        {
+          "id": "988d4f70-b340-11ed-b67d-b356d861831b:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 1
+          },
+          "location_id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042"
+        },
+        {
+          "id": "063a93d0-1a42-11ee-8ddd-2bac5af1417f:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 1
+          },
+          "location_id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042"
+        },
+        {
+          "id": "7f0677d0-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 1
+          },
+          "location_id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042"
+        },
+        {
+          "id": "7eaebae0-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 1
+          },
+          "location_id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042"
+        }
+      ],
+      "provider": {
+        "id": "MR8mcezPPQEA-r8EhP6UN9",
+        "locations": [
+          {
+            "id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042"
+          }
+        ]
+      },
+      "fulfillments": [
+        {
+          "end": {
+            "location": {
+              "gps": "26.849441465615914,80.99205368752338",
+              "address": {
+                "area_code": "226010"
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/Chattybao/Logs_Dec_13/Retail/Flow 3/select_updated.json
+++ b/Chattybao/Logs_Dec_13/Retail/Flow 3/select_updated.json
@@ -1,0 +1,64 @@
+{
+  "context": {
+    "domain": "ONDC:RET10",
+    "country": "IND",
+    "city": "std:0522",
+    "action": "select",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_uri": "https://ondc-seller-preprod.chattybao.com/ondc/bpp",
+    "transaction_id": "0af31cfc-670b-43d8-bc62-40b16af18a32",
+    "message_id": "4b72476c-cd73-4d27-ba71-2cfbb116a06b",
+    "timestamp": "2023-12-13T07:07:30.606Z",
+    "bpp_id": "ondc-seller-preprod.chattybao.com/ondc",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "items": [
+        {
+          "id": "988d4f70-b340-11ed-b67d-b356d861831b:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 1
+          },
+          "location_id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042"
+        },
+        {
+          "id": "7f0677d0-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 1
+          },
+          "location_id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042"
+        },
+        {
+          "id": "7eaebae0-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 1
+          },
+          "location_id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042"
+        }
+      ],
+      "provider": {
+        "id": "MR8mcezPPQEA-r8EhP6UN9",
+        "locations": [
+          {
+            "id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042"
+          }
+        ]
+      },
+      "fulfillments": [
+        {
+          "end": {
+            "location": {
+              "gps": "26.856159,81.004399",
+              "address": {
+                "area_code": "226010"
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/Chattybao/Logs_Dec_13/Retail/Flow 4/cancel.json
+++ b/Chattybao/Logs_Dec_13/Retail/Flow 4/cancel.json
@@ -1,0 +1,25 @@
+{
+  "context": {
+    "domain": "ONDC:RET10",
+    "country": "IND",
+    "city": "std:0522",
+    "action": "cancel",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_uri": "https://ondc-seller-preprod.chattybao.com/ondc/bpp",
+    "transaction_id": "dc7cfce5-611b-4de0-a803-5adf0b735694",
+    "message_id": "1dcc52ee-e086-4755-95a3-4014a854d52a",
+    "timestamp": "2023-12-13T07:20:51.726Z",
+    "bpp_id": "ondc-seller-preprod.chattybao.com/ondc",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order_id": "2023-12-13-878347",
+    "cancellation_reason_id": "010",
+    "descriptor": {
+      "name": "fulfillment",
+      "short_desc": "1"
+    }
+  }
+}

--- a/Chattybao/Logs_Dec_13/Retail/Flow 4/confirm.json
+++ b/Chattybao/Logs_Dec_13/Retail/Flow 4/confirm.json
@@ -1,0 +1,216 @@
+{
+  "context": {
+    "domain": "ONDC:RET10",
+    "country": "IND",
+    "city": "std:0522",
+    "action": "confirm",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_uri": "https://ondc-seller-preprod.chattybao.com/ondc/bpp",
+    "transaction_id": "dc7cfce5-611b-4de0-a803-5adf0b735694",
+    "message_id": "58b298d3-1224-4f7e-9713-38b1c5398858",
+    "timestamp": "2023-12-13T07:19:55.446Z",
+    "bpp_id": "ondc-seller-preprod.chattybao.com/ondc",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "id": "2023-12-13-878347",
+      "state": "Created",
+      "billing": {
+        "address": {
+          "name": "Venkat",
+          "building": "4-32",
+          "locality": "Shankar Chauraha Road",
+          "city": "Lucknow",
+          "state": "Uttar Pradesh",
+          "country": "IND",
+          "area_code": "226010"
+        },
+        "phone": "9739374094",
+        "name": "Venkat",
+        "email": "venkyuvr@gmail.com",
+        "created_at": "2023-12-13T07:19:18.158Z",
+        "updated_at": "2023-12-13T07:19:18.158Z"
+      },
+      "items": [
+        {
+          "id": "7f0677d0-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "1"
+        },
+        {
+          "id": "82479910-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 1
+          },
+          "fulfillment_id": "1"
+        }
+      ],
+      "provider": {
+        "id": "MR8mcezPPQEA-r8EhP6UN9",
+        "locations": [
+          {
+            "id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042"
+          }
+        ]
+      },
+      "fulfillments": [
+        {
+          "id": "1",
+          "tracking": true,
+          "end": {
+            "contact": {
+              "email": "venkyuvr@gmail.com",
+              "phone": "9739374094"
+            },
+            "person": {
+              "name": "Venkat"
+            },
+            "location": {
+              "gps": "26.849441465615914, 80.99205368752338",
+              "address": {
+                "name": "Venkat",
+                "building": "4-32",
+                "locality": "Shankar Chauraha Road",
+                "city": "Lucknow",
+                "state": "Uttar Pradesh",
+                "country": "IND",
+                "area_code": "226010"
+              }
+            }
+          },
+          "type": "Delivery"
+        }
+      ],
+      "payment": {
+        "uri": "https://juspay.in/",
+        "tl_method": "http/get",
+        "params": {
+          "amount": "1958",
+          "currency": "INR",
+          "transaction_id": "d85ca671-4248-4f4b-b12d-ddf238f7bbf7"
+        },
+        "status": "PAID",
+        "type": "ON-ORDER",
+        "collected_by": "BAP",
+        "@ondc/org/buyer_app_finder_fee_type": "percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "seller-app",
+            "settlement_phase": "sale-amount",
+            "settlement_type": "neft",
+            "beneficiary_name": "CHATTYBAO TECHNOLOGIES PRIVATE LIMITED NODAL ACCOUNT",
+            "upi_address": "",
+            "settlement_bank_account_no": "661505602069",
+            "settlement_ifsc_code": "ICIC0006615",
+            "bank_name": "ICICI\",",
+            "branch_name": "Sco 31, Sector 18, Udyog Vihar, Gurgaon - 122016, Haryana"
+          }
+        ]
+      },
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "1958"
+        },
+        "breakup": [
+          {
+            "title": "Apple Kinnaur 500 g",
+            "@ondc/org/item_id": "7f0677d0-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/title_type": "item",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "price": {
+              "currency": "INR",
+              "value": "130"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "65"
+              }
+            }
+          },
+          {
+            "title": "Bel (wood apple) 1 piece (400 - 600 g)",
+            "@ondc/org/item_id": "82479910-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/title_type": "item",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "price": {
+              "currency": "INR",
+              "value": "1778"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "1778"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "1",
+            "title": "Delivery Charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "42"
+            }
+          },
+          {
+            "@ondc/org/item_id": "1",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "8"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "quote",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "fulfillment"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "ttl": "P4D"
+      },
+      "tags": [
+        {
+          "code": "bpp_terms",
+          "list": [
+            {
+              "code": "tax_number",
+              "value": "07AAJCC8423B1ZW"
+            }
+          ]
+        },
+        {
+          "code": "bap_terms",
+          "list": [
+            {
+              "code": "tax_number",
+              "value": "BUYER-APP-GSTN-ONDC"
+            }
+          ]
+        }
+      ],
+      "created_at": "2023-12-13T07:19:55.446Z",
+      "updated_at": "2023-12-13T07:19:55.446Z"
+    }
+  }
+}

--- a/Chattybao/Logs_Dec_13/Retail/Flow 4/init.json
+++ b/Chattybao/Logs_Dec_13/Retail/Flow 4/init.json
@@ -1,0 +1,87 @@
+{
+  "context": {
+    "domain": "ONDC:RET10",
+    "country": "IND",
+    "city": "std:0522",
+    "action": "init",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_uri": "https://ondc-seller-preprod.chattybao.com/ondc/bpp",
+    "transaction_id": "dc7cfce5-611b-4de0-a803-5adf0b735694",
+    "message_id": "6a374aa7-eee6-4215-9c5a-bdc9ec2aac01",
+    "timestamp": "2023-12-13T07:19:18.158Z",
+    "bpp_id": "ondc-seller-preprod.chattybao.com/ondc",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "provider": {
+        "id": "MR8mcezPPQEA-r8EhP6UN9",
+        "locations": [
+          {
+            "id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042"
+          }
+        ]
+      },
+      "items": [
+        {
+          "id": "7f0677d0-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 2
+          },
+          "location_id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042",
+          "fulfillment_id": "1"
+        },
+        {
+          "id": "82479910-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 1
+          },
+          "location_id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042",
+          "fulfillment_id": "1"
+        }
+      ],
+      "billing": {
+        "address": {
+          "building": "4-32",
+          "city": "Lucknow",
+          "state": "Uttar Pradesh",
+          "country": "IND",
+          "area_code": "226010",
+          "locality": "Shankar Chauraha Road",
+          "name": "Venkat"
+        },
+        "phone": "9739374094",
+        "name": "Venkat",
+        "email": "venkyuvr@gmail.com",
+        "created_at": "2023-12-13T07:19:18.158Z",
+        "updated_at": "2023-12-13T07:19:18.158Z"
+      },
+      "fulfillments": [
+        {
+          "id": "1",
+          "type": "Delivery",
+          "end": {
+            "contact": {
+              "email": "venkyuvr@gmail.com",
+              "phone": "9739374094"
+            },
+            "location": {
+              "gps": "26.849441465615914, 80.99205368752338",
+              "address": {
+                "building": "4-32",
+                "city": "Lucknow",
+                "state": "Uttar Pradesh",
+                "country": "IND",
+                "area_code": "226010",
+                "locality": "Shankar Chauraha Road",
+                "name": "Venkat"
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/Chattybao/Logs_Dec_13/Retail/Flow 4/on_cancel.json
+++ b/Chattybao/Logs_Dec_13/Retail/Flow 4/on_cancel.json
@@ -1,0 +1,411 @@
+{
+  "context": {
+    "domain": "ONDC:RET10",
+    "country": "IND",
+    "city": "std:0522",
+    "action": "on_cancel",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_uri": "https://ondc-seller-preprod.chattybao.com/ondc/bpp",
+    "transaction_id": "dc7cfce5-611b-4de0-a803-5adf0b735694",
+    "message_id": "257a7b50-9988-11ee-a063-913f64757eea",
+    "timestamp": "2023-12-13T07:20:51.845Z",
+    "bpp_id": "ondc-seller-preprod.chattybao.com/ondc",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "id": "0000114168",
+      "state": "Cancelled",
+      "provider": {
+        "id": "MR8mcezPPQEA-r8EhP6UN9",
+        "locations": [
+          {
+            "id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042"
+          }
+        ]
+      },
+      "items": [
+        {
+          "id": "7f0677d0-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "1"
+        },
+        {
+          "id": "82479910-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 1
+          },
+          "fulfillment_id": "1"
+        }
+      ],
+      "billing": {
+        "address": {
+          "name": "Venkat",
+          "building": "4-32",
+          "locality": "Shankar Chauraha Road",
+          "city": "Lucknow",
+          "state": "Uttar Pradesh",
+          "country": "IND",
+          "area_code": "226010"
+        },
+        "phone": "9739374094",
+        "name": "Venkat",
+        "email": "venkyuvr@gmail.com",
+        "created_at": "2023-12-13T07:19:18.158Z",
+        "updated_at": "2023-12-13T07:19:18.158Z"
+      },
+      "cancellation": {
+        "cancelled_by": "buyer-app-preprod-v2.ondc.org",
+        "reason": {
+          "id": "010"
+        }
+      },
+      "fulfillment": [
+        {
+          "@ondc/org/provider_name": "tester shatrughan fru and veg",
+          "state": {
+            "descriptor": {
+              "code": "Cancelled",
+              "name": "Cancelled"
+            }
+          },
+          "start": {
+            "location": {
+              "id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042",
+              "descriptor": {
+                "name": "tester shatrughan fru and veg"
+              },
+              "gps": "26.854719,80.998035",
+              "address": {
+                "locality": "4/267, Vivek Khand 4 Gomti Nagar",
+                "city": "Uttar Pradesh",
+                "area_code": "226010",
+                "state": "lucknow"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2023-12-13T07:19:55.524Z",
+                "end": "2023-12-13T07:49:55.524Z"
+              }
+            },
+            "instructions": {
+              "code": "2",
+              "name": "ONDC order",
+              "short_desc": "ONDC order",
+              "long_desc": "ONDC order"
+            },
+            "contact": {
+              "phone": "8840019700",
+              "email": "help@chattybao.com"
+            }
+          },
+          "id": "1",
+          "tracking": true,
+          "end": {
+            "contact": {
+              "email": "venkyuvr@gmail.com",
+              "phone": "9739374094"
+            },
+            "person": {
+              "name": "Venkat"
+            },
+            "location": {
+              "gps": "26.849441465615914, 80.99205368752338",
+              "address": {
+                "name": "Venkat",
+                "building": "4-32",
+                "locality": "Shankar Chauraha Road",
+                "city": "Lucknow",
+                "state": "Uttar Pradesh",
+                "country": "IND",
+                "area_code": "226010"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2023-12-13T07:19:55.524Z",
+                "end": "2023-12-13T08:19:55.524Z"
+              }
+            }
+          },
+          "type": "Delivery",
+          "@ondc/org/TAT": "PT60M",
+          "tags": [
+            {
+              "code": "cancel_request",
+              "list": [
+                {
+                  "code": "reason_id",
+                  "value": "010"
+                },
+                {
+                  "code": "initiated_by",
+                  "value": "buyer-app-preprod-v2.ondc.org"
+                }
+              ]
+            },
+            {
+              "code": "precancel_state",
+              "list": [
+                {
+                  "code": "fulfillment_state",
+                  "value": "Cancelled"
+                },
+                {
+                  "code": "updated_at",
+                  "value": "2023-12-13T07:20:51.842Z"
+                }
+              ]
+            },
+            {
+              "code": "quote_trail",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "item"
+                },
+                {
+                  "code": "subtype",
+                  "value": "item"
+                },
+                {
+                  "code": "id",
+                  "value": "7f0677d0-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9"
+                },
+                {
+                  "code": "currency",
+                  "value": "INR"
+                },
+                {
+                  "code": "value",
+                  "value": "-130"
+                }
+              ]
+            },
+            {
+              "code": "quote_trail",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "item"
+                },
+                {
+                  "code": "subtype",
+                  "value": "item"
+                },
+                {
+                  "code": "id",
+                  "value": "82479910-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9"
+                },
+                {
+                  "code": "currency",
+                  "value": "INR"
+                },
+                {
+                  "code": "value",
+                  "value": "-1778"
+                }
+              ]
+            },
+            {
+              "code": "quote_trail",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "delivery"
+                },
+                {
+                  "code": "subtype",
+                  "value": "item"
+                },
+                {
+                  "code": "id",
+                  "value": "1"
+                },
+                {
+                  "code": "currency",
+                  "value": "INR"
+                },
+                {
+                  "code": "value",
+                  "value": "-42"
+                }
+              ]
+            },
+            {
+              "code": "quote_trail",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "tax"
+                },
+                {
+                  "code": "subtype",
+                  "value": "item"
+                },
+                {
+                  "code": "id",
+                  "value": "1"
+                },
+                {
+                  "code": "currency",
+                  "value": "INR"
+                },
+                {
+                  "code": "value",
+                  "value": "-8"
+                }
+              ]
+            },
+            {
+              "code": "quote_trail",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "misc"
+                },
+                {
+                  "code": "subtype",
+                  "value": "item"
+                },
+                {
+                  "code": "id",
+                  "value": "M1"
+                },
+                {
+                  "code": "currency",
+                  "value": "INR"
+                },
+                {
+                  "code": "value",
+                  "value": "-0.00"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "quote": {
+        "breakup": [
+          {
+            "title": "Apple Kinnaur 500 g",
+            "@ondc/org/item_id": "7f0677d0-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/title_type": "item",
+            "@ondc/org/item_quantity": {
+              "count": 0
+            },
+            "price": {
+              "currency": "INR",
+              "value": "0.00"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "65"
+              }
+            }
+          },
+          {
+            "title": "Bel (wood apple) 1 piece (400 - 600 g)",
+            "@ondc/org/item_id": "82479910-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/title_type": "item",
+            "@ondc/org/item_quantity": {
+              "count": 0
+            },
+            "price": {
+              "currency": "INR",
+              "value": "0.00"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "1778"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "1",
+            "title": "Delivery Charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "0.00"
+            }
+          },
+          {
+            "@ondc/org/item_id": "1",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "0.00"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "quote",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "fulfillment"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "M1",
+            "title": "Cancellation charges",
+            "@ondc/org/title_type": "misc",
+            "price": {
+              "currency": "INR",
+              "value": "50.00"
+            }
+          }
+        ],
+        "price": {
+          "currency": "INR",
+          "value": "50.00"
+        }
+      },
+      "payment": {
+        "uri": "https://juspay.in/",
+        "tl_method": "http/get",
+        "params": {
+          "amount": "1958",
+          "currency": "INR",
+          "transaction_id": "d85ca671-4248-4f4b-b12d-ddf238f7bbf7"
+        },
+        "status": "PAID",
+        "type": "ON-ORDER",
+        "collected_by": "BAP",
+        "@ondc/org/buyer_app_finder_fee_type": "percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "seller-app",
+            "settlement_phase": "sale-amount",
+            "settlement_type": "neft",
+            "beneficiary_name": "CHATTYBAO TECHNOLOGIES PRIVATE LIMITED NODAL ACCOUNT",
+            "upi_address": "",
+            "settlement_bank_account_no": "661505602069",
+            "settlement_ifsc_code": "ICIC0006615",
+            "bank_name": "ICICI\",",
+            "branch_name": "Sco 31, Sector 18, Udyog Vihar, Gurgaon - 122016, Haryana"
+          }
+        ],
+        "@ondc/org/settlement_basis": "delivery",
+        "@ondc/org/settlement_window": "P1D",
+        "@ondc/org/withholding_amount": "10.00"
+      },
+      "created_at": "2023-12-13T07:19:55.446Z",
+      "updated_at": "2023-12-13T07:20:51.844Z"
+    }
+  }
+}

--- a/Chattybao/Logs_Dec_13/Retail/Flow 4/on_confirm.json
+++ b/Chattybao/Logs_Dec_13/Retail/Flow 4/on_confirm.json
@@ -1,0 +1,263 @@
+{
+  "context": {
+    "domain": "ONDC:RET10",
+    "country": "IND",
+    "city": "std:0522",
+    "action": "on_confirm",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_uri": "https://ondc-seller-preprod.chattybao.com/ondc/bpp",
+    "transaction_id": "dc7cfce5-611b-4de0-a803-5adf0b735694",
+    "message_id": "58b298d3-1224-4f7e-9713-38b1c5398858",
+    "timestamp": "2023-12-13T07:19:55.525Z",
+    "bpp_id": "ondc-seller-preprod.chattybao.com/ondc",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "id": "2023-12-13-878347",
+      "state": "Accepted",
+      "billing": {
+        "address": {
+          "name": "Venkat",
+          "building": "4-32",
+          "locality": "Shankar Chauraha Road",
+          "city": "Lucknow",
+          "state": "Uttar Pradesh",
+          "country": "IND",
+          "area_code": "226010"
+        },
+        "phone": "9739374094",
+        "name": "Venkat",
+        "email": "venkyuvr@gmail.com",
+        "created_at": "2023-12-13T07:19:18.158Z",
+        "updated_at": "2023-12-13T07:19:18.158Z"
+      },
+      "items": [
+        {
+          "id": "7f0677d0-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "1"
+        },
+        {
+          "id": "82479910-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 1
+          },
+          "fulfillment_id": "1"
+        }
+      ],
+      "provider": {
+        "id": "MR8mcezPPQEA-r8EhP6UN9",
+        "locations": [
+          {
+            "id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042"
+          }
+        ]
+      },
+      "fulfillments": [
+        {
+          "@ondc/org/provider_name": "tester shatrughan fru and veg",
+          "state": {
+            "descriptor": {
+              "code": "Pending"
+            }
+          },
+          "start": {
+            "location": {
+              "id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042",
+              "descriptor": {
+                "name": "tester shatrughan fru and veg"
+              },
+              "gps": "26.854719,80.998035",
+              "address": {
+                "locality": "4/267, Vivek Khand 4 Gomti Nagar",
+                "city": "Uttar Pradesh",
+                "area_code": "226010",
+                "state": "lucknow"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2023-12-13T07:19:55.524Z",
+                "end": "2023-12-13T07:49:55.524Z"
+              }
+            },
+            "instructions": {
+              "code": "2",
+              "name": "ONDC order",
+              "short_desc": "ONDC order",
+              "long_desc": "ONDC order"
+            },
+            "contact": {
+              "phone": "8840019700",
+              "email": "help@chattybao.com"
+            }
+          },
+          "id": "1",
+          "tracking": true,
+          "end": {
+            "contact": {
+              "email": "venkyuvr@gmail.com",
+              "phone": "9739374094"
+            },
+            "person": {
+              "name": "Venkat"
+            },
+            "location": {
+              "gps": "26.849441465615914, 80.99205368752338",
+              "address": {
+                "name": "Venkat",
+                "building": "4-32",
+                "locality": "Shankar Chauraha Road",
+                "city": "Lucknow",
+                "state": "Uttar Pradesh",
+                "country": "IND",
+                "area_code": "226010"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2023-12-13T07:19:55.524Z",
+                "end": "2023-12-13T08:19:55.524Z"
+              }
+            }
+          },
+          "type": "Delivery"
+        }
+      ],
+      "payment": {
+        "uri": "https://juspay.in/",
+        "tl_method": "http/get",
+        "params": {
+          "amount": "1958",
+          "currency": "INR",
+          "transaction_id": "d85ca671-4248-4f4b-b12d-ddf238f7bbf7"
+        },
+        "status": "PAID",
+        "type": "ON-ORDER",
+        "collected_by": "BAP",
+        "@ondc/org/buyer_app_finder_fee_type": "percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "seller-app",
+            "settlement_phase": "sale-amount",
+            "settlement_type": "neft",
+            "beneficiary_name": "CHATTYBAO TECHNOLOGIES PRIVATE LIMITED NODAL ACCOUNT",
+            "upi_address": "",
+            "settlement_bank_account_no": "661505602069",
+            "settlement_ifsc_code": "ICIC0006615",
+            "bank_name": "ICICI\",",
+            "branch_name": "Sco 31, Sector 18, Udyog Vihar, Gurgaon - 122016, Haryana"
+          }
+        ],
+        "@ondc/org/settlement_basis": "delivery",
+        "@ondc/org/settlement_window": "P1D",
+        "@ondc/org/withholding_amount": "10.00"
+      },
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "1958"
+        },
+        "breakup": [
+          {
+            "title": "Apple Kinnaur 500 g",
+            "@ondc/org/item_id": "7f0677d0-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/title_type": "item",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "price": {
+              "currency": "INR",
+              "value": "130"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "65"
+              }
+            }
+          },
+          {
+            "title": "Bel (wood apple) 1 piece (400 - 600 g)",
+            "@ondc/org/item_id": "82479910-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/title_type": "item",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "price": {
+              "currency": "INR",
+              "value": "1778"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "1778"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "1",
+            "title": "Delivery Charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "42"
+            }
+          },
+          {
+            "@ondc/org/item_id": "1",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "8"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "quote",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "fulfillment"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "ttl": "P4D"
+      },
+      "tags": [
+        {
+          "code": "bpp_terms",
+          "list": [
+            {
+              "code": "tax_number",
+              "value": "07AAJCC8423B1ZW"
+            }
+          ]
+        },
+        {
+          "code": "bap_terms",
+          "list": [
+            {
+              "code": "tax_number",
+              "value": "BUYER-APP-GSTN-ONDC"
+            }
+          ]
+        }
+      ],
+      "created_at": "2023-12-13T07:19:55.446Z",
+      "updated_at": "2023-12-13T07:19:55.525Z",
+      "rateable": true
+    }
+  }
+}

--- a/Chattybao/Logs_Dec_13/Retail/Flow 4/on_init.json
+++ b/Chattybao/Logs_Dec_13/Retail/Flow 4/on_init.json
@@ -1,0 +1,299 @@
+{
+  "context": {
+    "domain": "ONDC:RET10",
+    "country": "IND",
+    "city": "std:0522",
+    "action": "on_init",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_uri": "https://ondc-seller-preprod.chattybao.com/ondc/bpp",
+    "transaction_id": "dc7cfce5-611b-4de0-a803-5adf0b735694",
+    "message_id": "6a374aa7-eee6-4215-9c5a-bdc9ec2aac01",
+    "timestamp": "2023-12-13T07:19:19.210Z",
+    "bpp_id": "ondc-seller-preprod.chattybao.com/ondc",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "items": [
+        {
+          "id": "7f0677d0-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 2
+          },
+          "location_id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042",
+          "fulfillment_id": "1"
+        },
+        {
+          "id": "82479910-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 1
+          },
+          "location_id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042",
+          "fulfillment_id": "1"
+        }
+      ],
+      "billing": {
+        "address": {
+          "building": "4-32",
+          "city": "Lucknow",
+          "state": "Uttar Pradesh",
+          "country": "IND",
+          "area_code": "226010",
+          "locality": "Shankar Chauraha Road",
+          "name": "Venkat"
+        },
+        "phone": "9739374094",
+        "name": "Venkat",
+        "email": "venkyuvr@gmail.com",
+        "created_at": "2023-12-13T07:19:18.158Z",
+        "updated_at": "2023-12-13T07:19:18.158Z"
+      },
+      "fulfillments": [
+        {
+          "id": "1",
+          "type": "Delivery",
+          "end": {
+            "contact": {
+              "email": "venkyuvr@gmail.com",
+              "phone": "9739374094"
+            },
+            "location": {
+              "gps": "26.849441465615914, 80.99205368752338",
+              "address": {
+                "building": "4-32",
+                "city": "Lucknow",
+                "state": "Uttar Pradesh",
+                "country": "IND",
+                "area_code": "226010",
+                "locality": "Shankar Chauraha Road",
+                "name": "Venkat"
+              }
+            }
+          },
+          "tracking": true
+        }
+      ],
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "1958"
+        },
+        "breakup": [
+          {
+            "title": "Apple Kinnaur 500 g",
+            "@ondc/org/item_id": "7f0677d0-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/title_type": "item",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "price": {
+              "currency": "INR",
+              "value": "130"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "65"
+              }
+            }
+          },
+          {
+            "title": "Bel (wood apple) 1 piece (400 - 600 g)",
+            "@ondc/org/item_id": "82479910-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/title_type": "item",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "price": {
+              "currency": "INR",
+              "value": "1778"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "1778"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "1",
+            "title": "Delivery Charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "42"
+            }
+          },
+          {
+            "@ondc/org/item_id": "1",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "8"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "quote",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "fulfillment"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "ttl": "P4D"
+      },
+      "provider": {
+        "id": "MR8mcezPPQEA-r8EhP6UN9",
+        "locations": [
+          {
+            "id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042"
+          }
+        ]
+      },
+      "provider_location": {
+        "id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042"
+      },
+      "payment": {
+        "type": "ON-ORDER",
+        "collected_by": "BAP",
+        "status": "NOT-PAID",
+        "@ondc/org/settlement_basis": "delivery",
+        "@ondc/org/settlement_window": "P1D",
+        "@ondc/org/withholding_amount": "10.00",
+        "@ondc/org/buyer_app_finder_fee_type": "percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "3",
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "seller-app",
+            "settlement_phase": "sale-amount",
+            "settlement_type": "neft",
+            "beneficiary_name": "CHATTYBAO TECHNOLOGIES PRIVATE LIMITED NODAL ACCOUNT",
+            "upi_address": "",
+            "settlement_bank_account_no": "661505602069",
+            "settlement_ifsc_code": "ICIC0006615",
+            "bank_name": "ICICI\",",
+            "branch_name": "Sco 31, Sector 18, Udyog Vihar, Gurgaon - 122016, Haryana"
+          }
+        ]
+      },
+      "cancellation_terms": [
+        {
+          "fulfillment_state": {
+            "descriptor": {
+              "code": "Pending",
+              "short_desc": ""
+            }
+          },
+          "refund_eligible": true,
+          "reason_required": false,
+          "cancellation_fee": {
+            "percentage": "0.00",
+            "amount": {
+              "currency": "INR",
+              "value": "0.00"
+            }
+          }
+        },
+        {
+          "fulfillment_state": {
+            "descriptor": {
+              "code": "Packed",
+              "short_desc": "001,003"
+            }
+          },
+          "refund_eligible": true,
+          "reason_required": true,
+          "cancellation_fee": {
+            "percentage": "0.00",
+            "amount": {
+              "currency": "INR",
+              "value": "0.00"
+            }
+          }
+        },
+        {
+          "fulfillment_state": {
+            "descriptor": {
+              "code": "Order-picked-up",
+              "short_desc": "001,003"
+            }
+          },
+          "refund_eligible": true,
+          "reason_required": true,
+          "cancellation_fee": {
+            "amount": {
+              "currency": "INR",
+              "value": "50.00"
+            }
+          }
+        },
+        {
+          "fulfillment_state": {
+            "descriptor": {
+              "code": "Out-for-delivery",
+              "short_desc": "009"
+            }
+          },
+          "refund_eligible": false,
+          "reason_required": true,
+          "cancellation_fee": {
+            "percentage": "100.00"
+          }
+        },
+        {
+          "fulfillment_state": {
+            "descriptor": {
+              "code": "Out-for-delivery",
+              "short_desc": "010,011,012,013,014,015"
+            }
+          },
+          "refund_eligible": false,
+          "reason_required": true,
+          "cancellation_fee": {
+            "percentage": "100.00"
+          }
+        }
+      ],
+      "tags": [
+        {
+          "code": "bpp_terms",
+          "list": [
+            {
+              "code": "max_liability",
+              "value": "2"
+            },
+            {
+              "code": "max_liability_cap",
+              "value": "10000.00"
+            },
+            {
+              "code": "mandatory_arbitration",
+              "value": "false"
+            },
+            {
+              "code": "court_jurisdiction",
+              "value": "Delhi"
+            },
+            {
+              "code": "delay_interest",
+              "value": "1000.00"
+            },
+            {
+              "code": "tax_number",
+              "value": "07AAJCC8423B1ZW"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/Chattybao/Logs_Dec_13/Retail/Flow 4/on_select.json
+++ b/Chattybao/Logs_Dec_13/Retail/Flow 4/on_select.json
@@ -1,0 +1,186 @@
+{
+  "context": {
+    "domain": "ONDC:RET10",
+    "country": "IND",
+    "city": "std:0522",
+    "action": "on_select",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_uri": "https://ondc-seller-preprod.chattybao.com/ondc/bpp",
+    "transaction_id": "dc7cfce5-611b-4de0-a803-5adf0b735694",
+    "message_id": "1b929d23-7c31-4b72-a0f2-dc9475cbd3c5",
+    "timestamp": "2023-12-13T07:18:31.341Z",
+    "bpp_id": "ondc-seller-preprod.chattybao.com/ondc",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "provider": {
+        "id": "MR8mcezPPQEA-r8EhP6UN9",
+        "locations": [
+          {
+            "id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042"
+          }
+        ]
+      },
+      "items": [
+        {
+          "@ondc/org/available_on_cod": false,
+          "@ondc/org/cancellable": true,
+          "@ondc/org/contact_details_consumer_care": "ChattyBao Help, help@chattybao.com,7353256777",
+          "@ondc/org/mandatory_reqs_veggies_fruits": {},
+          "@ondc/org/returnable": true,
+          "@ondc/org/seller_pickup_return": true,
+          "@ondc/org/statutory_reqs_packaged_commodities": {},
+          "@ondc/org/statutory_reqs_prepackaged_food": {},
+          "matched": true,
+          "rateable": true,
+          "recommended": true,
+          "fulfillment_id": "1",
+          "id": "82479910-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+          "price": {
+            "currency": "INR",
+            "value": "1778"
+          },
+          "quantity": {
+            "selected": {
+              "count": 1
+            }
+          }
+        },
+        {
+          "@ondc/org/available_on_cod": false,
+          "@ondc/org/cancellable": true,
+          "@ondc/org/contact_details_consumer_care": "ChattyBao Help, help@chattybao.com,7353256777",
+          "@ondc/org/mandatory_reqs_veggies_fruits": {},
+          "@ondc/org/returnable": true,
+          "@ondc/org/seller_pickup_return": true,
+          "@ondc/org/statutory_reqs_packaged_commodities": {},
+          "@ondc/org/statutory_reqs_prepackaged_food": {},
+          "matched": true,
+          "rateable": true,
+          "recommended": true,
+          "fulfillment_id": "1",
+          "id": "7f0677d0-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+          "price": {
+            "currency": "INR",
+            "value": "65"
+          },
+          "quantity": {
+            "selected": {
+              "count": 2
+            }
+          }
+        }
+      ],
+      "fulfillments": [
+        {
+          "id": "1",
+          "type": "Delivery",
+          "@ondc/org/provider_name": "Chattybao Logistics",
+          "tracking": true,
+          "@ondc/org/category": "Immediate Delivery",
+          "@ondc/org/TAT": "PT60M",
+          "state": {
+            "descriptor": {
+              "code": "Serviceable"
+            }
+          }
+        }
+      ],
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "1958"
+        },
+        "breakup": [
+          {
+            "@ondc/org/item_id": "82479910-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "@ondc/org/title_type": "item",
+            "title": "Bel (wood apple) 1 piece (400 - 600 g)",
+            "price": {
+              "currency": "INR",
+              "value": "1778"
+            },
+            "item": {
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "1778"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "7f0677d0-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "@ondc/org/title_type": "item",
+            "title": "Apple Kinnaur 500 g",
+            "price": {
+              "currency": "INR",
+              "value": "130"
+            },
+            "item": {
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "65"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "1",
+            "title": "Delivery Charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "42"
+            }
+          },
+          {
+            "@ondc/org/item_id": "1",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "8"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "quote",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "fulfillment"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "ttl": "P4D"
+      }
+    }
+  }
+}

--- a/Chattybao/Logs_Dec_13/Retail/Flow 4/on_status_cancelled.json
+++ b/Chattybao/Logs_Dec_13/Retail/Flow 4/on_status_cancelled.json
@@ -1,0 +1,411 @@
+{
+  "context": {
+    "domain": "ONDC:RET10",
+    "country": "IND",
+    "city": "std:0522",
+    "action": "on_status",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_uri": "https://ondc-seller-preprod.chattybao.com/ondc/bpp",
+    "transaction_id": "dc7cfce5-611b-4de0-a803-5adf0b735694",
+    "message_id": "21e8cf72-90cd-444d-9cc5-762181db2cb4",
+    "timestamp": "2023-12-13T07:22:21.423Z",
+    "bpp_id": "ondc-seller-preprod.chattybao.com/ondc",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "id": "0000114168",
+      "state": "Cancelled",
+      "provider": {
+        "id": "MR8mcezPPQEA-r8EhP6UN9",
+        "locations": [
+          {
+            "id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042"
+          }
+        ]
+      },
+      "items": [
+        {
+          "id": "7f0677d0-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "1"
+        },
+        {
+          "id": "82479910-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 1
+          },
+          "fulfillment_id": "1"
+        }
+      ],
+      "billing": {
+        "address": {
+          "name": "Venkat",
+          "building": "4-32",
+          "locality": "Shankar Chauraha Road",
+          "city": "Lucknow",
+          "state": "Uttar Pradesh",
+          "country": "IND",
+          "area_code": "226010"
+        },
+        "phone": "9739374094",
+        "name": "Venkat",
+        "email": "venkyuvr@gmail.com",
+        "created_at": "2023-12-13T07:19:18.158Z",
+        "updated_at": "2023-12-13T07:19:18.158Z"
+      },
+      "cancellation": {
+        "cancelled_by": "buyer-app-preprod-v2.ondc.org",
+        "reason": {
+          "id": "010"
+        }
+      },
+      "fulfillment": [
+        {
+          "@ondc/org/provider_name": "tester shatrughan fru and veg",
+          "state": {
+            "descriptor": {
+              "code": "Cancelled",
+              "name": "Cancelled"
+            }
+          },
+          "start": {
+            "location": {
+              "id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042",
+              "descriptor": {
+                "name": "tester shatrughan fru and veg"
+              },
+              "gps": "26.854719,80.998035",
+              "address": {
+                "locality": "4/267, Vivek Khand 4 Gomti Nagar",
+                "city": "Uttar Pradesh",
+                "area_code": "226010",
+                "state": "lucknow"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2023-12-13T07:19:55.524Z",
+                "end": "2023-12-13T07:49:55.524Z"
+              }
+            },
+            "instructions": {
+              "code": "2",
+              "name": "ONDC order",
+              "short_desc": "ONDC order",
+              "long_desc": "ONDC order"
+            },
+            "contact": {
+              "phone": "8840019700",
+              "email": "help@chattybao.com"
+            }
+          },
+          "id": "1",
+          "tracking": true,
+          "end": {
+            "contact": {
+              "email": "venkyuvr@gmail.com",
+              "phone": "9739374094"
+            },
+            "person": {
+              "name": "Venkat"
+            },
+            "location": {
+              "gps": "26.849441465615914, 80.99205368752338",
+              "address": {
+                "name": "Venkat",
+                "building": "4-32",
+                "locality": "Shankar Chauraha Road",
+                "city": "Lucknow",
+                "state": "Uttar Pradesh",
+                "country": "IND",
+                "area_code": "226010"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2023-12-13T07:19:55.524Z",
+                "end": "2023-12-13T08:19:55.524Z"
+              }
+            }
+          },
+          "type": "Delivery",
+          "@ondc/org/TAT": "PT60M",
+          "tags": [
+            {
+              "code": "cancel_request",
+              "list": [
+                {
+                  "code": "reason_id",
+                  "value": "010"
+                },
+                {
+                  "code": "initiated_by",
+                  "value": "buyer-app-preprod-v2.ondc.org"
+                }
+              ]
+            },
+            {
+              "code": "precancel_state",
+              "list": [
+                {
+                  "code": "fulfillment_state",
+                  "value": "Cancelled"
+                },
+                {
+                  "code": "updated_at",
+                  "value": "2023-12-13T07:20:51.842Z"
+                }
+              ]
+            },
+            {
+              "code": "quote_trail",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "item"
+                },
+                {
+                  "code": "subtype",
+                  "value": "item"
+                },
+                {
+                  "code": "id",
+                  "value": "7f0677d0-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9"
+                },
+                {
+                  "code": "currency",
+                  "value": "INR"
+                },
+                {
+                  "code": "value",
+                  "value": "-130"
+                }
+              ]
+            },
+            {
+              "code": "quote_trail",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "item"
+                },
+                {
+                  "code": "subtype",
+                  "value": "item"
+                },
+                {
+                  "code": "id",
+                  "value": "82479910-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9"
+                },
+                {
+                  "code": "currency",
+                  "value": "INR"
+                },
+                {
+                  "code": "value",
+                  "value": "-1778"
+                }
+              ]
+            },
+            {
+              "code": "quote_trail",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "delivery"
+                },
+                {
+                  "code": "subtype",
+                  "value": "item"
+                },
+                {
+                  "code": "id",
+                  "value": "1"
+                },
+                {
+                  "code": "currency",
+                  "value": "INR"
+                },
+                {
+                  "code": "value",
+                  "value": "-42"
+                }
+              ]
+            },
+            {
+              "code": "quote_trail",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "tax"
+                },
+                {
+                  "code": "subtype",
+                  "value": "item"
+                },
+                {
+                  "code": "id",
+                  "value": "1"
+                },
+                {
+                  "code": "currency",
+                  "value": "INR"
+                },
+                {
+                  "code": "value",
+                  "value": "-8"
+                }
+              ]
+            },
+            {
+              "code": "quote_trail",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "misc"
+                },
+                {
+                  "code": "subtype",
+                  "value": "item"
+                },
+                {
+                  "code": "id",
+                  "value": "M1"
+                },
+                {
+                  "code": "currency",
+                  "value": "INR"
+                },
+                {
+                  "code": "value",
+                  "value": "-0.00"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "quote": {
+        "breakup": [
+          {
+            "title": "Apple Kinnaur 500 g",
+            "@ondc/org/item_id": "7f0677d0-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/title_type": "item",
+            "@ondc/org/item_quantity": {
+              "count": 0
+            },
+            "price": {
+              "currency": "INR",
+              "value": "0.00"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "65"
+              }
+            }
+          },
+          {
+            "title": "Bel (wood apple) 1 piece (400 - 600 g)",
+            "@ondc/org/item_id": "82479910-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/title_type": "item",
+            "@ondc/org/item_quantity": {
+              "count": 0
+            },
+            "price": {
+              "currency": "INR",
+              "value": "0.00"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "1778"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "1",
+            "title": "Delivery Charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "0.00"
+            }
+          },
+          {
+            "@ondc/org/item_id": "1",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "0.00"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "quote",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "fulfillment"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "M1",
+            "title": "Cancellation charges",
+            "@ondc/org/title_type": "misc",
+            "price": {
+              "currency": "INR",
+              "value": "50.00"
+            }
+          }
+        ],
+        "price": {
+          "currency": "INR",
+          "value": "50.00"
+        }
+      },
+      "payment": {
+        "uri": "https://juspay.in/",
+        "tl_method": "http/get",
+        "params": {
+          "amount": "1958",
+          "currency": "INR",
+          "transaction_id": "d85ca671-4248-4f4b-b12d-ddf238f7bbf7"
+        },
+        "status": "PAID",
+        "type": "ON-ORDER",
+        "collected_by": "BAP",
+        "@ondc/org/buyer_app_finder_fee_type": "percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "seller-app",
+            "settlement_phase": "sale-amount",
+            "settlement_type": "neft",
+            "beneficiary_name": "CHATTYBAO TECHNOLOGIES PRIVATE LIMITED NODAL ACCOUNT",
+            "upi_address": "",
+            "settlement_bank_account_no": "661505602069",
+            "settlement_ifsc_code": "ICIC0006615",
+            "bank_name": "ICICI\",",
+            "branch_name": "Sco 31, Sector 18, Udyog Vihar, Gurgaon - 122016, Haryana"
+          }
+        ],
+        "@ondc/org/settlement_basis": "delivery",
+        "@ondc/org/settlement_window": "P1D",
+        "@ondc/org/withholding_amount": "10.00"
+      },
+      "created_at": "2023-12-13T07:19:55.446Z",
+      "updated_at": "2023-12-13T07:22:21.423Z"
+    }
+  }
+}

--- a/Chattybao/Logs_Dec_13/Retail/Flow 4/on_status_pending.json
+++ b/Chattybao/Logs_Dec_13/Retail/Flow 4/on_status_pending.json
@@ -1,0 +1,249 @@
+{
+  "context": {
+    "domain": "ONDC:RET10",
+    "country": "IND",
+    "city": "std:0522",
+    "action": "on_status",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_uri": "https://ondc-seller-preprod.chattybao.com/ondc/bpp",
+    "transaction_id": "dc7cfce5-611b-4de0-a803-5adf0b735694",
+    "message_id": "042e28c0-9988-11ee-a063-913f64757eea",
+    "timestamp": "2023-12-13T07:19:55.979Z",
+    "bpp_id": "ondc-seller-preprod.chattybao.com/ondc",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "id": "2023-12-13-878347",
+      "state": "Accepted",
+      "provider": {
+        "id": "MR8mcezPPQEA-r8EhP6UN9",
+        "locations": [
+          {
+            "id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042"
+          }
+        ]
+      },
+      "items": [
+        {
+          "id": "7f0677d0-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "1",
+          "@ondc/org/returnable": true,
+          "@ondc/org/cancellable": true
+        },
+        {
+          "id": "82479910-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 1
+          },
+          "fulfillment_id": "1",
+          "@ondc/org/returnable": true,
+          "@ondc/org/cancellable": true
+        }
+      ],
+      "billing": {
+        "address": {
+          "name": "Venkat",
+          "building": "4-32",
+          "locality": "Shankar Chauraha Road",
+          "city": "Lucknow",
+          "state": "Uttar Pradesh",
+          "country": "IND",
+          "area_code": "226010"
+        },
+        "phone": "9739374094",
+        "name": "Venkat",
+        "email": "help@chattybao.com",
+        "created_at": "2023-12-13T07:19:18.158Z",
+        "updated_at": "2023-12-13T07:19:18.158Z"
+      },
+      "fulfillments": [
+        {
+          "@ondc/org/provider_name": "tester shatrughan fru and veg",
+          "state": {
+            "descriptor": {
+              "code": "Pending",
+              "name": "Pending"
+            }
+          },
+          "start": {
+            "location": {
+              "id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042",
+              "descriptor": {
+                "name": "tester shatrughan fru and veg"
+              },
+              "gps": "26.854719,80.998035",
+              "address": {
+                "locality": "4/267, Vivek Khand 4 Gomti Nagar",
+                "city": "Uttar Pradesh",
+                "area_code": "226010",
+                "state": "lucknow"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2023-12-13T07:19:55.524Z",
+                "end": "2023-12-13T07:49:55.524Z"
+              }
+            },
+            "instructions": {
+              "code": "2",
+              "name": "ONDC order",
+              "short_desc": "ONDC order",
+              "long_desc": "ONDC order"
+            },
+            "contact": {
+              "phone": "8840019700",
+              "email": "help@chattybao.com"
+            }
+          },
+          "id": "1",
+          "tracking": true,
+          "end": {
+            "contact": {
+              "email": "venkyuvr@gmail.com",
+              "phone": "9739374094"
+            },
+            "person": {
+              "name": "Venkat"
+            },
+            "location": {
+              "gps": "26.849441465615914, 80.99205368752338",
+              "address": {
+                "name": "Venkat",
+                "building": "4-32",
+                "locality": "Shankar Chauraha Road",
+                "city": "Lucknow",
+                "state": "Uttar Pradesh",
+                "country": "IND",
+                "area_code": "226010"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2023-12-13T07:19:55.524Z",
+                "end": "2023-12-13T08:19:55.524Z"
+              }
+            }
+          },
+          "type": "Delivery",
+          "@ondc/org/TAT": "PT60M"
+        }
+      ],
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "1958"
+        },
+        "breakup": [
+          {
+            "title": "Apple Kinnaur 500 g",
+            "@ondc/org/item_id": "7f0677d0-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/title_type": "item",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "price": {
+              "currency": "INR",
+              "value": "130"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "65"
+              }
+            }
+          },
+          {
+            "title": "Bel (wood apple) 1 piece (400 - 600 g)",
+            "@ondc/org/item_id": "82479910-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/title_type": "item",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "price": {
+              "currency": "INR",
+              "value": "1778"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "1778"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "1",
+            "title": "Delivery Charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "42"
+            }
+          },
+          {
+            "@ondc/org/item_id": "1",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "8"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "quote",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "fulfillment"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "ttl": "P4D"
+      },
+      "payment": {
+        "uri": "https://juspay.in/",
+        "tl_method": "http/get",
+        "params": {
+          "amount": "1958",
+          "currency": "INR",
+          "transaction_id": "d85ca671-4248-4f4b-b12d-ddf238f7bbf7"
+        },
+        "status": "PAID",
+        "type": "ON-ORDER",
+        "collected_by": "BAP",
+        "@ondc/org/buyer_app_finder_fee_type": "percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "seller-app",
+            "settlement_phase": "sale-amount",
+            "settlement_type": "neft",
+            "beneficiary_name": "CHATTYBAO TECHNOLOGIES PRIVATE LIMITED NODAL ACCOUNT",
+            "upi_address": "",
+            "settlement_bank_account_no": "661505602069",
+            "settlement_ifsc_code": "ICIC0006615",
+            "bank_name": "ICICI\",",
+            "branch_name": "Sco 31, Sector 18, Udyog Vihar, Gurgaon - 122016, Haryana",
+            "settlement_timestamp": "2023-12-14T07:49:55.524Z"
+          }
+        ],
+        "@ondc/org/settlement_basis": "delivery",
+        "@ondc/org/settlement_window": "P1D",
+        "@ondc/org/withholding_amount": "10.00"
+      },
+      "created_at": "2023-12-13T07:19:55.446Z",
+      "updated_at": "2023-12-13T07:19:55.979Z"
+    }
+  }
+}

--- a/Chattybao/Logs_Dec_13/Retail/Flow 4/select.json
+++ b/Chattybao/Logs_Dec_13/Retail/Flow 4/select.json
@@ -1,0 +1,57 @@
+{
+  "context": {
+    "domain": "ONDC:RET10",
+    "country": "IND",
+    "city": "std:0522",
+    "action": "select",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_uri": "https://ondc-seller-preprod.chattybao.com/ondc/bpp",
+    "transaction_id": "dc7cfce5-611b-4de0-a803-5adf0b735694",
+    "message_id": "1b929d23-7c31-4b72-a0f2-dc9475cbd3c5",
+    "timestamp": "2023-12-13T07:18:30.836Z",
+    "bpp_id": "ondc-seller-preprod.chattybao.com/ondc",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "items": [
+        {
+          "id": "7f0677d0-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 2
+          },
+          "location_id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042"
+        },
+        {
+          "id": "82479910-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 1
+          },
+          "location_id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042"
+        }
+      ],
+      "provider": {
+        "id": "MR8mcezPPQEA-r8EhP6UN9",
+        "locations": [
+          {
+            "id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042"
+          }
+        ]
+      },
+      "fulfillments": [
+        {
+          "end": {
+            "location": {
+              "gps": "26.849441465615914,80.99205368752338",
+              "address": {
+                "area_code": "226010"
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/Chattybao/Logs_Dec_13/Retail/Flow 5/confirm.json
+++ b/Chattybao/Logs_Dec_13/Retail/Flow 5/confirm.json
@@ -1,0 +1,191 @@
+{
+  "context": {
+    "domain": "ONDC:RET10",
+    "country": "IND",
+    "city": "std:0522",
+    "action": "confirm",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_uri": "https://ondc-seller-preprod.chattybao.com/ondc/bpp",
+    "transaction_id": "ccbc94e3-660e-46f4-8d61-a38b8ef5524d",
+    "message_id": "326a5cd1-661d-47b8-ae12-ce314a91c26b",
+    "timestamp": "2023-12-13T07:26:08.588Z",
+    "bpp_id": "ondc-seller-preprod.chattybao.com/ondc",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "id": "2023-12-13-554248",
+      "state": "Created",
+      "billing": {
+        "address": {
+          "name": "Venkat",
+          "building": "4-32",
+          "locality": "Shankar Chauraha Road",
+          "city": "Lucknow",
+          "state": "Uttar Pradesh",
+          "country": "IND",
+          "area_code": "226010"
+        },
+        "phone": "9739374094",
+        "name": "Venkat",
+        "email": "venkyuvr@gmail.com",
+        "created_at": "2023-12-13T07:25:30.051Z",
+        "updated_at": "2023-12-13T07:25:30.051Z"
+      },
+      "items": [
+        {
+          "id": "7f0677d0-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "1"
+        }
+      ],
+      "provider": {
+        "id": "MR8mcezPPQEA-r8EhP6UN9",
+        "locations": [
+          {
+            "id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042"
+          }
+        ]
+      },
+      "fulfillments": [
+        {
+          "id": "1",
+          "tracking": true,
+          "end": {
+            "contact": {
+              "email": "venkyuvr@gmail.com",
+              "phone": "9739374094"
+            },
+            "person": {
+              "name": "Venkat"
+            },
+            "location": {
+              "gps": "26.849441465615914, 80.99205368752338",
+              "address": {
+                "name": "Venkat",
+                "building": "4-32",
+                "locality": "Shankar Chauraha Road",
+                "city": "Lucknow",
+                "state": "Uttar Pradesh",
+                "country": "IND",
+                "area_code": "226010"
+              }
+            }
+          },
+          "type": "Delivery"
+        }
+      ],
+      "payment": {
+        "uri": "https://juspay.in/",
+        "tl_method": "http/get",
+        "params": {
+          "amount": "180",
+          "currency": "INR",
+          "transaction_id": "6ecee2dc-2586-4523-9a01-6e6be21be824"
+        },
+        "status": "PAID",
+        "type": "ON-ORDER",
+        "collected_by": "BAP",
+        "@ondc/org/buyer_app_finder_fee_type": "percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "seller-app",
+            "settlement_phase": "sale-amount",
+            "settlement_type": "neft",
+            "beneficiary_name": "CHATTYBAO TECHNOLOGIES PRIVATE LIMITED NODAL ACCOUNT",
+            "upi_address": "",
+            "settlement_bank_account_no": "661505602069",
+            "settlement_ifsc_code": "ICIC0006615",
+            "bank_name": "ICICI\",",
+            "branch_name": "Sco 31, Sector 18, Udyog Vihar, Gurgaon - 122016, Haryana"
+          }
+        ]
+      },
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "180"
+        },
+        "breakup": [
+          {
+            "title": "Apple Kinnaur 500 g",
+            "@ondc/org/item_id": "7f0677d0-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/title_type": "item",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "price": {
+              "currency": "INR",
+              "value": "130"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "65"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "1",
+            "title": "Delivery Charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "42"
+            }
+          },
+          {
+            "@ondc/org/item_id": "1",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "8"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "quote",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "fulfillment"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "ttl": "P4D"
+      },
+      "tags": [
+        {
+          "code": "bpp_terms",
+          "list": [
+            {
+              "code": "tax_number",
+              "value": "07AAJCC8423B1ZW"
+            }
+          ]
+        },
+        {
+          "code": "bap_terms",
+          "list": [
+            {
+              "code": "tax_number",
+              "value": "BUYER-APP-GSTN-ONDC"
+            }
+          ]
+        }
+      ],
+      "created_at": "2023-12-13T07:26:08.588Z",
+      "updated_at": "2023-12-13T07:26:08.588Z"
+    }
+  }
+}

--- a/Chattybao/Logs_Dec_13/Retail/Flow 5/init.json
+++ b/Chattybao/Logs_Dec_13/Retail/Flow 5/init.json
@@ -1,0 +1,79 @@
+{
+  "context": {
+    "domain": "ONDC:RET10",
+    "country": "IND",
+    "city": "std:0522",
+    "action": "init",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_uri": "https://ondc-seller-preprod.chattybao.com/ondc/bpp",
+    "transaction_id": "ccbc94e3-660e-46f4-8d61-a38b8ef5524d",
+    "message_id": "5542f822-525f-481f-b48f-5ef5b5c1a2dd",
+    "timestamp": "2023-12-13T07:25:30.051Z",
+    "bpp_id": "ondc-seller-preprod.chattybao.com/ondc",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "provider": {
+        "id": "MR8mcezPPQEA-r8EhP6UN9",
+        "locations": [
+          {
+            "id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042"
+          }
+        ]
+      },
+      "items": [
+        {
+          "id": "7f0677d0-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 2
+          },
+          "location_id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042",
+          "fulfillment_id": "1"
+        }
+      ],
+      "billing": {
+        "address": {
+          "building": "4-32",
+          "city": "Lucknow",
+          "state": "Uttar Pradesh",
+          "country": "IND",
+          "area_code": "226010",
+          "locality": "Shankar Chauraha Road",
+          "name": "Venkat"
+        },
+        "phone": "9739374094",
+        "name": "Venkat",
+        "email": "venkyuvr@gmail.com",
+        "created_at": "2023-12-13T07:25:30.051Z",
+        "updated_at": "2023-12-13T07:25:30.051Z"
+      },
+      "fulfillments": [
+        {
+          "id": "1",
+          "type": "Delivery",
+          "end": {
+            "contact": {
+              "email": "venkyuvr@gmail.com",
+              "phone": "9739374094"
+            },
+            "location": {
+              "gps": "26.849441465615914, 80.99205368752338",
+              "address": {
+                "building": "4-32",
+                "city": "Lucknow",
+                "state": "Uttar Pradesh",
+                "country": "IND",
+                "area_code": "226010",
+                "locality": "Shankar Chauraha Road",
+                "name": "Venkat"
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/Chattybao/Logs_Dec_13/Retail/Flow 5/on_cancel_rto.json
+++ b/Chattybao/Logs_Dec_13/Retail/Flow 5/on_cancel_rto.json
@@ -1,0 +1,485 @@
+{
+  "context": {
+    "domain": "ONDC:RET10",
+    "country": "IND",
+    "city": "std:0522",
+    "action": "on_cancel",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_uri": "https://ondc-seller-preprod.chattybao.com/ondc/bpp",
+    "transaction_id": "ccbc94e3-660e-46f4-8d61-a38b8ef5524d",
+    "message_id": "3a87c650-9989-11ee-a063-913f64757eea",
+    "timestamp": "2023-12-13T07:28:36.661Z",
+    "bpp_id": "ondc-seller-preprod.chattybao.com/ondc",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "id": "0000114171",
+      "state": "Cancelled",
+      "provider": {
+        "id": "MR8mcezPPQEA-r8EhP6UN9",
+        "locations": [
+          {
+            "id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042"
+          }
+        ]
+      },
+      "items": [
+        {
+          "id": "7f0677d0-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "1"
+        }
+      ],
+      "billing": {
+        "address": {
+          "name": "Venkat",
+          "building": "4-32",
+          "locality": "Shankar Chauraha Road",
+          "city": "Lucknow",
+          "state": "Uttar Pradesh",
+          "country": "IND",
+          "area_code": "226010"
+        },
+        "phone": "9739374094",
+        "name": "Venkat",
+        "email": "venkyuvr@gmail.com",
+        "created_at": "2023-12-13T07:25:30.051Z",
+        "updated_at": "2023-12-13T07:25:30.051Z"
+      },
+      "cancellation": {
+        "cancelled_by": "ondc-seller-preprod.chattybao.com/ondc",
+        "reason": {
+          "id": "011"
+        }
+      },
+      "fulfillment": [
+        {
+          "@ondc/org/provider_name": "tester shatrughan fru and veg",
+          "state": {
+            "descriptor": {
+              "code": "Cancelled",
+              "name": "Cancelled"
+            }
+          },
+          "start": {
+            "location": {
+              "id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042",
+              "descriptor": {
+                "name": "tester shatrughan fru and veg"
+              },
+              "gps": "26.854719,80.998035",
+              "address": {
+                "locality": "4/267, Vivek Khand 4 Gomti Nagar",
+                "city": "Uttar Pradesh",
+                "area_code": "226010",
+                "state": "lucknow"
+              }
+            },
+            "time": {
+              "timestamp": "2023-12-13T07:27:32.278Z",
+              "range": {
+                "start": "2023-12-13T07:26:08.692Z",
+                "end": "2023-12-13T07:56:08.692Z"
+              }
+            },
+            "instructions": {
+              "code": "2",
+              "name": "ONDC order",
+              "short_desc": "ONDC order",
+              "long_desc": "ONDC order"
+            },
+            "contact": {
+              "phone": "8840019700",
+              "email": "help@chattybao.com"
+            }
+          },
+          "id": "1",
+          "tracking": true,
+          "end": {
+            "contact": {
+              "email": "venkyuvr@gmail.com",
+              "phone": "9739374094"
+            },
+            "person": {
+              "name": "Venkat"
+            },
+            "location": {
+              "gps": "26.849441465615914, 80.99205368752338",
+              "address": {
+                "name": "Venkat",
+                "building": "4-32",
+                "locality": "Shankar Chauraha Road",
+                "city": "Lucknow",
+                "state": "Uttar Pradesh",
+                "country": "IND",
+                "area_code": "226010"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2023-12-13T07:26:08.694Z",
+                "end": "2023-12-13T08:26:08.694Z"
+              }
+            }
+          },
+          "type": "Delivery",
+          "@ondc/org/TAT": "PT60M",
+          "tags": [
+            {
+              "code": "cancel_request",
+              "list": [
+                {
+                  "code": "reason_id",
+                  "value": "011"
+                },
+                {
+                  "code": "initiated_by",
+                  "value": "ondc-seller-preprod.chattybao.com/ondc"
+                },
+                {
+                  "code": "retry_count",
+                  "value": "3"
+                },
+                {
+                  "code": "rto_id",
+                  "value": "F1-RTO"
+                }
+              ]
+            },
+            {
+              "code": "precancel_state",
+              "list": [
+                {
+                  "code": "fulfillment_state",
+                  "value": "Out-for-delivery"
+                },
+                {
+                  "code": "updated_at",
+                  "value": "2023-12-13T07:28:36.658Z"
+                }
+              ]
+            },
+            {
+              "code": "quote_trail",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "item"
+                },
+                {
+                  "code": "subtype",
+                  "value": "item"
+                },
+                {
+                  "code": "id",
+                  "value": "7f0677d0-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9"
+                },
+                {
+                  "code": "currency",
+                  "value": "INR"
+                },
+                {
+                  "code": "value",
+                  "value": "-0.00"
+                }
+              ]
+            },
+            {
+              "code": "quote_trail",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "delivery"
+                },
+                {
+                  "code": "subtype",
+                  "value": "item"
+                },
+                {
+                  "code": "id",
+                  "value": "1"
+                },
+                {
+                  "code": "currency",
+                  "value": "INR"
+                },
+                {
+                  "code": "value",
+                  "value": "-0.00"
+                }
+              ]
+            },
+            {
+              "code": "quote_trail",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "tax"
+                },
+                {
+                  "code": "subtype",
+                  "value": "item"
+                },
+                {
+                  "code": "id",
+                  "value": "1"
+                },
+                {
+                  "code": "currency",
+                  "value": "INR"
+                },
+                {
+                  "code": "value",
+                  "value": "-0.00"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "id": "F1-RTO",
+          "type": "RTO",
+          "state": {
+            "descriptor": {
+              "code": "RTO-Disposed"
+            }
+          },
+          "start": {
+            "time": {
+              "timestamp": "2023-12-13T07:28:36.660Z"
+            }
+          },
+          "end": {
+            "time": {
+              "timestamp": "2023-12-13T07:28:36.660Z"
+            }
+          },
+          "tags": [
+            {
+              "code": "quote_trail",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "delivery"
+                },
+                {
+                  "code": "id",
+                  "value": "F1-RTO"
+                },
+                {
+                  "code": "currency",
+                  "value": "INR"
+                },
+                {
+                  "code": "value",
+                  "value": "0.00"
+                }
+              ]
+            },
+            {
+              "code": "quote_trail",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "item"
+                },
+                {
+                  "code": "subtype",
+                  "value": "item"
+                },
+                {
+                  "code": "id",
+                  "value": "7f0677d0-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9"
+                },
+                {
+                  "code": "currency",
+                  "value": "INR"
+                },
+                {
+                  "code": "value",
+                  "value": "-0.00"
+                }
+              ]
+            },
+            {
+              "code": "quote_trail",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "delivery"
+                },
+                {
+                  "code": "subtype",
+                  "value": "item"
+                },
+                {
+                  "code": "id",
+                  "value": "1"
+                },
+                {
+                  "code": "currency",
+                  "value": "INR"
+                },
+                {
+                  "code": "value",
+                  "value": "-0.00"
+                }
+              ]
+            },
+            {
+              "code": "quote_trail",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "tax"
+                },
+                {
+                  "code": "subtype",
+                  "value": "item"
+                },
+                {
+                  "code": "id",
+                  "value": "1"
+                },
+                {
+                  "code": "currency",
+                  "value": "INR"
+                },
+                {
+                  "code": "value",
+                  "value": "-0.00"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "180"
+        },
+        "breakup": [
+          {
+            "title": "Apple Kinnaur 500 g",
+            "@ondc/org/item_id": "7f0677d0-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/title_type": "item",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "price": {
+              "currency": "INR",
+              "value": "130"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "65"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "1",
+            "title": "Delivery Charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "42"
+            }
+          },
+          {
+            "@ondc/org/item_id": "1",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "8"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "quote",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "fulfillment"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "F1-RTO",
+            "title": "Delivery charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "0.00"
+            }
+          },
+          {
+            "@ondc/org/item_id": "F1-RTO",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "0.00"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "quote",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "fulfillment"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "ttl": "P4D"
+      },
+      "payment": {
+        "uri": "https://juspay.in/",
+        "tl_method": "http/get",
+        "params": {
+          "amount": "180",
+          "currency": "INR",
+          "transaction_id": "6ecee2dc-2586-4523-9a01-6e6be21be824"
+        },
+        "status": "PAID",
+        "type": "ON-ORDER",
+        "collected_by": "BAP",
+        "@ondc/org/buyer_app_finder_fee_type": "percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "seller-app",
+            "settlement_phase": "sale-amount",
+            "settlement_type": "neft",
+            "beneficiary_name": "CHATTYBAO TECHNOLOGIES PRIVATE LIMITED NODAL ACCOUNT",
+            "upi_address": "",
+            "settlement_bank_account_no": "661505602069",
+            "settlement_ifsc_code": "ICIC0006615",
+            "bank_name": "ICICI\",",
+            "branch_name": "Sco 31, Sector 18, Udyog Vihar, Gurgaon - 122016, Haryana"
+          }
+        ],
+        "@ondc/org/settlement_basis": "delivery",
+        "@ondc/org/settlement_window": "P1D",
+        "@ondc/org/withholding_amount": "10.00"
+      },
+      "created_at": "2023-12-13T07:26:08.588Z",
+      "updated_at": "2023-12-13T07:28:36.660Z"
+    }
+  }
+}

--- a/Chattybao/Logs_Dec_13/Retail/Flow 5/on_confirm.json
+++ b/Chattybao/Logs_Dec_13/Retail/Flow 5/on_confirm.json
@@ -1,0 +1,238 @@
+{
+  "context": {
+    "domain": "ONDC:RET10",
+    "country": "IND",
+    "city": "std:0522",
+    "action": "on_confirm",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_uri": "https://ondc-seller-preprod.chattybao.com/ondc/bpp",
+    "transaction_id": "ccbc94e3-660e-46f4-8d61-a38b8ef5524d",
+    "message_id": "326a5cd1-661d-47b8-ae12-ce314a91c26b",
+    "timestamp": "2023-12-13T07:26:08.696Z",
+    "bpp_id": "ondc-seller-preprod.chattybao.com/ondc",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "id": "2023-12-13-554248",
+      "state": "Accepted",
+      "billing": {
+        "address": {
+          "name": "Venkat",
+          "building": "4-32",
+          "locality": "Shankar Chauraha Road",
+          "city": "Lucknow",
+          "state": "Uttar Pradesh",
+          "country": "IND",
+          "area_code": "226010"
+        },
+        "phone": "9739374094",
+        "name": "Venkat",
+        "email": "venkyuvr@gmail.com",
+        "created_at": "2023-12-13T07:25:30.051Z",
+        "updated_at": "2023-12-13T07:25:30.051Z"
+      },
+      "items": [
+        {
+          "id": "7f0677d0-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "1"
+        }
+      ],
+      "provider": {
+        "id": "MR8mcezPPQEA-r8EhP6UN9",
+        "locations": [
+          {
+            "id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042"
+          }
+        ]
+      },
+      "fulfillments": [
+        {
+          "@ondc/org/provider_name": "tester shatrughan fru and veg",
+          "state": {
+            "descriptor": {
+              "code": "Pending"
+            }
+          },
+          "start": {
+            "location": {
+              "id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042",
+              "descriptor": {
+                "name": "tester shatrughan fru and veg"
+              },
+              "gps": "26.854719,80.998035",
+              "address": {
+                "locality": "4/267, Vivek Khand 4 Gomti Nagar",
+                "city": "Uttar Pradesh",
+                "area_code": "226010",
+                "state": "lucknow"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2023-12-13T07:26:08.692Z",
+                "end": "2023-12-13T07:56:08.692Z"
+              }
+            },
+            "instructions": {
+              "code": "2",
+              "name": "ONDC order",
+              "short_desc": "ONDC order",
+              "long_desc": "ONDC order"
+            },
+            "contact": {
+              "phone": "8840019700",
+              "email": "help@chattybao.com"
+            }
+          },
+          "id": "1",
+          "tracking": true,
+          "end": {
+            "contact": {
+              "email": "venkyuvr@gmail.com",
+              "phone": "9739374094"
+            },
+            "person": {
+              "name": "Venkat"
+            },
+            "location": {
+              "gps": "26.849441465615914, 80.99205368752338",
+              "address": {
+                "name": "Venkat",
+                "building": "4-32",
+                "locality": "Shankar Chauraha Road",
+                "city": "Lucknow",
+                "state": "Uttar Pradesh",
+                "country": "IND",
+                "area_code": "226010"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2023-12-13T07:26:08.694Z",
+                "end": "2023-12-13T08:26:08.694Z"
+              }
+            }
+          },
+          "type": "Delivery"
+        }
+      ],
+      "payment": {
+        "uri": "https://juspay.in/",
+        "tl_method": "http/get",
+        "params": {
+          "amount": "180",
+          "currency": "INR",
+          "transaction_id": "6ecee2dc-2586-4523-9a01-6e6be21be824"
+        },
+        "status": "PAID",
+        "type": "ON-ORDER",
+        "collected_by": "BAP",
+        "@ondc/org/buyer_app_finder_fee_type": "percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "seller-app",
+            "settlement_phase": "sale-amount",
+            "settlement_type": "neft",
+            "beneficiary_name": "CHATTYBAO TECHNOLOGIES PRIVATE LIMITED NODAL ACCOUNT",
+            "upi_address": "",
+            "settlement_bank_account_no": "661505602069",
+            "settlement_ifsc_code": "ICIC0006615",
+            "bank_name": "ICICI\",",
+            "branch_name": "Sco 31, Sector 18, Udyog Vihar, Gurgaon - 122016, Haryana"
+          }
+        ],
+        "@ondc/org/settlement_basis": "delivery",
+        "@ondc/org/settlement_window": "P1D",
+        "@ondc/org/withholding_amount": "10.00"
+      },
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "180"
+        },
+        "breakup": [
+          {
+            "title": "Apple Kinnaur 500 g",
+            "@ondc/org/item_id": "7f0677d0-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/title_type": "item",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "price": {
+              "currency": "INR",
+              "value": "130"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "65"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "1",
+            "title": "Delivery Charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "42"
+            }
+          },
+          {
+            "@ondc/org/item_id": "1",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "8"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "quote",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "fulfillment"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "ttl": "P4D"
+      },
+      "tags": [
+        {
+          "code": "bpp_terms",
+          "list": [
+            {
+              "code": "tax_number",
+              "value": "07AAJCC8423B1ZW"
+            }
+          ]
+        },
+        {
+          "code": "bap_terms",
+          "list": [
+            {
+              "code": "tax_number",
+              "value": "BUYER-APP-GSTN-ONDC"
+            }
+          ]
+        }
+      ],
+      "created_at": "2023-12-13T07:26:08.588Z",
+      "updated_at": "2023-12-13T07:26:08.696Z",
+      "rateable": true
+    }
+  }
+}

--- a/Chattybao/Logs_Dec_13/Retail/Flow 5/on_init.json
+++ b/Chattybao/Logs_Dec_13/Retail/Flow 5/on_init.json
@@ -1,0 +1,273 @@
+{
+  "context": {
+    "domain": "ONDC:RET10",
+    "country": "IND",
+    "city": "std:0522",
+    "action": "on_init",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_uri": "https://ondc-seller-preprod.chattybao.com/ondc/bpp",
+    "transaction_id": "ccbc94e3-660e-46f4-8d61-a38b8ef5524d",
+    "message_id": "5542f822-525f-481f-b48f-5ef5b5c1a2dd",
+    "timestamp": "2023-12-13T07:25:31.059Z",
+    "bpp_id": "ondc-seller-preprod.chattybao.com/ondc",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "items": [
+        {
+          "id": "7f0677d0-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 2
+          },
+          "location_id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042",
+          "fulfillment_id": "1"
+        }
+      ],
+      "billing": {
+        "address": {
+          "building": "4-32",
+          "city": "Lucknow",
+          "state": "Uttar Pradesh",
+          "country": "IND",
+          "area_code": "226010",
+          "locality": "Shankar Chauraha Road",
+          "name": "Venkat"
+        },
+        "phone": "9739374094",
+        "name": "Venkat",
+        "email": "venkyuvr@gmail.com",
+        "created_at": "2023-12-13T07:25:30.051Z",
+        "updated_at": "2023-12-13T07:25:30.051Z"
+      },
+      "fulfillments": [
+        {
+          "id": "1",
+          "type": "Delivery",
+          "end": {
+            "contact": {
+              "email": "venkyuvr@gmail.com",
+              "phone": "9739374094"
+            },
+            "location": {
+              "gps": "26.849441465615914, 80.99205368752338",
+              "address": {
+                "building": "4-32",
+                "city": "Lucknow",
+                "state": "Uttar Pradesh",
+                "country": "IND",
+                "area_code": "226010",
+                "locality": "Shankar Chauraha Road",
+                "name": "Venkat"
+              }
+            }
+          },
+          "tracking": true
+        }
+      ],
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "180"
+        },
+        "breakup": [
+          {
+            "title": "Apple Kinnaur 500 g",
+            "@ondc/org/item_id": "7f0677d0-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/title_type": "item",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "price": {
+              "currency": "INR",
+              "value": "130"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "65"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "1",
+            "title": "Delivery Charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "42"
+            }
+          },
+          {
+            "@ondc/org/item_id": "1",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "8"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "quote",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "fulfillment"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "ttl": "P4D"
+      },
+      "provider": {
+        "id": "MR8mcezPPQEA-r8EhP6UN9",
+        "locations": [
+          {
+            "id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042"
+          }
+        ]
+      },
+      "provider_location": {
+        "id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042"
+      },
+      "payment": {
+        "type": "ON-ORDER",
+        "collected_by": "BAP",
+        "status": "NOT-PAID",
+        "@ondc/org/settlement_basis": "delivery",
+        "@ondc/org/settlement_window": "P1D",
+        "@ondc/org/withholding_amount": "10.00",
+        "@ondc/org/buyer_app_finder_fee_type": "percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "3",
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "seller-app",
+            "settlement_phase": "sale-amount",
+            "settlement_type": "neft",
+            "beneficiary_name": "CHATTYBAO TECHNOLOGIES PRIVATE LIMITED NODAL ACCOUNT",
+            "upi_address": "",
+            "settlement_bank_account_no": "661505602069",
+            "settlement_ifsc_code": "ICIC0006615",
+            "bank_name": "ICICI\",",
+            "branch_name": "Sco 31, Sector 18, Udyog Vihar, Gurgaon - 122016, Haryana"
+          }
+        ]
+      },
+      "cancellation_terms": [
+        {
+          "fulfillment_state": {
+            "descriptor": {
+              "code": "Pending",
+              "short_desc": ""
+            }
+          },
+          "refund_eligible": true,
+          "reason_required": false,
+          "cancellation_fee": {
+            "percentage": "0.00",
+            "amount": {
+              "currency": "INR",
+              "value": "0.00"
+            }
+          }
+        },
+        {
+          "fulfillment_state": {
+            "descriptor": {
+              "code": "Packed",
+              "short_desc": "001,003"
+            }
+          },
+          "refund_eligible": true,
+          "reason_required": true,
+          "cancellation_fee": {
+            "percentage": "0.00",
+            "amount": {
+              "currency": "INR",
+              "value": "0.00"
+            }
+          }
+        },
+        {
+          "fulfillment_state": {
+            "descriptor": {
+              "code": "Order-picked-up",
+              "short_desc": "001,003"
+            }
+          },
+          "refund_eligible": true,
+          "reason_required": true,
+          "cancellation_fee": {
+            "amount": {
+              "currency": "INR",
+              "value": "50.00"
+            }
+          }
+        },
+        {
+          "fulfillment_state": {
+            "descriptor": {
+              "code": "Out-for-delivery",
+              "short_desc": "009"
+            }
+          },
+          "refund_eligible": false,
+          "reason_required": true,
+          "cancellation_fee": {
+            "percentage": "100.00"
+          }
+        },
+        {
+          "fulfillment_state": {
+            "descriptor": {
+              "code": "Out-for-delivery",
+              "short_desc": "010,011,012,013,014,015"
+            }
+          },
+          "refund_eligible": false,
+          "reason_required": true,
+          "cancellation_fee": {
+            "percentage": "100.00"
+          }
+        }
+      ],
+      "tags": [
+        {
+          "code": "bpp_terms",
+          "list": [
+            {
+              "code": "max_liability",
+              "value": "2"
+            },
+            {
+              "code": "max_liability_cap",
+              "value": "10000.00"
+            },
+            {
+              "code": "mandatory_arbitration",
+              "value": "false"
+            },
+            {
+              "code": "court_jurisdiction",
+              "value": "Delhi"
+            },
+            {
+              "code": "delay_interest",
+              "value": "1000.00"
+            },
+            {
+              "code": "tax_number",
+              "value": "07AAJCC8423B1ZW"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/Chattybao/Logs_Dec_13/Retail/Flow 5/on_select.json
+++ b/Chattybao/Logs_Dec_13/Retail/Flow 5/on_select.json
@@ -1,0 +1,136 @@
+{
+  "context": {
+    "domain": "ONDC:RET10",
+    "country": "IND",
+    "city": "std:0522",
+    "action": "on_select",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_uri": "https://ondc-seller-preprod.chattybao.com/ondc/bpp",
+    "transaction_id": "ccbc94e3-660e-46f4-8d61-a38b8ef5524d",
+    "message_id": "d6b3eb4e-c248-4cbe-aa5a-3d44fa9d7283",
+    "timestamp": "2023-12-13T07:24:28.382Z",
+    "bpp_id": "ondc-seller-preprod.chattybao.com/ondc",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "provider": {
+        "id": "MR8mcezPPQEA-r8EhP6UN9",
+        "locations": [
+          {
+            "id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042"
+          }
+        ]
+      },
+      "items": [
+        {
+          "@ondc/org/available_on_cod": false,
+          "@ondc/org/cancellable": true,
+          "@ondc/org/contact_details_consumer_care": "ChattyBao Help, help@chattybao.com,7353256777",
+          "@ondc/org/mandatory_reqs_veggies_fruits": {},
+          "@ondc/org/returnable": true,
+          "@ondc/org/seller_pickup_return": true,
+          "@ondc/org/statutory_reqs_packaged_commodities": {},
+          "@ondc/org/statutory_reqs_prepackaged_food": {},
+          "matched": true,
+          "rateable": true,
+          "recommended": true,
+          "fulfillment_id": "1",
+          "id": "7f0677d0-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+          "price": {
+            "currency": "INR",
+            "value": "65"
+          },
+          "quantity": {
+            "selected": {
+              "count": 2
+            }
+          }
+        }
+      ],
+      "fulfillments": [
+        {
+          "id": "1",
+          "type": "Delivery",
+          "@ondc/org/provider_name": "Chattybao Logistics",
+          "tracking": true,
+          "@ondc/org/category": "Immediate Delivery",
+          "@ondc/org/TAT": "PT60M",
+          "state": {
+            "descriptor": {
+              "code": "Serviceable"
+            }
+          }
+        }
+      ],
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "180"
+        },
+        "breakup": [
+          {
+            "@ondc/org/item_id": "7f0677d0-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "@ondc/org/title_type": "item",
+            "title": "Apple Kinnaur 500 g",
+            "price": {
+              "currency": "INR",
+              "value": "130"
+            },
+            "item": {
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "65"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "1",
+            "title": "Delivery Charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "42"
+            }
+          },
+          {
+            "@ondc/org/item_id": "1",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "8"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "quote",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "fulfillment"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "ttl": "P4D"
+      }
+    }
+  }
+}

--- a/Chattybao/Logs_Dec_13/Retail/Flow 5/on_status_cancelled.json
+++ b/Chattybao/Logs_Dec_13/Retail/Flow 5/on_status_cancelled.json
@@ -1,0 +1,485 @@
+{
+  "context": {
+    "domain": "ONDC:RET10",
+    "country": "IND",
+    "city": "std:0522",
+    "action": "on_status",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_uri": "https://ondc-seller-preprod.chattybao.com/ondc/bpp",
+    "transaction_id": "ccbc94e3-660e-46f4-8d61-a38b8ef5524d",
+    "message_id": "440eb9c0-df86-4c02-93ee-38c98f1e4294",
+    "timestamp": "2023-12-13T07:29:03.793Z",
+    "bpp_id": "ondc-seller-preprod.chattybao.com/ondc",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "id": "0000114171",
+      "state": "Cancelled",
+      "provider": {
+        "id": "MR8mcezPPQEA-r8EhP6UN9",
+        "locations": [
+          {
+            "id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042"
+          }
+        ]
+      },
+      "items": [
+        {
+          "id": "7f0677d0-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "1"
+        }
+      ],
+      "billing": {
+        "address": {
+          "name": "Venkat",
+          "building": "4-32",
+          "locality": "Shankar Chauraha Road",
+          "city": "Lucknow",
+          "state": "Uttar Pradesh",
+          "country": "IND",
+          "area_code": "226010"
+        },
+        "phone": "9739374094",
+        "name": "Venkat",
+        "email": "venkyuvr@gmail.com",
+        "created_at": "2023-12-13T07:25:30.051Z",
+        "updated_at": "2023-12-13T07:25:30.051Z"
+      },
+      "cancellation": {
+        "cancelled_by": "ondc-seller-preprod.chattybao.com/ondc",
+        "reason": {
+          "id": "011"
+        }
+      },
+      "fulfillment": [
+        {
+          "@ondc/org/provider_name": "tester shatrughan fru and veg",
+          "state": {
+            "descriptor": {
+              "code": "Cancelled",
+              "name": "Cancelled"
+            }
+          },
+          "start": {
+            "location": {
+              "id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042",
+              "descriptor": {
+                "name": "tester shatrughan fru and veg"
+              },
+              "gps": "26.854719,80.998035",
+              "address": {
+                "locality": "4/267, Vivek Khand 4 Gomti Nagar",
+                "city": "Uttar Pradesh",
+                "area_code": "226010",
+                "state": "lucknow"
+              }
+            },
+            "time": {
+              "timestamp": "2023-12-13T07:27:32.278Z",
+              "range": {
+                "start": "2023-12-13T07:26:08.692Z",
+                "end": "2023-12-13T07:56:08.692Z"
+              }
+            },
+            "instructions": {
+              "code": "2",
+              "name": "ONDC order",
+              "short_desc": "ONDC order",
+              "long_desc": "ONDC order"
+            },
+            "contact": {
+              "phone": "8840019700",
+              "email": "help@chattybao.com"
+            }
+          },
+          "id": "1",
+          "tracking": true,
+          "end": {
+            "contact": {
+              "email": "venkyuvr@gmail.com",
+              "phone": "9739374094"
+            },
+            "person": {
+              "name": "Venkat"
+            },
+            "location": {
+              "gps": "26.849441465615914, 80.99205368752338",
+              "address": {
+                "name": "Venkat",
+                "building": "4-32",
+                "locality": "Shankar Chauraha Road",
+                "city": "Lucknow",
+                "state": "Uttar Pradesh",
+                "country": "IND",
+                "area_code": "226010"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2023-12-13T07:26:08.694Z",
+                "end": "2023-12-13T08:26:08.694Z"
+              }
+            }
+          },
+          "type": "Delivery",
+          "@ondc/org/TAT": "PT60M",
+          "tags": [
+            {
+              "code": "cancel_request",
+              "list": [
+                {
+                  "code": "reason_id",
+                  "value": "011"
+                },
+                {
+                  "code": "initiated_by",
+                  "value": "ondc-seller-preprod.chattybao.com/ondc"
+                },
+                {
+                  "code": "retry_count",
+                  "value": "3"
+                },
+                {
+                  "code": "rto_id",
+                  "value": "F1-RTO"
+                }
+              ]
+            },
+            {
+              "code": "precancel_state",
+              "list": [
+                {
+                  "code": "fulfillment_state",
+                  "value": "Out-for-delivery"
+                },
+                {
+                  "code": "updated_at",
+                  "value": "2023-12-13T07:28:36.658Z"
+                }
+              ]
+            },
+            {
+              "code": "quote_trail",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "item"
+                },
+                {
+                  "code": "subtype",
+                  "value": "item"
+                },
+                {
+                  "code": "id",
+                  "value": "7f0677d0-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9"
+                },
+                {
+                  "code": "currency",
+                  "value": "INR"
+                },
+                {
+                  "code": "value",
+                  "value": "-0.00"
+                }
+              ]
+            },
+            {
+              "code": "quote_trail",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "delivery"
+                },
+                {
+                  "code": "subtype",
+                  "value": "item"
+                },
+                {
+                  "code": "id",
+                  "value": "1"
+                },
+                {
+                  "code": "currency",
+                  "value": "INR"
+                },
+                {
+                  "code": "value",
+                  "value": "-0.00"
+                }
+              ]
+            },
+            {
+              "code": "quote_trail",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "tax"
+                },
+                {
+                  "code": "subtype",
+                  "value": "item"
+                },
+                {
+                  "code": "id",
+                  "value": "1"
+                },
+                {
+                  "code": "currency",
+                  "value": "INR"
+                },
+                {
+                  "code": "value",
+                  "value": "-0.00"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "id": "F1-RTO",
+          "type": "RTO",
+          "state": {
+            "descriptor": {
+              "code": "RTO-Disposed"
+            }
+          },
+          "start": {
+            "time": {
+              "timestamp": "2023-12-13T07:28:36.660Z"
+            }
+          },
+          "end": {
+            "time": {
+              "timestamp": "2023-12-13T07:28:36.660Z"
+            }
+          },
+          "tags": [
+            {
+              "code": "quote_trail",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "delivery"
+                },
+                {
+                  "code": "id",
+                  "value": "F1-RTO"
+                },
+                {
+                  "code": "currency",
+                  "value": "INR"
+                },
+                {
+                  "code": "value",
+                  "value": "0.00"
+                }
+              ]
+            },
+            {
+              "code": "quote_trail",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "item"
+                },
+                {
+                  "code": "subtype",
+                  "value": "item"
+                },
+                {
+                  "code": "id",
+                  "value": "7f0677d0-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9"
+                },
+                {
+                  "code": "currency",
+                  "value": "INR"
+                },
+                {
+                  "code": "value",
+                  "value": "-0.00"
+                }
+              ]
+            },
+            {
+              "code": "quote_trail",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "delivery"
+                },
+                {
+                  "code": "subtype",
+                  "value": "item"
+                },
+                {
+                  "code": "id",
+                  "value": "1"
+                },
+                {
+                  "code": "currency",
+                  "value": "INR"
+                },
+                {
+                  "code": "value",
+                  "value": "-0.00"
+                }
+              ]
+            },
+            {
+              "code": "quote_trail",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "tax"
+                },
+                {
+                  "code": "subtype",
+                  "value": "item"
+                },
+                {
+                  "code": "id",
+                  "value": "1"
+                },
+                {
+                  "code": "currency",
+                  "value": "INR"
+                },
+                {
+                  "code": "value",
+                  "value": "-0.00"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "180"
+        },
+        "breakup": [
+          {
+            "title": "Apple Kinnaur 500 g",
+            "@ondc/org/item_id": "7f0677d0-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/title_type": "item",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "price": {
+              "currency": "INR",
+              "value": "130"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "65"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "1",
+            "title": "Delivery Charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "42"
+            }
+          },
+          {
+            "@ondc/org/item_id": "1",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "8"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "quote",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "fulfillment"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "F1-RTO",
+            "title": "Delivery charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "0.00"
+            }
+          },
+          {
+            "@ondc/org/item_id": "F1-RTO",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "0.00"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "quote",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "fulfillment"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "ttl": "P4D"
+      },
+      "payment": {
+        "uri": "https://juspay.in/",
+        "tl_method": "http/get",
+        "params": {
+          "amount": "180",
+          "currency": "INR",
+          "transaction_id": "6ecee2dc-2586-4523-9a01-6e6be21be824"
+        },
+        "status": "PAID",
+        "type": "ON-ORDER",
+        "collected_by": "BAP",
+        "@ondc/org/buyer_app_finder_fee_type": "percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "seller-app",
+            "settlement_phase": "sale-amount",
+            "settlement_type": "neft",
+            "beneficiary_name": "CHATTYBAO TECHNOLOGIES PRIVATE LIMITED NODAL ACCOUNT",
+            "upi_address": "",
+            "settlement_bank_account_no": "661505602069",
+            "settlement_ifsc_code": "ICIC0006615",
+            "bank_name": "ICICI\",",
+            "branch_name": "Sco 31, Sector 18, Udyog Vihar, Gurgaon - 122016, Haryana"
+          }
+        ],
+        "@ondc/org/settlement_basis": "delivery",
+        "@ondc/org/settlement_window": "P1D",
+        "@ondc/org/withholding_amount": "10.00"
+      },
+      "created_at": "2023-12-13T07:26:08.588Z",
+      "updated_at": "2023-12-13T07:29:03.793Z"
+    }
+  }
+}

--- a/Chattybao/Logs_Dec_13/Retail/Flow 5/on_status_out_for_delivery.json
+++ b/Chattybao/Logs_Dec_13/Retail/Flow 5/on_status_out_for_delivery.json
@@ -1,0 +1,223 @@
+{
+  "context": {
+    "domain": "ONDC:RET10",
+    "country": "IND",
+    "city": "std:0522",
+    "action": "on_status",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_uri": "https://ondc-seller-preprod.chattybao.com/ondc/bpp",
+    "transaction_id": "ccbc94e3-660e-46f4-8d61-a38b8ef5524d",
+    "message_id": "1d6dabc0-9989-11ee-a063-913f64757eea",
+    "timestamp": "2023-12-13T07:27:47.836Z",
+    "bpp_id": "ondc-seller-preprod.chattybao.com/ondc",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "id": "2023-12-13-554248",
+      "state": "In-progress",
+      "provider": {
+        "id": "MR8mcezPPQEA-r8EhP6UN9",
+        "locations": [
+          {
+            "id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042"
+          }
+        ]
+      },
+      "items": [
+        {
+          "id": "7f0677d0-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "1",
+          "@ondc/org/returnable": true,
+          "@ondc/org/cancellable": true
+        }
+      ],
+      "billing": {
+        "address": {
+          "name": "Venkat",
+          "building": "4-32",
+          "locality": "Shankar Chauraha Road",
+          "city": "Lucknow",
+          "state": "Uttar Pradesh",
+          "country": "IND",
+          "area_code": "226010"
+        },
+        "phone": "9739374094",
+        "name": "Venkat",
+        "email": "help@chattybao.com",
+        "created_at": "2023-12-13T07:25:30.051Z",
+        "updated_at": "2023-12-13T07:25:30.051Z"
+      },
+      "fulfillments": [
+        {
+          "@ondc/org/provider_name": "tester shatrughan fru and veg",
+          "state": {
+            "descriptor": {
+              "code": "Out-for-delivery",
+              "name": "Out for delivery"
+            }
+          },
+          "start": {
+            "location": {
+              "id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042",
+              "descriptor": {
+                "name": "tester shatrughan fru and veg"
+              },
+              "gps": "26.854719,80.998035",
+              "address": {
+                "locality": "4/267, Vivek Khand 4 Gomti Nagar",
+                "city": "Uttar Pradesh",
+                "area_code": "226010",
+                "state": "lucknow"
+              }
+            },
+            "time": {
+              "timestamp": "2023-12-13T07:27:32.278Z",
+              "range": {
+                "start": "2023-12-13T07:26:08.692Z",
+                "end": "2023-12-13T07:56:08.692Z"
+              }
+            },
+            "instructions": {
+              "code": "2",
+              "name": "ONDC order",
+              "short_desc": "ONDC order",
+              "long_desc": "ONDC order"
+            },
+            "contact": {
+              "phone": "8840019700",
+              "email": "help@chattybao.com"
+            }
+          },
+          "id": "1",
+          "tracking": true,
+          "end": {
+            "contact": {
+              "email": "venkyuvr@gmail.com",
+              "phone": "9739374094"
+            },
+            "person": {
+              "name": "Venkat"
+            },
+            "location": {
+              "gps": "26.849441465615914, 80.99205368752338",
+              "address": {
+                "name": "Venkat",
+                "building": "4-32",
+                "locality": "Shankar Chauraha Road",
+                "city": "Lucknow",
+                "state": "Uttar Pradesh",
+                "country": "IND",
+                "area_code": "226010"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2023-12-13T07:26:08.694Z",
+                "end": "2023-12-13T08:26:08.694Z"
+              }
+            }
+          },
+          "type": "Delivery",
+          "@ondc/org/TAT": "PT60M"
+        }
+      ],
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "180"
+        },
+        "breakup": [
+          {
+            "title": "Apple Kinnaur 500 g",
+            "@ondc/org/item_id": "7f0677d0-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/title_type": "item",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "price": {
+              "currency": "INR",
+              "value": "130"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "65"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "1",
+            "title": "Delivery Charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "42"
+            }
+          },
+          {
+            "@ondc/org/item_id": "1",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "8"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "quote",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "fulfillment"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "ttl": "P4D"
+      },
+      "payment": {
+        "uri": "https://juspay.in/",
+        "tl_method": "http/get",
+        "params": {
+          "amount": "180",
+          "currency": "INR",
+          "transaction_id": "6ecee2dc-2586-4523-9a01-6e6be21be824"
+        },
+        "status": "PAID",
+        "type": "ON-ORDER",
+        "collected_by": "BAP",
+        "@ondc/org/buyer_app_finder_fee_type": "percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "seller-app",
+            "settlement_phase": "sale-amount",
+            "settlement_type": "neft",
+            "beneficiary_name": "CHATTYBAO TECHNOLOGIES PRIVATE LIMITED NODAL ACCOUNT",
+            "upi_address": "",
+            "settlement_bank_account_no": "661505602069",
+            "settlement_ifsc_code": "ICIC0006615",
+            "bank_name": "ICICI\",",
+            "branch_name": "Sco 31, Sector 18, Udyog Vihar, Gurgaon - 122016, Haryana",
+            "settlement_timestamp": "2023-12-14T07:56:08.692Z"
+          }
+        ],
+        "@ondc/org/settlement_basis": "delivery",
+        "@ondc/org/settlement_window": "P1D",
+        "@ondc/org/withholding_amount": "10.00"
+      },
+      "created_at": "2023-12-13T07:26:08.588Z",
+      "updated_at": "2023-12-13T07:27:47.836Z"
+    }
+  }
+}

--- a/Chattybao/Logs_Dec_13/Retail/Flow 5/on_status_pending(packed).json
+++ b/Chattybao/Logs_Dec_13/Retail/Flow 5/on_status_pending(packed).json
@@ -1,0 +1,222 @@
+{
+  "context": {
+    "domain": "ONDC:RET10",
+    "country": "IND",
+    "city": "std:0522",
+    "action": "on_status",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_uri": "https://ondc-seller-preprod.chattybao.com/ondc/bpp",
+    "transaction_id": "ccbc94e3-660e-46f4-8d61-a38b8ef5524d",
+    "message_id": "ef10ed50-9988-11ee-a063-913f64757eea",
+    "timestamp": "2023-12-13T07:26:30.053Z",
+    "bpp_id": "ondc-seller-preprod.chattybao.com/ondc",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "id": "2023-12-13-554248",
+      "state": "In-progress",
+      "provider": {
+        "id": "MR8mcezPPQEA-r8EhP6UN9",
+        "locations": [
+          {
+            "id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042"
+          }
+        ]
+      },
+      "items": [
+        {
+          "id": "7f0677d0-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "1",
+          "@ondc/org/returnable": true,
+          "@ondc/org/cancellable": true
+        }
+      ],
+      "billing": {
+        "address": {
+          "name": "Venkat",
+          "building": "4-32",
+          "locality": "Shankar Chauraha Road",
+          "city": "Lucknow",
+          "state": "Uttar Pradesh",
+          "country": "IND",
+          "area_code": "226010"
+        },
+        "phone": "9739374094",
+        "name": "Venkat",
+        "email": "help@chattybao.com",
+        "created_at": "2023-12-13T07:25:30.051Z",
+        "updated_at": "2023-12-13T07:25:30.051Z"
+      },
+      "fulfillments": [
+        {
+          "@ondc/org/provider_name": "tester shatrughan fru and veg",
+          "state": {
+            "descriptor": {
+              "code": "Packed",
+              "name": "Packed"
+            }
+          },
+          "start": {
+            "location": {
+              "id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042",
+              "descriptor": {
+                "name": "tester shatrughan fru and veg"
+              },
+              "gps": "26.854719,80.998035",
+              "address": {
+                "locality": "4/267, Vivek Khand 4 Gomti Nagar",
+                "city": "Uttar Pradesh",
+                "area_code": "226010",
+                "state": "lucknow"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2023-12-13T07:26:08.692Z",
+                "end": "2023-12-13T07:56:08.692Z"
+              }
+            },
+            "instructions": {
+              "code": "2",
+              "name": "ONDC order",
+              "short_desc": "ONDC order",
+              "long_desc": "ONDC order"
+            },
+            "contact": {
+              "phone": "8840019700",
+              "email": "help@chattybao.com"
+            }
+          },
+          "id": "1",
+          "tracking": true,
+          "end": {
+            "contact": {
+              "email": "venkyuvr@gmail.com",
+              "phone": "9739374094"
+            },
+            "person": {
+              "name": "Venkat"
+            },
+            "location": {
+              "gps": "26.849441465615914, 80.99205368752338",
+              "address": {
+                "name": "Venkat",
+                "building": "4-32",
+                "locality": "Shankar Chauraha Road",
+                "city": "Lucknow",
+                "state": "Uttar Pradesh",
+                "country": "IND",
+                "area_code": "226010"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2023-12-13T07:26:08.694Z",
+                "end": "2023-12-13T08:26:08.694Z"
+              }
+            }
+          },
+          "type": "Delivery",
+          "@ondc/org/TAT": "PT60M"
+        }
+      ],
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "180"
+        },
+        "breakup": [
+          {
+            "title": "Apple Kinnaur 500 g",
+            "@ondc/org/item_id": "7f0677d0-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/title_type": "item",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "price": {
+              "currency": "INR",
+              "value": "130"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "65"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "1",
+            "title": "Delivery Charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "42"
+            }
+          },
+          {
+            "@ondc/org/item_id": "1",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "8"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "quote",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "fulfillment"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "ttl": "P4D"
+      },
+      "payment": {
+        "uri": "https://juspay.in/",
+        "tl_method": "http/get",
+        "params": {
+          "amount": "180",
+          "currency": "INR",
+          "transaction_id": "6ecee2dc-2586-4523-9a01-6e6be21be824"
+        },
+        "status": "PAID",
+        "type": "ON-ORDER",
+        "collected_by": "BAP",
+        "@ondc/org/buyer_app_finder_fee_type": "percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "seller-app",
+            "settlement_phase": "sale-amount",
+            "settlement_type": "neft",
+            "beneficiary_name": "CHATTYBAO TECHNOLOGIES PRIVATE LIMITED NODAL ACCOUNT",
+            "upi_address": "",
+            "settlement_bank_account_no": "661505602069",
+            "settlement_ifsc_code": "ICIC0006615",
+            "bank_name": "ICICI\",",
+            "branch_name": "Sco 31, Sector 18, Udyog Vihar, Gurgaon - 122016, Haryana",
+            "settlement_timestamp": "2023-12-14T07:56:08.692Z"
+          }
+        ],
+        "@ondc/org/settlement_basis": "delivery",
+        "@ondc/org/settlement_window": "P1D",
+        "@ondc/org/withholding_amount": "10.00"
+      },
+      "created_at": "2023-12-13T07:26:08.588Z",
+      "updated_at": "2023-12-13T07:26:30.053Z"
+    }
+  }
+}

--- a/Chattybao/Logs_Dec_13/Retail/Flow 5/on_status_picked.json
+++ b/Chattybao/Logs_Dec_13/Retail/Flow 5/on_status_picked.json
@@ -1,0 +1,223 @@
+{
+  "context": {
+    "domain": "ONDC:RET10",
+    "country": "IND",
+    "city": "std:0522",
+    "action": "on_status",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_uri": "https://ondc-seller-preprod.chattybao.com/ondc/bpp",
+    "transaction_id": "ccbc94e3-660e-46f4-8d61-a38b8ef5524d",
+    "message_id": "142914f0-9989-11ee-a063-913f64757eea",
+    "timestamp": "2023-12-13T07:27:32.287Z",
+    "bpp_id": "ondc-seller-preprod.chattybao.com/ondc",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "id": "2023-12-13-554248",
+      "state": "In-progress",
+      "provider": {
+        "id": "MR8mcezPPQEA-r8EhP6UN9",
+        "locations": [
+          {
+            "id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042"
+          }
+        ]
+      },
+      "items": [
+        {
+          "id": "7f0677d0-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "1",
+          "@ondc/org/returnable": true,
+          "@ondc/org/cancellable": true
+        }
+      ],
+      "billing": {
+        "address": {
+          "name": "Venkat",
+          "building": "4-32",
+          "locality": "Shankar Chauraha Road",
+          "city": "Lucknow",
+          "state": "Uttar Pradesh",
+          "country": "IND",
+          "area_code": "226010"
+        },
+        "phone": "9739374094",
+        "name": "Venkat",
+        "email": "help@chattybao.com",
+        "created_at": "2023-12-13T07:25:30.051Z",
+        "updated_at": "2023-12-13T07:25:30.051Z"
+      },
+      "fulfillments": [
+        {
+          "@ondc/org/provider_name": "tester shatrughan fru and veg",
+          "state": {
+            "descriptor": {
+              "code": "Order-picked-up",
+              "name": "Order picked up"
+            }
+          },
+          "start": {
+            "location": {
+              "id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042",
+              "descriptor": {
+                "name": "tester shatrughan fru and veg"
+              },
+              "gps": "26.854719,80.998035",
+              "address": {
+                "locality": "4/267, Vivek Khand 4 Gomti Nagar",
+                "city": "Uttar Pradesh",
+                "area_code": "226010",
+                "state": "lucknow"
+              }
+            },
+            "time": {
+              "timestamp": "2023-12-13T07:27:32.278Z",
+              "range": {
+                "start": "2023-12-13T07:26:08.692Z",
+                "end": "2023-12-13T07:56:08.692Z"
+              }
+            },
+            "instructions": {
+              "code": "2",
+              "name": "ONDC order",
+              "short_desc": "ONDC order",
+              "long_desc": "ONDC order"
+            },
+            "contact": {
+              "phone": "8840019700",
+              "email": "help@chattybao.com"
+            }
+          },
+          "id": "1",
+          "tracking": true,
+          "end": {
+            "contact": {
+              "email": "venkyuvr@gmail.com",
+              "phone": "9739374094"
+            },
+            "person": {
+              "name": "Venkat"
+            },
+            "location": {
+              "gps": "26.849441465615914, 80.99205368752338",
+              "address": {
+                "name": "Venkat",
+                "building": "4-32",
+                "locality": "Shankar Chauraha Road",
+                "city": "Lucknow",
+                "state": "Uttar Pradesh",
+                "country": "IND",
+                "area_code": "226010"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2023-12-13T07:26:08.694Z",
+                "end": "2023-12-13T08:26:08.694Z"
+              }
+            }
+          },
+          "type": "Delivery",
+          "@ondc/org/TAT": "PT60M"
+        }
+      ],
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "180"
+        },
+        "breakup": [
+          {
+            "title": "Apple Kinnaur 500 g",
+            "@ondc/org/item_id": "7f0677d0-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/title_type": "item",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "price": {
+              "currency": "INR",
+              "value": "130"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "65"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "1",
+            "title": "Delivery Charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "42"
+            }
+          },
+          {
+            "@ondc/org/item_id": "1",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "8"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "quote",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "fulfillment"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "ttl": "P4D"
+      },
+      "payment": {
+        "uri": "https://juspay.in/",
+        "tl_method": "http/get",
+        "params": {
+          "amount": "180",
+          "currency": "INR",
+          "transaction_id": "6ecee2dc-2586-4523-9a01-6e6be21be824"
+        },
+        "status": "PAID",
+        "type": "ON-ORDER",
+        "collected_by": "BAP",
+        "@ondc/org/buyer_app_finder_fee_type": "percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "seller-app",
+            "settlement_phase": "sale-amount",
+            "settlement_type": "neft",
+            "beneficiary_name": "CHATTYBAO TECHNOLOGIES PRIVATE LIMITED NODAL ACCOUNT",
+            "upi_address": "",
+            "settlement_bank_account_no": "661505602069",
+            "settlement_ifsc_code": "ICIC0006615",
+            "bank_name": "ICICI\",",
+            "branch_name": "Sco 31, Sector 18, Udyog Vihar, Gurgaon - 122016, Haryana",
+            "settlement_timestamp": "2023-12-14T07:56:08.692Z"
+          }
+        ],
+        "@ondc/org/settlement_basis": "delivery",
+        "@ondc/org/settlement_window": "P1D",
+        "@ondc/org/withholding_amount": "10.00"
+      },
+      "created_at": "2023-12-13T07:26:08.588Z",
+      "updated_at": "2023-12-13T07:27:32.287Z"
+    }
+  }
+}

--- a/Chattybao/Logs_Dec_13/Retail/Flow 5/select.json
+++ b/Chattybao/Logs_Dec_13/Retail/Flow 5/select.json
@@ -1,0 +1,50 @@
+{
+  "context": {
+    "domain": "ONDC:RET10",
+    "country": "IND",
+    "city": "std:0522",
+    "action": "select",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_uri": "https://ondc-seller-preprod.chattybao.com/ondc/bpp",
+    "transaction_id": "ccbc94e3-660e-46f4-8d61-a38b8ef5524d",
+    "message_id": "d6b3eb4e-c248-4cbe-aa5a-3d44fa9d7283",
+    "timestamp": "2023-12-13T07:24:28.032Z",
+    "bpp_id": "ondc-seller-preprod.chattybao.com/ondc",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "items": [
+        {
+          "id": "7f0677d0-35e4-11ee-95dc-396fe1db85181:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 2
+          },
+          "location_id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042"
+        }
+      ],
+      "provider": {
+        "id": "MR8mcezPPQEA-r8EhP6UN9",
+        "locations": [
+          {
+            "id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042"
+          }
+        ]
+      },
+      "fulfillments": [
+        {
+          "end": {
+            "location": {
+              "gps": "26.849441465615914,80.99205368752338",
+              "address": {
+                "area_code": "226010"
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
on_search_inc_refresh

    message Id for /search_inc_refresh and /on_search_inc_refresh api should be same

on_search_full_catalog_refresh

    message/catalog/bpp/descriptor/images should have valid https image url
    message/catalog/bpp/providers/images cannot have property '@ondc/org/return_window' be 'NA'

select

    timestamp for /on_search api cannot be greater than or equal to /select api

on_confirm

    order.updated_at timestamp should not be greater then the context.timestamp


first point is not applicable as on_search is unsolicited call, rest are fixed