### PR TITLE
[PAYTM] Updated Search:On_Search.json

### DIFF
--- a/Paytm/SellerApp/V1.2 Paytm Seller Logs/Search:On_Search/Search:On_Search.json
+++ b/Paytm/SellerApp/V1.2 Paytm Seller Logs/Search:On_Search/Search:On_Search.json
@@ -1,5098 +1,21654 @@
-
 {
-    "context" : {
-      "domain" : "ONDC:RET11",
-      "action" : "search",
-      "country" : "IND",
-      "city" : "std:0124",
-      "core_version" : "1.2.0",
-      "bap_id" : "buyer-app-preprod-v2.ondc.org",
-      "bap_uri" : "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
-      "transaction_id" : "7432ac34-22bf-4c4b-a6cf-54939a389a30",
-      "message_id" : "74bc032e-e78b-4f44-a004-2d754155b73e",
-      "timestamp" : "2023-12-19T14:00:01.541Z",
-      "ttl" : "PT30S"
-    },
-    "message" : {
-      "intent" : {
-        "fulfillment" : {
-          "type" : "Delivery",
-          "end" : null
-        },
-        "payment" : {
-          "@ondc/org/buyer_app_finder_fee_type" : "percent",
-          "@ondc/org/buyer_app_finder_fee_amount" : "5"
-        },
-        "category" : null,
-        "item" : null,
-        "tags" : null
-      }
+  "context": {
+    "domain": "ONDC:RET11",
+    "action": "search",
+    "country": "IND",
+    "city": "std:0124",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "transaction_id": "abcf476d-5fd9-4be6-8f3b-3536c055d1cd",
+    "message_id": "5f3a3506-73bc-4c15-844d-b197b9e78929",
+    "timestamp": "2023-12-20T10:30:01.091Z",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "intent": {
+      "fulfillment": {
+        "type": "Delivery",
+        "end": null
+      },
+      "payment": {
+        "@ondc/org/buyer_app_finder_fee_type": "percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "5"
+      },
+      "category": null,
+      "item": null,
+      "tags": null
     }
   }
+}
 
 
 {
-    "context": {
-        "domain": "ONDC:RET11",
-        "action": "on_search",
-        "country": "IND",
-        "city": "std:0124",
-        "core_version": "1.2.0",
-        "bap_id": "buyer-app-preprod-v2.ondc.org",
-        "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
-        "transaction_id" : "7432ac34-22bf-4c4b-a6cf-54939a389a30",
-        "message_id" : "74bc032e-e78b-4f44-a004-2d754155b73e",
-        "timestamp" : "2023-12-19T14:00:01.541Z",
-        "bpp_id": "ondc-seller-staging.paytm.com",
-        "bpp_uri": "https://ondc-seller-staging.paytm.com/seller"
-    },
-    "message": {
-        "catalog": {
-            "bpp/descriptor": {
-                "name": "Seller NP",
-                "symbol": "https://sellerNP.com/images/np.png",
-                "short_desc": "Seller Marketplace",
-                "long_desc": "Seller Marketplace",
-                "images": [
-                    "https://sellerNP.com/images/np.png"
-                ]
-            },
-            "bpp/providers": [
-                {
-                    "id": "63798557",
-                    "time": {
-                        "label": "enable",
-                        "timestamp": "2023-11-21T08:03:57.000Z"
-                    },
-                    "fulfillments": [
-                        {
-                            "id": "F1",
-                            "type": "Delivery",
-                            "contact": {
-                                "phone": "7125426621",
-                                "email": "oe-test@mail.com"
-                            }
-                        }
-                    ],
-                    "descriptor": {
-                        "name": "name of merchant",
-                        "symbol": "https://assetscdn1.paytm.com/merchant_logo/merchant_staging/merchant/63798557/logo/logo_1.png",
-                        "short_desc": " Momo is a fast-food and quick-service restaurant chain that specializes in serving",
-                        "long_desc": " Momo is a fast-food and quick-service restaurant chain that specializes in serving",
-                        "images": [
-                            "https://sellerNP.com/images/store1.png"
-                        ]
-                    },
-                    "ttl": "P1D",
-                    "items": [
-                        {
-                            "id": "1235217288",
-                            "descriptor": {
-                                "name": "Spicy Chicken Wings",
-                                "symbol": "",
-                                "short_desc": "Chicken fillet in a bun  with coleslaw,lettuce, pickles and our  spicy cocktail sauce. This sandwich is made with care to make sure that each and every bite is packed with Mmmm",
-                                "long_desc": "Chicken fillet in a bun  with coleslaw,lettuce, pickles and our  spicy cocktail sauce. This sandwich is made with care to make sure that each and every bite is packed with Mmmm",
-                                "images": []
-                            },
-                            "quantity": {
-                                "available": {
-                                    "count": "99"
-                                },
-                                "maximum": {
-                                    "count": "99"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "unit",
-                                        "value": "1"
-                                    }
-                                }
-                            },
-                            "price": {
-                                "currency": "INR",
-                                "value": "269.0",
-                                "maximum_value": "269.0"
-                            },
-                            "category_id": "F&B",
-                            "category_ids": [
-                                "1125:1"
-                            ],
-                            "fulfillment_id": "F1",
-                            "location_id": "1031222",
-                            "@ondc/org/returnable": false,
-                            "@ondc/org/cancellable": false,
-                            "@ondc/org/return_window": "",
-                            "@ondc/org/time_to_ship": "PT0M",
-                            "@ondc/org/available_on_cod": false,
-                            "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
-                            "tags": [
-                                {
-                                    "code": "veg_nonveg",
-                                    "list": [
-                                        {
-                                            "code": "veg",
-                                            "value": "yes"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "custom_group",
-                                    "list": [
-                                        {
-                                            "code": "id",
-                                            "value": "157920"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "config",
-                                    "list": [
-                                        {
-                                            "code": "id",
-                                            "value": "157920"
-                                        },
-                                        {
-                                            "code": "min",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "max",
-                                            "value": "1"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "1235193813",
-                            "descriptor": {
-                                "name": "DeW",
-                                "symbol": "",
-                                "short_desc": "DeW",
-                                "long_desc": "DeW",
-                                "images": []
-                            },
-                            "quantity": {
-                                "available": {
-                                    "count": "99"
-                                },
-                                "maximum": {
-                                    "count": "99"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "unit",
-                                        "value": "1"
-                                    }
-                                }
-                            },
-                            "price": {
-                                "currency": "INR",
-                                "value": "90.0",
-                                "maximum_value": "90.0"
-                            },
-                            "category_id": "F&B",
-                            "category_ids": [
-                                "1123:1"
-                            ],
-                            "fulfillment_id": "F1",
-                            "location_id": "1031222",
-                            "@ondc/org/returnable": false,
-                            "@ondc/org/cancellable": false,
-                            "@ondc/org/return_window": "",
-                            "@ondc/org/time_to_ship": "PT0M",
-                            "@ondc/org/available_on_cod": false,
-                            "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
-                            "tags": [
-                                {
-                                    "code": "veg_nonveg",
-                                    "list": [
-                                        {
-                                            "code": "veg",
-                                            "value": "yes"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "custom_group",
-                                    "list": [
-                                        {
-                                            "code": "id",
-                                            "value": "157892"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "config",
-                                    "list": [
-                                        {
-                                            "code": "id",
-                                            "value": "157892"
-                                        },
-                                        {
-                                            "code": "min",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "max",
-                                            "value": "1"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "1235193835",
-                            "descriptor": {
-                                "name": "Nescafe Intense",
-                                "symbol": "",
-                                "short_desc": "Nescafe Intense",
-                                "long_desc": "Nescafe Intense",
-                                "images": []
-                            },
-                            "quantity": {
-                                "available": {
-                                    "count": "99"
-                                },
-                                "maximum": {
-                                    "count": "99"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "unit",
-                                        "value": "1"
-                                    }
-                                }
-                            },
-                            "price": {
-                                "currency": "INR",
-                                "value": "33.25",
-                                "maximum_value": "33.25"
-                            },
-                            "category_id": "F&B",
-                            "category_ids": [
-                                "1124:1"
-                            ],
-                            "fulfillment_id": "F1",
-                            "location_id": "1031222",
-                            "@ondc/org/returnable": false,
-                            "@ondc/org/cancellable": false,
-                            "@ondc/org/return_window": "",
-                            "@ondc/org/time_to_ship": "PT0M",
-                            "@ondc/org/available_on_cod": false,
-                            "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
-                            "tags": [
-                                {
-                                    "code": "veg_nonveg",
-                                    "list": [
-                                        {
-                                            "code": "veg",
-                                            "value": "yes"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "custom_group",
-                                    "list": [
-                                        {
-                                            "code": "id",
-                                            "value": "157893"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "config",
-                                    "list": [
-                                        {
-                                            "code": "id",
-                                            "value": "157893"
-                                        },
-                                        {
-                                            "code": "min",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "max",
-                                            "value": "1"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "1235193883",
-                            "descriptor": {
-                                "name": "Chicken Loppypop",
-                                "symbol": "",
-                                "short_desc": "Chicken Loppypop",
-                                "long_desc": "Chicken Loppypop",
-                                "images": []
-                            },
-                            "quantity": {
-                                "available": {
-                                    "count": "99"
-                                },
-                                "maximum": {
-                                    "count": "99"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "unit",
-                                        "value": "1"
-                                    }
-                                }
-                            },
-                            "price": {
-                                "currency": "INR",
-                                "value": "150.0",
-                                "maximum_value": "150.0"
-                            },
-                            "category_id": "F&B",
-                            "category_ids": [
-                                "1126:2"
-                            ],
-                            "fulfillment_id": "F1",
-                            "location_id": "1031222",
-                            "@ondc/org/returnable": false,
-                            "@ondc/org/cancellable": false,
-                            "@ondc/org/return_window": "",
-                            "@ondc/org/time_to_ship": "PT0M",
-                            "@ondc/org/available_on_cod": false,
-                            "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
-                            "tags": [
-                                {
-                                    "code": "veg_nonveg",
-                                    "list": [
-                                        {
-                                            "code": "non-veg",
-                                            "value": "yes"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "1235193881",
-                            "descriptor": {
-                                "name": "Chicken Kosha With Polau",
-                                "symbol": "",
-                                "short_desc": "Chicken Kosha With Polau",
-                                "long_desc": "Chicken Kosha With Polau",
-                                "images": []
-                            },
-                            "quantity": {
-                                "available": {
-                                    "count": "99"
-                                },
-                                "maximum": {
-                                    "count": "99"
-                                },
-                                "unitized": {}
-                            },
-                            "price": {
-                                "currency": "INR",
-                                "value": "700.0",
-                                "maximum_value": "700.0"
-                            },
-                            "category_id": "F&B",
-                            "category_ids": [
-                                "1126:1"
-                            ],
-                            "fulfillment_id": "1000160",
-                            "location_id": "1031222",
-                            "@ondc/org/returnable": false,
-                            "@ondc/org/cancellable": false,
-                            "@ondc/org/return_window": "",
-                            "@ondc/org/time_to_ship": "PT0M",
-                            "@ondc/org/available_on_cod": false,
-                            "@ondc/org/contact_details_consumer_care": "7125426621, oe-test@mail.com",
-                            "tags": [
-                                {
-                                    "code": "veg_nonveg",
-                                    "list": [
-                                        {
-                                            "code": "non-veg",
-                                            "value": "yes"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "1235217289",
-                            "descriptor": {
-                                "name": "Chicken Meal 1",
-                                "symbol": "",
-                                "short_desc": "Chicken fillet in a bun  with coleslaw,lettuce, pickles and our  spicy cocktail sauce. This sandwich is made with care to make sure that each and every bite is packed with Mmmm",
-                                "long_desc": "Chicken fillet in a bun  with coleslaw,lettuce, pickles and our  spicy cocktail sauce. This sandwich is made with care to make sure that each and every bite is packed with Mmmm",
-                                "images": []
-                            },
-                            "quantity": {
-                                "available": {
-                                    "count": "99"
-                                },
-                                "maximum": {
-                                    "count": "99"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "unit",
-                                        "value": "1"
-                                    }
-                                }
-                            },
-                            "price": {
-                                "currency": "INR",
-                                "value": "239.0",
-                                "maximum_value": "239.0"
-                            },
-                            "category_id": "F&B",
-                            "category_ids": [
-                                "1125:1"
-                            ],
-                            "fulfillment_id": "F1",
-                            "location_id": "1031222",
-                            "@ondc/org/returnable": false,
-                            "@ondc/org/cancellable": false,
-                            "@ondc/org/return_window": "",
-                            "@ondc/org/time_to_ship": "PT0M",
-                            "@ondc/org/available_on_cod": false,
-                            "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
-                            "tags": [
-                                {
-                                    "code": "veg_nonveg",
-                                    "list": [
-                                        {
-                                            "code": "veg",
-                                            "value": "yes"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "custom_group",
-                                    "list": [
-                                        {
-                                            "code": "id",
-                                            "value": "157900"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "config",
-                                    "list": [
-                                        {
-                                            "code": "id",
-                                            "value": "157900"
-                                        },
-                                        {
-                                            "code": "min",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "max",
-                                            "value": "1"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "1235193861",
-                            "descriptor": {
-                                "name": "Vanilla Icecream",
-                                "symbol": "",
-                                "short_desc": "demo 4 demo 4 demo 4 dmwo 4",
-                                "long_desc": "demo 4 demo 4 demo 4 dmwo 4",
-                                "images": []
-                            },
-                            "quantity": {
-                                "available": {
-                                    "count": "99"
-                                },
-                                "maximum": {
-                                    "count": "99"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "unit",
-                                        "value": "1"
-                                    }
-                                }
-                            },
-                            "price": {
-                                "currency": "INR",
-                                "value": "19.0",
-                                "maximum_value": "19.0"
-                            },
-                            "category_id": "F&B",
-                            "category_ids": [
-                                "1119:1"
-                            ],
-                            "fulfillment_id": "F1",
-                            "location_id": "1031222",
-                            "@ondc/org/returnable": false,
-                            "@ondc/org/cancellable": false,
-                            "@ondc/org/return_window": "",
-                            "@ondc/org/time_to_ship": "PT0M",
-                            "@ondc/org/available_on_cod": false,
-                            "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
-                            "tags": [
-                                {
-                                    "code": "veg_nonveg",
-                                    "list": [
-                                        {
-                                            "code": "veg",
-                                            "value": "yes"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "custom_group",
-                                    "list": [
-                                        {
-                                            "code": "id",
-                                            "value": "157893"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "config",
-                                    "list": [
-                                        {
-                                            "code": "id",
-                                            "value": "157893"
-                                        },
-                                        {
-                                            "code": "min",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "max",
-                                            "value": "1"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "1235193783",
-                            "descriptor": {
-                                "name": "Chicken Fillet Burger Combo",
-                                "symbol": "",
-                                "short_desc": "2 Chicken Fillet burgers, fries and choice of  soft drink. 2 Crispy chicken fillet burgers, topped with tangy sliced pickles ,lettuce and Albaik International's signature garlic sauce, placed between a freshly baked bun  served with a portion of fries and a soft drink",
-                                "long_desc": "2 Chicken Fillet burgers, fries and choice of  soft drink. 2 Crispy chicken fillet burgers, topped with tangy sliced pickles ,lettuce and Albaik International's signature garlic sauce, placed between a freshly baked bun  served with a portion of fries and a soft drink",
-                                "images": []
-                            },
-                            "quantity": {
-                                "available": {
-                                    "count": "99"
-                                },
-                                "maximum": {
-                                    "count": "99"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "unit",
-                                        "value": "1"
-                                    }
-                                }
-                            },
-                            "price": {
-                                "currency": "INR",
-                                "value": "269.0",
-                                "maximum_value": "269.0"
-                            },
-                            "category_id": "F&B",
-                            "category_ids": [
-                                "1125:1"
-                            ],
-                            "fulfillment_id": "F1",
-                            "location_id": "1031222",
-                            "@ondc/org/returnable": false,
-                            "@ondc/org/cancellable": false,
-                            "@ondc/org/return_window": "",
-                            "@ondc/org/time_to_ship": "PT0M",
-                            "@ondc/org/available_on_cod": false,
-                            "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
-                            "tags": [
-                                {
-                                    "code": "veg_nonveg",
-                                    "list": [
-                                        {
-                                            "code": "veg",
-                                            "value": "yes"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "custom_group",
-                                    "list": [
-                                        {
-                                            "code": "id",
-                                            "value": "157893"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "config",
-                                    "list": [
-                                        {
-                                            "code": "id",
-                                            "value": "157893"
-                                        },
-                                        {
-                                            "code": "min",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "max",
-                                            "value": "1"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "1235193885",
-                            "descriptor": {
-                                "name": "Chicken Fry",
-                                "symbol": "",
-                                "short_desc": "Chicken Fry",
-                                "long_desc": "Chicken Fry",
-                                "images": []
-                            },
-                            "quantity": {
-                                "available": {
-                                    "count": "99"
-                                },
-                                "maximum": {
-                                    "count": "99"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "unit",
-                                        "value": "1"
-                                    }
-                                }
-                            },
-                            "price": {
-                                "currency": "INR",
-                                "value": "120.0",
-                                "maximum_value": "120.0"
-                            },
-                            "category_id": "F&B",
-                            "category_ids": [
-                                "1126:5"
-                            ],
-                            "fulfillment_id": "F1",
-                            "location_id": "1031222",
-                            "@ondc/org/returnable": false,
-                            "@ondc/org/cancellable": false,
-                            "@ondc/org/return_window": "",
-                            "@ondc/org/time_to_ship": "PT0M",
-                            "@ondc/org/available_on_cod": false,
-                            "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
-                            "tags": [
-                                {
-                                    "code": "veg_nonveg",
-                                    "list": [
-                                        {
-                                            "code": "non-veg",
-                                            "value": "yes"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "custom_group",
-                                    "list": [
-                                        {
-                                            "code": "id",
-                                            "value": "157893"
-                                        },
-                                        {
-                                            "code": "id",
-                                            "value": "157896"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "config",
-                                    "list": [
-                                        {
-                                            "code": "id",
-                                            "value": "157893"
-                                        },
-                                        {
-                                            "code": "min",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "max",
-                                            "value": "1"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "config",
-                                    "list": [
-                                        {
-                                            "code": "id",
-                                            "value": "157896"
-                                        },
-                                        {
-                                            "code": "min",
-                                            "value": "0"
-                                        },
-                                        {
-                                            "code": "max",
-                                            "value": "1"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "1235193840",
-                            "descriptor": {
-                                "name": "Icecream With Chocolate Syrup",
-                                "symbol": "",
-                                "short_desc": "demo 2 demo demo2 demo 2 demo",
-                                "long_desc": "demo 2 demo demo2 demo 2 demo",
-                                "images": []
-                            },
-                            "quantity": {
-                                "available": {
-                                    "count": "99"
-                                },
-                                "maximum": {
-                                    "count": "99"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "unit",
-                                        "value": "1"
-                                    }
-                                }
-                            },
-                            "price": {
-                                "currency": "INR",
-                                "value": "29.0",
-                                "maximum_value": "29.0"
-                            },
-                            "category_id": "F&B",
-                            "category_ids": [
-                                "1119:1"
-                            ],
-                            "fulfillment_id": "F1",
-                            "location_id": "1031222",
-                            "@ondc/org/returnable": false,
-                            "@ondc/org/cancellable": false,
-                            "@ondc/org/return_window": "",
-                            "@ondc/org/time_to_ship": "PT0M",
-                            "@ondc/org/available_on_cod": false,
-                            "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
-                            "tags": [
-                                {
-                                    "code": "veg_nonveg",
-                                    "list": [
-                                        {
-                                            "code": "veg",
-                                            "value": "yes"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "custom_group",
-                                    "list": [
-                                        {
-                                            "code": "id",
-                                            "value": "157893"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "config",
-                                    "list": [
-                                        {
-                                            "code": "id",
-                                            "value": "157893"
-                                        },
-                                        {
-                                            "code": "min",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "max",
-                                            "value": "1"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "1235193884",
-                            "descriptor": {
-                                "name": "Chicken Ukkad",
-                                "symbol": "",
-                                "short_desc": "Chicken Ukkad",
-                                "long_desc": "Chicken Ukkad",
-                                "images": []
-                            },
-                            "quantity": {
-                                "available": {
-                                    "count": "99"
-                                },
-                                "maximum": {
-                                    "count": "99"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "unit",
-                                        "value": "1"
-                                    }
-                                }
-                            },
-                            "price": {
-                                "currency": "INR",
-                                "value": "160.0",
-                                "maximum_value": "160.0"
-                            },
-                            "category_id": "F&B",
-                            "category_ids": [
-                                "1126:6"
-                            ],
-                            "fulfillment_id": "F1",
-                            "location_id": "1031222",
-                            "@ondc/org/returnable": false,
-                            "@ondc/org/cancellable": false,
-                            "@ondc/org/return_window": "",
-                            "@ondc/org/time_to_ship": "PT0M",
-                            "@ondc/org/available_on_cod": false,
-                            "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
-                            "tags": [
-                                {
-                                    "code": "veg_nonveg",
-                                    "list": [
-                                        {
-                                            "code": "non-veg",
-                                            "value": "yes"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "custom_group",
-                                    "list": [
-                                        {
-                                            "code": "id",
-                                            "value": "157896"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "config",
-                                    "list": [
-                                        {
-                                            "code": "id",
-                                            "value": "157896"
-                                        },
-                                        {
-                                            "code": "min",
-                                            "value": "0"
-                                        },
-                                        {
-                                            "code": "max",
-                                            "value": "1"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "1235193814",
-                            "descriptor": {
-                                "name": "Panner Onion",
-                                "symbol": "",
-                                "short_desc": "Panner Onion",
-                                "long_desc": "Panner Onion",
-                                "images": []
-                            },
-                            "quantity": {
-                                "available": {
-                                    "count": "99"
-                                },
-                                "maximum": {
-                                    "count": "99"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "unit",
-                                        "value": "1"
-                                    }
-                                }
-                            },
-                            "price": {
-                                "currency": "INR",
-                                "value": "90.0",
-                                "maximum_value": "90.0"
-                            },
-                            "category_id": "F&B",
-                            "category_ids": [
-                                "1125:1"
-                            ],
-                            "fulfillment_id": "F1",
-                            "location_id": "1031222",
-                            "@ondc/org/returnable": false,
-                            "@ondc/org/cancellable": false,
-                            "@ondc/org/return_window": "",
-                            "@ondc/org/time_to_ship": "PT0M",
-                            "@ondc/org/available_on_cod": false,
-                            "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
-                            "tags": [
-                                {
-                                    "code": "veg_nonveg",
-                                    "list": [
-                                        {
-                                            "code": "veg",
-                                            "value": "yes"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "custom_group",
-                                    "list": [
-                                        {
-                                            "code": "id",
-                                            "value": "157892"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "config",
-                                    "list": [
-                                        {
-                                            "code": "id",
-                                            "value": "157892"
-                                        },
-                                        {
-                                            "code": "min",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "max",
-                                            "value": "1"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "1235217280",
-                            "descriptor": {
-                                "name": "Albaik International Chicken Meal",
-                                "symbol": "",
-                                "short_desc": "Chicken meal comes with fries, a bun and  garlic sauce.The first bite will have you going Mmmmm - Every piece of Albaik International's Chicken is marinated in our signature marinade - a unique and tantalizing blend of 18 herbs and spices",
-                                "long_desc": "Chicken meal comes with fries, a bun and  garlic sauce.The first bite will have you going Mmmmm - Every piece of Albaik International's Chicken is marinated in our signature marinade - a unique and tantalizing blend of 18 herbs and spices",
-                                "images": []
-                            },
-                            "quantity": {
-                                "available": {
-                                    "count": "99"
-                                },
-                                "maximum": {
-                                    "count": "99"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "unit",
-                                        "value": "1"
-                                    }
-                                }
-                            },
-                            "price": {
-                                "currency": "INR",
-                                "value": "300.0",
-                                "maximum_value": "330.0"
-                            },
-                            "category_id": "F&B",
-                            "category_ids": [
-                                "1125:1"
-                            ],
-                            "fulfillment_id": "F1",
-                            "location_id": "1031222",
-                            "@ondc/org/returnable": false,
-                            "@ondc/org/cancellable": false,
-                            "@ondc/org/return_window": "",
-                            "@ondc/org/time_to_ship": "PT0M",
-                            "@ondc/org/available_on_cod": false,
-                            "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
-                            "tags": [
-                                {
-                                    "code": "veg_nonveg",
-                                    "list": [
-                                        {
-                                            "code": "veg",
-                                            "value": "yes"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "custom_group",
-                                    "list": [
-                                        {
-                                            "code": "id",
-                                            "value": "157919"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "config",
-                                    "list": [
-                                        {
-                                            "code": "id",
-                                            "value": "157919"
-                                        },
-                                        {
-                                            "code": "min",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "max",
-                                            "value": "1"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "1235217283",
-                            "descriptor": {
-                                "name": "Shrimp Meal",
-                                "symbol": "",
-                                "short_desc": "Shrimp Meal",
-                                "long_desc": "Shrimp Meal",
-                                "images": []
-                            },
-                            "quantity": {
-                                "available": {
-                                    "count": "99"
-                                },
-                                "maximum": {
-                                    "count": "99"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "unit",
-                                        "value": "1"
-                                    }
-                                }
-                            },
-                            "price": {
-                                "currency": "INR",
-                                "value": "419.0",
-                                "maximum_value": "419.0"
-                            },
-                            "category_id": "F&B",
-                            "category_ids": [
-                                "1122:1"
-                            ],
-                            "fulfillment_id": "F1",
-                            "location_id": "1031222",
-                            "@ondc/org/returnable": false,
-                            "@ondc/org/cancellable": false,
-                            "@ondc/org/return_window": "",
-                            "@ondc/org/time_to_ship": "PT0M",
-                            "@ondc/org/available_on_cod": false,
-                            "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
-                            "tags": [
-                                {
-                                    "code": "veg_nonveg",
-                                    "list": [
-                                        {
-                                            "code": "veg",
-                                            "value": "yes"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "custom_group",
-                                    "list": [
-                                        {
-                                            "code": "id",
-                                            "value": "157913"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "config",
-                                    "list": [
-                                        {
-                                            "code": "id",
-                                            "value": "157913"
-                                        },
-                                        {
-                                            "code": "min",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "max",
-                                            "value": "1"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "1235217292",
-                            "descriptor": {
-                                "name": "Spicy Value Shrimp Meal",
-                                "symbol": "",
-                                "short_desc": "Spicy Value Shrimp Meal",
-                                "long_desc": "Spicy Value Shrimp Meal",
-                                "images": []
-                            },
-                            "quantity": {
-                                "available": {
-                                    "count": "99"
-                                },
-                                "maximum": {
-                                    "count": "99"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "unit",
-                                        "value": "1"
-                                    }
-                                }
-                            },
-                            "price": {
-                                "currency": "INR",
-                                "value": "399.0",
-                                "maximum_value": "399.0"
-                            },
-                            "category_id": "F&B",
-                            "category_ids": [
-                                "1122:1"
-                            ],
-                            "fulfillment_id": "F1",
-                            "location_id": "1031222",
-                            "@ondc/org/returnable": false,
-                            "@ondc/org/cancellable": false,
-                            "@ondc/org/return_window": "",
-                            "@ondc/org/time_to_ship": "PT0M",
-                            "@ondc/org/available_on_cod": false,
-                            "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
-                            "tags": [
-                                {
-                                    "code": "veg_nonveg",
-                                    "list": [
-                                        {
-                                            "code": "veg",
-                                            "value": "yes"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "custom_group",
-                                    "list": [
-                                        {
-                                            "code": "id",
-                                            "value": "157917"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "config",
-                                    "list": [
-                                        {
-                                            "code": "id",
-                                            "value": "157917"
-                                        },
-                                        {
-                                            "code": "min",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "max",
-                                            "value": "1"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "1235217285",
-                            "descriptor": {
-                                "name": "Fish Fillet Meal",
-                                "symbol": "",
-                                "short_desc": "Fish Fillet Meal",
-                                "long_desc": "Fish Fillet Meal",
-                                "images": []
-                            },
-                            "quantity": {
-                                "available": {
-                                    "count": "99"
-                                },
-                                "maximum": {
-                                    "count": "99"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "unit",
-                                        "value": "1"
-                                    }
-                                }
-                            },
-                            "price": {
-                                "currency": "INR",
-                                "value": "299.0",
-                                "maximum_value": "299.0"
-                            },
-                            "category_id": "F&B",
-                            "category_ids": [
-                                "1122:1"
-                            ],
-                            "fulfillment_id": "F1",
-                            "location_id": "1031222",
-                            "@ondc/org/returnable": false,
-                            "@ondc/org/cancellable": false,
-                            "@ondc/org/return_window": "",
-                            "@ondc/org/time_to_ship": "PT0M",
-                            "@ondc/org/available_on_cod": false,
-                            "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
-                            "tags": [
-                                {
-                                    "code": "veg_nonveg",
-                                    "list": [
-                                        {
-                                            "code": "veg",
-                                            "value": "yes"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "custom_group",
-                                    "list": [
-                                        {
-                                            "code": "id",
-                                            "value": "157911"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "config",
-                                    "list": [
-                                        {
-                                            "code": "id",
-                                            "value": "157911"
-                                        },
-                                        {
-                                            "code": "min",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "max",
-                                            "value": "1"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "1235217293",
-                            "descriptor": {
-                                "name": "Spicy Shrimp Meal",
-                                "symbol": "",
-                                "short_desc": "Spicy Shrimp Meal",
-                                "long_desc": "Spicy Shrimp Meal",
-                                "images": []
-                            },
-                            "quantity": {
-                                "available": {
-                                    "count": "99"
-                                },
-                                "maximum": {
-                                    "count": "99"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "unit",
-                                        "value": "1"
-                                    }
-                                }
-                            },
-                            "price": {
-                                "currency": "INR",
-                                "value": "419.0",
-                                "maximum_value": "419.0"
-                            },
-                            "category_id": "F&B",
-                            "category_ids": [
-                                "1122:1"
-                            ],
-                            "fulfillment_id": "F1",
-                            "location_id": "1031222",
-                            "@ondc/org/returnable": false,
-                            "@ondc/org/cancellable": false,
-                            "@ondc/org/return_window": "",
-                            "@ondc/org/time_to_ship": "PT0M",
-                            "@ondc/org/available_on_cod": false,
-                            "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
-                            "tags": [
-                                {
-                                    "code": "veg_nonveg",
-                                    "list": [
-                                        {
-                                            "code": "veg",
-                                            "value": "yes"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "custom_group",
-                                    "list": [
-                                        {
-                                            "code": "id",
-                                            "value": "157918"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "config",
-                                    "list": [
-                                        {
-                                            "code": "id",
-                                            "value": "157918"
-                                        },
-                                        {
-                                            "code": "min",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "max",
-                                            "value": "1"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "1235217286",
-                            "descriptor": {
-                                "name": "Value Shrimp Meal",
-                                "symbol": "",
-                                "short_desc": "Value Shrimp Meal",
-                                "long_desc": "Value Shrimp Meal",
-                                "images": []
-                            },
-                            "quantity": {
-                                "available": {
-                                    "count": "99"
-                                },
-                                "maximum": {
-                                    "count": "99"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "unit",
-                                        "value": "1"
-                                    }
-                                }
-                            },
-                            "price": {
-                                "currency": "INR",
-                                "value": "399.0",
-                                "maximum_value": "399.0"
-                            },
-                            "category_id": "F&B",
-                            "category_ids": [
-                                "1122:1"
-                            ],
-                            "fulfillment_id": "F1",
-                            "location_id": "1031222",
-                            "@ondc/org/returnable": false,
-                            "@ondc/org/cancellable": false,
-                            "@ondc/org/return_window": "",
-                            "@ondc/org/time_to_ship": "PT0M",
-                            "@ondc/org/available_on_cod": false,
-                            "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
-                            "tags": [
-                                {
-                                    "code": "veg_nonveg",
-                                    "list": [
-                                        {
-                                            "code": "veg",
-                                            "value": "yes"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "custom_group",
-                                    "list": [
-                                        {
-                                            "code": "id",
-                                            "value": "157912"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "config",
-                                    "list": [
-                                        {
-                                            "code": "id",
-                                            "value": "157912"
-                                        },
-                                        {
-                                            "code": "min",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "max",
-                                            "value": "1"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "1235193777",
-                            "descriptor": {
-                                "name": "Chicken Fillet Nugget Snack",
-                                "symbol": "",
-                                "short_desc": "chicken fillet  nuggets come with a sauce of your choice (nugget/garlic sauce). Bite-sized pieces of tender all breast chicken fillets, marinated in our unique & signature blend, breaded and seasoned to perfection, then deep-fried until deliciously tender, crispy with a golden crust",
-                                "long_desc": "chicken fillet  nuggets come with a sauce of your choice (nugget/garlic sauce). Bite-sized pieces of tender all breast chicken fillets, marinated in our unique & signature blend, breaded and seasoned to perfection, then deep-fried until deliciously tender, crispy with a golden crust",
-                                "images": []
-                            },
-                            "quantity": {
-                                "available": {
-                                    "count": "99"
-                                },
-                                "maximum": {
-                                    "count": "99"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "unit",
-                                        "value": "1"
-                                    }
-                                }
-                            },
-                            "price": {
-                                "currency": "INR",
-                                "value": "319.0",
-                                "maximum_value": "319.0"
-                            },
-                            "category_id": "F&B",
-                            "category_ids": [
-                                "1125:1"
-                            ],
-                            "fulfillment_id": "F1",
-                            "location_id": "1031222",
-                            "@ondc/org/returnable": false,
-                            "@ondc/org/cancellable": false,
-                            "@ondc/org/return_window": "",
-                            "@ondc/org/time_to_ship": "PT0M",
-                            "@ondc/org/available_on_cod": false,
-                            "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
-                            "tags": [
-                                {
-                                    "code": "veg_nonveg",
-                                    "list": [
-                                        {
-                                            "code": "veg",
-                                            "value": "yes"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "custom_group",
-                                    "list": [
-                                        {
-                                            "code": "id",
-                                            "value": "157892"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "config",
-                                    "list": [
-                                        {
-                                            "code": "id",
-                                            "value": "157892"
-                                        },
-                                        {
-                                            "code": "min",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "max",
-                                            "value": "1"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "1235193780",
-                            "descriptor": {
-                                "name": "Fish Fillet Sandwich Combo",
-                                "symbol": "",
-                                "short_desc": "Fish Fillet Sandwich Combo",
-                                "long_desc": "Fish Fillet Sandwich Combo",
-                                "images": []
-                            },
-                            "quantity": {
-                                "available": {
-                                    "count": "99"
-                                },
-                                "maximum": {
-                                    "count": "99"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "unit",
-                                        "value": "1"
-                                    }
-                                }
-                            },
-                            "price": {
-                                "currency": "INR",
-                                "value": "299.0",
-                                "maximum_value": "299.0"
-                            },
-                            "category_id": "F&B",
-                            "category_ids": [
-                                "1122:1"
-                            ],
-                            "fulfillment_id": "F1",
-                            "location_id": "1031222",
-                            "@ondc/org/returnable": false,
-                            "@ondc/org/cancellable": false,
-                            "@ondc/org/return_window": "",
-                            "@ondc/org/time_to_ship": "PT0M",
-                            "@ondc/org/available_on_cod": false,
-                            "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
-                            "tags": [
-                                {
-                                    "code": "veg_nonveg",
-                                    "list": [
-                                        {
-                                            "code": "veg",
-                                            "value": "yes"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "custom_group",
-                                    "list": [
-                                        {
-                                            "code": "id",
-                                            "value": "157893"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "config",
-                                    "list": [
-                                        {
-                                            "code": "id",
-                                            "value": "157893"
-                                        },
-                                        {
-                                            "code": "min",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "max",
-                                            "value": "1"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "1235193880",
-                            "descriptor": {
-                                "name": "Promotion Ice",
-                                "symbol": "",
-                                "short_desc": "demo 1 demo1 demo 1",
-                                "long_desc": "demo 1 demo1 demo 1",
-                                "images": []
-                            },
-                            "quantity": {
-                                "available": {
-                                    "count": "99"
-                                },
-                                "maximum": {
-                                    "count": "99"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "unit",
-                                        "value": "1"
-                                    }
-                                }
-                            },
-                            "price": {
-                                "currency": "INR",
-                                "value": "0.95",
-                                "maximum_value": "0.95"
-                            },
-                            "category_id": "F&B",
-                            "category_ids": [
-                                "1119:1"
-                            ],
-                            "fulfillment_id": "F1",
-                            "location_id": "1031222",
-                            "@ondc/org/returnable": false,
-                            "@ondc/org/cancellable": false,
-                            "@ondc/org/return_window": "",
-                            "@ondc/org/time_to_ship": "PT0M",
-                            "@ondc/org/available_on_cod": false,
-                            "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
-                            "tags": [
-                                {
-                                    "code": "veg_nonveg",
-                                    "list": [
-                                        {
-                                            "code": "veg",
-                                            "value": "yes"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "custom_group",
-                                    "list": [
-                                        {
-                                            "code": "id",
-                                            "value": "157893"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "config",
-                                    "list": [
-                                        {
-                                            "code": "id",
-                                            "value": "157893"
-                                        },
-                                        {
-                                            "code": "min",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "max",
-                                            "value": "1"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "1235217290",
-                            "descriptor": {
-                                "name": "Chicken Wings",
-                                "symbol": "",
-                                "short_desc": "Chicken fillet in a bun  with coleslaw,lettuce, pickles and our  spicy cocktail sauce. This sandwich is made with care to make sure that each and every bite is packed with Mmmm",
-                                "long_desc": "Chicken fillet in a bun  with coleslaw,lettuce, pickles and our  spicy cocktail sauce. This sandwich is made with care to make sure that each and every bite is packed with Mmmm",
-                                "images": []
-                            },
-                            "quantity": {
-                                "available": {
-                                    "count": "99"
-                                },
-                                "maximum": {
-                                    "count": "99"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "unit",
-                                        "value": "1"
-                                    }
-                                }
-                            },
-                            "price": {
-                                "currency": "INR",
-                                "value": "269.0",
-                                "maximum_value": "269.0"
-                            },
-                            "category_id": "F&B",
-                            "category_ids": [
-                                "1125:1"
-                            ],
-                            "fulfillment_id": "F1",
-                            "location_id": "1031222",
-                            "@ondc/org/returnable": false,
-                            "@ondc/org/cancellable": false,
-                            "@ondc/org/return_window": "",
-                            "@ondc/org/time_to_ship": "PT0M",
-                            "@ondc/org/available_on_cod": false,
-                            "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
-                            "tags": [
-                                {
-                                    "code": "veg_nonveg",
-                                    "list": [
-                                        {
-                                            "code": "veg",
-                                            "value": "yes"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "custom_group",
-                                    "list": [
-                                        {
-                                            "code": "id",
-                                            "value": "157915"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "config",
-                                    "list": [
-                                        {
-                                            "code": "id",
-                                            "value": "157915"
-                                        },
-                                        {
-                                            "code": "min",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "max",
-                                            "value": "1"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "1235217287",
-                            "descriptor": {
-                                "name": "Chicken Drumstick Spicy",
-                                "symbol": "",
-                                "short_desc": "Chicken fillet in a bun  with coleslaw,lettuce, pickles and our  spicy cocktail sauce. This sandwich is made with care to make sure that each and every bite is packed with Mmmm",
-                                "long_desc": "Chicken fillet in a bun  with coleslaw,lettuce, pickles and our  spicy cocktail sauce. This sandwich is made with care to make sure that each and every bite is packed with Mmmm",
-                                "images": []
-                            },
-                            "quantity": {
-                                "available": {
-                                    "count": "99"
-                                },
-                                "maximum": {
-                                    "count": "99"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "unit",
-                                        "value": "1"
-                                    }
-                                }
-                            },
-                            "price": {
-                                "currency": "INR",
-                                "value": "359.0",
-                                "maximum_value": "359.0"
-                            },
-                            "category_id": "F&B",
-                            "category_ids": [
-                                "1125:1"
-                            ],
-                            "fulfillment_id": "F1",
-                            "location_id": "1031222",
-                            "@ondc/org/returnable": false,
-                            "@ondc/org/cancellable": false,
-                            "@ondc/org/return_window": "",
-                            "@ondc/org/time_to_ship": "PT0M",
-                            "@ondc/org/available_on_cod": false,
-                            "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
-                            "tags": [
-                                {
-                                    "code": "veg_nonveg",
-                                    "list": [
-                                        {
-                                            "code": "veg",
-                                            "value": "yes"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "custom_group",
-                                    "list": [
-                                        {
-                                            "code": "id",
-                                            "value": "157914"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "config",
-                                    "list": [
-                                        {
-                                            "code": "id",
-                                            "value": "157914"
-                                        },
-                                        {
-                                            "code": "min",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "max",
-                                            "value": "1"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "1235217281",
-                            "descriptor": {
-                                "name": "Chicken Drumsticks",
-                                "symbol": "",
-                                "short_desc": "Crispy chicken drumsticks come with some fries and garlic sauce. Albaik International's Chicken drumsticks are marinated in our signature marinade - a unique and tantalizing blend of 18 herbs and spices",
-                                "long_desc": "Crispy chicken drumsticks come with some fries and garlic sauce. Albaik International's Chicken drumsticks are marinated in our signature marinade - a unique and tantalizing blend of 18 herbs and spices",
-                                "images": []
-                            },
-                            "quantity": {
-                                "available": {
-                                    "count": "99"
-                                },
-                                "maximum": {
-                                    "count": "99"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "unit",
-                                        "value": "1"
-                                    }
-                                }
-                            },
-                            "price": {
-                                "currency": "INR",
-                                "value": "359.0",
-                                "maximum_value": "359.0"
-                            },
-                            "category_id": "F&B",
-                            "category_ids": [
-                                "1125:1"
-                            ],
-                            "fulfillment_id": "F1",
-                            "location_id": "1031222",
-                            "@ondc/org/returnable": false,
-                            "@ondc/org/cancellable": false,
-                            "@ondc/org/return_window": "",
-                            "@ondc/org/time_to_ship": "PT0M",
-                            "@ondc/org/available_on_cod": false,
-                            "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
-                            "tags": [
-                                {
-                                    "code": "veg_nonveg",
-                                    "list": [
-                                        {
-                                            "code": "veg",
-                                            "value": "yes"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "custom_group",
-                                    "list": [
-                                        {
-                                            "code": "id",
-                                            "value": "157909"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "config",
-                                    "list": [
-                                        {
-                                            "code": "id",
-                                            "value": "157909"
-                                        },
-                                        {
-                                            "code": "min",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "max",
-                                            "value": "1"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "1235217294",
-                            "descriptor": {
-                                "name": "Macchiato",
-                                "symbol": "",
-                                "short_desc": "Macchiato",
-                                "long_desc": "Macchiato",
-                                "images": []
-                            },
-                            "quantity": {
-                                "available": {
-                                    "count": "99"
-                                },
-                                "maximum": {
-                                    "count": "99"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "unit",
-                                        "value": "1"
-                                    }
-                                }
-                            },
-                            "price": {
-                                "currency": "INR",
-                                "value": "139.0",
-                                "maximum_value": "139.0"
-                            },
-                            "category_id": "F&B",
-                            "category_ids": [
-                                "1124:1"
-                            ],
-                            "fulfillment_id": "F1",
-                            "location_id": "1031222",
-                            "@ondc/org/returnable": false,
-                            "@ondc/org/cancellable": false,
-                            "@ondc/org/return_window": "",
-                            "@ondc/org/time_to_ship": "PT0M",
-                            "@ondc/org/available_on_cod": false,
-                            "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
-                            "tags": [
-                                {
-                                    "code": "veg_nonveg",
-                                    "list": [
-                                        {
-                                            "code": "veg",
-                                            "value": "yes"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "custom_group",
-                                    "list": [
-                                        {
-                                            "code": "id",
-                                            "value": "157907"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "config",
-                                    "list": [
-                                        {
-                                            "code": "id",
-                                            "value": "157907"
-                                        },
-                                        {
-                                            "code": "min",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "max",
-                                            "value": "1"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "1235217295",
-                            "descriptor": {
-                                "name": "Americano",
-                                "symbol": "",
-                                "short_desc": "Americano",
-                                "long_desc": "Americano",
-                                "images": []
-                            },
-                            "quantity": {
-                                "available": {
-                                    "count": "99"
-                                },
-                                "maximum": {
-                                    "count": "99"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "unit",
-                                        "value": "1"
-                                    }
-                                }
-                            },
-                            "price": {
-                                "currency": "INR",
-                                "value": "139.0",
-                                "maximum_value": "139.0"
-                            },
-                            "category_id": "F&B",
-                            "category_ids": [
-                                "1123:1"
-                            ],
-                            "fulfillment_id": "F1",
-                            "location_id": "1031222",
-                            "@ondc/org/returnable": false,
-                            "@ondc/org/cancellable": false,
-                            "@ondc/org/return_window": "",
-                            "@ondc/org/time_to_ship": "PT0M",
-                            "@ondc/org/available_on_cod": false,
-                            "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
-                            "tags": [
-                                {
-                                    "code": "veg_nonveg",
-                                    "list": [
-                                        {
-                                            "code": "veg",
-                                            "value": "yes"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "custom_group",
-                                    "list": [
-                                        {
-                                            "code": "id",
-                                            "value": "157916"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "config",
-                                    "list": [
-                                        {
-                                            "code": "id",
-                                            "value": "157916"
-                                        },
-                                        {
-                                            "code": "min",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "max",
-                                            "value": "1"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "1235193778",
-                            "descriptor": {
-                                "name": "Chicken Fillet Sandwich Combo",
-                                "symbol": "",
-                                "short_desc": "Chicken fillet sandwich, fries and choice of soft drink. Prepared with care ensuring each and every bite is packed with Mmmm",
-                                "long_desc": "Chicken fillet sandwich, fries and choice of soft drink. Prepared with care ensuring each and every bite is packed with Mmmm",
-                                "images": []
-                            },
-                            "quantity": {
-                                "available": {
-                                    "count": "99"
-                                },
-                                "maximum": {
-                                    "count": "99"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "unit",
-                                        "value": "1"
-                                    }
-                                }
-                            },
-                            "price": {
-                                "currency": "INR",
-                                "value": "289.0",
-                                "maximum_value": "289.0"
-                            },
-                            "category_id": "F&B",
-                            "category_ids": [
-                                "1125:1"
-                            ],
-                            "fulfillment_id": "F1",
-                            "location_id": "1031222",
-                            "@ondc/org/returnable": false,
-                            "@ondc/org/cancellable": false,
-                            "@ondc/org/return_window": "",
-                            "@ondc/org/time_to_ship": "PT0M",
-                            "@ondc/org/available_on_cod": false,
-                            "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
-                            "tags": [
-                                {
-                                    "code": "veg_nonveg",
-                                    "list": [
-                                        {
-                                            "code": "veg",
-                                            "value": "yes"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "custom_group",
-                                    "list": [
-                                        {
-                                            "code": "id",
-                                            "value": "157893"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "config",
-                                    "list": [
-                                        {
-                                            "code": "id",
-                                            "value": "157893"
-                                        },
-                                        {
-                                            "code": "min",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "max",
-                                            "value": "1"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "1235193857",
-                            "descriptor": {
-                                "name": "7\"up",
-                                "symbol": "",
-                                "short_desc": "7\"up",
-                                "long_desc": "7\"up",
-                                "images": []
-                            },
-                            "quantity": {
-                                "available": {
-                                    "count": "99"
-                                },
-                                "maximum": {
-                                    "count": "99"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "unit",
-                                        "value": "1"
-                                    }
-                                }
-                            },
-                            "price": {
-                                "currency": "INR",
-                                "value": "28.5",
-                                "maximum_value": "28.5"
-                            },
-                            "category_id": "F&B",
-                            "category_ids": [
-                                "1123:1"
-                            ],
-                            "fulfillment_id": "F1",
-                            "location_id": "1031222",
-                            "@ondc/org/returnable": false,
-                            "@ondc/org/cancellable": false,
-                            "@ondc/org/return_window": "",
-                            "@ondc/org/time_to_ship": "PT0M",
-                            "@ondc/org/available_on_cod": false,
-                            "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
-                            "tags": [
-                                {
-                                    "code": "veg_nonveg",
-                                    "list": [
-                                        {
-                                            "code": "veg",
-                                            "value": "yes"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "custom_group",
-                                    "list": [
-                                        {
-                                            "code": "id",
-                                            "value": "157892"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "config",
-                                    "list": [
-                                        {
-                                            "code": "id",
-                                            "value": "157892"
-                                        },
-                                        {
-                                            "code": "min",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "max",
-                                            "value": "1"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "1235193862",
-                            "descriptor": {
-                                "name": "Juices",
-                                "symbol": "",
-                                "short_desc": "Pomogranate,Orange,Apple And Mixed Fruit Juice",
-                                "long_desc": "Pomogranate,Orange,Apple And Mixed Fruit Juice",
-                                "images": []
-                            },
-                            "quantity": {
-                                "available": {
-                                    "count": "99"
-                                },
-                                "maximum": {
-                                    "count": "99"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "unit",
-                                        "value": "1"
-                                    }
-                                }
-                            },
-                            "price": {
-                                "currency": "INR",
-                                "value": "19.0",
-                                "maximum_value": "19.0"
-                            },
-                            "category_id": "F&B",
-                            "category_ids": [
-                                "1123:1"
-                            ],
-                            "fulfillment_id": "F1",
-                            "location_id": "1031222",
-                            "@ondc/org/returnable": false,
-                            "@ondc/org/cancellable": false,
-                            "@ondc/org/return_window": "",
-                            "@ondc/org/time_to_ship": "PT0M",
-                            "@ondc/org/available_on_cod": false,
-                            "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
-                            "tags": [
-                                {
-                                    "code": "veg_nonveg",
-                                    "list": [
-                                        {
-                                            "code": "veg",
-                                            "value": "yes"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "custom_group",
-                                    "list": [
-                                        {
-                                            "code": "id",
-                                            "value": "157894"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "config",
-                                    "list": [
-                                        {
-                                            "code": "id",
-                                            "value": "157894"
-                                        },
-                                        {
-                                            "code": "min",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "max",
-                                            "value": "1"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "1235217291",
-                            "descriptor": {
-                                "name": "Chicken Fillet Nuggets Meal",
-                                "symbol": "",
-                                "short_desc": "chicken fillet nuggets come with fries, a bun and a sauce of your choice   (nuggets sauce/garlic sauce) Tender all breast chicken fillets pieces marinated in our unique & signature blend then breaded, seasoned to perfection and deep-fried in 100% pure vegetable oil until each piece is moist, tender and juicy from the inside, crispy and perfectly golden on the outside allowing for the Mmmm sensation with every bite",
-                                "long_desc": "chicken fillet nuggets come with fries, a bun and a sauce of your choice   (nuggets sauce/garlic sauce) Tender all breast chicken fillets pieces marinated in our unique & signature blend then breaded, seasoned to perfection and deep-fried in 100% pure vegetable oil until each piece is moist, tender and juicy from the inside, crispy and perfectly golden on the outside allowing for the Mmmm sensation with every bite",
-                                "images": []
-                            },
-                            "quantity": {
-                                "available": {
-                                    "count": "99"
-                                },
-                                "maximum": {
-                                    "count": "99"
-                                },
-                                "unitized": {
-                                    "measure": {
-                                        "unit": "unit",
-                                        "value": "1"
-                                    }
-                                }
-                            },
-                            "price": {
-                                "currency": "INR",
-                                "value": "609.0",
-                                "maximum_value": "609.0"
-                            },
-                            "category_id": "F&B",
-                            "category_ids": [
-                                "1125:1"
-                            ],
-                            "fulfillment_id": "F1",
-                            "location_id": "1031222",
-                            "@ondc/org/returnable": false,
-                            "@ondc/org/cancellable": false,
-                            "@ondc/org/return_window": "",
-                            "@ondc/org/time_to_ship": "PT0M",
-                            "@ondc/org/available_on_cod": false,
-                            "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
-                            "tags": [
-                                {
-                                    "code": "veg_nonveg",
-                                    "list": [
-                                        {
-                                            "code": "veg",
-                                            "value": "yes"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "custom_group",
-                                    "list": [
-                                        {
-                                            "code": "id",
-                                            "value": "157910"
-                                        },
-                                        {
-                                            "code": "id",
-                                            "value": "157892"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "config",
-                                    "list": [
-                                        {
-                                            "code": "id",
-                                            "value": "157910"
-                                        },
-                                        {
-                                            "code": "min",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "max",
-                                            "value": "1"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "config",
-                                    "list": [
-                                        {
-                                            "code": "id",
-                                            "value": "157892"
-                                        },
-                                        {
-                                            "code": "min",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "max",
-                                            "value": "1"
-                                        }
-                                    ]
-                                }
-                            ]
-                        }
-                    ],
-                    "@ondc/org/fssai_license_no": "13619014000591",
-                    "tags": [
-                        {
-                            "code": "timing",
-                            "list": [
-                                {
-                                    "code": "type",
-                                    "value": "Delivery"
-                                },
-                                {
-                                    "code": "location",
-                                    "value": "1031222"
-                                },
-                                {
-                                    "code": "day_from",
-                                    "value": "3"
-                                },
-                                {
-                                    "code": "day_to",
-                                    "value": "3"
-                                },
-                                {
-                                    "code": "time_from",
-                                    "value": "0000"
-                                },
-                                {
-                                    "code": "time_to",
-                                    "value": "2355"
-                                }
-                            ]
-                        },
-                        {
-                            "code": "timing",
-                            "list": [
-                                {
-                                    "code": "type",
-                                    "value": "Delivery"
-                                },
-                                {
-                                    "code": "location",
-                                    "value": "1031222"
-                                },
-                                {
-                                    "code": "day_from",
-                                    "value": "5"
-                                },
-                                {
-                                    "code": "day_to",
-                                    "value": "5"
-                                },
-                                {
-                                    "code": "time_from",
-                                    "value": "0300"
-                                },
-                                {
-                                    "code": "time_to",
-                                    "value": "2359"
-                                }
-                            ]
-                        },
-                        {
-                            "code": "timing",
-                            "list": [
-                                {
-                                    "code": "type",
-                                    "value": "Delivery"
-                                },
-                                {
-                                    "code": "location",
-                                    "value": "1031222"
-                                },
-                                {
-                                    "code": "day_from",
-                                    "value": "7"
-                                },
-                                {
-                                    "code": "day_to",
-                                    "value": "7"
-                                },
-                                {
-                                    "code": "time_from",
-                                    "value": "0300"
-                                },
-                                {
-                                    "code": "time_to",
-                                    "value": "2315"
-                                }
-                            ]
-                        },
-                        {
-                            "code": "timing",
-                            "list": [
-                                {
-                                    "code": "type",
-                                    "value": "Delivery"
-                                },
-                                {
-                                    "code": "location",
-                                    "value": "1031222"
-                                },
-                                {
-                                    "code": "day_from",
-                                    "value": "6"
-                                },
-                                {
-                                    "code": "day_to",
-                                    "value": "6"
-                                },
-                                {
-                                    "code": "time_from",
-                                    "value": "0000"
-                                },
-                                {
-                                    "code": "time_to",
-                                    "value": "2359"
-                                }
-                            ]
-                        },
-                        {
-                            "code": "timing",
-                            "list": [
-                                {
-                                    "code": "type",
-                                    "value": "Delivery"
-                                },
-                                {
-                                    "code": "location",
-                                    "value": "1031222"
-                                },
-                                {
-                                    "code": "day_from",
-                                    "value": "2"
-                                },
-                                {
-                                    "code": "day_to",
-                                    "value": "2"
-                                },
-                                {
-                                    "code": "time_from",
-                                    "value": "0300"
-                                },
-                                {
-                                    "code": "time_to",
-                                    "value": "2355"
-                                }
-                            ]
-                        },
-                        {
-                            "code": "timing",
-                            "list": [
-                                {
-                                    "code": "type",
-                                    "value": "Delivery"
-                                },
-                                {
-                                    "code": "location",
-                                    "value": "1031222"
-                                },
-                                {
-                                    "code": "day_from",
-                                    "value": "4"
-                                },
-                                {
-                                    "code": "day_to",
-                                    "value": "4"
-                                },
-                                {
-                                    "code": "time_from",
-                                    "value": "0300"
-                                },
-                                {
-                                    "code": "time_to",
-                                    "value": "2355"
-                                }
-                            ]
-                        },
-                        {
-                            "code": "timing",
-                            "list": [
-                                {
-                                    "code": "type",
-                                    "value": "Delivery"
-                                },
-                                {
-                                    "code": "location",
-                                    "value": "1031222"
-                                },
-                                {
-                                    "code": "day_from",
-                                    "value": "5"
-                                },
-                                {
-                                    "code": "day_to",
-                                    "value": "5"
-                                },
-                                {
-                                    "code": "time_from",
-                                    "value": "0200"
-                                },
-                                {
-                                    "code": "time_to",
-                                    "value": "2330"
-                                }
-                            ]
-                        },
-                        {
-                            "code": "timing",
-                            "list": [
-                                {
-                                    "code": "type",
-                                    "value": "Delivery"
-                                },
-                                {
-                                    "code": "location",
-                                    "value": "1031222"
-                                },
-                                {
-                                    "code": "day_from",
-                                    "value": "1"
-                                },
-                                {
-                                    "code": "day_to",
-                                    "value": "1"
-                                },
-                                {
-                                    "code": "time_from",
-                                    "value": "0900"
-                                },
-                                {
-                                    "code": "time_to",
-                                    "value": "2355"
-                                }
-                            ]
-                        },
-                        {
-                            "code": "serviceability",
-                            "list": [
-                                {
-                                    "code": "location",
-                                    "value": "1031222"
-                                },
-                                {
-                                    "code": "category",
-                                    "value": "F&B"
-                                },
-                                {
-                                    "code": "type",
-                                    "value": "10"
-                                },
-                                {
-                                    "code": "val",
-                                    "value": "5000"
-                                },
-                                {
-                                    "code": "unit",
-                                    "value": "meter"
-                                }
-                            ]
-                        }
-                    ],
-                    "locations": [
-                        {
-                            "id": "1031222",
-                            "gps": "28.488251,77.086563",
-                            "address": {
-                                "street": "898 Carver Park",
-                                "city": "Pearson",
-                                "state": "Uttar Pradesh",
-                                "area_code": "110001",
-                                "locality": "Carver Park"
-                            },
-                            "time": {
-                                "label": "enable",
-                                "timestamp": "2023-10-16T04:24:07.000Z",
-                                "schedule": {
-                                    "holidays": []
-                                }
-                            }
-                        }
-                    ],
-                    "categories": [
-                        {
-                            "id": "1118",
-                            "parent_category_id": "",
-                            "descriptor": {
-                                "name": "Pcat1",
-                                "short_desc": "Pcat1",
-                                "long_desc": "Pcat1",
-                                "images": []
-                            },
-                            "tags": [
-                                {
-                                    "code": "type",
-                                    "list": [
-                                        {
-                                            "code": "type",
-                                            "value": "custom_menu"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "display",
-                                    "list": [
-                                        {
-                                            "code": "rank",
-                                            "value": "1"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "1119",
-                            "parent_category_id": "1118",
-                            "descriptor": {
-                                "name": "Desserts",
-                                "short_desc": "Desserts",
-                                "long_desc": "Desserts",
-                                "images": []
-                            },
-                            "tags": [
-                                {
-                                    "code": "type",
-                                    "list": [
-                                        {
-                                            "code": "type",
-                                            "value": "custom_menu"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "display",
-                                    "list": [
-                                        {
-                                            "code": "rank",
-                                            "value": "5"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "1120",
-                            "parent_category_id": "1118",
-                            "descriptor": {
-                                "name": "Add Ons",
-                                "short_desc": "Add Ons",
-                                "long_desc": "Add Ons",
-                                "images": []
-                            },
-                            "tags": [
-                                {
-                                    "code": "type",
-                                    "list": [
-                                        {
-                                            "code": "type",
-                                            "value": "custom_menu"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "display",
-                                    "list": [
-                                        {
-                                            "code": "rank",
-                                            "value": "2"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "1121",
-                            "parent_category_id": "",
-                            "descriptor": {
-                                "name": "Side Orders",
-                                "short_desc": "Side Orders",
-                                "long_desc": "Side Orders",
-                                "images": []
-                            },
-                            "tags": [
-                                {
-                                    "code": "type",
-                                    "list": [
-                                        {
-                                            "code": "type",
-                                            "value": "custom_menu"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "display",
-                                    "list": [
-                                        {
-                                            "code": "rank",
-                                            "value": "8"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "1122",
-                            "parent_category_id": "",
-                            "descriptor": {
-                                "name": "Seafood Meal",
-                                "short_desc": "Seafood Meal",
-                                "long_desc": "Seafood Meal",
-                                "images": []
-                            },
-                            "tags": [
-                                {
-                                    "code": "type",
-                                    "list": [
-                                        {
-                                            "code": "type",
-                                            "value": "custom_menu"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "display",
-                                    "list": [
-                                        {
-                                            "code": "rank",
-                                            "value": "7"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "1123",
-                            "parent_category_id": "",
-                            "descriptor": {
-                                "name": "Beverages",
-                                "short_desc": "Beverages",
-                                "long_desc": "Beverages",
-                                "images": []
-                            },
-                            "tags": [
-                                {
-                                    "code": "type",
-                                    "list": [
-                                        {
-                                            "code": "type",
-                                            "value": "custom_menu"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "display",
-                                    "list": [
-                                        {
-                                            "code": "rank",
-                                            "value": "6"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "1124",
-                            "parent_category_id": "",
-                            "descriptor": {
-                                "name": "Hot Coffees",
-                                "short_desc": "Hot Coffees",
-                                "long_desc": "Hot Coffees",
-                                "images": []
-                            },
-                            "tags": [
-                                {
-                                    "code": "type",
-                                    "list": [
-                                        {
-                                            "code": "type",
-                                            "value": "custom_menu"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "display",
-                                    "list": [
-                                        {
-                                            "code": "rank",
-                                            "value": "4"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "1125",
-                            "parent_category_id": "",
-                            "descriptor": {
-                                "name": "Chicken Meal",
-                                "short_desc": "Chicken Meal",
-                                "long_desc": "Chicken Meal",
-                                "images": []
-                            },
-                            "tags": [
-                                {
-                                    "code": "type",
-                                    "list": [
-                                        {
-                                            "code": "type",
-                                            "value": "custom_menu"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "display",
-                                    "list": [
-                                        {
-                                            "code": "rank",
-                                            "value": "3"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "1126",
-                            "parent_category_id": "",
-                            "descriptor": {
-                                "name": "Chicken",
-                                "short_desc": "Chicken",
-                                "long_desc": "Chicken",
-                                "images": []
-                            },
-                            "tags": [
-                                {
-                                    "code": "type",
-                                    "list": [
-                                        {
-                                            "code": "type",
-                                            "value": "custom_menu"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "display",
-                                    "list": [
-                                        {
-                                            "code": "rank",
-                                            "value": "1"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "157892",
-                            "descriptor": {
-                                "name": "Choice Of Sauce"
-                            },
-                            "tags": [
-                                {
-                                    "code": "type",
-                                    "list": [
-                                        {
-                                            "code": "type",
-                                            "value": "custom_group"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "config",
-                                    "list": [
-                                        {
-                                            "code": "min",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "max",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "input",
-                                            "value": "select"
-                                        },
-                                        {
-                                            "code": "seq",
-                                            "value": "1"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "157893",
-                            "descriptor": {
-                                "name": "Choice Of Soft Drink"
-                            },
-                            "tags": [
-                                {
-                                    "code": "type",
-                                    "list": [
-                                        {
-                                            "code": "type",
-                                            "value": "custom_group"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "config",
-                                    "list": [
-                                        {
-                                            "code": "min",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "max",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "input",
-                                            "value": "select"
-                                        },
-                                        {
-                                            "code": "seq",
-                                            "value": "3"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "157894",
-                            "descriptor": {
-                                "name": "Choice Of Juice"
-                            },
-                            "tags": [
-                                {
-                                    "code": "type",
-                                    "list": [
-                                        {
-                                            "code": "type",
-                                            "value": "custom_group"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "config",
-                                    "list": [
-                                        {
-                                            "code": "min",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "max",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "input",
-                                            "value": "select"
-                                        },
-                                        {
-                                            "code": "seq",
-                                            "value": "4"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "157895",
-                            "descriptor": {
-                                "name": "Soft Drinks"
-                            },
-                            "tags": [
-                                {
-                                    "code": "type",
-                                    "list": [
-                                        {
-                                            "code": "type",
-                                            "value": "custom_group"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "config",
-                                    "list": [
-                                        {
-                                            "code": "min",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "max",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "input",
-                                            "value": "select"
-                                        },
-                                        {
-                                            "code": "seq",
-                                            "value": "5"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "157896",
-                            "descriptor": {
-                                "name": "Chicken"
-                            },
-                            "tags": [
-                                {
-                                    "code": "type",
-                                    "list": [
-                                        {
-                                            "code": "type",
-                                            "value": "custom_group"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "config",
-                                    "list": [
-                                        {
-                                            "code": "min",
-                                            "value": "0"
-                                        },
-                                        {
-                                            "code": "max",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "input",
-                                            "value": "select"
-                                        },
-                                        {
-                                            "code": "seq",
-                                            "value": "6"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "157897",
-                            "descriptor": {
-                                "name": "Salad"
-                            },
-                            "tags": [
-                                {
-                                    "code": "type",
-                                    "list": [
-                                        {
-                                            "code": "type",
-                                            "value": "custom_group"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "config",
-                                    "list": [
-                                        {
-                                            "code": "min",
-                                            "value": "0"
-                                        },
-                                        {
-                                            "code": "max",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "input",
-                                            "value": "select"
-                                        },
-                                        {
-                                            "code": "seq",
-                                            "value": "7"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "157898",
-                            "descriptor": {
-                                "name": "Alcoholic Drink"
-                            },
-                            "tags": [
-                                {
-                                    "code": "type",
-                                    "list": [
-                                        {
-                                            "code": "type",
-                                            "value": "custom_group"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "config",
-                                    "list": [
-                                        {
-                                            "code": "min",
-                                            "value": "0"
-                                        },
-                                        {
-                                            "code": "max",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "input",
-                                            "value": "select"
-                                        },
-                                        {
-                                            "code": "seq",
-                                            "value": "8"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "157899",
-                            "descriptor": {
-                                "name": "Soya Beans Items"
-                            },
-                            "tags": [
-                                {
-                                    "code": "type",
-                                    "list": [
-                                        {
-                                            "code": "type",
-                                            "value": "custom_group"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "config",
-                                    "list": [
-                                        {
-                                            "code": "min",
-                                            "value": "0"
-                                        },
-                                        {
-                                            "code": "max",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "input",
-                                            "value": "select"
-                                        },
-                                        {
-                                            "code": "seq",
-                                            "value": "9"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "157900",
-                            "descriptor": {
-                                "name": "Quantity"
-                            },
-                            "tags": [
-                                {
-                                    "code": "type",
-                                    "list": [
-                                        {
-                                            "code": "type",
-                                            "value": "custom_group"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "config",
-                                    "list": [
-                                        {
-                                            "code": "min",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "max",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "input",
-                                            "value": "select"
-                                        },
-                                        {
-                                            "code": "seq",
-                                            "value": "1"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "157901",
-                            "descriptor": {
-                                "name": "Portion"
-                            },
-                            "tags": [
-                                {
-                                    "code": "type",
-                                    "list": [
-                                        {
-                                            "code": "type",
-                                            "value": "custom_group"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "config",
-                                    "list": [
-                                        {
-                                            "code": "min",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "max",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "input",
-                                            "value": "select"
-                                        },
-                                        {
-                                            "code": "seq",
-                                            "value": "1"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "157902",
-                            "descriptor": {
-                                "name": "Portion"
-                            },
-                            "tags": [
-                                {
-                                    "code": "type",
-                                    "list": [
-                                        {
-                                            "code": "type",
-                                            "value": "custom_group"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "config",
-                                    "list": [
-                                        {
-                                            "code": "min",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "max",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "input",
-                                            "value": "select"
-                                        },
-                                        {
-                                            "code": "seq",
-                                            "value": "1"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "157903",
-                            "descriptor": {
-                                "name": "Portion"
-                            },
-                            "tags": [
-                                {
-                                    "code": "type",
-                                    "list": [
-                                        {
-                                            "code": "type",
-                                            "value": "custom_group"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "config",
-                                    "list": [
-                                        {
-                                            "code": "min",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "max",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "input",
-                                            "value": "select"
-                                        },
-                                        {
-                                            "code": "seq",
-                                            "value": "1"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "157904",
-                            "descriptor": {
-                                "name": "Portion"
-                            },
-                            "tags": [
-                                {
-                                    "code": "type",
-                                    "list": [
-                                        {
-                                            "code": "type",
-                                            "value": "custom_group"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "config",
-                                    "list": [
-                                        {
-                                            "code": "min",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "max",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "input",
-                                            "value": "select"
-                                        },
-                                        {
-                                            "code": "seq",
-                                            "value": "1"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "157905",
-                            "descriptor": {
-                                "name": "Portion"
-                            },
-                            "tags": [
-                                {
-                                    "code": "type",
-                                    "list": [
-                                        {
-                                            "code": "type",
-                                            "value": "custom_group"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "config",
-                                    "list": [
-                                        {
-                                            "code": "min",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "max",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "input",
-                                            "value": "select"
-                                        },
-                                        {
-                                            "code": "seq",
-                                            "value": "1"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "157906",
-                            "descriptor": {
-                                "name": "Quantity"
-                            },
-                            "tags": [
-                                {
-                                    "code": "type",
-                                    "list": [
-                                        {
-                                            "code": "type",
-                                            "value": "custom_group"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "config",
-                                    "list": [
-                                        {
-                                            "code": "min",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "max",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "input",
-                                            "value": "select"
-                                        },
-                                        {
-                                            "code": "seq",
-                                            "value": "1"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "157907",
-                            "descriptor": {
-                                "name": "Portion"
-                            },
-                            "tags": [
-                                {
-                                    "code": "type",
-                                    "list": [
-                                        {
-                                            "code": "type",
-                                            "value": "custom_group"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "config",
-                                    "list": [
-                                        {
-                                            "code": "min",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "max",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "input",
-                                            "value": "select"
-                                        },
-                                        {
-                                            "code": "seq",
-                                            "value": "1"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "157908",
-                            "descriptor": {
-                                "name": "Portion"
-                            },
-                            "tags": [
-                                {
-                                    "code": "type",
-                                    "list": [
-                                        {
-                                            "code": "type",
-                                            "value": "custom_group"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "config",
-                                    "list": [
-                                        {
-                                            "code": "min",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "max",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "input",
-                                            "value": "select"
-                                        },
-                                        {
-                                            "code": "seq",
-                                            "value": "1"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "157909",
-                            "descriptor": {
-                                "name": "Quantity"
-                            },
-                            "tags": [
-                                {
-                                    "code": "type",
-                                    "list": [
-                                        {
-                                            "code": "type",
-                                            "value": "custom_group"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "config",
-                                    "list": [
-                                        {
-                                            "code": "min",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "max",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "input",
-                                            "value": "select"
-                                        },
-                                        {
-                                            "code": "seq",
-                                            "value": "1"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "157910",
-                            "descriptor": {
-                                "name": "Quantity"
-                            },
-                            "tags": [
-                                {
-                                    "code": "type",
-                                    "list": [
-                                        {
-                                            "code": "type",
-                                            "value": "custom_group"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "config",
-                                    "list": [
-                                        {
-                                            "code": "min",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "max",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "input",
-                                            "value": "select"
-                                        },
-                                        {
-                                            "code": "seq",
-                                            "value": "1"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "157911",
-                            "descriptor": {
-                                "name": "Quantity"
-                            },
-                            "tags": [
-                                {
-                                    "code": "type",
-                                    "list": [
-                                        {
-                                            "code": "type",
-                                            "value": "custom_group"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "config",
-                                    "list": [
-                                        {
-                                            "code": "min",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "max",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "input",
-                                            "value": "select"
-                                        },
-                                        {
-                                            "code": "seq",
-                                            "value": "1"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "157912",
-                            "descriptor": {
-                                "name": "Quantity"
-                            },
-                            "tags": [
-                                {
-                                    "code": "type",
-                                    "list": [
-                                        {
-                                            "code": "type",
-                                            "value": "custom_group"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "config",
-                                    "list": [
-                                        {
-                                            "code": "min",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "max",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "input",
-                                            "value": "select"
-                                        },
-                                        {
-                                            "code": "seq",
-                                            "value": "1"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "157913",
-                            "descriptor": {
-                                "name": "Quantity"
-                            },
-                            "tags": [
-                                {
-                                    "code": "type",
-                                    "list": [
-                                        {
-                                            "code": "type",
-                                            "value": "custom_group"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "config",
-                                    "list": [
-                                        {
-                                            "code": "min",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "max",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "input",
-                                            "value": "select"
-                                        },
-                                        {
-                                            "code": "seq",
-                                            "value": "1"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "157914",
-                            "descriptor": {
-                                "name": "Quantity"
-                            },
-                            "tags": [
-                                {
-                                    "code": "type",
-                                    "list": [
-                                        {
-                                            "code": "type",
-                                            "value": "custom_group"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "config",
-                                    "list": [
-                                        {
-                                            "code": "min",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "max",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "input",
-                                            "value": "select"
-                                        },
-                                        {
-                                            "code": "seq",
-                                            "value": "1"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "157915",
-                            "descriptor": {
-                                "name": "Quantity"
-                            },
-                            "tags": [
-                                {
-                                    "code": "type",
-                                    "list": [
-                                        {
-                                            "code": "type",
-                                            "value": "custom_group"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "config",
-                                    "list": [
-                                        {
-                                            "code": "min",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "max",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "input",
-                                            "value": "select"
-                                        },
-                                        {
-                                            "code": "seq",
-                                            "value": "1"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "157916",
-                            "descriptor": {
-                                "name": "Portion"
-                            },
-                            "tags": [
-                                {
-                                    "code": "type",
-                                    "list": [
-                                        {
-                                            "code": "type",
-                                            "value": "custom_group"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "config",
-                                    "list": [
-                                        {
-                                            "code": "min",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "max",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "input",
-                                            "value": "select"
-                                        },
-                                        {
-                                            "code": "seq",
-                                            "value": "1"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "157917",
-                            "descriptor": {
-                                "name": "Quantity"
-                            },
-                            "tags": [
-                                {
-                                    "code": "type",
-                                    "list": [
-                                        {
-                                            "code": "type",
-                                            "value": "custom_group"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "config",
-                                    "list": [
-                                        {
-                                            "code": "min",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "max",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "input",
-                                            "value": "select"
-                                        },
-                                        {
-                                            "code": "seq",
-                                            "value": "1"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "157918",
-                            "descriptor": {
-                                "name": "Quantity"
-                            },
-                            "tags": [
-                                {
-                                    "code": "type",
-                                    "list": [
-                                        {
-                                            "code": "type",
-                                            "value": "custom_group"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "config",
-                                    "list": [
-                                        {
-                                            "code": "min",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "max",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "input",
-                                            "value": "select"
-                                        },
-                                        {
-                                            "code": "seq",
-                                            "value": "1"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "157919",
-                            "descriptor": {
-                                "name": "Quantity"
-                            },
-                            "tags": [
-                                {
-                                    "code": "type",
-                                    "list": [
-                                        {
-                                            "code": "type",
-                                            "value": "custom_group"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "config",
-                                    "list": [
-                                        {
-                                            "code": "min",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "max",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "input",
-                                            "value": "select"
-                                        },
-                                        {
-                                            "code": "seq",
-                                            "value": "1"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "157920",
-                            "descriptor": {
-                                "name": "Quantity"
-                            },
-                            "tags": [
-                                {
-                                    "code": "type",
-                                    "list": [
-                                        {
-                                            "code": "type",
-                                            "value": "custom_group"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "config",
-                                    "list": [
-                                        {
-                                            "code": "min",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "max",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "input",
-                                            "value": "select"
-                                        },
-                                        {
-                                            "code": "seq",
-                                            "value": "1"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "157921",
-                            "descriptor": {
-                                "name": "Quantity"
-                            },
-                            "tags": [
-                                {
-                                    "code": "type",
-                                    "list": [
-                                        {
-                                            "code": "type",
-                                            "value": "custom_group"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "config",
-                                    "list": [
-                                        {
-                                            "code": "min",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "max",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "input",
-                                            "value": "select"
-                                        },
-                                        {
-                                            "code": "seq",
-                                            "value": "1"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "157922",
-                            "descriptor": {
-                                "name": "Quantity"
-                            },
-                            "tags": [
-                                {
-                                    "code": "type",
-                                    "list": [
-                                        {
-                                            "code": "type",
-                                            "value": "custom_group"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "config",
-                                    "list": [
-                                        {
-                                            "code": "min",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "max",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "input",
-                                            "value": "select"
-                                        },
-                                        {
-                                            "code": "seq",
-                                            "value": "1"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "157923",
-                            "descriptor": {
-                                "name": "Quantity"
-                            },
-                            "tags": [
-                                {
-                                    "code": "type",
-                                    "list": [
-                                        {
-                                            "code": "type",
-                                            "value": "custom_group"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "config",
-                                    "list": [
-                                        {
-                                            "code": "min",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "max",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "input",
-                                            "value": "select"
-                                        },
-                                        {
-                                            "code": "seq",
-                                            "value": "1"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "157924",
-                            "descriptor": {
-                                "name": "Size"
-                            },
-                            "tags": [
-                                {
-                                    "code": "type",
-                                    "list": [
-                                        {
-                                            "code": "type",
-                                            "value": "custom_group"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "config",
-                                    "list": [
-                                        {
-                                            "code": "min",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "max",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "input",
-                                            "value": "select"
-                                        },
-                                        {
-                                            "code": "seq",
-                                            "value": "3"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "157925",
-                            "descriptor": {
-                                "name": "Size"
-                            },
-                            "tags": [
-                                {
-                                    "code": "type",
-                                    "list": [
-                                        {
-                                            "code": "type",
-                                            "value": "custom_group"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "config",
-                                    "list": [
-                                        {
-                                            "code": "min",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "max",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "input",
-                                            "value": "select"
-                                        },
-                                        {
-                                            "code": "seq",
-                                            "value": "4"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "157926",
-                            "descriptor": {
-                                "name": "Size"
-                            },
-                            "tags": [
-                                {
-                                    "code": "type",
-                                    "list": [
-                                        {
-                                            "code": "type",
-                                            "value": "custom_group"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "config",
-                                    "list": [
-                                        {
-                                            "code": "min",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "max",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "input",
-                                            "value": "select"
-                                        },
-                                        {
-                                            "code": "seq",
-                                            "value": "7"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "157927",
-                            "descriptor": {
-                                "name": "Size"
-                            },
-                            "tags": [
-                                {
-                                    "code": "type",
-                                    "list": [
-                                        {
-                                            "code": "type",
-                                            "value": "custom_group"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "config",
-                                    "list": [
-                                        {
-                                            "code": "min",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "max",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "input",
-                                            "value": "select"
-                                        },
-                                        {
-                                            "code": "seq",
-                                            "value": "8"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "158259",
-                            "descriptor": {
-                                "name": "Quantity"
-                            },
-                            "tags": [
-                                {
-                                    "code": "type",
-                                    "list": [
-                                        {
-                                            "code": "type",
-                                            "value": "custom_group"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "config",
-                                    "list": [
-                                        {
-                                            "code": "min",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "max",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "input",
-                                            "value": "select"
-                                        },
-                                        {
-                                            "code": "seq",
-                                            "value": "1"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "158998",
-                            "descriptor": {
-                                "name": "Quantity"
-                            },
-                            "tags": [
-                                {
-                                    "code": "type",
-                                    "list": [
-                                        {
-                                            "code": "type",
-                                            "value": "custom_group"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "config",
-                                    "list": [
-                                        {
-                                            "code": "min",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "max",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "input",
-                                            "value": "select"
-                                        },
-                                        {
-                                            "code": "seq",
-                                            "value": "1"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "158999",
-                            "descriptor": {
-                                "name": "Quantity"
-                            },
-                            "tags": [
-                                {
-                                    "code": "type",
-                                    "list": [
-                                        {
-                                            "code": "type",
-                                            "value": "custom_group"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "config",
-                                    "list": [
-                                        {
-                                            "code": "min",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "max",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "input",
-                                            "value": "select"
-                                        },
-                                        {
-                                            "code": "seq",
-                                            "value": "1"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "159000",
-                            "descriptor": {
-                                "name": "Quantity"
-                            },
-                            "tags": [
-                                {
-                                    "code": "type",
-                                    "list": [
-                                        {
-                                            "code": "type",
-                                            "value": "custom_group"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "config",
-                                    "list": [
-                                        {
-                                            "code": "min",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "max",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "input",
-                                            "value": "select"
-                                        },
-                                        {
-                                            "code": "seq",
-                                            "value": "1"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "159001",
-                            "descriptor": {
-                                "name": "Quantity"
-                            },
-                            "tags": [
-                                {
-                                    "code": "type",
-                                    "list": [
-                                        {
-                                            "code": "type",
-                                            "value": "custom_group"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "config",
-                                    "list": [
-                                        {
-                                            "code": "min",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "max",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "input",
-                                            "value": "select"
-                                        },
-                                        {
-                                            "code": "seq",
-                                            "value": "1"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "159016",
-                            "descriptor": {
-                                "name": "Portion"
-                            },
-                            "tags": [
-                                {
-                                    "code": "type",
-                                    "list": [
-                                        {
-                                            "code": "type",
-                                            "value": "custom_group"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "config",
-                                    "list": [
-                                        {
-                                            "code": "min",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "max",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "input",
-                                            "value": "select"
-                                        },
-                                        {
-                                            "code": "seq",
-                                            "value": "1"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "159019",
-                            "descriptor": {
-                                "name": "Quantity"
-                            },
-                            "tags": [
-                                {
-                                    "code": "type",
-                                    "list": [
-                                        {
-                                            "code": "type",
-                                            "value": "custom_group"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "config",
-                                    "list": [
-                                        {
-                                            "code": "min",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "max",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "input",
-                                            "value": "select"
-                                        },
-                                        {
-                                            "code": "seq",
-                                            "value": "1"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "159022",
-                            "descriptor": {
-                                "name": "Quantity"
-                            },
-                            "tags": [
-                                {
-                                    "code": "type",
-                                    "list": [
-                                        {
-                                            "code": "type",
-                                            "value": "custom_group"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "config",
-                                    "list": [
-                                        {
-                                            "code": "min",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "max",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "input",
-                                            "value": "select"
-                                        },
-                                        {
-                                            "code": "seq",
-                                            "value": "1"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "159023",
-                            "descriptor": {
-                                "name": "Portion"
-                            },
-                            "tags": [
-                                {
-                                    "code": "type",
-                                    "list": [
-                                        {
-                                            "code": "type",
-                                            "value": "custom_group"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "config",
-                                    "list": [
-                                        {
-                                            "code": "min",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "max",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "input",
-                                            "value": "select"
-                                        },
-                                        {
-                                            "code": "seq",
-                                            "value": "1"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "159152",
-                            "descriptor": {
-                                "name": "Portion"
-                            },
-                            "tags": [
-                                {
-                                    "code": "type",
-                                    "list": [
-                                        {
-                                            "code": "type",
-                                            "value": "custom_group"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "config",
-                                    "list": [
-                                        {
-                                            "code": "min",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "max",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "input",
-                                            "value": "select"
-                                        },
-                                        {
-                                            "code": "seq",
-                                            "value": "1"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "159153",
-                            "descriptor": {
-                                "name": "Quantity"
-                            },
-                            "tags": [
-                                {
-                                    "code": "type",
-                                    "list": [
-                                        {
-                                            "code": "type",
-                                            "value": "custom_group"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "config",
-                                    "list": [
-                                        {
-                                            "code": "min",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "max",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "input",
-                                            "value": "select"
-                                        },
-                                        {
-                                            "code": "seq",
-                                            "value": "1"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "159164",
-                            "descriptor": {
-                                "name": "Quantity"
-                            },
-                            "tags": [
-                                {
-                                    "code": "type",
-                                    "list": [
-                                        {
-                                            "code": "type",
-                                            "value": "custom_group"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "config",
-                                    "list": [
-                                        {
-                                            "code": "min",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "max",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "input",
-                                            "value": "select"
-                                        },
-                                        {
-                                            "code": "seq",
-                                            "value": "1"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "159171",
-                            "descriptor": {
-                                "name": "Portion Size"
-                            },
-                            "tags": [
-                                {
-                                    "code": "type",
-                                    "list": [
-                                        {
-                                            "code": "type",
-                                            "value": "custom_group"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "config",
-                                    "list": [
-                                        {
-                                            "code": "min",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "max",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "input",
-                                            "value": "select"
-                                        },
-                                        {
-                                            "code": "seq",
-                                            "value": "1"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "159209",
-                            "descriptor": {
-                                "name": "Dal Baati Add On"
-                            },
-                            "tags": [
-                                {
-                                    "code": "type",
-                                    "list": [
-                                        {
-                                            "code": "type",
-                                            "value": "custom_group"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "config",
-                                    "list": [
-                                        {
-                                            "code": "min",
-                                            "value": "0"
-                                        },
-                                        {
-                                            "code": "max",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "input",
-                                            "value": "select"
-                                        },
-                                        {
-                                            "code": "seq",
-                                            "value": "10"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "159210",
-                            "descriptor": {
-                                "name": "Portion Size"
-                            },
-                            "tags": [
-                                {
-                                    "code": "type",
-                                    "list": [
-                                        {
-                                            "code": "type",
-                                            "value": "custom_group"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "config",
-                                    "list": [
-                                        {
-                                            "code": "min",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "max",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "input",
-                                            "value": "select"
-                                        },
-                                        {
-                                            "code": "seq",
-                                            "value": "1"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "159211",
-                            "descriptor": {
-                                "name": "Quantity"
-                            },
-                            "tags": [
-                                {
-                                    "code": "type",
-                                    "list": [
-                                        {
-                                            "code": "type",
-                                            "value": "custom_group"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "config",
-                                    "list": [
-                                        {
-                                            "code": "min",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "max",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "input",
-                                            "value": "select"
-                                        },
-                                        {
-                                            "code": "seq",
-                                            "value": "1"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "159219",
-                            "descriptor": {
-                                "name": "Quantity"
-                            },
-                            "tags": [
-                                {
-                                    "code": "type",
-                                    "list": [
-                                        {
-                                            "code": "type",
-                                            "value": "custom_group"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "config",
-                                    "list": [
-                                        {
-                                            "code": "min",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "max",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "input",
-                                            "value": "select"
-                                        },
-                                        {
-                                            "code": "seq",
-                                            "value": "1"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "159220",
-                            "descriptor": {
-                                "name": "Quantity"
-                            },
-                            "tags": [
-                                {
-                                    "code": "type",
-                                    "list": [
-                                        {
-                                            "code": "type",
-                                            "value": "custom_group"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "config",
-                                    "list": [
-                                        {
-                                            "code": "min",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "max",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "input",
-                                            "value": "select"
-                                        },
-                                        {
-                                            "code": "seq",
-                                            "value": "1"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "159221",
-                            "descriptor": {
-                                "name": "Quantity"
-                            },
-                            "tags": [
-                                {
-                                    "code": "type",
-                                    "list": [
-                                        {
-                                            "code": "type",
-                                            "value": "custom_group"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "config",
-                                    "list": [
-                                        {
-                                            "code": "min",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "max",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "input",
-                                            "value": "select"
-                                        },
-                                        {
-                                            "code": "seq",
-                                            "value": "1"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "167284",
-                            "descriptor": {
-                                "name": "Quantity"
-                            },
-                            "tags": [
-                                {
-                                    "code": "type",
-                                    "list": [
-                                        {
-                                            "code": "type",
-                                            "value": "custom_group"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "config",
-                                    "list": [
-                                        {
-                                            "code": "min",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "max",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "input",
-                                            "value": "select"
-                                        },
-                                        {
-                                            "code": "seq",
-                                            "value": "1"
-                                        }
-                                    ]
-                                }
-                            ]
-                        }
-                    ]
-                }
+  "context": {
+    "domain": "ONDC:RET11",
+    "action": "on_search",
+    "country": "IND",
+    "city": "std:0124",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "transaction_id": "abcf476d-5fd9-4be6-8f3b-3536c055d1cd",
+    "message_id": "5f3a3506-73bc-4c15-844d-b197b9e78929",
+    "timestamp": "2023-12-20T10:30:01.091Z",
+    "bpp_id": "ondc-seller-staging.paytm.com",
+    "bpp_uri": "https://ondc-seller-staging.paytm.com/seller"
+  },
+  "message": {
+    "catalog": {
+      "bpp/descriptor": {
+        "name": "Seller NP",
+        "symbol": "https://sellerNP.com/images/np.png",
+        "short_desc": "Seller Marketplace",
+        "long_desc": "Seller Marketplace",
+        "images": [
+          "https://sellerNP.com/images/np.png"
+        ]
+      },
+      "bpp/providers": [
+        {
+          "id": "63798557",
+          "time": {
+            "label": "enable",
+            "timestamp": "2023-11-21T08:03:57.000Z"
+          },
+          "fulfillments": [
+            {
+              "id": "F1",
+              "type": "Delivery",
+              "contact": {
+                "phone": "7125426621",
+                "email": "oe-test@mail.com"
+              }
+            }
+          ],
+          "descriptor": {
+            "name": "name of merchant",
+            "symbol": "https://assetscdn1.paytm.com/merchant_logo/merchant_staging/merchant/63798557/logo/logo_1.png",
+            "short_desc": " Momo is a fast-food and quick-service restaurant chain that specializes in serving",
+            "long_desc": " Momo is a fast-food and quick-service restaurant chain that specializes in serving",
+            "images": [
+              "https://sellerNP.com/images/store1.png"
             ]
+          },
+          "ttl": "P1D",
+          "items": [
+            {
+              "id": "1235217312",
+              "descriptor": {
+                "name": "SatyaChikecnItem2",
+                "symbol": "",
+                "short_desc": "Test Chickecn",
+                "long_desc": "Test Chickecn",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "40.4",
+                "maximum_value": "101.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [
+                "1126:1"
+              ],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "non_veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "custom_group",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "159001"
+                    },
+                    {
+                      "code": "id",
+                      "value": "157897"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "159001"
+                    },
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157897"
+                    },
+                    {
+                      "code": "min",
+                      "value": "0"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235193312",
+              "descriptor": {
+                "name": "6 Pieces",
+                "symbol": "",
+                "short_desc": "6 Pieces",
+                "long_desc": "6 Pieces",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "0.0",
+                "maximum_value": "0.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157911"
+                    },
+                    {
+                      "code": "default",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235222936",
+              "descriptor": {
+                "name": "Large",
+                "symbol": "",
+                "short_desc": "Large",
+                "long_desc": "Large",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "40.0",
+                "maximum_value": "100.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "159152"
+                    },
+                    {
+                      "code": "default",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "child",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157897"
+                    }
+                  ]
+                },
+                {
+                  "code": "child",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157897"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235193256",
+              "descriptor": {
+                "name": "Small",
+                "symbol": "",
+                "short_desc": "Small",
+                "long_desc": "Small",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "0.0",
+                "maximum_value": "0.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157901"
+                    },
+                    {
+                      "code": "default",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235188625",
+              "descriptor": {
+                "name": "Add Chips",
+                "symbol": "",
+                "short_desc": "Add Chips",
+                "long_desc": "Add Chips",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "4.0",
+                "maximum_value": "10.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157898"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235193833",
+              "descriptor": {
+                "name": "Nescafe Latte",
+                "symbol": "",
+                "short_desc": "Nescafe Latte",
+                "long_desc": "Nescafe Latte",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "13.3",
+                "maximum_value": "33.25"
+              },
+              "category_id": "F&B",
+              "category_ids": [
+                "1123:1"
+              ],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235217122",
+              "descriptor": {
+                "name": "8 Pieces",
+                "symbol": "",
+                "short_desc": "8 Pieces",
+                "long_desc": "8 Pieces",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "0.0",
+                "maximum_value": "0.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "non_veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "159001"
+                    },
+                    {
+                      "code": "default",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "child",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157897"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235222978",
+              "descriptor": {
+                "name": "Yash Ki Thali",
+                "symbol": "",
+                "short_desc": "Yash Ki Thali",
+                "long_desc": "Yash Ki Thali",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "80.0",
+                "maximum_value": "200.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [
+                "1121:1"
+              ],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "custom_group",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "159171"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "159171"
+                    },
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235217194",
+              "descriptor": {
+                "name": "Small",
+                "symbol": "",
+                "short_desc": "Small",
+                "long_desc": "Small",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "149.0",
+                "maximum_value": "149.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235222938",
+              "descriptor": {
+                "name": "4 Pieces",
+                "symbol": "",
+                "short_desc": "4 Pieces",
+                "long_desc": "4 Pieces",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "40.0",
+                "maximum_value": "100.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "159153"
+                    },
+                    {
+                      "code": "default",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "child",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157894"
+                    }
+                  ]
+                },
+                {
+                  "code": "child",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157894"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235193282",
+              "descriptor": {
+                "name": "3 Pieces",
+                "symbol": "",
+                "short_desc": "3 Pieces",
+                "long_desc": "3 Pieces",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "0.0",
+                "maximum_value": "0.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157915"
+                    },
+                    {
+                      "code": "default",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235188634",
+              "descriptor": {
+                "name": "Salad",
+                "symbol": "",
+                "short_desc": "Salad",
+                "long_desc": "Salad",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "8.0",
+                "maximum_value": "20.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157899"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235193859",
+              "descriptor": {
+                "name": "Saj Bread",
+                "symbol": "",
+                "short_desc": "Saj Bread",
+                "long_desc": "Saj Bread",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "7.6",
+                "maximum_value": "19.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [
+                "1121:1"
+              ],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235222979",
+              "descriptor": {
+                "name": "Aloo Tikki",
+                "symbol": "",
+                "short_desc": "Good Tikki",
+                "long_desc": "Good Tikki",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "80.0",
+                "maximum_value": "200.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [
+                "1121:1"
+              ],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "custom_group",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "159153"
+                    },
+                    {
+                      "code": "id",
+                      "value": "157892"
+                    },
+                    {
+                      "code": "id",
+                      "value": "157894"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "159153"
+                    },
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157892"
+                    },
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157894"
+                    },
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235193811",
+              "descriptor": {
+                "name": "Fries",
+                "symbol": "",
+                "short_desc": "Fries",
+                "long_desc": "Fries",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "31.6",
+                "maximum_value": "79.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [
+                "1120:1"
+              ],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235193316",
+              "descriptor": {
+                "name": "10 Pieces",
+                "symbol": "",
+                "short_desc": "10 Pieces",
+                "long_desc": "10 Pieces",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "40.0",
+                "maximum_value": "100.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157911"
+                    },
+                    {
+                      "code": "default",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235188620",
+              "descriptor": {
+                "name": "Garlic Sauce",
+                "symbol": "",
+                "short_desc": "Garlic Sauce",
+                "long_desc": "Garlic Sauce",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "0.0",
+                "maximum_value": "0.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157892"
+                    },
+                    {
+                      "code": "default",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235217124",
+              "descriptor": {
+                "name": "10 Pieces",
+                "symbol": "",
+                "short_desc": "10 Pieces",
+                "long_desc": "10 Pieces",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "1.6",
+                "maximum_value": "4.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "non_veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "159001"
+                    },
+                    {
+                      "code": "default",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "child",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157897"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235217284",
+              "descriptor": {
+                "name": "Sauce",
+                "symbol": "",
+                "short_desc": "Sauce",
+                "long_desc": "Sauce",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "40.0",
+                "maximum_value": "100.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [
+                "1120:1"
+              ],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235193269",
+              "descriptor": {
+                "name": "Large",
+                "symbol": "",
+                "short_desc": "Large",
+                "long_desc": "Large",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "8.0",
+                "maximum_value": "20.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157901"
+                    },
+                    {
+                      "code": "default",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235193861",
+              "descriptor": {
+                "name": "Vanilla Icecream",
+                "symbol": "",
+                "short_desc": "demo 4 demo 4 demo 4 dmwo 4",
+                "long_desc": "demo 4 demo 4 demo 4 dmwo 4",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "7.6",
+                "maximum_value": "19.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [
+                "1119:1"
+              ],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "custom_group",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157893"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157893"
+                    },
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235193829",
+              "descriptor": {
+                "name": "Fanta",
+                "symbol": "",
+                "short_desc": "Fanta",
+                "long_desc": "Fanta",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "15.2",
+                "maximum_value": "38.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [
+                "1123:1"
+              ],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235188621",
+              "descriptor": {
+                "name": "Pepsi",
+                "symbol": "",
+                "short_desc": "Pepsi",
+                "long_desc": "Pepsi",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "0.0",
+                "maximum_value": "0.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157893"
+                    },
+                    {
+                      "code": "default",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235217190",
+              "descriptor": {
+                "name": "10 Pieces",
+                "symbol": "",
+                "short_desc": "10 Pieces",
+                "long_desc": "10 Pieces",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "399.0",
+                "maximum_value": "399.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235217302",
+              "descriptor": {
+                "name": "Mochacinno",
+                "symbol": "",
+                "short_desc": "Mochacinno",
+                "long_desc": "Mochacinno",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "63.6",
+                "maximum_value": "159.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [
+                "1123:1"
+              ],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "custom_group",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157903"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157903"
+                    },
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235193311",
+              "descriptor": {
+                "name": "1 Kg",
+                "symbol": "",
+                "short_desc": "1 Kg",
+                "long_desc": "1 Kg",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "60.0",
+                "maximum_value": "150.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "non_veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157921"
+                    },
+                    {
+                      "code": "default",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235217183",
+              "descriptor": {
+                "name": "10 Pieces",
+                "symbol": "",
+                "short_desc": "10 Pieces",
+                "long_desc": "10 Pieces",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "479.0",
+                "maximum_value": "479.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235193247",
+              "descriptor": {
+                "name": "Chicken",
+                "symbol": "",
+                "short_desc": "Chicken",
+                "long_desc": "Chicken",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "0.0",
+                "maximum_value": "0.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "non_veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157926"
+                    },
+                    {
+                      "code": "default",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "child",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157896"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235193208",
+              "descriptor": {
+                "name": "8 Pieces",
+                "symbol": "",
+                "short_desc": "8 Pieces",
+                "long_desc": "8 Pieces",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "0.0",
+                "maximum_value": "0.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157913"
+                    },
+                    {
+                      "code": "default",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235193329",
+              "descriptor": {
+                "name": "Large",
+                "symbol": "",
+                "short_desc": "Large",
+                "long_desc": "Large",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "8.0",
+                "maximum_value": "20.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157903"
+                    },
+                    {
+                      "code": "default",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235217289",
+              "descriptor": {
+                "name": "Chicken Meal 1",
+                "symbol": "",
+                "short_desc": "Chicken fillet in a bun  with coleslaw,lettuce, pickles and our  spicy cocktail sauce. This sandwich is made with care to make sure that each and every bite is packed with Mmmm",
+                "long_desc": "Chicken fillet in a bun  with coleslaw,lettuce, pickles and our  spicy cocktail sauce. This sandwich is made with care to make sure that each and every bite is packed with Mmmm",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "95.6",
+                "maximum_value": "239.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [
+                "1125:1"
+              ],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "custom_group",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157900"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157900"
+                    },
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235193810",
+              "descriptor": {
+                "name": "French Fries",
+                "symbol": "",
+                "short_desc": "Golden crispy French fries served with  Ketchup",
+                "long_desc": "Golden crispy French fries served with  Ketchup",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "35.6",
+                "maximum_value": "89.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [
+                "1121:1"
+              ],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235193826",
+              "descriptor": {
+                "name": "Demo Add Hazelnut",
+                "symbol": "",
+                "short_desc": "Demo Add Hazelnut",
+                "long_desc": "Demo Add Hazelnut",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "19.6",
+                "maximum_value": "49.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [
+                "1120:1"
+              ],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235220266",
+              "descriptor": {
+                "name": "Sasti Thali",
+                "symbol": "",
+                "short_desc": "Sasti Thali",
+                "long_desc": "Sasti Thali",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "1000.0",
+                "maximum_value": "2500.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [
+                "1126:1"
+              ],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "non_veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "custom_group",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157897"
+                    },
+                    {
+                      "code": "id",
+                      "value": "157898"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157897"
+                    },
+                    {
+                      "code": "min",
+                      "value": "0"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157898"
+                    },
+                    {
+                      "code": "min",
+                      "value": "0"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235223274",
+              "descriptor": {
+                "name": "4 Pieces",
+                "symbol": "",
+                "short_desc": "4 Pieces",
+                "long_desc": "4 Pieces",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "0.0",
+                "maximum_value": "0.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "159219"
+                    },
+                    {
+                      "code": "default",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "child",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157895"
+                    }
+                  ]
+                },
+                {
+                  "code": "child",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157895"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235188642",
+              "descriptor": {
+                "name": "Some Chutny",
+                "symbol": "",
+                "short_desc": "Some Chutny",
+                "long_desc": "Some Chutny",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "2.0",
+                "maximum_value": "5.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157896"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235193210",
+              "descriptor": {
+                "name": "10 Pieces",
+                "symbol": "",
+                "short_desc": "10 Pieces",
+                "long_desc": "10 Pieces",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "24.0",
+                "maximum_value": "60.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157912"
+                    },
+                    {
+                      "code": "default",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235336251",
+              "descriptor": {
+                "name": "TestMSPData1",
+                "symbol": "",
+                "short_desc": "Test Addon",
+                "long_desc": "Test Addon",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "40.0",
+                "maximum_value": "100.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [
+                "1120:1"
+              ],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "non_veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "custom_group",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "167284"
+                    },
+                    {
+                      "code": "id",
+                      "value": "157894"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "167284"
+                    },
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157894"
+                    },
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235188627",
+              "descriptor": {
+                "name": "Mango",
+                "symbol": "",
+                "short_desc": "Mango",
+                "long_desc": "Mango",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "0.0",
+                "maximum_value": "0.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157894"
+                    },
+                    {
+                      "code": "default",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235193251",
+              "descriptor": {
+                "name": "Small",
+                "symbol": "",
+                "short_desc": "Small",
+                "long_desc": "Small",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "0.0",
+                "maximum_value": "0.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157908"
+                    },
+                    {
+                      "code": "default",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "child",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157895"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235217180",
+              "descriptor": {
+                "name": "2 Pieces",
+                "symbol": "",
+                "short_desc": "2 Pieces",
+                "long_desc": "2 Pieces",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "175.0",
+                "maximum_value": "175.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235188637",
+              "descriptor": {
+                "name": "Coke",
+                "symbol": "",
+                "short_desc": "Coke",
+                "long_desc": "Coke",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "4.0",
+                "maximum_value": "10.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157895"
+                    },
+                    {
+                      "code": "default",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235217317",
+              "descriptor": {
+                "name": "SatyaFood2",
+                "symbol": "",
+                "short_desc": "TestChkickenmeal2",
+                "long_desc": "TestChkickenmeal2",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "140.4",
+                "maximum_value": "351.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [
+                "1125:1"
+              ],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "custom_group",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157895"
+                    },
+                    {
+                      "code": "id",
+                      "value": "157898"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157895"
+                    },
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157898"
+                    },
+                    {
+                      "code": "min",
+                      "value": "0"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235217125",
+              "descriptor": {
+                "name": "8 Pieces",
+                "symbol": "",
+                "short_desc": "8 Pieces",
+                "long_desc": "8 Pieces",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "0.0",
+                "maximum_value": "0.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "158998"
+                    },
+                    {
+                      "code": "default",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "child",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157897"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235217198",
+              "descriptor": {
+                "name": "10 Pieces",
+                "symbol": "",
+                "short_desc": "10 Pieces",
+                "long_desc": "10 Pieces",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "105.0",
+                "maximum_value": "105.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "non_veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235217126",
+              "descriptor": {
+                "name": "2 Pieces",
+                "symbol": "",
+                "short_desc": "2 Pieces",
+                "long_desc": "2 Pieces",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "0.0",
+                "maximum_value": "0.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "non_veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "159000"
+                    },
+                    {
+                      "code": "default",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235193326",
+              "descriptor": {
+                "name": "2 Pieces",
+                "symbol": "",
+                "short_desc": "2 Pieces",
+                "long_desc": "2 Pieces",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "0.0",
+                "maximum_value": "0.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157900"
+                    },
+                    {
+                      "code": "default",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235193358",
+              "descriptor": {
+                "name": "6 Pieces",
+                "symbol": "",
+                "short_desc": "6 Pieces",
+                "long_desc": "6 Pieces",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "136.0",
+                "maximum_value": "340.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157914"
+                    },
+                    {
+                      "code": "default",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235193327",
+              "descriptor": {
+                "name": "6 Pieces",
+                "symbol": "",
+                "short_desc": "6 Pieces",
+                "long_desc": "6 Pieces",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "92.0",
+                "maximum_value": "230.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157920"
+                    },
+                    {
+                      "code": "default",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235193863",
+              "descriptor": {
+                "name": "Water",
+                "symbol": "",
+                "short_desc": "Water",
+                "long_desc": "Water",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "3.8",
+                "maximum_value": "9.5"
+              },
+              "category_id": "F&B",
+              "category_ids": [
+                "1123:1"
+              ],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235193831",
+              "descriptor": {
+                "name": "Sprite",
+                "symbol": "",
+                "short_desc": "Sprite",
+                "long_desc": "Sprite",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "15.2",
+                "maximum_value": "38.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [
+                "1123:1"
+              ],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235193783",
+              "descriptor": {
+                "name": "Chicken Fillet Burger Combo",
+                "symbol": "",
+                "short_desc": "2 Chicken Fillet burgers, fries and choice of  soft drink. 2 Crispy chicken fillet burgers, topped with tangy sliced pickles ,lettuce and Albaik International's signature garlic sauce, placed between a freshly baked bun  served with a portion of fries and a soft drink",
+                "long_desc": "2 Chicken Fillet burgers, fries and choice of  soft drink. 2 Crispy chicken fillet burgers, topped with tangy sliced pickles ,lettuce and Albaik International's signature garlic sauce, placed between a freshly baked bun  served with a portion of fries and a soft drink",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "107.6",
+                "maximum_value": "269.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [
+                "1125:1"
+              ],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "custom_group",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157893"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157893"
+                    },
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235193774",
+              "descriptor": {
+                "name": "Long Island Iced Tea",
+                "symbol": "",
+                "short_desc": "Long Island Iced Tea",
+                "long_desc": "Long Island Iced Tea",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "180.0",
+                "maximum_value": "450.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [
+                "1123:1"
+              ],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235193784",
+              "descriptor": {
+                "name": "Big Baik Sandwich",
+                "symbol": "",
+                "short_desc": "Chicken fillet in a bun with coleslaw,lettuce, pickles and our special cocktail sauce. This sandwich is made with care to make sure that each and every bite is packed with Mmmm",
+                "long_desc": "Chicken fillet in a bun with coleslaw,lettuce, pickles and our special cocktail sauce. This sandwich is made with care to make sure that each and every bite is packed with Mmmm",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "83.6",
+                "maximum_value": "209.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [
+                "1125:1"
+              ],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235193806",
+              "descriptor": {
+                "name": "Thumsup Big",
+                "symbol": "",
+                "short_desc": "Thumsup Big",
+                "long_desc": "Thumsup Big",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "22.8",
+                "maximum_value": "57.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [
+                "1121:1"
+              ],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235193855",
+              "descriptor": {
+                "name": "Miranda",
+                "symbol": "",
+                "short_desc": "Miranda",
+                "long_desc": "Miranda",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "11.4",
+                "maximum_value": "28.5"
+              },
+              "category_id": "F&B",
+              "category_ids": [
+                "1123:1"
+              ],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235223256",
+              "descriptor": {
+                "name": "Premium",
+                "symbol": "",
+                "short_desc": "Premium",
+                "long_desc": "Premium",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "0.0",
+                "maximum_value": "0.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "159210"
+                    },
+                    {
+                      "code": "default",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "child",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "159209"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235217297",
+              "descriptor": {
+                "name": "Paytm Energy Drink",
+                "symbol": "",
+                "short_desc": "this is a test energy drink",
+                "long_desc": "this is a test energy drink",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "70.0",
+                "maximum_value": "175.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [
+                "1123:1"
+              ],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "custom_group",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "158259"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "158259"
+                    },
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235193881",
+              "descriptor": {
+                "name": "Chicken Kosha With Polau",
+                "symbol": "",
+                "short_desc": "Chicken Kosha With Polau",
+                "long_desc": "Chicken Kosha With Polau",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "280.0",
+                "maximum_value": "700.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [
+                "1126:1"
+              ],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "non_veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235193313",
+              "descriptor": {
+                "name": "3 Pieces",
+                "symbol": "",
+                "short_desc": "3 Pieces",
+                "long_desc": "3 Pieces",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "0.0",
+                "maximum_value": "0.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157920"
+                    },
+                    {
+                      "code": "default",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235222937",
+              "descriptor": {
+                "name": "2 Pieces",
+                "symbol": "",
+                "short_desc": "2 Pieces",
+                "long_desc": "2 Pieces",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "0.0",
+                "maximum_value": "0.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "159153"
+                    },
+                    {
+                      "code": "default",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "child",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157894"
+                    }
+                  ]
+                },
+                {
+                  "code": "child",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157894"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235193249",
+              "descriptor": {
+                "name": "8 Pieces",
+                "symbol": "",
+                "short_desc": "8 Pieces",
+                "long_desc": "8 Pieces",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "12.0",
+                "maximum_value": "30.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "non_veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157922"
+                    },
+                    {
+                      "code": "default",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235188618",
+              "descriptor": {
+                "name": "Nugget & Sauce",
+                "symbol": "",
+                "short_desc": "Nugget & Sauce",
+                "long_desc": "Nugget & Sauce",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "0.0",
+                "maximum_value": "0.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157892"
+                    },
+                    {
+                      "code": "default",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235223258",
+              "descriptor": {
+                "name": "6 Pieces",
+                "symbol": "",
+                "short_desc": "6 Pieces",
+                "long_desc": "6 Pieces",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "0.0",
+                "maximum_value": "0.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "non_veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "159211"
+                    },
+                    {
+                      "code": "default",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "child",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157892"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235217187",
+              "descriptor": {
+                "name": "Large",
+                "symbol": "",
+                "short_desc": "Large",
+                "long_desc": "Large",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "189.0",
+                "maximum_value": "189.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235217331",
+              "descriptor": {
+                "name": "SatyaPizzaNew1",
+                "symbol": "",
+                "short_desc": "TestPizzaNew2",
+                "long_desc": "TestPizzaNew2",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "400.4",
+                "maximum_value": "1001.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [
+                "1126:1"
+              ],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "non_veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "custom_group",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "159022"
+                    },
+                    {
+                      "code": "id",
+                      "value": "157895"
+                    },
+                    {
+                      "code": "id",
+                      "value": "157896"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "159022"
+                    },
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157895"
+                    },
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157896"
+                    },
+                    {
+                      "code": "min",
+                      "value": "0"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235217315",
+              "descriptor": {
+                "name": "Small",
+                "symbol": "",
+                "short_desc": "Small",
+                "long_desc": "Small",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "0.0",
+                "maximum_value": "0.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "non_veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "159016"
+                    },
+                    {
+                      "code": "default",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235193860",
+              "descriptor": {
+                "name": "Bun",
+                "symbol": "",
+                "short_desc": "A pieces of seasame bun baked fresh daily from the best bakeries in town. Soft and delicious",
+                "long_desc": "A pieces of seasame bun baked fresh daily from the best bakeries in town. Soft and delicious",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "7.6",
+                "maximum_value": "19.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [
+                "1121:1"
+              ],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235193364",
+              "descriptor": {
+                "name": "8 Pieces",
+                "symbol": "",
+                "short_desc": "8 Pieces",
+                "long_desc": "8 Pieces",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "0.0",
+                "maximum_value": "0.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157912"
+                    },
+                    {
+                      "code": "default",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235193813",
+              "descriptor": {
+                "name": "DeW",
+                "symbol": "",
+                "short_desc": "DeW",
+                "long_desc": "DeW",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "36.0",
+                "maximum_value": "90.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [
+                "1123:1"
+              ],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "custom_group",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157892"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157892"
+                    },
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235222981",
+              "descriptor": {
+                "name": "SatyaPFFMenu1",
+                "symbol": "",
+                "short_desc": "TestPFFdata1",
+                "long_desc": "TestPFFdata1",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "388.4",
+                "maximum_value": "971.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [
+                "1126:1"
+              ],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "non_veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "custom_group",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "159164"
+                    },
+                    {
+                      "code": "id",
+                      "value": "157892"
+                    },
+                    {
+                      "code": "id",
+                      "value": "157895"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "159164"
+                    },
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157892"
+                    },
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157895"
+                    },
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235223277",
+              "descriptor": {
+                "name": "BurgerDemo1",
+                "symbol": "",
+                "short_desc": "This is test data",
+                "long_desc": "This is test data",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "40.0",
+                "maximum_value": "100.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [
+                "1126:1"
+              ],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "non_veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "custom_group",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "159220"
+                    },
+                    {
+                      "code": "id",
+                      "value": "157894"
+                    },
+                    {
+                      "code": "id",
+                      "value": "157895"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "159220"
+                    },
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157894"
+                    },
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157895"
+                    },
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235193328",
+              "descriptor": {
+                "name": "10 Pieces",
+                "symbol": "",
+                "short_desc": "10 Pieces",
+                "long_desc": "10 Pieces",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "24.0",
+                "maximum_value": "60.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157910"
+                    },
+                    {
+                      "code": "default",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "child",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157892"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235217288",
+              "descriptor": {
+                "name": "Spicy Chicken Wings",
+                "symbol": "",
+                "short_desc": "Chicken fillet in a bun  with coleslaw,lettuce, pickles and our  spicy cocktail sauce. This sandwich is made with care to make sure that each and every bite is packed with Mmmm",
+                "long_desc": "Chicken fillet in a bun  with coleslaw,lettuce, pickles and our  spicy cocktail sauce. This sandwich is made with care to make sure that each and every bite is packed with Mmmm",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "107.6",
+                "maximum_value": "269.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [
+                "1125:1"
+              ],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "custom_group",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157920"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157920"
+                    },
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235193224",
+              "descriptor": {
+                "name": "Chicken",
+                "symbol": "",
+                "short_desc": "Chicken",
+                "long_desc": "Chicken",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "0.0",
+                "maximum_value": "0.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "non_veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157925"
+                    },
+                    {
+                      "code": "default",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "child",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157896"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235217128",
+              "descriptor": {
+                "name": "4 Pieces",
+                "symbol": "",
+                "short_desc": "4 Pieces",
+                "long_desc": "4 Pieces",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "20.0",
+                "maximum_value": "50.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "non_veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "159000"
+                    },
+                    {
+                      "code": "default",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235193280",
+              "descriptor": {
+                "name": "250 Gm",
+                "symbol": "",
+                "short_desc": "250 Gm",
+                "long_desc": "250 Gm",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "0.0",
+                "maximum_value": "0.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "non_veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157921"
+                    },
+                    {
+                      "code": "default",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235193864",
+              "descriptor": {
+                "name": "Bisleri 1000ml",
+                "symbol": "",
+                "short_desc": "Bisleri 1000ml",
+                "long_desc": "Bisleri 1000ml",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "7.6",
+                "maximum_value": "19.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [
+                "1123:1"
+              ],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235217329",
+              "descriptor": {
+                "name": "Small",
+                "symbol": "",
+                "short_desc": "Small",
+                "long_desc": "Small",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "0.0",
+                "maximum_value": "0.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "non_veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "159023"
+                    },
+                    {
+                      "code": "default",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "child",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157897"
+                    }
+                  ]
+                },
+                {
+                  "code": "child",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157897"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235193827",
+              "descriptor": {
+                "name": "Add Cinnamon",
+                "symbol": "",
+                "short_desc": "Add Cinnamon",
+                "long_desc": "Add Cinnamon",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "19.6",
+                "maximum_value": "49.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [
+                "1124:1"
+              ],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235193835",
+              "descriptor": {
+                "name": "Nescafe Intense",
+                "symbol": "",
+                "short_desc": "Nescafe Intense",
+                "long_desc": "Nescafe Intense",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "13.3",
+                "maximum_value": "33.25"
+              },
+              "category_id": "F&B",
+              "category_ids": [
+                "1124:1"
+              ],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "custom_group",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157893"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157893"
+                    },
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235193803",
+              "descriptor": {
+                "name": "Fish Fillet Burger Anand",
+                "symbol": "",
+                "short_desc": "Fish Fillet Burger Anand",
+                "long_desc": "Fish Fillet Burger Anand",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "75.6",
+                "maximum_value": "189.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [
+                "1122:1"
+              ],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235223276",
+              "descriptor": {
+                "name": "DosaDemoTest",
+                "symbol": "",
+                "short_desc": "This is test data",
+                "long_desc": "This is test data",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "80.0",
+                "maximum_value": "200.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [
+                "1123:1"
+              ],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "custom_group",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "159219"
+                    },
+                    {
+                      "code": "id",
+                      "value": "157894"
+                    },
+                    {
+                      "code": "id",
+                      "value": "157895"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "159219"
+                    },
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157894"
+                    },
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157895"
+                    },
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235193853",
+              "descriptor": {
+                "name": "Garlic Sauce",
+                "symbol": "",
+                "short_desc": "Our signature garlic sauce will always have you asking for more.",
+                "long_desc": "Our signature garlic sauce will always have you asking for more.",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "0.0",
+                "maximum_value": "0.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [
+                "1121:1"
+              ],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235217309",
+              "descriptor": {
+                "name": "Chicken Soup Bowl",
+                "symbol": "",
+                "short_desc": "Chicken Soup Bowl",
+                "long_desc": "Chicken Soup Bowl",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "26.0",
+                "maximum_value": "65.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [
+                "1126:4"
+              ],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "non_veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "custom_group",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157925"
+                    },
+                    {
+                      "code": "id",
+                      "value": "157896"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157925"
+                    },
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157896"
+                    },
+                    {
+                      "code": "min",
+                      "value": "0"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235217181",
+              "descriptor": {
+                "name": "10 Pieces",
+                "symbol": "",
+                "short_desc": "10 Pieces",
+                "long_desc": "10 Pieces",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "500.0",
+                "maximum_value": "500.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235193237",
+              "descriptor": {
+                "name": "Large",
+                "symbol": "",
+                "short_desc": "Large",
+                "long_desc": "Large",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "8.0",
+                "maximum_value": "20.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157902"
+                    },
+                    {
+                      "code": "default",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235217197",
+              "descriptor": {
+                "name": "8 Pieces",
+                "symbol": "",
+                "short_desc": "8 Pieces",
+                "long_desc": "8 Pieces",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "101.0",
+                "maximum_value": "101.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "non_veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235193302",
+              "descriptor": {
+                "name": "8 Pieces",
+                "symbol": "",
+                "short_desc": "8 Pieces",
+                "long_desc": "8 Pieces",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "20.0",
+                "maximum_value": "50.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157911"
+                    },
+                    {
+                      "code": "default",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235188622",
+              "descriptor": {
+                "name": "Add Chilly",
+                "symbol": "",
+                "short_desc": "Add Chilly",
+                "long_desc": "Add Chilly",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "2.0",
+                "maximum_value": "5.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157897"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235217311",
+              "descriptor": {
+                "name": "Chicken Hnadi",
+                "symbol": "",
+                "short_desc": "Chicken Hnadi",
+                "long_desc": "Chicken Hnadi",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "28.0",
+                "maximum_value": "70.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [
+                "1126:3"
+              ],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "non_veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "custom_group",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157924"
+                    },
+                    {
+                      "code": "id",
+                      "value": "157896"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157924"
+                    },
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157896"
+                    },
+                    {
+                      "code": "min",
+                      "value": "0"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235193883",
+              "descriptor": {
+                "name": "Chicken Loppypop",
+                "symbol": "",
+                "short_desc": "Chicken Loppypop",
+                "long_desc": "Chicken Loppypop",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "60.0",
+                "maximum_value": "150.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [
+                "1126:2"
+              ],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "non_veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235193800",
+              "descriptor": {
+                "name": "Chicken Fillet Burger",
+                "symbol": "",
+                "short_desc": "Chicken fillet steak in a bun with  pickles,lettuce  ,our signature garlic sauce and some frie. Crispy  chicken fillet burger , topped with tangy sliced pickles ,lettuce and Albaik International's signature garlic sauce, placed between a freshly baked bun",
+                "long_desc": "Chicken fillet steak in a bun with  pickles,lettuce  ,our signature garlic sauce and some frie. Crispy  chicken fillet burger , topped with tangy sliced pickles ,lettuce and Albaik International's signature garlic sauce, placed between a freshly baked bun",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "75.6",
+                "maximum_value": "189.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [
+                "1125:1"
+              ],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235193779",
+              "descriptor": {
+                "name": "Spicy Double Baik",
+                "symbol": "",
+                "short_desc": "Spicy Double Baik",
+                "long_desc": "Spicy Double Baik",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "103.6",
+                "maximum_value": "259.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [
+                "1125:1"
+              ],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235193785",
+              "descriptor": {
+                "name": "Chicken Fillet Sandwich",
+                "symbol": "",
+                "short_desc": "Chicken fillet wrapped in Arabic bread with our signature garlic sauce, lettuce ,pickles and fries inside. Prepared with care ensuring each and every bite is packed with Mmmm",
+                "long_desc": "Chicken fillet wrapped in Arabic bread with our signature garlic sauce, lettuce ,pickles and fries inside. Prepared with care ensuring each and every bite is packed with Mmmm",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "83.6",
+                "maximum_value": "209.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [
+                "1125:1"
+              ],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235193854",
+              "descriptor": {
+                "name": "Nugget Sauce",
+                "symbol": "",
+                "short_desc": "Hot & spicy nugget sauce won't surely let you down.",
+                "long_desc": "Hot & spicy nugget sauce won't surely let you down.",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "7.6",
+                "maximum_value": "19.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [
+                "1121:1"
+              ],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235193222",
+              "descriptor": {
+                "name": "8 Pieces",
+                "symbol": "",
+                "short_desc": "8 Pieces",
+                "long_desc": "8 Pieces",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "0.0",
+                "maximum_value": "0.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157917"
+                    },
+                    {
+                      "code": "default",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235193342",
+              "descriptor": {
+                "name": "2 Pieces",
+                "symbol": "",
+                "short_desc": "2 Pieces",
+                "long_desc": "2 Pieces",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "0.0",
+                "maximum_value": "0.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157919"
+                    },
+                    {
+                      "code": "default",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235188623",
+              "descriptor": {
+                "name": "Miranda",
+                "symbol": "",
+                "short_desc": "Miranda",
+                "long_desc": "Miranda",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "0.0",
+                "maximum_value": "0.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157893"
+                    },
+                    {
+                      "code": "default",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235193359",
+              "descriptor": {
+                "name": "8 Pieces",
+                "symbol": "",
+                "short_desc": "8 Pieces",
+                "long_desc": "8 Pieces",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "240.0",
+                "maximum_value": "600.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157919"
+                    },
+                    {
+                      "code": "default",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235222960",
+              "descriptor": {
+                "name": "10 Pieces",
+                "symbol": "",
+                "short_desc": "10 Pieces",
+                "long_desc": "10 Pieces",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "0.0",
+                "maximum_value": "0.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "non_veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "159164"
+                    },
+                    {
+                      "code": "default",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "child",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157895"
+                    }
+                  ]
+                },
+                {
+                  "code": "child",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157895"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235193288",
+              "descriptor": {
+                "name": "6 Pieces",
+                "symbol": "",
+                "short_desc": "6 Pieces",
+                "long_desc": "6 Pieces",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "0.0",
+                "maximum_value": "0.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157906"
+                    },
+                    {
+                      "code": "default",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "child",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157898"
+                    }
+                  ]
+                },
+                {
+                  "code": "child",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157898"
+                    }
+                  ]
+                },
+                {
+                  "code": "child",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157898"
+                    }
+                  ]
+                },
+                {
+                  "code": "child",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157898"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235193296",
+              "descriptor": {
+                "name": "Large",
+                "symbol": "",
+                "short_desc": "Large",
+                "long_desc": "Large",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "8.0",
+                "maximum_value": "20.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157916"
+                    },
+                    {
+                      "code": "default",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235217296",
+              "descriptor": {
+                "name": "Soft Drinks",
+                "symbol": "",
+                "short_desc": "Coke , Diet Coke , Thums Up , Fanta , Nescafe Cold Coffee",
+                "long_desc": "Coke , Diet Coke , Thums Up , Fanta , Nescafe Cold Coffee",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "16.0",
+                "maximum_value": "40.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [
+                "1123:1"
+              ],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "custom_group",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157908"
+                    },
+                    {
+                      "code": "id",
+                      "value": "157895"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157908"
+                    },
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157895"
+                    },
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235223288",
+              "descriptor": {
+                "name": "Pizza Offer Demo",
+                "symbol": "",
+                "short_desc": "This is test data",
+                "long_desc": "This is test data",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "200.0",
+                "maximum_value": "500.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [
+                "1126:1"
+              ],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "non_veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "custom_group",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "159221"
+                    },
+                    {
+                      "code": "id",
+                      "value": "157897"
+                    },
+                    {
+                      "code": "id",
+                      "value": "159209"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "159221"
+                    },
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157897"
+                    },
+                    {
+                      "code": "min",
+                      "value": "0"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "159209"
+                    },
+                    {
+                      "code": "min",
+                      "value": "0"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235217280",
+              "descriptor": {
+                "name": "Albaik International Chicken Meal1",
+                "symbol": "",
+                "short_desc": "Chicken meal comes with fries, a bun and  garlic sauce.The first bite will have you going Mmmmm - Every piece of Albaik International's Chicken is marinated in our signature marinade - a unique and tantalizing blend of 18 herbs and spices",
+                "long_desc": "Chicken meal comes with fries, a bun and  garlic sauce.The first bite will have you going Mmmmm - Every piece of Albaik International's Chicken is marinated in our signature marinade - a unique and tantalizing blend of 18 herbs and spices",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "140.0",
+                "maximum_value": "350.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [
+                "1125:1"
+              ],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "custom_group",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157919"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157919"
+                    },
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235193273",
+              "descriptor": {
+                "name": "8 Pieces",
+                "symbol": "",
+                "short_desc": "8 Pieces",
+                "long_desc": "8 Pieces",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "0.0",
+                "maximum_value": "0.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "non_veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157923"
+                    },
+                    {
+                      "code": "default",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "child",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157897"
+                    }
+                  ]
+                },
+                {
+                  "code": "child",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157897"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235193809",
+              "descriptor": {
+                "name": "Add Caramel",
+                "symbol": "",
+                "short_desc": "Add Caramel",
+                "long_desc": "Add Caramel",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "19.6",
+                "maximum_value": "49.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [
+                "1124:1"
+              ],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235336250",
+              "descriptor": {
+                "name": "10 Pieces",
+                "symbol": "",
+                "short_desc": "10 Pieces",
+                "long_desc": "10 Pieces",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "0.0",
+                "maximum_value": "0.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "non_veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "167284"
+                    },
+                    {
+                      "code": "default",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "child",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157894"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235193314",
+              "descriptor": {
+                "name": "8 Pieces",
+                "symbol": "",
+                "short_desc": "8 Pieces",
+                "long_desc": "8 Pieces",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "0.0",
+                "maximum_value": "0.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157910"
+                    },
+                    {
+                      "code": "default",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "child",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157892"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235193258",
+              "descriptor": {
+                "name": "Chicken",
+                "symbol": "",
+                "short_desc": "Chicken",
+                "long_desc": "Chicken",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "0.0",
+                "maximum_value": "0.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "non_veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157922"
+                    },
+                    {
+                      "code": "default",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "child",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157899"
+                    }
+                  ]
+                },
+                {
+                  "code": "child",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157899"
+                    }
+                  ]
+                },
+                {
+                  "code": "child",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157899"
+                    }
+                  ]
+                },
+                {
+                  "code": "child",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157899"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235188626",
+              "descriptor": {
+                "name": "7\"up",
+                "symbol": "",
+                "short_desc": "7\"up",
+                "long_desc": "7\"up",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "0.0",
+                "maximum_value": "0.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157893"
+                    },
+                    {
+                      "code": "default",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235217298",
+              "descriptor": {
+                "name": "Caramel Affogatto",
+                "symbol": "",
+                "short_desc": "Caramel Affogatto",
+                "long_desc": "Caramel Affogatto",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "67.6",
+                "maximum_value": "169.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [
+                "1124:1"
+              ],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "custom_group",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157904"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157904"
+                    },
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235188628",
+              "descriptor": {
+                "name": "Chilly Masala",
+                "symbol": "",
+                "short_desc": "Chilly Masala",
+                "long_desc": "Chilly Masala",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "4.0",
+                "maximum_value": "10.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157898"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235193836",
+              "descriptor": {
+                "name": "Pepsi",
+                "symbol": "",
+                "short_desc": "Pepsi",
+                "long_desc": "Pepsi",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "11.4",
+                "maximum_value": "28.5"
+              },
+              "category_id": "F&B",
+              "category_ids": [
+                "1123:1"
+              ],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235193828",
+              "descriptor": {
+                "name": "Diet Coke",
+                "symbol": "",
+                "short_desc": "Diet Coke",
+                "long_desc": "Diet Coke",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "15.2",
+                "maximum_value": "38.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [
+                "1123:1"
+              ],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235193236",
+              "descriptor": {
+                "name": "10 Pieces",
+                "symbol": "",
+                "short_desc": "10 Pieces",
+                "long_desc": "10 Pieces",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "24.0",
+                "maximum_value": "60.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157917"
+                    },
+                    {
+                      "code": "default",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235216396",
+              "descriptor": {
+                "name": "2 Pieces",
+                "symbol": "",
+                "short_desc": "2 Pieces",
+                "long_desc": "2 Pieces",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "0.0",
+                "maximum_value": "0.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "158259"
+                    },
+                    {
+                      "code": "default",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235193884",
+              "descriptor": {
+                "name": "Chicken Ukkad",
+                "symbol": "",
+                "short_desc": "Chicken Ukkad",
+                "long_desc": "Chicken Ukkad",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "64.0",
+                "maximum_value": "160.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [
+                "1126:6"
+              ],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "non_veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "custom_group",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157896"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157896"
+                    },
+                    {
+                      "code": "min",
+                      "value": "0"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235188644",
+              "descriptor": {
+                "name": "Add Green Chutny",
+                "symbol": "",
+                "short_desc": "Add Green Chutny",
+                "long_desc": "Add Green Chutny",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "2.0",
+                "maximum_value": "5.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157896"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235193885",
+              "descriptor": {
+                "name": "Chicken Fry",
+                "symbol": "",
+                "short_desc": "Chicken Fry",
+                "long_desc": "Chicken Fry",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "48.0",
+                "maximum_value": "120.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [
+                "1126:5"
+              ],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "non_veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "custom_group",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157893"
+                    },
+                    {
+                      "code": "id",
+                      "value": "157896"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157893"
+                    },
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157896"
+                    },
+                    {
+                      "code": "min",
+                      "value": "0"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235216397",
+              "descriptor": {
+                "name": "10 Pieces",
+                "symbol": "",
+                "short_desc": "10 Pieces",
+                "long_desc": "10 Pieces",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "130.0",
+                "maximum_value": "325.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "158259"
+                    },
+                    {
+                      "code": "default",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235193840",
+              "descriptor": {
+                "name": "Icecream With Chocolate Syrup",
+                "symbol": "",
+                "short_desc": "demo 2 demo demo2 demo 2 demo",
+                "long_desc": "demo 2 demo demo2 demo 2 demo",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "11.6",
+                "maximum_value": "29.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [
+                "1119:1"
+              ],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "custom_group",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157893"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157893"
+                    },
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235222976",
+              "descriptor": {
+                "name": "Premium",
+                "symbol": "",
+                "short_desc": "Premium",
+                "long_desc": "Premium",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "0.0",
+                "maximum_value": "0.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "159171"
+                    },
+                    {
+                      "code": "default",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235217304",
+              "descriptor": {
+                "name": "SatyaChikecnItem1011",
+                "symbol": "",
+                "short_desc": "Test Chickecn",
+                "long_desc": "Test Chickecn",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "40.4",
+                "maximum_value": "101.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [
+                "1126:1"
+              ],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "custom_group",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "158999"
+                    },
+                    {
+                      "code": "id",
+                      "value": "157897"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "158999"
+                    },
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157897"
+                    },
+                    {
+                      "code": "min",
+                      "value": "0"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235193832",
+              "descriptor": {
+                "name": "Coke",
+                "symbol": "",
+                "short_desc": "Coke",
+                "long_desc": "Coke",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "15.2",
+                "maximum_value": "38.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [
+                "1123:1"
+              ],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235217185",
+              "descriptor": {
+                "name": "10 Pieces",
+                "symbol": "",
+                "short_desc": "10 Pieces",
+                "long_desc": "10 Pieces",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "479.0",
+                "maximum_value": "479.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235193209",
+              "descriptor": {
+                "name": "10 Pieces",
+                "symbol": "",
+                "short_desc": "10 Pieces",
+                "long_desc": "10 Pieces",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "24.0",
+                "maximum_value": "60.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157913"
+                    },
+                    {
+                      "code": "default",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235217305",
+              "descriptor": {
+                "name": "ITALIAN PIZZA",
+                "symbol": "",
+                "short_desc": "ITALIAN PIZZA",
+                "long_desc": "ITALIAN PIZZA",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "32.0",
+                "maximum_value": "80.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [
+                "1121:1"
+              ],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "custom_group",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157906"
+                    },
+                    {
+                      "code": "id",
+                      "value": "157892"
+                    },
+                    {
+                      "code": "id",
+                      "value": "157895"
+                    },
+                    {
+                      "code": "id",
+                      "value": "157897"
+                    },
+                    {
+                      "code": "id",
+                      "value": "157898"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157906"
+                    },
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157892"
+                    },
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157895"
+                    },
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157897"
+                    },
+                    {
+                      "code": "min",
+                      "value": "0"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157898"
+                    },
+                    {
+                      "code": "min",
+                      "value": "0"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235193298",
+              "descriptor": {
+                "name": "Chicken",
+                "symbol": "",
+                "short_desc": "Chicken",
+                "long_desc": "Chicken",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "0.0",
+                "maximum_value": "0.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "non_veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157927"
+                    },
+                    {
+                      "code": "default",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "child",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157896"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235217282",
+              "descriptor": {
+                "name": "Spicy",
+                "symbol": "",
+                "short_desc": "Spicy",
+                "long_desc": "Spicy",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "40.0",
+                "maximum_value": "100.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [
+                "1120:1"
+              ],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235223259",
+              "descriptor": {
+                "name": "Thal_Harsh",
+                "symbol": "",
+                "short_desc": "Thal_Harsh",
+                "long_desc": "Thal_Harsh",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "56.8",
+                "maximum_value": "142.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [
+                "1126:1"
+              ],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "non_veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235217123",
+              "descriptor": {
+                "name": "10 Pieces",
+                "symbol": "",
+                "short_desc": "10 Pieces",
+                "long_desc": "10 Pieces",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "1.6",
+                "maximum_value": "4.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "158999"
+                    },
+                    {
+                      "code": "default",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "child",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157897"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235223252",
+              "descriptor": {
+                "name": "Extra Ghee",
+                "symbol": "",
+                "short_desc": "Extra Ghee",
+                "long_desc": "Extra Ghee",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "8.0",
+                "maximum_value": "20.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "159209"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235217301",
+              "descriptor": {
+                "name": "Cappuccino",
+                "symbol": "",
+                "short_desc": "Cappuccino",
+                "long_desc": "Cappuccino",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "59.6",
+                "maximum_value": "149.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [
+                "1124:1"
+              ],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "custom_group",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157902"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157902"
+                    },
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235223261",
+              "descriptor": {
+                "name": "BurgerDemo",
+                "symbol": "",
+                "short_desc": "This is test data",
+                "long_desc": "This is test data",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "200.0",
+                "maximum_value": "500.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [
+                "1126:1"
+              ],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "non_veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "custom_group",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "159211"
+                    },
+                    {
+                      "code": "id",
+                      "value": "157892"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "159211"
+                    },
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157892"
+                    },
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235223253",
+              "descriptor": {
+                "name": "Extra Baati",
+                "symbol": "",
+                "short_desc": "Extra Baati",
+                "long_desc": "Extra Baati",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "12.0",
+                "maximum_value": "30.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "159209"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235188630",
+              "descriptor": {
+                "name": "Add Chilly",
+                "symbol": "",
+                "short_desc": "Add Chilly",
+                "long_desc": "Add Chilly",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "2.0",
+                "maximum_value": "5.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157899"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235193814",
+              "descriptor": {
+                "name": "Panner Onion",
+                "symbol": "",
+                "short_desc": "Panner Onion",
+                "long_desc": "Panner Onion",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "36.0",
+                "maximum_value": "90.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [
+                "1125:1"
+              ],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "custom_group",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157892"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157892"
+                    },
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235217318",
+              "descriptor": {
+                "name": "SatyaPizza1",
+                "symbol": "",
+                "short_desc": "TestPizza1",
+                "long_desc": "TestPizza1",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "48.4",
+                "maximum_value": "121.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [
+                "1126:1"
+              ],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "non_veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "custom_group",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "159016"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "159016"
+                    },
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235188638",
+              "descriptor": {
+                "name": "Diet Coke",
+                "symbol": "",
+                "short_desc": "Diet Coke",
+                "long_desc": "Diet Coke",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "8.0",
+                "maximum_value": "20.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157895"
+                    },
+                    {
+                      "code": "default",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235193295",
+              "descriptor": {
+                "name": "500 Gm",
+                "symbol": "",
+                "short_desc": "500 Gm",
+                "long_desc": "500 Gm",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "20.0",
+                "maximum_value": "50.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "non_veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157921"
+                    },
+                    {
+                      "code": "default",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235217127",
+              "descriptor": {
+                "name": "10 Pieces",
+                "symbol": "",
+                "short_desc": "10 Pieces",
+                "long_desc": "10 Pieces",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "1.6",
+                "maximum_value": "4.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "158998"
+                    },
+                    {
+                      "code": "default",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "child",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157897"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235188631",
+              "descriptor": {
+                "name": "Mixed Fruit",
+                "symbol": "",
+                "short_desc": "Mixed Fruit",
+                "long_desc": "Mixed Fruit",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "0.0",
+                "maximum_value": "0.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157894"
+                    },
+                    {
+                      "code": "default",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235193807",
+              "descriptor": {
+                "name": "Corn On The Cob",
+                "symbol": "",
+                "short_desc": "Served piping hot with a pack of butter on the side to spread on top",
+                "long_desc": "Served piping hot with a pack of butter on the side to spread on top",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "39.6",
+                "maximum_value": "99.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [
+                "1121:1"
+              ],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235193802",
+              "descriptor": {
+                "name": "Hommos",
+                "symbol": "",
+                "short_desc": "Creamy, rich Albaik International's hommos is prepared with crushed chickpeas mixed with tahini sauce and drizzled with pure olive oil and topped with a green olive; served with our signature saj bread",
+                "long_desc": "Creamy, rich Albaik International's hommos is prepared with crushed chickpeas mixed with tahini sauce and drizzled with pure olive oil and topped with a green olive; served with our signature saj bread",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "67.6",
+                "maximum_value": "169.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [
+                "1121:1"
+              ],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235188641",
+              "descriptor": {
+                "name": "Nescafe Cold Coffee",
+                "symbol": "",
+                "short_desc": "Nescafe Cold Coffee",
+                "long_desc": "Nescafe Cold Coffee",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "20.0",
+                "maximum_value": "50.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157895"
+                    },
+                    {
+                      "code": "default",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235217281",
+              "descriptor": {
+                "name": "Chicken Drumsticks",
+                "symbol": "",
+                "short_desc": "Crispy chicken drumsticks come with some fries and garlic sauce. Albaik International's Chicken drumsticks are marinated in our signature marinade - a unique and tantalizing blend of 18 herbs and spices",
+                "long_desc": "Crispy chicken drumsticks come with some fries and garlic sauce. Albaik International's Chicken drumsticks are marinated in our signature marinade - a unique and tantalizing blend of 18 herbs and spices",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "143.6",
+                "maximum_value": "359.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [
+                "1125:1"
+              ],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "custom_group",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157909"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157909"
+                    },
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235223257",
+              "descriptor": {
+                "name": "Premium Ultra Pro Max",
+                "symbol": "",
+                "short_desc": "Premium Ultra Pro Max",
+                "long_desc": "Premium Ultra Pro Max",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "60.0",
+                "maximum_value": "150.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "159210"
+                    },
+                    {
+                      "code": "default",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "child",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "159209"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235193265",
+              "descriptor": {
+                "name": "Small",
+                "symbol": "",
+                "short_desc": "Small",
+                "long_desc": "Small",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "0.0",
+                "maximum_value": "0.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157907"
+                    },
+                    {
+                      "code": "default",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235193297",
+              "descriptor": {
+                "name": "6 Pieces",
+                "symbol": "",
+                "short_desc": "6 Pieces",
+                "long_desc": "6 Pieces",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "92.0",
+                "maximum_value": "230.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157915"
+                    },
+                    {
+                      "code": "default",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235193778",
+              "descriptor": {
+                "name": "Chicken Fillet Sandwich Combo",
+                "symbol": "",
+                "short_desc": "Chicken fillet sandwich, fries and choice of soft drink. Prepared with care ensuring each and every bite is packed with Mmmm",
+                "long_desc": "Chicken fillet sandwich, fries and choice of soft drink. Prepared with care ensuring each and every bite is packed with Mmmm",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "115.6",
+                "maximum_value": "289.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [
+                "1125:1"
+              ],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "custom_group",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157893"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157893"
+                    },
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235217186",
+              "descriptor": {
+                "name": "Small",
+                "symbol": "",
+                "short_desc": "Small",
+                "long_desc": "Small",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "169.0",
+                "maximum_value": "169.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235193346",
+              "descriptor": {
+                "name": "4 Pieces",
+                "symbol": "",
+                "short_desc": "4 Pieces",
+                "long_desc": "4 Pieces",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "80.0",
+                "maximum_value": "200.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157919"
+                    },
+                    {
+                      "code": "default",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235193858",
+              "descriptor": {
+                "name": "Tartar Sauce",
+                "symbol": "",
+                "short_desc": "A Treat for your taste buds with this  sauce made with mayonnaise , parsley ,carrot, gherkins  & lime juice",
+                "long_desc": "A Treat for your taste buds with this  sauce made with mayonnaise , parsley ,carrot, gherkins  & lime juice",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "7.6",
+                "maximum_value": "19.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [
+                "1121:1"
+              ],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235188635",
+              "descriptor": {
+                "name": "Guava",
+                "symbol": "",
+                "short_desc": "Guava",
+                "long_desc": "Guava",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "0.0",
+                "maximum_value": "0.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157894"
+                    },
+                    {
+                      "code": "default",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235217307",
+              "descriptor": {
+                "name": "SatyaITem1",
+                "symbol": "",
+                "short_desc": "Test Data1",
+                "long_desc": "Test Data1",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "40.0",
+                "maximum_value": "100.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [
+                "1126:1"
+              ],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "non_veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "custom_group",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "159000"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "159000"
+                    },
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235217323",
+              "descriptor": {
+                "name": "10 Pieces",
+                "symbol": "",
+                "short_desc": "10 Pieces",
+                "long_desc": "10 Pieces",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "0.0",
+                "maximum_value": "0.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "non_veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "159019"
+                    },
+                    {
+                      "code": "default",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235223260",
+              "descriptor": {
+                "name": "Dal Baati Churma",
+                "symbol": "",
+                "short_desc": "Famous Rajasthani Dal, Baati, Churma",
+                "long_desc": "Famous Rajasthani Dal, Baati, Churma",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "100.0",
+                "maximum_value": "250.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [
+                "1121:1"
+              ],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "custom_group",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "159210"
+                    },
+                    {
+                      "code": "id",
+                      "value": "159209"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "159210"
+                    },
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "159209"
+                    },
+                    {
+                      "code": "min",
+                      "value": "0"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235188636",
+              "descriptor": {
+                "name": "Add Lemon",
+                "symbol": "",
+                "short_desc": "Add Lemon",
+                "long_desc": "Add Lemon",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "2.0",
+                "maximum_value": "5.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157899"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235193804",
+              "descriptor": {
+                "name": "Double Espresso",
+                "symbol": "",
+                "short_desc": "Double Espresso",
+                "long_desc": "Double Espresso",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "59.6",
+                "maximum_value": "149.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [
+                "1124:1"
+              ],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235217332",
+              "descriptor": {
+                "name": "SatyaTestPizza1",
+                "symbol": "",
+                "short_desc": "TestPizza3",
+                "long_desc": "TestPizza3",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "100.4",
+                "maximum_value": "251.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [
+                "1126:1"
+              ],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "non_veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "custom_group",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "159023"
+                    },
+                    {
+                      "code": "id",
+                      "value": "157894"
+                    },
+                    {
+                      "code": "id",
+                      "value": "157897"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "159023"
+                    },
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157894"
+                    },
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157897"
+                    },
+                    {
+                      "code": "min",
+                      "value": "0"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235217316",
+              "descriptor": {
+                "name": "Large",
+                "symbol": "",
+                "short_desc": "Large",
+                "long_desc": "Large",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "52.0",
+                "maximum_value": "130.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "non_veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "159016"
+                    },
+                    {
+                      "code": "default",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235217308",
+              "descriptor": {
+                "name": "Malai Kopta",
+                "symbol": "",
+                "short_desc": "Malai Kopta",
+                "long_desc": "Malai Kopta",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "4.0",
+                "maximum_value": "10.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [
+                "1122:1"
+              ],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "non_veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "custom_group",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157923"
+                    },
+                    {
+                      "code": "id",
+                      "value": "157892"
+                    },
+                    {
+                      "code": "id",
+                      "value": "157897"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157923"
+                    },
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157892"
+                    },
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157897"
+                    },
+                    {
+                      "code": "min",
+                      "value": "0"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235193301",
+              "descriptor": {
+                "name": "Small",
+                "symbol": "",
+                "short_desc": "Small",
+                "long_desc": "Small",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "0.0",
+                "maximum_value": "0.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157905"
+                    },
+                    {
+                      "code": "default",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235217189",
+              "descriptor": {
+                "name": "6 Pieces",
+                "symbol": "",
+                "short_desc": "6 Pieces",
+                "long_desc": "6 Pieces",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "299.0",
+                "maximum_value": "299.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235193805",
+              "descriptor": {
+                "name": "Coleslaw Salad",
+                "symbol": "",
+                "short_desc": "Freshly prepared shredded cabbage and carrots mixed with our special salad dressing",
+                "long_desc": "Freshly prepared shredded cabbage and carrots mixed with our special salad dressing",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "35.6",
+                "maximum_value": "89.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [
+                "1121:1"
+              ],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235217182",
+              "descriptor": {
+                "name": "8 Pieces",
+                "symbol": "",
+                "short_desc": "8 Pieces",
+                "long_desc": "8 Pieces",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "419.0",
+                "maximum_value": "419.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235217294",
+              "descriptor": {
+                "name": "Macchiato",
+                "symbol": "",
+                "short_desc": "Macchiato",
+                "long_desc": "Macchiato",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "55.6",
+                "maximum_value": "139.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [
+                "1124:1"
+              ],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "custom_group",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157907"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157907"
+                    },
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235217191",
+              "descriptor": {
+                "name": "6 Pieces",
+                "symbol": "",
+                "short_desc": "6 Pieces",
+                "long_desc": "6 Pieces",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "80.0",
+                "maximum_value": "80.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235217295",
+              "descriptor": {
+                "name": "Americano",
+                "symbol": "",
+                "short_desc": "Americano",
+                "long_desc": "Americano",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "55.6",
+                "maximum_value": "139.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [
+                "1123:1"
+              ],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "custom_group",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157916"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157916"
+                    },
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235193263",
+              "descriptor": {
+                "name": "Chicken",
+                "symbol": "",
+                "short_desc": "Chicken",
+                "long_desc": "Chicken",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "0.0",
+                "maximum_value": "0.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "non_veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157924"
+                    },
+                    {
+                      "code": "default",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "child",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157896"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235193808",
+              "descriptor": {
+                "name": "Coke Big",
+                "symbol": "",
+                "short_desc": "Coke Big",
+                "long_desc": "Coke Big",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "22.8",
+                "maximum_value": "57.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [
+                "1123:1"
+              ],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235193856",
+              "descriptor": {
+                "name": "Cocktaill Sauce",
+                "symbol": "",
+                "short_desc": "Albaik International's special blend makes a delicious addition to any of our specialties",
+                "long_desc": "Albaik International's special blend makes a delicious addition to any of our specialties",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "7.6",
+                "maximum_value": "19.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [
+                "1121:1"
+              ],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235217184",
+              "descriptor": {
+                "name": "8 Pieces",
+                "symbol": "",
+                "short_desc": "8 Pieces",
+                "long_desc": "8 Pieces",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "419.0",
+                "maximum_value": "419.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235193857",
+              "descriptor": {
+                "name": "7\"up",
+                "symbol": "",
+                "short_desc": "7\"up",
+                "long_desc": "7\"up",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "11.4",
+                "maximum_value": "28.5"
+              },
+              "category_id": "F&B",
+              "category_ids": [
+                "1123:1"
+              ],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "custom_group",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157892"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157892"
+                    },
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235217121",
+              "descriptor": {
+                "name": "8 Pieces",
+                "symbol": "",
+                "short_desc": "8 Pieces",
+                "long_desc": "8 Pieces",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "0.0",
+                "maximum_value": "0.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "158999"
+                    },
+                    {
+                      "code": "default",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "child",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157897"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235217177",
+              "descriptor": {
+                "name": "SatyaAddon1",
+                "symbol": "",
+                "short_desc": "TestAddon",
+                "long_desc": "TestAddon",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "43.2",
+                "maximum_value": "108.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [
+                "1120:1"
+              ],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235193330",
+              "descriptor": {
+                "name": "4 Pieces",
+                "symbol": "",
+                "short_desc": "4 Pieces",
+                "long_desc": "4 Pieces",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "80.0",
+                "maximum_value": "200.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157900"
+                    },
+                    {
+                      "code": "default",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235193866",
+              "descriptor": {
+                "name": "Cheese Slice",
+                "symbol": "",
+                "short_desc": "Cheese Slice",
+                "long_desc": "Cheese Slice",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "7.6",
+                "maximum_value": "19.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [
+                "1120:1"
+              ],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235193882",
+              "descriptor": {
+                "name": "Chicken Istooooo",
+                "symbol": "",
+                "short_desc": "Chicken Istooooo",
+                "long_desc": "Chicken Istooooo",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "36.4",
+                "maximum_value": "91.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [
+                "1125:1"
+              ],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "non_veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235217290",
+              "descriptor": {
+                "name": "Chicken Wings",
+                "symbol": "",
+                "short_desc": "Chicken fillet in a bun  with coleslaw,lettuce, pickles and our  spicy cocktail sauce. This sandwich is made with care to make sure that each and every bite is packed with Mmmm",
+                "long_desc": "Chicken fillet in a bun  with coleslaw,lettuce, pickles and our  spicy cocktail sauce. This sandwich is made with care to make sure that each and every bite is packed with Mmmm",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "107.6",
+                "maximum_value": "269.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [
+                "1125:1"
+              ],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "custom_group",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157915"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157915"
+                    },
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235217291",
+              "descriptor": {
+                "name": "Chicken Fillet Nuggets Meal",
+                "symbol": "",
+                "short_desc": "chicken fillet nuggets come with fries, a bun and a sauce of your choice   (nuggets sauce/garlic sauce) Tender all breast chicken fillets pieces marinated in our unique & signature blend then breaded, seasoned to perfection and deep-fried in 100% pure vegetable oil until each piece is moist, tender and juicy from the inside, crispy and perfectly golden on the outside allowing for the Mmmm sensation with every bite",
+                "long_desc": "chicken fillet nuggets come with fries, a bun and a sauce of your choice   (nuggets sauce/garlic sauce) Tender all breast chicken fillets pieces marinated in our unique & signature blend then breaded, seasoned to perfection and deep-fried in 100% pure vegetable oil until each piece is moist, tender and juicy from the inside, crispy and perfectly golden on the outside allowing for the Mmmm sensation with every bite",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "163.6",
+                "maximum_value": "409.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [
+                "1125:1"
+              ],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "custom_group",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157910"
+                    },
+                    {
+                      "code": "id",
+                      "value": "157892"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157910"
+                    },
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157892"
+                    },
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235223275",
+              "descriptor": {
+                "name": "10 Pieces",
+                "symbol": "",
+                "short_desc": "10 Pieces",
+                "long_desc": "10 Pieces",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "0.0",
+                "maximum_value": "0.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "non_veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "159220"
+                    },
+                    {
+                      "code": "default",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "child",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157895"
+                    }
+                  ]
+                },
+                {
+                  "code": "child",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157895"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235193867",
+              "descriptor": {
+                "name": "Demo Dill Pickles",
+                "symbol": "",
+                "short_desc": "Demo Dill Pickles",
+                "long_desc": "Demo Dill Pickles",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "7.6",
+                "maximum_value": "19.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [
+                "1120:1"
+              ],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235193315",
+              "descriptor": {
+                "name": "Large",
+                "symbol": "",
+                "short_desc": "Large",
+                "long_desc": "Large",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "8.0",
+                "maximum_value": "20.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157905"
+                    },
+                    {
+                      "code": "default",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235193812",
+              "descriptor": {
+                "name": "Demo Add Irish Coffee",
+                "symbol": "",
+                "short_desc": "Demo Add Irish Coffee",
+                "long_desc": "Demo Add Irish Coffee",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "19.6",
+                "maximum_value": "49.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [
+                "1120:1"
+              ],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235193341",
+              "descriptor": {
+                "name": "3 Pieces",
+                "symbol": "",
+                "short_desc": "3 Pieces",
+                "long_desc": "3 Pieces",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "0.0",
+                "maximum_value": "0.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157914"
+                    },
+                    {
+                      "code": "default",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235193837",
+              "descriptor": {
+                "name": "Mounain Dew",
+                "symbol": "",
+                "short_desc": "Mounain Dew",
+                "long_desc": "Mounain Dew",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "11.4",
+                "maximum_value": "28.5"
+              },
+              "category_id": "F&B",
+              "category_ids": [
+                "1123:1"
+              ],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235193862",
+              "descriptor": {
+                "name": "Juices",
+                "symbol": "",
+                "short_desc": "Pomogranate,Orange,Apple And Mixed Fruit Juice",
+                "long_desc": "Pomogranate,Orange,Apple And Mixed Fruit Juice",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "7.6",
+                "maximum_value": "19.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [
+                "1123:1"
+              ],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "custom_group",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157894"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157894"
+                    },
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235193335",
+              "descriptor": {
+                "name": "8 Pieces",
+                "symbol": "",
+                "short_desc": "8 Pieces",
+                "long_desc": "8 Pieces",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "224.0",
+                "maximum_value": "560.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157900"
+                    },
+                    {
+                      "code": "default",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235193223",
+              "descriptor": {
+                "name": "Small",
+                "symbol": "",
+                "short_desc": "Small",
+                "long_desc": "Small",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "0.0",
+                "maximum_value": "0.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157902"
+                    },
+                    {
+                      "code": "default",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235217303",
+              "descriptor": {
+                "name": "SatyaChikecnItem101",
+                "symbol": "",
+                "short_desc": "Test Chickecn",
+                "long_desc": "Test Chickecn",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "40.4",
+                "maximum_value": "101.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [
+                "1126:1"
+              ],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "custom_group",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "158998"
+                    },
+                    {
+                      "code": "id",
+                      "value": "157897"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "158998"
+                    },
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157897"
+                    },
+                    {
+                      "code": "min",
+                      "value": "0"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235217199",
+              "descriptor": {
+                "name": "Small",
+                "symbol": "",
+                "short_desc": "Small",
+                "long_desc": "Small",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "149.0",
+                "maximum_value": "149.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235217287",
+              "descriptor": {
+                "name": "Chicken Drumstick Spicy",
+                "symbol": "",
+                "short_desc": "Chicken fillet in a bun  with coleslaw,lettuce, pickles and our  spicy cocktail sauce. This sandwich is made with care to make sure that each and every bite is packed with Mmmm",
+                "long_desc": "Chicken fillet in a bun  with coleslaw,lettuce, pickles and our  spicy cocktail sauce. This sandwich is made with care to make sure that each and every bite is packed with Mmmm",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "143.6",
+                "maximum_value": "359.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [
+                "1125:1"
+              ],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "custom_group",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157914"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157914"
+                    },
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235222935",
+              "descriptor": {
+                "name": "Small",
+                "symbol": "",
+                "short_desc": "Small",
+                "long_desc": "Small",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "0.0",
+                "maximum_value": "0.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "159152"
+                    },
+                    {
+                      "code": "default",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "child",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157897"
+                    }
+                  ]
+                },
+                {
+                  "code": "child",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157897"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235193781",
+              "descriptor": {
+                "name": "Shrimp Sandwich",
+                "symbol": "",
+                "short_desc": "Shrimp Sandwich",
+                "long_desc": "Shrimp Sandwich",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "91.6",
+                "maximum_value": "229.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [
+                "1122:1"
+              ],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235193787",
+              "descriptor": {
+                "name": "Fish Fillet Sandwich",
+                "symbol": "",
+                "short_desc": "Fish Fillet Sandwich",
+                "long_desc": "Fish Fillet Sandwich",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "83.6",
+                "maximum_value": "209.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [
+                "1122:1"
+              ],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235193776",
+              "descriptor": {
+                "name": "Double Baik",
+                "symbol": "",
+                "short_desc": "2 Pcs of Chicken fillet steak & cheese stacked in a bun with  pickles , lettuce ,our special sauce and some frie. Two of Albaik International's juicy chicken fillets topped with double the cheesy goodness and our signature cocktail sauce & garlic sauce  in our new unique bread. Experience an Mmmm with every bite",
+                "long_desc": "2 Pcs of Chicken fillet steak & cheese stacked in a bun with  pickles , lettuce ,our special sauce and some frie. Two of Albaik International's juicy chicken fillets topped with double the cheesy goodness and our signature cocktail sauce & garlic sauce  in our new unique bread. Experience an Mmmm with every bite",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "103.6",
+                "maximum_value": "259.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [
+                "1125:1"
+              ],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235193879",
+              "descriptor": {
+                "name": "Demo Brown Bag",
+                "symbol": "",
+                "short_desc": "Demo Brown Bag",
+                "long_desc": "Demo Brown Bag",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "0.4",
+                "maximum_value": "1.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [
+                "1120:1"
+              ],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235217286",
+              "descriptor": {
+                "name": "Value Shrimp Meal",
+                "symbol": "",
+                "short_desc": "Value Shrimp Meal",
+                "long_desc": "Value Shrimp Meal",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "159.6",
+                "maximum_value": "399.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [
+                "1122:1"
+              ],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "custom_group",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157912"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157912"
+                    },
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235193270",
+              "descriptor": {
+                "name": "Small",
+                "symbol": "",
+                "short_desc": "Small",
+                "long_desc": "Small",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "0.0",
+                "maximum_value": "0.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157904"
+                    },
+                    {
+                      "code": "default",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235193238",
+              "descriptor": {
+                "name": "8 Pieces",
+                "symbol": "",
+                "short_desc": "8 Pieces",
+                "long_desc": "8 Pieces",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "0.0",
+                "maximum_value": "0.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157918"
+                    },
+                    {
+                      "code": "default",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235223255",
+              "descriptor": {
+                "name": "Extra Ghatta Curry",
+                "symbol": "",
+                "short_desc": "Extra Ghatta Curry",
+                "long_desc": "Extra Ghatta Curry",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "32.0",
+                "maximum_value": "80.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "159209"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235193839",
+              "descriptor": {
+                "name": "Icecream With Strawberry Syrup",
+                "symbol": "",
+                "short_desc": "demo 3 demo demo 3 demo 3 demo",
+                "long_desc": "demo 3 demo demo 3 demo 3 demo",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "11.6",
+                "maximum_value": "29.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [
+                "1119:1"
+              ],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "custom_group",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157893"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157893"
+                    },
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235193287",
+              "descriptor": {
+                "name": "Large",
+                "symbol": "",
+                "short_desc": "Large",
+                "long_desc": "Large",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "8.0",
+                "maximum_value": "20.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157904"
+                    },
+                    {
+                      "code": "default",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235188639",
+              "descriptor": {
+                "name": "Thumps Up",
+                "symbol": "",
+                "short_desc": "Thumps Up",
+                "long_desc": "Thumps Up",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "12.0",
+                "maximum_value": "30.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157895"
+                    },
+                    {
+                      "code": "default",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235188640",
+              "descriptor": {
+                "name": "Fanta",
+                "symbol": "",
+                "short_desc": "Fanta",
+                "long_desc": "Fanta",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "16.0",
+                "maximum_value": "40.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157895"
+                    },
+                    {
+                      "code": "default",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235188624",
+              "descriptor": {
+                "name": "Add Ginger Soup",
+                "symbol": "",
+                "short_desc": "Add Ginger Soup",
+                "long_desc": "Add Ginger Soup",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "4.0",
+                "maximum_value": "10.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157898"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235217313",
+              "descriptor": {
+                "name": "Chicken Kaleji Fry",
+                "symbol": "",
+                "short_desc": "Chicken Kaleji Fry",
+                "long_desc": "Chicken Kaleji Fry",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "20.0",
+                "maximum_value": "50.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [
+                "1126:8"
+              ],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "non_veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "custom_group",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157927"
+                    },
+                    {
+                      "code": "id",
+                      "value": "157896"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157927"
+                    },
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157896"
+                    },
+                    {
+                      "code": "min",
+                      "value": "0"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235193281",
+              "descriptor": {
+                "name": "Large",
+                "symbol": "",
+                "short_desc": "Large",
+                "long_desc": "Large",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "8.0",
+                "maximum_value": "20.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157907"
+                    },
+                    {
+                      "code": "default",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235193321",
+              "descriptor": {
+                "name": "Small",
+                "symbol": "",
+                "short_desc": "Small",
+                "long_desc": "Small",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "0.0",
+                "maximum_value": "0.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157903"
+                    },
+                    {
+                      "code": "default",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235193834",
+              "descriptor": {
+                "name": "Nescafe Hazelnut",
+                "symbol": "",
+                "short_desc": "Nescafe Hazelnut",
+                "long_desc": "Nescafe Hazelnut",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "13.3",
+                "maximum_value": "33.25"
+              },
+              "category_id": "F&B",
+              "category_ids": [
+                "1123:1"
+              ],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235217330",
+              "descriptor": {
+                "name": "10 Pieces",
+                "symbol": "",
+                "short_desc": "10 Pieces",
+                "long_desc": "10 Pieces",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "0.0",
+                "maximum_value": "0.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "non_veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "159022"
+                    },
+                    {
+                      "code": "default",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "child",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157896"
+                    }
+                  ]
+                },
+                {
+                  "code": "child",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157896"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235217314",
+              "descriptor": {
+                "name": "Chicken Thali",
+                "symbol": "",
+                "short_desc": "Chicken Thali",
+                "long_desc": "Chicken Thali",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "40.0",
+                "maximum_value": "100.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [
+                "1126:7"
+              ],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "non_veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "custom_group",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157926"
+                    },
+                    {
+                      "code": "id",
+                      "value": "157896"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157926"
+                    },
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157896"
+                    },
+                    {
+                      "code": "min",
+                      "value": "0"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235193250",
+              "descriptor": {
+                "name": "10 Pieces",
+                "symbol": "",
+                "short_desc": "10 Pieces",
+                "long_desc": "10 Pieces",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "24.0",
+                "maximum_value": "60.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157918"
+                    },
+                    {
+                      "code": "default",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235217283",
+              "descriptor": {
+                "name": "Shrimp Meal",
+                "symbol": "",
+                "short_desc": "Shrimp Meal",
+                "long_desc": "Shrimp Meal",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "167.6",
+                "maximum_value": "419.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [
+                "1122:1"
+              ],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "custom_group",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157913"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157913"
+                    },
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235193780",
+              "descriptor": {
+                "name": "Fish Fillet Sandwich Combo",
+                "symbol": "",
+                "short_desc": "Fish Fillet Sandwich Combo",
+                "long_desc": "Fish Fillet Sandwich Combo",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "119.6",
+                "maximum_value": "299.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [
+                "1122:1"
+              ],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "custom_group",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157893"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157893"
+                    },
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235217292",
+              "descriptor": {
+                "name": "Spicy Value Shrimp Meal",
+                "symbol": "",
+                "short_desc": "Spicy Value Shrimp Meal",
+                "long_desc": "Spicy Value Shrimp Meal",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "159.6",
+                "maximum_value": "399.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [
+                "1122:1"
+              ],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "custom_group",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157917"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157917"
+                    },
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235217196",
+              "descriptor": {
+                "name": "Chicken",
+                "symbol": "",
+                "short_desc": "Chicken",
+                "long_desc": "Chicken",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "100.0",
+                "maximum_value": "100.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "non_veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235193340",
+              "descriptor": {
+                "name": "3 Pieces",
+                "symbol": "",
+                "short_desc": "3 Pieces",
+                "long_desc": "3 Pieces",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "0.0",
+                "maximum_value": "0.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157909"
+                    },
+                    {
+                      "code": "default",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235222980",
+              "descriptor": {
+                "name": "Paytm Special Dish",
+                "symbol": "",
+                "short_desc": "Paytm Special Dish",
+                "long_desc": "Paytm Special Dish",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "80.0",
+                "maximum_value": "200.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [
+                "1121:1"
+              ],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "custom_group",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "159152"
+                    },
+                    {
+                      "code": "id",
+                      "value": "157892"
+                    },
+                    {
+                      "code": "id",
+                      "value": "157897"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "159152"
+                    },
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157892"
+                    },
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157897"
+                    },
+                    {
+                      "code": "min",
+                      "value": "0"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235188645",
+              "descriptor": {
+                "name": "Add Lemon",
+                "symbol": "",
+                "short_desc": "Add Lemon",
+                "long_desc": "Add Lemon",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "4.0",
+                "maximum_value": "10.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157896"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235217192",
+              "descriptor": {
+                "name": "3 Pieces",
+                "symbol": "",
+                "short_desc": "3 Pieces",
+                "long_desc": "3 Pieces",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "269.0",
+                "maximum_value": "269.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235193264",
+              "descriptor": {
+                "name": "Large",
+                "symbol": "",
+                "short_desc": "Large",
+                "long_desc": "Large",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "2.0",
+                "maximum_value": "5.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157908"
+                    },
+                    {
+                      "code": "default",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "child",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157895"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235193880",
+              "descriptor": {
+                "name": "Promotion Ice",
+                "symbol": "",
+                "short_desc": "demo 1 demo1 demo 1",
+                "long_desc": "demo 1 demo1 demo 1",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "0.38",
+                "maximum_value": "0.95"
+              },
+              "category_id": "F&B",
+              "category_ids": [
+                "1119:1"
+              ],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "custom_group",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157893"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157893"
+                    },
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235188632",
+              "descriptor": {
+                "name": "Add Chutny",
+                "symbol": "",
+                "short_desc": "Add Chutny",
+                "long_desc": "Add Chutny",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "2.0",
+                "maximum_value": "5.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157899"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235188633",
+              "descriptor": {
+                "name": "Pomegranate",
+                "symbol": "",
+                "short_desc": "Pomegranate",
+                "long_desc": "Pomegranate",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "0.0",
+                "maximum_value": "0.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157894"
+                    },
+                    {
+                      "code": "default",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235193865",
+              "descriptor": {
+                "name": "Spicy Cocktail Sauce",
+                "symbol": "",
+                "short_desc": "Spicy Cocktail Sauce",
+                "long_desc": "Spicy Cocktail Sauce",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "7.6",
+                "maximum_value": "19.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [
+                "1121:1"
+              ],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235217193",
+              "descriptor": {
+                "name": "6 Pieces",
+                "symbol": "",
+                "short_desc": "6 Pieces",
+                "long_desc": "6 Pieces",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "499.0",
+                "maximum_value": "499.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235222977",
+              "descriptor": {
+                "name": "Premium Ultra Pro Max",
+                "symbol": "",
+                "short_desc": "Premium Ultra Pro Max",
+                "long_desc": "Premium Ultra Pro Max",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "40.0",
+                "maximum_value": "100.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "159171"
+                    },
+                    {
+                      "code": "default",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235217306",
+              "descriptor": {
+                "name": "Chicken",
+                "symbol": "",
+                "short_desc": "Chicken",
+                "long_desc": "Chicken",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "20.0",
+                "maximum_value": "50.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [
+                "1125:1"
+              ],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "non_veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "custom_group",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157921"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157921"
+                    },
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235217299",
+              "descriptor": {
+                "name": "Flat White",
+                "symbol": "",
+                "short_desc": "Flat White",
+                "long_desc": "Flat White",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "59.6",
+                "maximum_value": "149.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [
+                "1121:1"
+              ],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "custom_group",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157901"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157901"
+                    },
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235188643",
+              "descriptor": {
+                "name": "Add Tamato",
+                "symbol": "",
+                "short_desc": "Add Tamato",
+                "long_desc": "Add Tamato",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "4.0",
+                "maximum_value": "10.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157896"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235188619",
+              "descriptor": {
+                "name": "Add Green Chutny",
+                "symbol": "",
+                "short_desc": "Add Green Chutny",
+                "long_desc": "Add Green Chutny",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "2.0",
+                "maximum_value": "5.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157897"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235217195",
+              "descriptor": {
+                "name": "Large",
+                "symbol": "",
+                "short_desc": "Large",
+                "long_desc": "Large",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "169.0",
+                "maximum_value": "169.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235217188",
+              "descriptor": {
+                "name": "8 Pieces",
+                "symbol": "",
+                "short_desc": "8 Pieces",
+                "long_desc": "8 Pieces",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "349.0",
+                "maximum_value": "349.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235217324",
+              "descriptor": {
+                "name": "SatyaPizzaNew11",
+                "symbol": "",
+                "short_desc": "TestPizzaNew",
+                "long_desc": "TestPizzaNew",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "220.4",
+                "maximum_value": "551.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [
+                "1126:1"
+              ],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "non_veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "custom_group",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "159019"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "159019"
+                    },
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235217300",
+              "descriptor": {
+                "name": "Hot Chocolate",
+                "symbol": "",
+                "short_desc": "Hot Chocolate",
+                "long_desc": "Hot Chocolate",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "59.6",
+                "maximum_value": "149.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [
+                "1124:1"
+              ],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "custom_group",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157905"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157905"
+                    },
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235188629",
+              "descriptor": {
+                "name": "Apple",
+                "symbol": "",
+                "short_desc": "Apple",
+                "long_desc": "Apple",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "0.0",
+                "maximum_value": "0.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157894"
+                    },
+                    {
+                      "code": "default",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235217293",
+              "descriptor": {
+                "name": "Spicy Shrimp Meal",
+                "symbol": "",
+                "short_desc": "Spicy Shrimp Meal",
+                "long_desc": "Spicy Shrimp Meal",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "167.6",
+                "maximum_value": "419.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [
+                "1122:1"
+              ],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "custom_group",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157918"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157918"
+                    },
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235193286",
+              "descriptor": {
+                "name": "Small",
+                "symbol": "",
+                "short_desc": "Small",
+                "long_desc": "Small",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "0.0",
+                "maximum_value": "0.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157916"
+                    },
+                    {
+                      "code": "default",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235217285",
+              "descriptor": {
+                "name": "Fish Fillet Meal",
+                "symbol": "",
+                "short_desc": "Fish Fillet Meal",
+                "long_desc": "Fish Fillet Meal",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "119.6",
+                "maximum_value": "299.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [
+                "1122:1"
+              ],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "custom_group",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157911"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157911"
+                    },
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235193357",
+              "descriptor": {
+                "name": "6 Pieces",
+                "symbol": "",
+                "short_desc": "6 Pieces",
+                "long_desc": "6 Pieces",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "136.0",
+                "maximum_value": "340.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157909"
+                    },
+                    {
+                      "code": "default",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235193838",
+              "descriptor": {
+                "name": "Diet Pepsi",
+                "symbol": "",
+                "short_desc": "Diet Pepsi",
+                "long_desc": "Diet Pepsi",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "11.4",
+                "maximum_value": "28.5"
+              },
+              "category_id": "F&B",
+              "category_ids": [
+                "1123:1"
+              ],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235223254",
+              "descriptor": {
+                "name": "Lehsun Chutney",
+                "symbol": "",
+                "short_desc": "Lehsun Chutney",
+                "long_desc": "Lehsun Chutney",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "8.0",
+                "maximum_value": "20.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "159209"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235188646",
+              "descriptor": {
+                "name": "Provide Salad Extra",
+                "symbol": "",
+                "short_desc": "Provide Salad Extra",
+                "long_desc": "Provide Salad Extra",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "8.0",
+                "maximum_value": "20.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157896"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235193830",
+              "descriptor": {
+                "name": "Thumsup",
+                "symbol": "",
+                "short_desc": "Thumsup",
+                "long_desc": "Thumsup",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "15.2",
+                "maximum_value": "38.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [
+                "1123:1"
+              ],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235223287",
+              "descriptor": {
+                "name": "2 Pieces",
+                "symbol": "",
+                "short_desc": "2 Pieces",
+                "long_desc": "2 Pieces",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "0.0",
+                "maximum_value": "0.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "non_veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "159221"
+                    },
+                    {
+                      "code": "default",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "child",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "159209"
+                    }
+                  ]
+                },
+                {
+                  "code": "child",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "159209"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235193773",
+              "descriptor": {
+                "name": "Double Chicken Burger Combo (?????? ????????)",
+                "symbol": "",
+                "short_desc": "Chicken fillet in a bun  with coleslaw,lettuce, pickles and our  spicy cocktail sauce. This sandwich is made with care to make sure that each and every bite is packed with Mmmm",
+                "long_desc": "Chicken fillet in a bun  with coleslaw,lettuce, pickles and our  spicy cocktail sauce. This sandwich is made with care to make sure that each and every bite is packed with Mmmm",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "175.6",
+                "maximum_value": "439.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [
+                "1125:1"
+              ],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235193782",
+              "descriptor": {
+                "name": "Spicy Shrimp Sandwich",
+                "symbol": "",
+                "short_desc": "Spicy Shrimp Sandwich",
+                "long_desc": "Spicy Shrimp Sandwich",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "91.6",
+                "maximum_value": "229.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [
+                "1122:1"
+              ],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235193786",
+              "descriptor": {
+                "name": "Big Baik Spicy Sandwich",
+                "symbol": "",
+                "short_desc": "Chicken fillet in a bun  with coleslaw,lettuce, pickles and our  spicy cocktail sauce. This sandwich is made with care to make sure that each and every bite is packed with Mmmm",
+                "long_desc": "Chicken fillet in a bun  with coleslaw,lettuce, pickles and our  spicy cocktail sauce. This sandwich is made with care to make sure that each and every bite is packed with Mmmm",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "83.6",
+                "maximum_value": "209.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [
+                "1125:1"
+              ],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235193777",
+              "descriptor": {
+                "name": "Chicken Fillet Nugget Snack",
+                "symbol": "",
+                "short_desc": "chicken fillet  nuggets come with a sauce of your choice (nugget/garlic sauce). Bite-sized pieces of tender all breast chicken fillets, marinated in our unique & signature blend, breaded and seasoned to perfection, then deep-fried until deliciously tender, crispy with a golden crust",
+                "long_desc": "chicken fillet  nuggets come with a sauce of your choice (nugget/garlic sauce). Bite-sized pieces of tender all breast chicken fillets, marinated in our unique & signature blend, breaded and seasoned to perfection, then deep-fried until deliciously tender, crispy with a golden crust",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "127.6",
+                "maximum_value": "319.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [
+                "1125:1"
+              ],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "custom_group",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157892"
+                    }
+                  ]
+                },
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "157892"
+                    },
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235193801",
+              "descriptor": {
+                "name": "Fries With Garlic Sauce",
+                "symbol": "",
+                "short_desc": "Golden crispy French fries served with Albaik International's signature garlic sauce",
+                "long_desc": "Golden crispy French fries served with Albaik International's signature garlic sauce",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "43.6",
+                "maximum_value": "109.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [
+                "1121:1"
+              ],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1235193775",
+              "descriptor": {
+                "name": "Fish Fillet Burger Combo",
+                "symbol": "",
+                "short_desc": "Fish Fillet Burger Combo",
+                "long_desc": "Fish Fillet Burger Combo",
+                "images": []
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "107.6",
+                "maximum_value": "269.0"
+              },
+              "category_id": "F&B",
+              "category_ids": [
+                "1122:1"
+              ],
+              "fulfillment_id": "F1",
+              "location_id": "1031222",
+              "@ondc/org/returnable": false,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "",
+              "@ondc/org/time_to_ship": "PT34M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "name of merchant,7125426621,oe-test@mail.com",
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "@ondc/org/fssai_license_no": "12345678987654",
+          "tags": [
+            {
+              "code": "timing",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "Delivery"
+                },
+                {
+                  "code": "location",
+                  "value": "1031222"
+                },
+                {
+                  "code": "day_from",
+                  "value": "3"
+                },
+                {
+                  "code": "day_to",
+                  "value": "3"
+                },
+                {
+                  "code": "time_from",
+                  "value": "0000"
+                },
+                {
+                  "code": "time_to",
+                  "value": "2355"
+                }
+              ]
+            },
+            {
+              "code": "timing",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "Delivery"
+                },
+                {
+                  "code": "location",
+                  "value": "1031222"
+                },
+                {
+                  "code": "day_from",
+                  "value": "5"
+                },
+                {
+                  "code": "day_to",
+                  "value": "5"
+                },
+                {
+                  "code": "time_from",
+                  "value": "0300"
+                },
+                {
+                  "code": "time_to",
+                  "value": "2359"
+                }
+              ]
+            },
+            {
+              "code": "timing",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "Delivery"
+                },
+                {
+                  "code": "location",
+                  "value": "1031222"
+                },
+                {
+                  "code": "day_from",
+                  "value": "7"
+                },
+                {
+                  "code": "day_to",
+                  "value": "7"
+                },
+                {
+                  "code": "time_from",
+                  "value": "0300"
+                },
+                {
+                  "code": "time_to",
+                  "value": "2315"
+                }
+              ]
+            },
+            {
+              "code": "timing",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "Delivery"
+                },
+                {
+                  "code": "location",
+                  "value": "1031222"
+                },
+                {
+                  "code": "day_from",
+                  "value": "6"
+                },
+                {
+                  "code": "day_to",
+                  "value": "6"
+                },
+                {
+                  "code": "time_from",
+                  "value": "0000"
+                },
+                {
+                  "code": "time_to",
+                  "value": "2359"
+                }
+              ]
+            },
+            {
+              "code": "timing",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "Delivery"
+                },
+                {
+                  "code": "location",
+                  "value": "1031222"
+                },
+                {
+                  "code": "day_from",
+                  "value": "2"
+                },
+                {
+                  "code": "day_to",
+                  "value": "2"
+                },
+                {
+                  "code": "time_from",
+                  "value": "0300"
+                },
+                {
+                  "code": "time_to",
+                  "value": "2355"
+                }
+              ]
+            },
+            {
+              "code": "timing",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "Delivery"
+                },
+                {
+                  "code": "location",
+                  "value": "1031222"
+                },
+                {
+                  "code": "day_from",
+                  "value": "4"
+                },
+                {
+                  "code": "day_to",
+                  "value": "4"
+                },
+                {
+                  "code": "time_from",
+                  "value": "0300"
+                },
+                {
+                  "code": "time_to",
+                  "value": "2355"
+                }
+              ]
+            },
+            {
+              "code": "timing",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "Delivery"
+                },
+                {
+                  "code": "location",
+                  "value": "1031222"
+                },
+                {
+                  "code": "day_from",
+                  "value": "5"
+                },
+                {
+                  "code": "day_to",
+                  "value": "5"
+                },
+                {
+                  "code": "time_from",
+                  "value": "0200"
+                },
+                {
+                  "code": "time_to",
+                  "value": "2330"
+                }
+              ]
+            },
+            {
+              "code": "timing",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "Delivery"
+                },
+                {
+                  "code": "location",
+                  "value": "1031222"
+                },
+                {
+                  "code": "day_from",
+                  "value": "1"
+                },
+                {
+                  "code": "day_to",
+                  "value": "1"
+                },
+                {
+                  "code": "time_from",
+                  "value": "0900"
+                },
+                {
+                  "code": "time_to",
+                  "value": "2355"
+                }
+              ]
+            },
+            {
+              "code": "serviceability",
+              "list": [
+                {
+                  "code": "location",
+                  "value": "1031222"
+                },
+                {
+                  "code": "category",
+                  "value": "F&B"
+                },
+                {
+                  "code": "type",
+                  "value": "10"
+                },
+                {
+                  "code": "val",
+                  "value": "5000"
+                },
+                {
+                  "code": "unit",
+                  "value": "meter"
+                }
+              ]
+            }
+          ],
+          "locations": [
+            {
+              "id": "1031222",
+              "gps": "28.488251,77.086563",
+              "address": {
+                "street": "898 Carver Park",
+                "city": "Pearson",
+                "state": "Uttar Pradesh",
+                "area_code": "110001",
+                "locality": "Carver Park"
+              },
+              "time": {
+                "label": "enable",
+                "timestamp": "2023-10-16T04:24:07.000Z",
+                "schedule": {
+                  "holidays": []
+                }
+              }
+            }
+          ],
+          "categories": [
+            {
+              "id": "1118",
+              "parent_category_id": "",
+              "descriptor": {
+                "name": "Pcat1",
+                "short_desc": "Pcat1",
+                "long_desc": "Pcat1",
+                "images": []
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "custom_menu"
+                    }
+                  ]
+                },
+                {
+                  "code": "display",
+                  "list": [
+                    {
+                      "code": "rank",
+                      "value": "1"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1119",
+              "parent_category_id": "1118",
+              "descriptor": {
+                "name": "Desserts",
+                "short_desc": "Desserts",
+                "long_desc": "Desserts",
+                "images": []
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "custom_menu"
+                    }
+                  ]
+                },
+                {
+                  "code": "display",
+                  "list": [
+                    {
+                      "code": "rank",
+                      "value": "5"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1120",
+              "parent_category_id": "1118",
+              "descriptor": {
+                "name": "Add Ons",
+                "short_desc": "Add Ons",
+                "long_desc": "Add Ons",
+                "images": []
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "custom_menu"
+                    }
+                  ]
+                },
+                {
+                  "code": "display",
+                  "list": [
+                    {
+                      "code": "rank",
+                      "value": "2"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1121",
+              "parent_category_id": "",
+              "descriptor": {
+                "name": "Side Orders",
+                "short_desc": "Side Orders",
+                "long_desc": "Side Orders",
+                "images": []
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "custom_menu"
+                    }
+                  ]
+                },
+                {
+                  "code": "display",
+                  "list": [
+                    {
+                      "code": "rank",
+                      "value": "8"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1122",
+              "parent_category_id": "",
+              "descriptor": {
+                "name": "Seafood Meal",
+                "short_desc": "Seafood Meal",
+                "long_desc": "Seafood Meal",
+                "images": []
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "custom_menu"
+                    }
+                  ]
+                },
+                {
+                  "code": "display",
+                  "list": [
+                    {
+                      "code": "rank",
+                      "value": "7"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1123",
+              "parent_category_id": "",
+              "descriptor": {
+                "name": "Beverages",
+                "short_desc": "Beverages",
+                "long_desc": "Beverages",
+                "images": []
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "custom_menu"
+                    }
+                  ]
+                },
+                {
+                  "code": "display",
+                  "list": [
+                    {
+                      "code": "rank",
+                      "value": "6"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1124",
+              "parent_category_id": "",
+              "descriptor": {
+                "name": "Hot Coffees",
+                "short_desc": "Hot Coffees",
+                "long_desc": "Hot Coffees",
+                "images": []
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "custom_menu"
+                    }
+                  ]
+                },
+                {
+                  "code": "display",
+                  "list": [
+                    {
+                      "code": "rank",
+                      "value": "4"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1125",
+              "parent_category_id": "",
+              "descriptor": {
+                "name": "Chicken Meal",
+                "short_desc": "Chicken Meal",
+                "long_desc": "Chicken Meal",
+                "images": []
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "custom_menu"
+                    }
+                  ]
+                },
+                {
+                  "code": "display",
+                  "list": [
+                    {
+                      "code": "rank",
+                      "value": "3"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "1126",
+              "parent_category_id": "",
+              "descriptor": {
+                "name": "Chicken",
+                "short_desc": "Chicken",
+                "long_desc": "Chicken",
+                "images": []
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "custom_menu"
+                    }
+                  ]
+                },
+                {
+                  "code": "display",
+                  "list": [
+                    {
+                      "code": "rank",
+                      "value": "1"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "157892",
+              "descriptor": {
+                "name": "Choice Of Sauce"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "custom_group"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    },
+                    {
+                      "code": "input",
+                      "value": "select"
+                    },
+                    {
+                      "code": "seq",
+                      "value": "1"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "157893",
+              "descriptor": {
+                "name": "Choice Of Soft Drink"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "custom_group"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    },
+                    {
+                      "code": "input",
+                      "value": "select"
+                    },
+                    {
+                      "code": "seq",
+                      "value": "3"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "157894",
+              "descriptor": {
+                "name": "Choice Of Juice"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "custom_group"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    },
+                    {
+                      "code": "input",
+                      "value": "select"
+                    },
+                    {
+                      "code": "seq",
+                      "value": "4"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "157895",
+              "descriptor": {
+                "name": "Soft Drinks"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "custom_group"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    },
+                    {
+                      "code": "input",
+                      "value": "select"
+                    },
+                    {
+                      "code": "seq",
+                      "value": "5"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "157896",
+              "descriptor": {
+                "name": "Chicken"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "custom_group"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "min",
+                      "value": "0"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    },
+                    {
+                      "code": "input",
+                      "value": "select"
+                    },
+                    {
+                      "code": "seq",
+                      "value": "6"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "157897",
+              "descriptor": {
+                "name": "Salad"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "custom_group"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "min",
+                      "value": "0"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    },
+                    {
+                      "code": "input",
+                      "value": "select"
+                    },
+                    {
+                      "code": "seq",
+                      "value": "7"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "157898",
+              "descriptor": {
+                "name": "Alcoholic Drink"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "custom_group"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "min",
+                      "value": "0"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    },
+                    {
+                      "code": "input",
+                      "value": "select"
+                    },
+                    {
+                      "code": "seq",
+                      "value": "8"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "157899",
+              "descriptor": {
+                "name": "Soya Beans Items"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "custom_group"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "min",
+                      "value": "0"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    },
+                    {
+                      "code": "input",
+                      "value": "select"
+                    },
+                    {
+                      "code": "seq",
+                      "value": "9"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "157900",
+              "descriptor": {
+                "name": "Quantity"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "custom_group"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    },
+                    {
+                      "code": "input",
+                      "value": "select"
+                    },
+                    {
+                      "code": "seq",
+                      "value": "1"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "157901",
+              "descriptor": {
+                "name": "Portion"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "custom_group"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    },
+                    {
+                      "code": "input",
+                      "value": "select"
+                    },
+                    {
+                      "code": "seq",
+                      "value": "1"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "157902",
+              "descriptor": {
+                "name": "Portion"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "custom_group"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    },
+                    {
+                      "code": "input",
+                      "value": "select"
+                    },
+                    {
+                      "code": "seq",
+                      "value": "1"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "157903",
+              "descriptor": {
+                "name": "Portion"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "custom_group"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    },
+                    {
+                      "code": "input",
+                      "value": "select"
+                    },
+                    {
+                      "code": "seq",
+                      "value": "1"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "157904",
+              "descriptor": {
+                "name": "Portion"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "custom_group"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    },
+                    {
+                      "code": "input",
+                      "value": "select"
+                    },
+                    {
+                      "code": "seq",
+                      "value": "1"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "157905",
+              "descriptor": {
+                "name": "Portion"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "custom_group"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    },
+                    {
+                      "code": "input",
+                      "value": "select"
+                    },
+                    {
+                      "code": "seq",
+                      "value": "1"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "157906",
+              "descriptor": {
+                "name": "Quantity"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "custom_group"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    },
+                    {
+                      "code": "input",
+                      "value": "select"
+                    },
+                    {
+                      "code": "seq",
+                      "value": "1"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "157907",
+              "descriptor": {
+                "name": "Portion"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "custom_group"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    },
+                    {
+                      "code": "input",
+                      "value": "select"
+                    },
+                    {
+                      "code": "seq",
+                      "value": "1"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "157908",
+              "descriptor": {
+                "name": "Portion"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "custom_group"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    },
+                    {
+                      "code": "input",
+                      "value": "select"
+                    },
+                    {
+                      "code": "seq",
+                      "value": "1"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "157909",
+              "descriptor": {
+                "name": "Quantity"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "custom_group"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    },
+                    {
+                      "code": "input",
+                      "value": "select"
+                    },
+                    {
+                      "code": "seq",
+                      "value": "1"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "157910",
+              "descriptor": {
+                "name": "Quantity"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "custom_group"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    },
+                    {
+                      "code": "input",
+                      "value": "select"
+                    },
+                    {
+                      "code": "seq",
+                      "value": "1"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "157911",
+              "descriptor": {
+                "name": "Quantity"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "custom_group"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    },
+                    {
+                      "code": "input",
+                      "value": "select"
+                    },
+                    {
+                      "code": "seq",
+                      "value": "1"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "157912",
+              "descriptor": {
+                "name": "Quantity"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "custom_group"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    },
+                    {
+                      "code": "input",
+                      "value": "select"
+                    },
+                    {
+                      "code": "seq",
+                      "value": "1"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "157913",
+              "descriptor": {
+                "name": "Quantity"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "custom_group"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    },
+                    {
+                      "code": "input",
+                      "value": "select"
+                    },
+                    {
+                      "code": "seq",
+                      "value": "1"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "157914",
+              "descriptor": {
+                "name": "Quantity"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "custom_group"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    },
+                    {
+                      "code": "input",
+                      "value": "select"
+                    },
+                    {
+                      "code": "seq",
+                      "value": "1"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "157915",
+              "descriptor": {
+                "name": "Quantity"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "custom_group"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    },
+                    {
+                      "code": "input",
+                      "value": "select"
+                    },
+                    {
+                      "code": "seq",
+                      "value": "1"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "157916",
+              "descriptor": {
+                "name": "Portion"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "custom_group"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    },
+                    {
+                      "code": "input",
+                      "value": "select"
+                    },
+                    {
+                      "code": "seq",
+                      "value": "1"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "157917",
+              "descriptor": {
+                "name": "Quantity"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "custom_group"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    },
+                    {
+                      "code": "input",
+                      "value": "select"
+                    },
+                    {
+                      "code": "seq",
+                      "value": "1"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "157918",
+              "descriptor": {
+                "name": "Quantity"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "custom_group"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    },
+                    {
+                      "code": "input",
+                      "value": "select"
+                    },
+                    {
+                      "code": "seq",
+                      "value": "1"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "157919",
+              "descriptor": {
+                "name": "Quantity"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "custom_group"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    },
+                    {
+                      "code": "input",
+                      "value": "select"
+                    },
+                    {
+                      "code": "seq",
+                      "value": "1"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "157920",
+              "descriptor": {
+                "name": "Quantity"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "custom_group"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    },
+                    {
+                      "code": "input",
+                      "value": "select"
+                    },
+                    {
+                      "code": "seq",
+                      "value": "1"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "157921",
+              "descriptor": {
+                "name": "Quantity"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "custom_group"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    },
+                    {
+                      "code": "input",
+                      "value": "select"
+                    },
+                    {
+                      "code": "seq",
+                      "value": "1"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "157922",
+              "descriptor": {
+                "name": "Quantity"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "custom_group"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    },
+                    {
+                      "code": "input",
+                      "value": "select"
+                    },
+                    {
+                      "code": "seq",
+                      "value": "1"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "157923",
+              "descriptor": {
+                "name": "Quantity"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "custom_group"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    },
+                    {
+                      "code": "input",
+                      "value": "select"
+                    },
+                    {
+                      "code": "seq",
+                      "value": "1"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "157924",
+              "descriptor": {
+                "name": "Size"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "custom_group"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    },
+                    {
+                      "code": "input",
+                      "value": "select"
+                    },
+                    {
+                      "code": "seq",
+                      "value": "3"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "157925",
+              "descriptor": {
+                "name": "Size"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "custom_group"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    },
+                    {
+                      "code": "input",
+                      "value": "select"
+                    },
+                    {
+                      "code": "seq",
+                      "value": "4"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "157926",
+              "descriptor": {
+                "name": "Size"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "custom_group"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    },
+                    {
+                      "code": "input",
+                      "value": "select"
+                    },
+                    {
+                      "code": "seq",
+                      "value": "7"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "157927",
+              "descriptor": {
+                "name": "Size"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "custom_group"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    },
+                    {
+                      "code": "input",
+                      "value": "select"
+                    },
+                    {
+                      "code": "seq",
+                      "value": "8"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "158259",
+              "descriptor": {
+                "name": "Quantity"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "custom_group"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    },
+                    {
+                      "code": "input",
+                      "value": "select"
+                    },
+                    {
+                      "code": "seq",
+                      "value": "1"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "158998",
+              "descriptor": {
+                "name": "Quantity"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "custom_group"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    },
+                    {
+                      "code": "input",
+                      "value": "select"
+                    },
+                    {
+                      "code": "seq",
+                      "value": "1"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "158999",
+              "descriptor": {
+                "name": "Quantity"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "custom_group"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    },
+                    {
+                      "code": "input",
+                      "value": "select"
+                    },
+                    {
+                      "code": "seq",
+                      "value": "1"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "159000",
+              "descriptor": {
+                "name": "Quantity"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "custom_group"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    },
+                    {
+                      "code": "input",
+                      "value": "select"
+                    },
+                    {
+                      "code": "seq",
+                      "value": "1"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "159001",
+              "descriptor": {
+                "name": "Quantity"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "custom_group"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    },
+                    {
+                      "code": "input",
+                      "value": "select"
+                    },
+                    {
+                      "code": "seq",
+                      "value": "1"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "159016",
+              "descriptor": {
+                "name": "Portion"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "custom_group"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    },
+                    {
+                      "code": "input",
+                      "value": "select"
+                    },
+                    {
+                      "code": "seq",
+                      "value": "1"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "159019",
+              "descriptor": {
+                "name": "Quantity"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "custom_group"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    },
+                    {
+                      "code": "input",
+                      "value": "select"
+                    },
+                    {
+                      "code": "seq",
+                      "value": "1"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "159022",
+              "descriptor": {
+                "name": "Quantity"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "custom_group"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    },
+                    {
+                      "code": "input",
+                      "value": "select"
+                    },
+                    {
+                      "code": "seq",
+                      "value": "1"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "159023",
+              "descriptor": {
+                "name": "Portion"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "custom_group"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    },
+                    {
+                      "code": "input",
+                      "value": "select"
+                    },
+                    {
+                      "code": "seq",
+                      "value": "1"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "159152",
+              "descriptor": {
+                "name": "Portion"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "custom_group"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    },
+                    {
+                      "code": "input",
+                      "value": "select"
+                    },
+                    {
+                      "code": "seq",
+                      "value": "1"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "159153",
+              "descriptor": {
+                "name": "Quantity"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "custom_group"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    },
+                    {
+                      "code": "input",
+                      "value": "select"
+                    },
+                    {
+                      "code": "seq",
+                      "value": "1"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "159164",
+              "descriptor": {
+                "name": "Quantity"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "custom_group"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    },
+                    {
+                      "code": "input",
+                      "value": "select"
+                    },
+                    {
+                      "code": "seq",
+                      "value": "1"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "159171",
+              "descriptor": {
+                "name": "Portion Size"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "custom_group"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    },
+                    {
+                      "code": "input",
+                      "value": "select"
+                    },
+                    {
+                      "code": "seq",
+                      "value": "1"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "159209",
+              "descriptor": {
+                "name": "Dal Baati Add On"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "custom_group"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "min",
+                      "value": "0"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    },
+                    {
+                      "code": "input",
+                      "value": "select"
+                    },
+                    {
+                      "code": "seq",
+                      "value": "10"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "159210",
+              "descriptor": {
+                "name": "Portion Size"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "custom_group"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    },
+                    {
+                      "code": "input",
+                      "value": "select"
+                    },
+                    {
+                      "code": "seq",
+                      "value": "1"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "159211",
+              "descriptor": {
+                "name": "Quantity"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "custom_group"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    },
+                    {
+                      "code": "input",
+                      "value": "select"
+                    },
+                    {
+                      "code": "seq",
+                      "value": "1"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "159219",
+              "descriptor": {
+                "name": "Quantity"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "custom_group"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    },
+                    {
+                      "code": "input",
+                      "value": "select"
+                    },
+                    {
+                      "code": "seq",
+                      "value": "1"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "159220",
+              "descriptor": {
+                "name": "Quantity"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "custom_group"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    },
+                    {
+                      "code": "input",
+                      "value": "select"
+                    },
+                    {
+                      "code": "seq",
+                      "value": "1"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "159221",
+              "descriptor": {
+                "name": "Quantity"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "custom_group"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    },
+                    {
+                      "code": "input",
+                      "value": "select"
+                    },
+                    {
+                      "code": "seq",
+                      "value": "1"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "167284",
+              "descriptor": {
+                "name": "Quantity"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "custom_group"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    },
+                    {
+                      "code": "input",
+                      "value": "select"
+                    },
+                    {
+                      "code": "seq",
+                      "value": "1"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
         }
+      ]
     }
+  }
 }


### PR DESCRIPTION
Incorporated feedback on below points: -
- tag code "non-veg" is not valid; should be "non_veg";
- contact_details_consumer_care is not consistent - check diff b/w item ids 1235193883, 1235193881;
- what does time_to_ship of PT0M mean - product is ready, packed & ready to ship?
- difficult to figure out which is base item / customization without tags.type being defined for each item;
- why is config being redefined for custom groups 157920 when there's no change in min/max/seq? (Commented on the issue)
- no data for item with base price of 0, either default selection price or range (lower/upper) should be defined so buyer app can show a price on the provider listing page; (Commented on the issue)