### PR TITLE
Chattybao - retail feedback changes

### DIFF
--- a/Chattybao/Logs_Jan_05/Retail/Flow 1/on_search_full_catalog.json
+++ b/Chattybao/Logs_Jan_05/Retail/Flow 1/on_search_full_catalog.json
@@ -1,0 +1,3222 @@
+{
+  "context": {
+    "domain": "ONDC:RET10",
+    "country": "IND",
+    "city": "std:0522",
+    "action": "on_search",
+    "core_version": "1.2.0",
+    "bap_id": "mappls.com",
+    "bap_uri": "https://mappls.com/store/ondc-preprod",
+    "transaction_id": "nfh8lgte55qpn5ol2ni8sv4i43073356",
+    "message_id": "48713dca54d570ca1cd8_1704440036",
+    "timestamp": "2024-01-05T07:33:56.562Z",
+    "ttl": "PT30S",
+    "bpp_id": "ondc-seller-preprod.chattybao.com/ondc",
+    "bpp_uri": "https://ondc-seller-preprod.chattybao.com/ondc/bpp"
+  },
+  "message": {
+    "catalog": {
+      "bpp/fulfillments": [
+        {
+          "id": "1",
+          "type": "Delivery"
+        }
+      ],
+      "bpp/descriptor": {
+        "name": "chattyBao",
+        "symbol": "https://chattybao.com/static/media/chattybao_logo.f1be2b203f63d9074817.png",
+        "short_desc": "ChattyBao Seller Marketplace",
+        "long_desc": "ChattyBao Seller Marketplace",
+        "images": [
+          "https://chattybao.com/static/media/chattybao_logo.f1be2b203f63d9074817.png"
+        ],
+        "tags": [
+          {
+            "code": "bpp_terms",
+            "list": [
+              {
+                "code": "np_type",
+                "value": "MSN"
+              }
+            ]
+          }
+        ]
+      },
+      "bpp/providers": [
+        {
+          "id": "MR8mcezPPQEA-r8EhP6UN9",
+          "time": {
+            "label": "enable",
+            "timestamp": "2024-01-05T07:33:56.432Z"
+          },
+          "fulfillments": [
+            {
+              "id": "1",
+              "type": "Delivery",
+              "contact": {
+                "phone": "8840019700",
+                "email": "help@chattybao.com"
+              }
+            }
+          ],
+          "descriptor": {
+            "name": "tester shatrughan grocery",
+            "symbol": "https://cdn.chattybao.com/shopoutside-temp_file_20230222_093036-0e1d5670-16a2-4a55-abcb-a25aa1711347.jpg",
+            "long_desc": "tester shatrughan grocery",
+            "short_desc": "tester shatrughan grocery",
+            "images": [
+              "https://cdn.chattybao.com/shopoutside-temp_file_20230222_093036-0e1d5670-16a2-4a55-abcb-a25aa1711347.jpg"
+            ]
+          },
+          "ttl": "P1D",
+          "locations": [
+            {
+              "id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042",
+              "gps": "26.854719,80.998035",
+              "time": {
+                "label": "enable",
+                "days": "1,2,3,4,5,6,7",
+                "timestamp": "2024-01-05T07:33:56.432Z",
+                "range": {
+                  "start": "0801",
+                  "end": "2200"
+                }
+              },
+              "address": {
+                "locality": "4/267, Vivek Khand 4",
+                "street": "Gomti Nagar",
+                "city": "Uttar Pradesh",
+                "area_code": "226010",
+                "state": "Lucknow"
+              },
+              "circle": {
+                "gps": "26.854719,80.998035",
+                "radius": {
+                  "unit": "km",
+                  "value": "5"
+                }
+              }
+            }
+          ],
+          "tags": [
+            {
+              "code": "order_value",
+              "list": [
+                {
+                  "code": "min_value",
+                  "value": "300.00"
+                }
+              ]
+            },
+            {
+              "code": "timing",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "Delivery"
+                },
+                {
+                  "code": "location",
+                  "value": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042"
+                },
+                {
+                  "code": "day_from",
+                  "value": "1"
+                },
+                {
+                  "code": "day_to",
+                  "value": "6"
+                },
+                {
+                  "code": "time_from",
+                  "value": "0801"
+                },
+                {
+                  "code": "time_to",
+                  "value": "2200"
+                }
+              ]
+            },
+            {
+              "code": "catalog_link",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "inline"
+                },
+                {
+                  "code": "type_value",
+                  "value": "https://s3.amazon.com/x-1234.zip"
+                },
+                {
+                  "code": "type_validity",
+                  "value": "PT24H"
+                },
+                {
+                  "code": "last_update",
+                  "value": "2023-05-21T00:00:00:000Z"
+                }
+              ]
+            },
+            {
+              "code": "serviceability",
+              "list": [
+                {
+                  "code": "location",
+                  "value": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042"
+                },
+                {
+                  "code": "category",
+                  "value": "Chocolates and Biscuits"
+                },
+                {
+                  "code": "type",
+                  "value": "10"
+                },
+                {
+                  "code": "val",
+                  "value": "5"
+                },
+                {
+                  "code": "unit",
+                  "value": "km"
+                }
+              ]
+            }
+          ],
+          "items": [
+            {
+              "id": "e54e3fc0-944c-11ee-848d-2d2b8538311e:MR8mcezPPQEA-r8EhP6UN9",
+              "time": {
+                "label": "enable",
+                "timestamp": "2024-01-05T07:33:56.432Z"
+              },
+              "descriptor": {
+                "name": "Ahaar Masoor Black Dal Premium 1 Kg",
+                "symbol": "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new//panelupload_1701874486278_Ahaar%20Masoor%20Black%20Dal%20Premium%201%20Kg_1.png",
+                "short_desc": "Ahaar Masoor Black Dal Premium 1 Kg",
+                "long_desc": "Ahaar Masoor Black Dal Premium 1 Kg",
+                "images": [
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new//panelupload_1701874486278_Ahaar%20Masoor%20Black%20Dal%20Premium%201%20Kg_1.png",
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new//panelupload_1701874486278_Ahaar%20Masoor%20Black%20Dal%20Premium%201%20Kg_2.png"
+                ],
+                "code": "1:8901524002148"
+              },
+              "quantity": {
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                },
+                "available": {
+                  "count": "0"
+                },
+                "maximum": {
+                  "count": "0"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "6500",
+                "maximum_value": "6500"
+              },
+              "category_id": "Atta, Flours and Sooji",
+              "location_id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042",
+              "fulfillment_id": "1",
+              "@ondc/org/returnable": true,
+              "@ondc/org/cancellable": true,
+              "@ondc/org/seller_pickup_return": false,
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/time_to_ship": "PT60M",
+              "@ondc/org/contact_details_consumer_care": "ChattyBao Help, help@chattybao.com,7353256777",
+              "@ondc/org/return_window": "P1D",
+              "matched": true,
+              "tags": [
+                {
+                  "code": "origin",
+                  "list": [
+                    {
+                      "code": "country",
+                      "value": "IND"
+                    }
+                  ]
+                },
+                {
+                  "code": "image",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "back_image"
+                    },
+                    {
+                      "code": "url",
+                      "value": "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new//panelupload_1701874486278_Ahaar%20Masoor%20Black%20Dal%20Premium%201%20Kg_2.png"
+                    }
+                  ]
+                },
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ],
+              "@ondc/org/statutory_reqs_packaged_commodities": {
+                "manufacturer_or_packer_name": "refer to back image",
+                "manufacturer_or_packer_address": "refer to back image",
+                "common_or_generic_name_of_commodity": "refer to back image",
+                "net_quantity_or_measure_of_commodity_in_pkg": "refer to back image",
+                "month_year_of_manufacture_packing_import": "refer to back image"
+              }
+            },
+            {
+              "id": "ded21392-1a41-11ee-8ddd-2bac5af1417f:MR8mcezPPQEA-r8EhP6UN9",
+              "time": {
+                "label": "enable",
+                "timestamp": "2024-01-05T07:33:56.432Z"
+              },
+              "descriptor": {
+                "name": "Aashirvaad Shudh Chakki Atta Whole Wheat 10 Kg",
+                "symbol": "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196846739_40127505_7-aashirvaad-shudh-chakki-atta.jpg",
+                "short_desc": "Aashirvaad Shudh Chakki Atta Whole Wheat 10 Kg",
+                "long_desc": "Aashirvaad Shudh Chakki Atta Whole Wheat 10 Kg",
+                "images": [
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196846739_40127505_7-aashirvaad-shudh-chakki-atta.jpg",
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196846964_40127505-3_8-aashirvaad-shudh-chakki-atta.jpg",
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196847065_40127506-9_2-aashirvaad-shudh-chakki-atta.jpg",
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196846983_aashirvaad-whole-wheat-atta-10-kg-legal-images-o490000041-p490000041-4-202207051337.jpg",
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196847015_40127506-4_8-aashirvaad-shudh-chakki-atta.jpg"
+                ],
+                "code": "1:8901725008895"
+              },
+              "quantity": {
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                },
+                "available": {
+                  "count": "0"
+                },
+                "maximum": {
+                  "count": "0"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "35",
+                "maximum_value": "250"
+              },
+              "category_id": "Atta, Flours and Sooji",
+              "location_id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042",
+              "fulfillment_id": "1",
+              "@ondc/org/returnable": true,
+              "@ondc/org/cancellable": true,
+              "@ondc/org/seller_pickup_return": false,
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/time_to_ship": "PT60M",
+              "@ondc/org/contact_details_consumer_care": "ChattyBao Help, help@chattybao.com,7353256777",
+              "@ondc/org/return_window": "P1D",
+              "matched": true,
+              "tags": [
+                {
+                  "code": "origin",
+                  "list": [
+                    {
+                      "code": "country",
+                      "value": "IND"
+                    }
+                  ]
+                },
+                {
+                  "code": "image",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "back_image"
+                    },
+                    {
+                      "code": "url",
+                      "value": "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196846964_40127505-3_8-aashirvaad-shudh-chakki-atta.jpg"
+                    }
+                  ]
+                },
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ],
+              "@ondc/org/statutory_reqs_packaged_commodities": {
+                "manufacturer_or_packer_name": "refer to back image",
+                "manufacturer_or_packer_address": "refer to back image",
+                "common_or_generic_name_of_commodity": "refer to back image",
+                "net_quantity_or_measure_of_commodity_in_pkg": "refer to back image",
+                "month_year_of_manufacture_packing_import": "refer to back image"
+              }
+            },
+            {
+              "id": "e31c8e80-1a41-11ee-8ddd-2bac5af1417f:MR8mcezPPQEA-r8EhP6UN9",
+              "time": {
+                "label": "enable",
+                "timestamp": "2024-01-05T07:33:56.432Z"
+              },
+              "descriptor": {
+                "name": "Anik Ghee Carton 1 L",
+                "symbol": "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196915259_ensure000371.jpg",
+                "short_desc": "Anik Ghee Carton 1 L",
+                "long_desc": "Anik Ghee Carton 1 L",
+                "images": [
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196915259_ensure000371.jpg",
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196914855_40053315-2_5-anik-ghee.jpg",
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196916779_1-ghee-1l-tetra-1-tetrapack-anik-original-imagk7yzhcf2k5hu.jpeg",
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196915339_1-ghee-1l-tetra-1-tetrapack-anik-original-imagk7yzjqzpqazf.jpeg"
+                ],
+                "code": "1:8906002091058"
+              },
+              "quantity": {
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                },
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "25000",
+                "maximum_value": "25000"
+              },
+              "category_id": "Oil & Ghee",
+              "location_id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042",
+              "fulfillment_id": "1",
+              "@ondc/org/returnable": true,
+              "@ondc/org/cancellable": true,
+              "@ondc/org/seller_pickup_return": false,
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/time_to_ship": "PT60M",
+              "@ondc/org/contact_details_consumer_care": "ChattyBao Help, help@chattybao.com,7353256777",
+              "@ondc/org/return_window": "P1D",
+              "matched": true,
+              "tags": [
+                {
+                  "code": "origin",
+                  "list": [
+                    {
+                      "code": "country",
+                      "value": "IND"
+                    }
+                  ]
+                },
+                {
+                  "code": "image",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "back_image"
+                    },
+                    {
+                      "code": "url",
+                      "value": "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196914855_40053315-2_5-anik-ghee.jpg"
+                    }
+                  ]
+                },
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ],
+              "@ondc/org/statutory_reqs_packaged_commodities": {
+                "manufacturer_or_packer_name": "refer to back image",
+                "manufacturer_or_packer_address": "refer to back image",
+                "common_or_generic_name_of_commodity": "refer to back image",
+                "net_quantity_or_measure_of_commodity_in_pkg": "refer to back image",
+                "month_year_of_manufacture_packing_import": "refer to back image"
+              }
+            },
+            {
+              "id": "4e5ffc10-944d-11ee-848d-2d2b8538311e:MR8mcezPPQEA-r8EhP6UN9",
+              "time": {
+                "label": "enable",
+                "timestamp": "2024-01-05T07:33:56.432Z"
+              },
+              "descriptor": {
+                "name": "Ahaar Malka Red Dal Premium 500 g",
+                "symbol": "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new//panelupload_1701874486278_Ahaar%20Malka%20Red%20Dal%20Premium%20500%20g_1.png",
+                "short_desc": "Ahaar Malka Red Dal Premium 500 g",
+                "long_desc": "Ahaar Malka Red Dal Premium 500 g",
+                "images": [
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new//panelupload_1701874486278_Ahaar%20Malka%20Red%20Dal%20Premium%20500%20g_1.png",
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new//panelupload_1701874486278_Ahaar%20Malka%20Red%20Dal%20Premium%20500%20g_2.png"
+                ],
+                "code": "1:8901524001899"
+              },
+              "quantity": {
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                },
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "1400",
+                "maximum_value": "1400"
+              },
+              "category_id": "Atta, Flours and Sooji",
+              "location_id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042",
+              "fulfillment_id": "1",
+              "@ondc/org/returnable": true,
+              "@ondc/org/cancellable": true,
+              "@ondc/org/seller_pickup_return": false,
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/time_to_ship": "PT60M",
+              "@ondc/org/contact_details_consumer_care": "ChattyBao Help, help@chattybao.com,7353256777",
+              "@ondc/org/return_window": "P1D",
+              "matched": true,
+              "tags": [
+                {
+                  "code": "origin",
+                  "list": [
+                    {
+                      "code": "country",
+                      "value": "IND"
+                    }
+                  ]
+                },
+                {
+                  "code": "image",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "back_image"
+                    },
+                    {
+                      "code": "url",
+                      "value": "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new//panelupload_1701874486278_Ahaar%20Malka%20Red%20Dal%20Premium%20500%20g_2.png"
+                    }
+                  ]
+                },
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ],
+              "@ondc/org/statutory_reqs_packaged_commodities": {
+                "manufacturer_or_packer_name": "refer to back image",
+                "manufacturer_or_packer_address": "refer to back image",
+                "common_or_generic_name_of_commodity": "refer to back image",
+                "net_quantity_or_measure_of_commodity_in_pkg": "refer to back image",
+                "month_year_of_manufacture_packing_import": "refer to back image"
+              }
+            },
+            {
+              "id": "2e4065c0-5dff-11ee-b94d-fbd52ac06897:MR8mcezPPQEA-r8EhP6UN9",
+              "time": {
+                "label": "enable",
+                "timestamp": "2024-01-05T07:33:56.432Z"
+              },
+              "descriptor": {
+                "name": "Britannia 50-50 Sweet & Salty Biscuits 62.8 g",
+                "symbol": "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695906099579_100012350_11-britannia-50-50-sweet-salty-biscuits.jpg",
+                "short_desc": "Britannia 50-50 Sweet & Salty Biscuits 62.8 g",
+                "long_desc": "Britannia 50-50 Sweet & Salty Biscuits 62.8 g",
+                "images": [
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695906099579_100012350_11-britannia-50-50-sweet-salty-biscuits.jpg",
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695906099532_100012350-3_6-britannia-50-50-sweet-salty-biscuits.jpg",
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695906099510_100012350-5_6-britannia-50-50-sweet-salty-biscuits.jpg",
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695906099747_100012350-6_4-britannia-50-50-sweet-salty-biscuits.jpg"
+                ],
+                "code": "1:8901063016873"
+              },
+              "quantity": {
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                },
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "2000",
+                "maximum_value": "2000"
+              },
+              "category_id": "Chocolates and Biscuits",
+              "location_id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042",
+              "fulfillment_id": "1",
+              "@ondc/org/returnable": true,
+              "@ondc/org/cancellable": true,
+              "@ondc/org/seller_pickup_return": false,
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/time_to_ship": "PT60M",
+              "@ondc/org/contact_details_consumer_care": "ChattyBao Help, help@chattybao.com,7353256777",
+              "@ondc/org/return_window": "P1D",
+              "matched": true,
+              "tags": [
+                {
+                  "code": "origin",
+                  "list": [
+                    {
+                      "code": "country",
+                      "value": "IND"
+                    }
+                  ]
+                },
+                {
+                  "code": "image",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "back_image"
+                    },
+                    {
+                      "code": "url",
+                      "value": "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695906099532_100012350-3_6-britannia-50-50-sweet-salty-biscuits.jpg"
+                    }
+                  ]
+                },
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ],
+              "@ondc/org/statutory_reqs_prepackaged_food": {
+                "nutritional_info": "refer to back image",
+                "additives_info": "refer to back image",
+                "brand_owner_FSSAI_license_no": "refer to back image",
+                "other_FSSAI_license_no": "refer to back image",
+                "importer_FSSAI_license_no": "refer to back image"
+              }
+            },
+            {
+              "id": "2f3fad50-5dff-11ee-b94d-fbd52ac06897:MR8mcezPPQEA-r8EhP6UN9",
+              "time": {
+                "label": "enable",
+                "timestamp": "2024-01-05T07:33:56.432Z"
+              },
+              "descriptor": {
+                "name": "Britannia 50-50 Maska Chaska Biscuit 105 g",
+                "symbol": "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695906099680_40025065_8-britannia-50-50-maska-chaska-salted-biscuits.jpg",
+                "short_desc": "Britannia 50-50 Maska Chaska Biscuit 105 g",
+                "long_desc": "Britannia 50-50 Maska Chaska Biscuit 105 g",
+                "images": [
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695906099680_40025065_8-britannia-50-50-maska-chaska-salted-biscuits.jpg",
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695906099658_40025065-3_5-britannia-50-50-maska-chaska-salted-biscuits.jpg",
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695906099652_40025065-5_5-britannia-50-50-maska-chaska-salted-biscuits.jpg",
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695906099710_40025065-6_1-britannia-50-50-maska-chaska-salted-biscuits.jpg"
+                ],
+                "code": "1:8901063017634"
+              },
+              "quantity": {
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                },
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "6000",
+                "maximum_value": "6000"
+              },
+              "category_id": "Chocolates and Biscuits",
+              "location_id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042",
+              "fulfillment_id": "1",
+              "@ondc/org/returnable": true,
+              "@ondc/org/cancellable": true,
+              "@ondc/org/seller_pickup_return": false,
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/time_to_ship": "PT60M",
+              "@ondc/org/contact_details_consumer_care": "ChattyBao Help, help@chattybao.com,7353256777",
+              "@ondc/org/return_window": "P1D",
+              "matched": true,
+              "tags": [
+                {
+                  "code": "origin",
+                  "list": [
+                    {
+                      "code": "country",
+                      "value": "IND"
+                    }
+                  ]
+                },
+                {
+                  "code": "image",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "back_image"
+                    },
+                    {
+                      "code": "url",
+                      "value": "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695906099658_40025065-3_5-britannia-50-50-maska-chaska-salted-biscuits.jpg"
+                    }
+                  ]
+                },
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ],
+              "@ondc/org/statutory_reqs_prepackaged_food": {
+                "nutritional_info": "refer to back image",
+                "additives_info": "refer to back image",
+                "brand_owner_FSSAI_license_no": "refer to back image",
+                "other_FSSAI_license_no": "refer to back image",
+                "importer_FSSAI_license_no": "refer to back image"
+              }
+            },
+            {
+              "id": "a2ff4dd0-944c-11ee-848d-2d2b8538311e:MR8mcezPPQEA-r8EhP6UN9",
+              "time": {
+                "label": "enable",
+                "timestamp": "2024-01-05T07:33:56.432Z"
+              },
+              "descriptor": {
+                "name": "Ahaar Basmati Rice Economy 1 Kg",
+                "symbol": "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new//panelupload_1701874486278_Ahaar%20Basmati%20Rice%20Economy%201%20Kg_1.png",
+                "short_desc": "Ahaar Basmati Rice Economy 1 Kg",
+                "long_desc": "Ahaar Basmati Rice Economy 1 Kg",
+                "images": [
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new//panelupload_1701874486278_Ahaar%20Basmati%20Rice%20Economy%201%20Kg_1.png",
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new//panelupload_1701874486278_Ahaar%20Basmati%20Rice%20Economy%201%20Kg_2.png"
+                ],
+                "code": "1:8901524000953"
+              },
+              "quantity": {
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                },
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "2500",
+                "maximum_value": "2500"
+              },
+              "category_id": "Atta, Flours and Sooji",
+              "location_id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042",
+              "fulfillment_id": "1",
+              "@ondc/org/returnable": true,
+              "@ondc/org/cancellable": true,
+              "@ondc/org/seller_pickup_return": false,
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/time_to_ship": "PT60M",
+              "@ondc/org/contact_details_consumer_care": "ChattyBao Help, help@chattybao.com,7353256777",
+              "@ondc/org/return_window": "P1D",
+              "matched": true,
+              "tags": [
+                {
+                  "code": "origin",
+                  "list": [
+                    {
+                      "code": "country",
+                      "value": "IND"
+                    }
+                  ]
+                },
+                {
+                  "code": "image",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "back_image"
+                    },
+                    {
+                      "code": "url",
+                      "value": "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new//panelupload_1701874486278_Ahaar%20Basmati%20Rice%20Economy%201%20Kg_2.png"
+                    }
+                  ]
+                },
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ],
+              "@ondc/org/statutory_reqs_packaged_commodities": {
+                "manufacturer_or_packer_name": "refer to back image",
+                "manufacturer_or_packer_address": "refer to back image",
+                "common_or_generic_name_of_commodity": "refer to back image",
+                "net_quantity_or_measure_of_commodity_in_pkg": "refer to back image",
+                "month_year_of_manufacture_packing_import": "refer to back image"
+              }
+            },
+            {
+              "id": "3799b340-9448-11ee-848d-2d2b8538311e:MR8mcezPPQEA-r8EhP6UN9",
+              "time": {
+                "label": "enable",
+                "timestamp": "2024-01-05T07:33:56.432Z"
+              },
+              "descriptor": {
+                "name": "Ahaar Besan Micro Refined 500 g",
+                "symbol": "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new//panelupload_1701874486278_Ahaar%20Besan%20Micro%20Refined%20500%20g_1.jpg",
+                "short_desc": "Ahaar Besan Micro Refined 500 g",
+                "long_desc": "Ahaar Besan Micro Refined 500 g",
+                "images": [
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new//panelupload_1701874486278_Ahaar%20Besan%20Micro%20Refined%20500%20g_1.jpg",
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new//panelupload_1701874486278_Ahaar%20Besan%20Micro%20Refined%20500%20g_2.jpg"
+                ],
+                "code": "1:8901524000212"
+              },
+              "quantity": {
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                },
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "3000",
+                "maximum_value": "3000"
+              },
+              "category_id": "Atta, Flours and Sooji",
+              "location_id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042",
+              "fulfillment_id": "1",
+              "@ondc/org/returnable": true,
+              "@ondc/org/cancellable": true,
+              "@ondc/org/seller_pickup_return": false,
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/time_to_ship": "PT60M",
+              "@ondc/org/contact_details_consumer_care": "ChattyBao Help, help@chattybao.com,7353256777",
+              "@ondc/org/return_window": "P1D",
+              "matched": true,
+              "tags": [
+                {
+                  "code": "origin",
+                  "list": [
+                    {
+                      "code": "country",
+                      "value": "IND"
+                    }
+                  ]
+                },
+                {
+                  "code": "image",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "back_image"
+                    },
+                    {
+                      "code": "url",
+                      "value": "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new//panelupload_1701874486278_Ahaar%20Besan%20Micro%20Refined%20500%20g_2.jpg"
+                    }
+                  ]
+                },
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ],
+              "@ondc/org/statutory_reqs_packaged_commodities": {
+                "manufacturer_or_packer_name": "refer to back image",
+                "manufacturer_or_packer_address": "refer to back image",
+                "common_or_generic_name_of_commodity": "refer to back image",
+                "net_quantity_or_measure_of_commodity_in_pkg": "refer to back image",
+                "month_year_of_manufacture_packing_import": "refer to back image"
+              }
+            },
+            {
+              "id": "e1d875c0-1a41-11ee-8ddd-2bac5af1417f:MR8mcezPPQEA-r8EhP6UN9",
+              "time": {
+                "label": "enable",
+                "timestamp": "2024-01-05T07:33:56.432Z"
+              },
+              "descriptor": {
+                "name": "Amul Pure Ghee Tin 1 L",
+                "symbol": "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196914877_214784_5-amul-amul-pure-ghee-1-l.jpg",
+                "short_desc": "Amul Pure Ghee Tin 1 L",
+                "long_desc": "Amul Pure Ghee Tin 1 L",
+                "images": [
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196914877_214784_5-amul-amul-pure-ghee-1-l.jpg",
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196914281_214784-2_5-amul-amul-pure-ghee-1-l.jpg",
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196913702_214784-3_5-amul-amul-pure-ghee-1-l.jpg",
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196916711_214784-4_5-amul-amul-pure-ghee-1-l.jpg"
+                ],
+                "code": "1:8901262030151"
+              },
+              "quantity": {
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                },
+                "available": {
+                  "count": "0"
+                },
+                "maximum": {
+                  "count": "0"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "12000",
+                "maximum_value": "12000"
+              },
+              "category_id": "Oil & Ghee",
+              "location_id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042",
+              "fulfillment_id": "1",
+              "@ondc/org/returnable": true,
+              "@ondc/org/cancellable": true,
+              "@ondc/org/seller_pickup_return": false,
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/time_to_ship": "PT60M",
+              "@ondc/org/contact_details_consumer_care": "ChattyBao Help, help@chattybao.com,7353256777",
+              "@ondc/org/return_window": "P1D",
+              "matched": true,
+              "tags": [
+                {
+                  "code": "origin",
+                  "list": [
+                    {
+                      "code": "country",
+                      "value": "IND"
+                    }
+                  ]
+                },
+                {
+                  "code": "image",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "back_image"
+                    },
+                    {
+                      "code": "url",
+                      "value": "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196914281_214784-2_5-amul-amul-pure-ghee-1-l.jpg"
+                    }
+                  ]
+                },
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ],
+              "@ondc/org/statutory_reqs_packaged_commodities": {
+                "manufacturer_or_packer_name": "refer to back image",
+                "manufacturer_or_packer_address": "refer to back image",
+                "common_or_generic_name_of_commodity": "refer to back image",
+                "net_quantity_or_measure_of_commodity_in_pkg": "refer to back image",
+                "month_year_of_manufacture_packing_import": "refer to back image"
+              }
+            },
+            {
+              "id": "e10631a0-1a41-11ee-8ddd-2bac5af1417f:MR8mcezPPQEA-r8EhP6UN9",
+              "time": {
+                "label": "enable",
+                "timestamp": "2024-01-05T07:33:56.432Z"
+              },
+              "descriptor": {
+                "name": "Amul Cow Ghee Carton 1L",
+                "symbol": "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196914127_40096994_1-amul-amul-cow-ghee-1-l.jpg",
+                "short_desc": "Amul Cow Ghee Carton 1L",
+                "long_desc": "Amul Cow Ghee Carton 1L",
+                "images": [
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196914127_40096994_1-amul-amul-cow-ghee-1-l.jpg",
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196914187_40096994-2_1-amul-amul-cow-ghee-1-l.jpg",
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196914375_40096994-3_1-amul-amul-cow-ghee-1-l.jpg",
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196914005_40096994-5_1-amul-amul-cow-ghee-1-l.jpg"
+                ],
+                "code": "1:8901262030878"
+              },
+              "quantity": {
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                },
+                "available": {
+                  "count": "0"
+                },
+                "maximum": {
+                  "count": "0"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "12000",
+                "maximum_value": "12000"
+              },
+              "category_id": "Oil & Ghee",
+              "location_id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042",
+              "fulfillment_id": "1",
+              "@ondc/org/returnable": true,
+              "@ondc/org/cancellable": true,
+              "@ondc/org/seller_pickup_return": false,
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/time_to_ship": "PT60M",
+              "@ondc/org/contact_details_consumer_care": "ChattyBao Help, help@chattybao.com,7353256777",
+              "@ondc/org/return_window": "P1D",
+              "matched": true,
+              "tags": [
+                {
+                  "code": "origin",
+                  "list": [
+                    {
+                      "code": "country",
+                      "value": "IND"
+                    }
+                  ]
+                },
+                {
+                  "code": "image",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "back_image"
+                    },
+                    {
+                      "code": "url",
+                      "value": "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196914187_40096994-2_1-amul-amul-cow-ghee-1-l.jpg"
+                    }
+                  ]
+                },
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ],
+              "@ondc/org/statutory_reqs_packaged_commodities": {
+                "manufacturer_or_packer_name": "refer to back image",
+                "manufacturer_or_packer_address": "refer to back image",
+                "common_or_generic_name_of_commodity": "refer to back image",
+                "net_quantity_or_measure_of_commodity_in_pkg": "refer to back image",
+                "month_year_of_manufacture_packing_import": "refer to back image"
+              }
+            },
+            {
+              "id": "f862b941-1a41-11ee-8ddd-2bac5af1417f:MR8mcezPPQEA-r8EhP6UN9",
+              "time": {
+                "label": "enable",
+                "timestamp": "2024-01-05T07:33:56.432Z"
+              },
+              "descriptor": {
+                "name": "Dhara Kachi Ghani Mustard Oil Bottle 1 L",
+                "symbol": "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196927301_212470_5-dhara-oil-mustard-kachi-ghani.jpg",
+                "short_desc": "Dhara Kachi Ghani Mustard Oil Bottle 1 L",
+                "long_desc": "Dhara Kachi Ghani Mustard Oil Bottle 1 L",
+                "images": [
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196927301_212470_5-dhara-oil-mustard-kachi-ghani.jpg",
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196927127_212470-2_3-dhara-oil-mustard-kachi-ghani.jpg",
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196927484_212470-4_2-dhara-oil-mustard-kachi-ghani.jpg",
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196927136_100005318-5_3-dhara-oil-mustard-kachi-ghani.jpg",
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196927049_212470-3_3-dhara-oil-mustard-kachi-ghani.jpg"
+                ],
+                "code": "1:8906004620263"
+              },
+              "quantity": {
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                },
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "14000",
+                "maximum_value": "14000"
+              },
+              "category_id": "Oil & Ghee",
+              "location_id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042",
+              "fulfillment_id": "1",
+              "@ondc/org/returnable": true,
+              "@ondc/org/cancellable": true,
+              "@ondc/org/seller_pickup_return": false,
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/time_to_ship": "PT60M",
+              "@ondc/org/contact_details_consumer_care": "ChattyBao Help, help@chattybao.com,7353256777",
+              "@ondc/org/return_window": "P1D",
+              "matched": true,
+              "tags": [
+                {
+                  "code": "origin",
+                  "list": [
+                    {
+                      "code": "country",
+                      "value": "IND"
+                    }
+                  ]
+                },
+                {
+                  "code": "image",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "back_image"
+                    },
+                    {
+                      "code": "url",
+                      "value": "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196927127_212470-2_3-dhara-oil-mustard-kachi-ghani.jpg"
+                    }
+                  ]
+                },
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ],
+              "@ondc/org/statutory_reqs_packaged_commodities": {
+                "manufacturer_or_packer_name": "refer to back image",
+                "manufacturer_or_packer_address": "refer to back image",
+                "common_or_generic_name_of_commodity": "refer to back image",
+                "net_quantity_or_measure_of_commodity_in_pkg": "refer to back image",
+                "month_year_of_manufacture_packing_import": "refer to back image"
+              }
+            },
+            {
+              "id": "2850ed60-5dff-11ee-b94d-fbd52ac06897:MR8mcezPPQEA-r8EhP6UN9",
+              "time": {
+                "label": "enable",
+                "timestamp": "2024-01-05T07:33:56.432Z"
+              },
+              "descriptor": {
+                "name": "Amul Butter Cookies 200 g",
+                "symbol": "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695906091558_40088517_2-amul-cookies-butter.jpg",
+                "short_desc": "Amul Butter Cookies 200 g",
+                "long_desc": "Amul Butter Cookies 200 g",
+                "images": [
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695906091558_40088517_2-amul-cookies-butter.jpg",
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695906092028_40088517-2_1-amul-cookies-butter.jpg",
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695906091954_40088517-4_1-amul-cookies-butter.jpg",
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695906091489_40088517-5_1-amul-cookies-butter.jpg"
+                ],
+                "code": "1:8901262220347"
+              },
+              "quantity": {
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                },
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "1200",
+                "maximum_value": "1200"
+              },
+              "category_id": "Chocolates and Biscuits",
+              "location_id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042",
+              "fulfillment_id": "1",
+              "@ondc/org/returnable": true,
+              "@ondc/org/cancellable": true,
+              "@ondc/org/seller_pickup_return": false,
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/time_to_ship": "PT60M",
+              "@ondc/org/contact_details_consumer_care": "ChattyBao Help, help@chattybao.com,7353256777",
+              "@ondc/org/return_window": "P1D",
+              "matched": true,
+              "tags": [
+                {
+                  "code": "origin",
+                  "list": [
+                    {
+                      "code": "country",
+                      "value": "IND"
+                    }
+                  ]
+                },
+                {
+                  "code": "image",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "back_image"
+                    },
+                    {
+                      "code": "url",
+                      "value": "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695906092028_40088517-2_1-amul-cookies-butter.jpg"
+                    }
+                  ]
+                },
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ],
+              "@ondc/org/statutory_reqs_prepackaged_food": {
+                "nutritional_info": "refer to back image",
+                "additives_info": "refer to back image",
+                "brand_owner_FSSAI_license_no": "refer to back image",
+                "other_FSSAI_license_no": "refer to back image",
+                "importer_FSSAI_license_no": "refer to back image"
+              }
+            },
+            {
+              "id": "e50d3af1-1a41-11ee-8ddd-2bac5af1417f:MR8mcezPPQEA-r8EhP6UN9",
+              "time": {
+                "label": "enable",
+                "timestamp": "2024-01-05T07:33:56.432Z"
+              },
+              "descriptor": {
+                "name": "Bail Kolhu Kachi Ghani Mustard Oil Bottle 1 L",
+                "symbol": "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196914986_51pjk6MKaeL._SX679_.jpg",
+                "short_desc": "Bail Kolhu Kachi Ghani Mustard Oil Bottle 1 L",
+                "long_desc": "Bail Kolhu Kachi Ghani Mustard Oil Bottle 1 L",
+                "images": [
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196914986_51pjk6MKaeL._SX679_.jpg",
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196914263_51Bs6R6Q3YL._SX679_.jpg",
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196915086_61paEtFD9AL._SX679_.jpg",
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196914168_51-02wuJ9uL._SX679_.jpg",
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196913908_61gVLGJ6gPL._SX679_.jpg"
+                ],
+                "code": "1:8906015010039"
+              },
+              "quantity": {
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                },
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "10000",
+                "maximum_value": "10000"
+              },
+              "category_id": "Oil & Ghee",
+              "location_id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042",
+              "fulfillment_id": "1",
+              "@ondc/org/returnable": true,
+              "@ondc/org/cancellable": true,
+              "@ondc/org/seller_pickup_return": false,
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/time_to_ship": "PT60M",
+              "@ondc/org/contact_details_consumer_care": "ChattyBao Help, help@chattybao.com,7353256777",
+              "@ondc/org/return_window": "P1D",
+              "matched": true,
+              "tags": [
+                {
+                  "code": "origin",
+                  "list": [
+                    {
+                      "code": "country",
+                      "value": "IND"
+                    }
+                  ]
+                },
+                {
+                  "code": "image",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "back_image"
+                    },
+                    {
+                      "code": "url",
+                      "value": "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196914263_51Bs6R6Q3YL._SX679_.jpg"
+                    }
+                  ]
+                },
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ],
+              "@ondc/org/statutory_reqs_packaged_commodities": {
+                "manufacturer_or_packer_name": "refer to back image",
+                "manufacturer_or_packer_address": "refer to back image",
+                "common_or_generic_name_of_commodity": "refer to back image",
+                "net_quantity_or_measure_of_commodity_in_pkg": "refer to back image",
+                "month_year_of_manufacture_packing_import": "refer to back image"
+              }
+            },
+            {
+              "id": "eaf66d60-1f05-11ee-8961-ab859ded98e0:MR8mcezPPQEA-r8EhP6UN9",
+              "time": {
+                "label": "enable",
+                "timestamp": "2024-01-05T07:33:56.432Z"
+              },
+              "descriptor": {
+                "name": "Britannia Bourbon Biscuit 150 g",
+                "symbol": "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695906064084_263593_10-britannia-bourbon-chocolate-cream-biscuits.jpg",
+                "short_desc": "Britannia Bourbon Biscuit 150 g",
+                "long_desc": "Britannia Bourbon Biscuit 150 g",
+                "images": [
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695906064084_263593_10-britannia-bourbon-chocolate-cream-biscuits.jpg",
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695906064014_britannia-bourbon-the-original-cream-biscuits-150-g-product-images-o490005349-p490005349-1-202203150315.jpg",
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695906064117_britannia-bourbon-the-original-cream-biscuits-150-g-legal-images-o490005349-p490005349-3-202203150315.jpg",
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695906064130_britannia-bourbon-the-original-cream-biscuits-150-g-legal-images-o490005349-p490005349-5-202203150315.jpg",
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695906064210_britannia-bourbon-the-original-cream-biscuits-150-g-legal-images-o490005349-p490005349-4-202203150315.jpg"
+                ],
+                "code": "1:8901063139213"
+              },
+              "quantity": {
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                },
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "12000",
+                "maximum_value": "12000"
+              },
+              "category_id": "Chocolates and Biscuits",
+              "location_id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042",
+              "fulfillment_id": "1",
+              "@ondc/org/returnable": true,
+              "@ondc/org/cancellable": true,
+              "@ondc/org/seller_pickup_return": false,
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/time_to_ship": "PT60M",
+              "@ondc/org/contact_details_consumer_care": "ChattyBao Help, help@chattybao.com,7353256777",
+              "@ondc/org/return_window": "P1D",
+              "matched": true,
+              "tags": [
+                {
+                  "code": "origin",
+                  "list": [
+                    {
+                      "code": "country",
+                      "value": "IND"
+                    }
+                  ]
+                },
+                {
+                  "code": "image",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "back_image"
+                    },
+                    {
+                      "code": "url",
+                      "value": "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695906064014_britannia-bourbon-the-original-cream-biscuits-150-g-product-images-o490005349-p490005349-1-202203150315.jpg"
+                    }
+                  ]
+                },
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ],
+              "@ondc/org/statutory_reqs_prepackaged_food": {
+                "nutritional_info": "refer to back image",
+                "additives_info": "refer to back image",
+                "brand_owner_FSSAI_license_no": "refer to back image",
+                "other_FSSAI_license_no": "refer to back image",
+                "importer_FSSAI_license_no": "refer to back image"
+              }
+            },
+            {
+              "id": "e3007b00-1a41-11ee-8ddd-2bac5af1417f:MR8mcezPPQEA-r8EhP6UN9",
+              "time": {
+                "label": "enable",
+                "timestamp": "2024-01-05T07:33:56.432Z"
+              },
+              "descriptor": {
+                "name": "Amul Pure Ghee Carton 1L",
+                "symbol": "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196913862_191057_5-amul-amul-pure-ghee-1-l.jpg",
+                "short_desc": "Amul Pure Ghee Carton 1L",
+                "long_desc": "Amul Pure Ghee Carton 1L",
+                "images": [
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196913862_191057_5-amul-amul-pure-ghee-1-l.jpg",
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196913808_191057-2_5-amul-amul-pure-ghee-1-l.jpg",
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196914805_191057-4_5-amul-amul-pure-ghee-1-l.jpg",
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196913976_191057-5_5-amul-amul-pure-ghee-1-l.jpg",
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196914662_191057-3_5-amul-amul-pure-ghee-1-l.jpg"
+                ],
+                "code": "1:8901262030618"
+              },
+              "quantity": {
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                },
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "3000",
+                "maximum_value": "3000"
+              },
+              "category_id": "Oil & Ghee",
+              "location_id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042",
+              "fulfillment_id": "1",
+              "@ondc/org/returnable": true,
+              "@ondc/org/cancellable": true,
+              "@ondc/org/seller_pickup_return": false,
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/time_to_ship": "PT60M",
+              "@ondc/org/contact_details_consumer_care": "ChattyBao Help, help@chattybao.com,7353256777",
+              "@ondc/org/return_window": "P1D",
+              "matched": true,
+              "tags": [
+                {
+                  "code": "origin",
+                  "list": [
+                    {
+                      "code": "country",
+                      "value": "IND"
+                    }
+                  ]
+                },
+                {
+                  "code": "image",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "back_image"
+                    },
+                    {
+                      "code": "url",
+                      "value": "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196913808_191057-2_5-amul-amul-pure-ghee-1-l.jpg"
+                    }
+                  ]
+                },
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ],
+              "@ondc/org/statutory_reqs_packaged_commodities": {
+                "manufacturer_or_packer_name": "refer to back image",
+                "manufacturer_or_packer_address": "refer to back image",
+                "common_or_generic_name_of_commodity": "refer to back image",
+                "net_quantity_or_measure_of_commodity_in_pkg": "refer to back image",
+                "month_year_of_manufacture_packing_import": "refer to back image"
+              }
+            },
+            {
+              "id": "2bbfc490-578c-11ee-b866-b3696924a09e:MR8mcezPPQEA-r8EhP6UN9",
+              "time": {
+                "label": "enable",
+                "timestamp": "2024-01-05T07:33:56.432Z"
+              },
+              "descriptor": {
+                "name": "Amul Pure Ghee Pouch 1L",
+                "symbol": "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196995222_40050536_5-amul-ghee.jpg",
+                "short_desc": "Amul Pure Ghee Pouch 1L",
+                "long_desc": "Amul Pure Ghee Pouch 1L",
+                "images": [
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196995222_40050536_5-amul-ghee.jpg",
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196994971_40050536-2_8-amul-ghee.jpg",
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196995170_40050536-3_8-amul-ghee.jpg",
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196996397_40050536-4_8-amul-ghee.jpg"
+                ],
+                "code": "1:8901262030366"
+              },
+              "quantity": {
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                },
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "44478",
+                "maximum_value": "44478"
+              },
+              "category_id": "Oil & Ghee",
+              "location_id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042",
+              "fulfillment_id": "1",
+              "@ondc/org/returnable": true,
+              "@ondc/org/cancellable": true,
+              "@ondc/org/seller_pickup_return": false,
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/time_to_ship": "PT60M",
+              "@ondc/org/contact_details_consumer_care": "ChattyBao Help, help@chattybao.com,7353256777",
+              "@ondc/org/return_window": "P1D",
+              "matched": true,
+              "tags": [
+                {
+                  "code": "origin",
+                  "list": [
+                    {
+                      "code": "country",
+                      "value": "IND"
+                    }
+                  ]
+                },
+                {
+                  "code": "image",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "back_image"
+                    },
+                    {
+                      "code": "url",
+                      "value": "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196994971_40050536-2_8-amul-ghee.jpg"
+                    }
+                  ]
+                },
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ],
+              "@ondc/org/statutory_reqs_packaged_commodities": {
+                "manufacturer_or_packer_name": "refer to back image",
+                "manufacturer_or_packer_address": "refer to back image",
+                "common_or_generic_name_of_commodity": "refer to back image",
+                "net_quantity_or_measure_of_commodity_in_pkg": "refer to back image",
+                "month_year_of_manufacture_packing_import": "refer to back image"
+              }
+            },
+            {
+              "id": "e5196ff0-1a41-11ee-8ddd-2bac5af1417f:MR8mcezPPQEA-r8EhP6UN9",
+              "time": {
+                "label": "enable",
+                "timestamp": "2024-01-05T07:33:56.432Z"
+              },
+              "descriptor": {
+                "name": "Bail Kolhu Kachi Ghani Mustard Oil Bottle 2 L",
+                "symbol": "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196915023_61wez3G58dL._SX679_.jpg",
+                "short_desc": "Bail Kolhu Kachi Ghani Mustard Oil Bottle 2 L",
+                "long_desc": "Bail Kolhu Kachi Ghani Mustard Oil Bottle 2 L",
+                "images": [
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196915023_61wez3G58dL._SX679_.jpg",
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196914144_51jKn0ZvMIL._SX679_.jpg",
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196914748_61paEtFD9AL._SX679_.jpg",
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196915069_51-02wuJ9uL._SX679_.jpg",
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196914837_61gVLGJ6gPL._SX679_.jpg",
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196914939_61SvAOChWPL._SX679_.jpg",
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196914247_61nx6bd7%2BhL._SX679_.jpg"
+                ],
+                "code": "1:8906015010046"
+              },
+              "quantity": {
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                },
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "10000",
+                "maximum_value": "10000"
+              },
+              "category_id": "Oil & Ghee",
+              "location_id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042",
+              "fulfillment_id": "1",
+              "@ondc/org/returnable": true,
+              "@ondc/org/cancellable": true,
+              "@ondc/org/seller_pickup_return": false,
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/time_to_ship": "PT60M",
+              "@ondc/org/contact_details_consumer_care": "ChattyBao Help, help@chattybao.com,7353256777",
+              "@ondc/org/return_window": "P1D",
+              "matched": true,
+              "tags": [
+                {
+                  "code": "origin",
+                  "list": [
+                    {
+                      "code": "country",
+                      "value": "IND"
+                    }
+                  ]
+                },
+                {
+                  "code": "image",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "back_image"
+                    },
+                    {
+                      "code": "url",
+                      "value": "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196914144_51jKn0ZvMIL._SX679_.jpg"
+                    }
+                  ]
+                },
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ],
+              "@ondc/org/statutory_reqs_packaged_commodities": {
+                "manufacturer_or_packer_name": "refer to back image",
+                "manufacturer_or_packer_address": "refer to back image",
+                "common_or_generic_name_of_commodity": "refer to back image",
+                "net_quantity_or_measure_of_commodity_in_pkg": "refer to back image",
+                "month_year_of_manufacture_packing_import": "refer to back image"
+              }
+            },
+            {
+              "id": "e2ee5290-1a41-11ee-8ddd-2bac5af1417f:MR8mcezPPQEA-r8EhP6UN9",
+              "time": {
+                "label": "enable",
+                "timestamp": "2024-01-05T07:33:56.432Z"
+              },
+              "descriptor": {
+                "name": "Anik Ghee Tin 1 L",
+                "symbol": "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196914207_anik-ghee-1-l-tin-product-images-o490012759-p490012759-0-202203151003.jpg",
+                "short_desc": "Anik Ghee Tin 1 L",
+                "long_desc": "Anik Ghee Tin 1 L",
+                "images": [
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196914207_anik-ghee-1-l-tin-product-images-o490012759-p490012759-0-202203151003.jpg",
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196915566_1-na-tin-anik-original-imagyzd5s6nggv7s.jpeg",
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196915243_1-na-tin-anik-original-imagyzd5g3zfjheg.jpeg",
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196915317_1-na-tin-anik-original-imagyzd5d4hurhna.jpeg"
+                ],
+                "code": "1:8906002091430"
+              },
+              "quantity": {
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                },
+                "available": {
+                  "count": "0"
+                },
+                "maximum": {
+                  "count": "0"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "3000",
+                "maximum_value": "3000"
+              },
+              "category_id": "Oil & Ghee",
+              "location_id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042",
+              "fulfillment_id": "1",
+              "@ondc/org/returnable": true,
+              "@ondc/org/cancellable": true,
+              "@ondc/org/seller_pickup_return": false,
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/time_to_ship": "PT60M",
+              "@ondc/org/contact_details_consumer_care": "ChattyBao Help, help@chattybao.com,7353256777",
+              "@ondc/org/return_window": "P1D",
+              "matched": true,
+              "tags": [
+                {
+                  "code": "origin",
+                  "list": [
+                    {
+                      "code": "country",
+                      "value": "IND"
+                    }
+                  ]
+                },
+                {
+                  "code": "image",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "back_image"
+                    },
+                    {
+                      "code": "url",
+                      "value": "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196915566_1-na-tin-anik-original-imagyzd5s6nggv7s.jpeg"
+                    }
+                  ]
+                },
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ],
+              "@ondc/org/statutory_reqs_packaged_commodities": {
+                "manufacturer_or_packer_name": "refer to back image",
+                "manufacturer_or_packer_address": "refer to back image",
+                "common_or_generic_name_of_commodity": "refer to back image",
+                "net_quantity_or_measure_of_commodity_in_pkg": "refer to back image",
+                "month_year_of_manufacture_packing_import": "refer to back image"
+              }
+            },
+            {
+              "id": "276aac10-5dff-11ee-b94d-fbd52ac06897:MR8mcezPPQEA-r8EhP6UN9",
+              "time": {
+                "label": "enable",
+                "timestamp": "2024-01-05T07:33:56.432Z"
+              },
+              "descriptor": {
+                "name": "Amul Chocolate Cookies 200 g",
+                "symbol": "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695906091889_40204111_1-amul-elaichi-nankhatai.jpg",
+                "short_desc": "Amul Chocolate Cookies 200 g",
+                "long_desc": "Amul Chocolate Cookies 200 g",
+                "images": [
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695906091889_40204111_1-amul-elaichi-nankhatai.jpg",
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695906091637_40204111-2_1-amul-elaichi-nankhatai.jpg",
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695906091693_40204111-4_1-amul-elaichi-nankhatai.jpg",
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695906092175_40204111-5_1-amul-elaichi-nankhatai.jpg"
+                ],
+                "code": "1:8901262220354"
+              },
+              "quantity": {
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                },
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "3000",
+                "maximum_value": "3000"
+              },
+              "category_id": "Chocolates and Biscuits",
+              "location_id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042",
+              "fulfillment_id": "1",
+              "@ondc/org/returnable": true,
+              "@ondc/org/cancellable": true,
+              "@ondc/org/seller_pickup_return": false,
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/time_to_ship": "PT60M",
+              "@ondc/org/contact_details_consumer_care": "ChattyBao Help, help@chattybao.com,7353256777",
+              "@ondc/org/return_window": "P1D",
+              "matched": true,
+              "tags": [
+                {
+                  "code": "origin",
+                  "list": [
+                    {
+                      "code": "country",
+                      "value": "IND"
+                    }
+                  ]
+                },
+                {
+                  "code": "image",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "back_image"
+                    },
+                    {
+                      "code": "url",
+                      "value": "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695906091637_40204111-2_1-amul-elaichi-nankhatai.jpg"
+                    }
+                  ]
+                },
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ],
+              "@ondc/org/statutory_reqs_prepackaged_food": {
+                "nutritional_info": "refer to back image",
+                "additives_info": "refer to back image",
+                "brand_owner_FSSAI_license_no": "refer to back image",
+                "other_FSSAI_license_no": "refer to back image",
+                "importer_FSSAI_license_no": "refer to back image"
+              }
+            },
+            {
+              "id": "e8a5a3f0-1a41-11ee-8ddd-2bac5af1417f:MR8mcezPPQEA-r8EhP6UN9",
+              "time": {
+                "label": "enable",
+                "timestamp": "2024-01-05T07:33:56.432Z"
+              },
+              "descriptor": {
+                "name": "Britannia 50-50 Maska Chaska Biscuit 300 g",
+                "symbol": "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695906041483_40203380_1-britannia-50-50-maska-chaska.jpg",
+                "short_desc": "Britannia 50-50 Maska Chaska Biscuit 300 g",
+                "long_desc": "Britannia 50-50 Maska Chaska Biscuit 300 g",
+                "images": [
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695906041483_40203380_1-britannia-50-50-maska-chaska.jpg",
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695906041371_britannia-50-50-maska-chaska-biscuits-300-g-product-images-o491587135-p590033900-1-202209151506.jpg",
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695906041887_britannia-50-50-maska-chaska-biscuits-300-g-legal-images-o491587135-p590033900-2-202209151506.jpg",
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695906041058_britannia-50-50-maska-chaska-biscuits-300-g-legal-images-o491587135-p590033900-4-202209151506.jpg",
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695906041597_britannia-50-50-maska-chaska-biscuits-300-g-legal-images-o491587135-p590033900-3-202209151506.jpg"
+                ],
+                "code": "1:8901063017399"
+              },
+              "quantity": {
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                },
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "3000",
+                "maximum_value": "3000"
+              },
+              "category_id": "Chocolates and Biscuits",
+              "location_id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042",
+              "fulfillment_id": "1",
+              "@ondc/org/returnable": true,
+              "@ondc/org/cancellable": true,
+              "@ondc/org/seller_pickup_return": false,
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/time_to_ship": "PT60M",
+              "@ondc/org/contact_details_consumer_care": "ChattyBao Help, help@chattybao.com,7353256777",
+              "@ondc/org/return_window": "P1D",
+              "matched": true,
+              "tags": [
+                {
+                  "code": "origin",
+                  "list": [
+                    {
+                      "code": "country",
+                      "value": "IND"
+                    }
+                  ]
+                },
+                {
+                  "code": "image",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "back_image"
+                    },
+                    {
+                      "code": "url",
+                      "value": "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695906041371_britannia-50-50-maska-chaska-biscuits-300-g-product-images-o491587135-p590033900-1-202209151506.jpg"
+                    }
+                  ]
+                },
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ],
+              "@ondc/org/statutory_reqs_prepackaged_food": {
+                "nutritional_info": "refer to back image",
+                "additives_info": "refer to back image",
+                "brand_owner_FSSAI_license_no": "refer to back image",
+                "other_FSSAI_license_no": "refer to back image",
+                "importer_FSSAI_license_no": "refer to back image"
+              }
+            }
+          ]
+        },
+        {
+          "id": "MlepomA3E7XUC_7MpLJgjn",
+          "time": {
+            "label": "disable",
+            "timestamp": "2024-01-05T07:33:56.432Z"
+          },
+          "fulfillments": [
+            {
+              "id": "1",
+              "type": "Delivery",
+              "contact": {
+                "phone": "9480323092",
+                "email": "help@chattybao.com"
+              }
+            }
+          ],
+          "descriptor": {
+            "name": "Tester Louis Resto",
+            "symbol": "https://categoryvisitingcards.s3.ap-south-1.amazonaws.com/panelupload_1686915131370_Biryani.png",
+            "long_desc": "Tester Louis Resto",
+            "short_desc": "Tester Louis Resto",
+            "images": [
+              "https://categoryvisitingcards.s3.ap-south-1.amazonaws.com/panelupload_1686915131370_Biryani.png"
+            ]
+          },
+          "ttl": "P1D",
+          "locations": [
+            {
+              "id": "15b5f8a0-29b5-11ed-93b0-8d73fff38901",
+              "gps": "26.844719,80.978035",
+              "time": {
+                "label": "enable",
+                "days": "1,2,3,4,6,7",
+                "timestamp": "2024-01-05T07:33:56.432Z",
+                "range": {
+                  "start": "0800",
+                  "end": "2200"
+                }
+              },
+              "address": {
+                "locality": "4/267, Vipin Khand 4",
+                "street": "Gomti Nagar",
+                "city": "Uttar Pradesh",
+                "area_code": "226010",
+                "state": "Lucknow"
+              },
+              "circle": {
+                "gps": "26.844719,80.978035",
+                "radius": {
+                  "unit": "km",
+                  "value": "5"
+                }
+              }
+            }
+          ],
+          "tags": [
+            {
+              "code": "order_value",
+              "list": [
+                {
+                  "code": "min_value",
+                  "value": "300.00"
+                }
+              ]
+            },
+            {
+              "code": "timing",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "Delivery"
+                },
+                {
+                  "code": "location",
+                  "value": "15b5f8a0-29b5-11ed-93b0-8d73fff38901"
+                },
+                {
+                  "code": "day_from",
+                  "value": "1"
+                },
+                {
+                  "code": "day_to",
+                  "value": "6"
+                },
+                {
+                  "code": "time_from",
+                  "value": "0800"
+                },
+                {
+                  "code": "time_to",
+                  "value": "2200"
+                }
+              ]
+            },
+            {
+              "code": "catalog_link",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "inline"
+                },
+                {
+                  "code": "type_value",
+                  "value": "https://s3.amazon.com/x-1234.zip"
+                },
+                {
+                  "code": "type_validity",
+                  "value": "PT24H"
+                },
+                {
+                  "code": "last_update",
+                  "value": "2023-05-21T00:00:00:000Z"
+                }
+              ]
+            },
+            {
+              "code": "serviceability",
+              "list": [
+                {
+                  "code": "locati2024-01-05T07:33:56.567530666Z on",
+                  "value": "15b5f8a0-29b5-11ed-93b0-8d73fff38901"
+                },
+                {
+                  "code": "category",
+                  "value": "Chocolates and Biscuits"
+                },
+                {
+                  "code": "type",
+                  "value": "10"
+                },
+                {
+                  "code": "val",
+                  "value": "5"
+                },
+                {
+                  "code": "unit",
+                  "value": "km"
+                }
+              ]
+            }
+          ],
+          "items": [
+            {
+              "id": "e54e3fc0-944c-11ee-848d-2d2b8538311e:MlepomA3E7XUC_7MpLJgjn",
+              "time": {
+                "label": "enable",
+                "timestamp": "2024-01-05T07:33:56.432Z"
+              },
+              "descriptor": {
+                "name": "Ahaar Masoor Black Dal Premium 1 Kg",
+                "symbol": "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new//panelupload_1701874486278_Ahaar%20Masoor%20Black%20Dal%20Premium%201%20Kg_1.png",
+                "short_desc": "Ahaar Masoor Black Dal Premium 1 Kg",
+                "long_desc": "Ahaar Masoor Black Dal Premium 1 Kg",
+                "images": [
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new//panelupload_1701874486278_Ahaar%20Masoor%20Black%20Dal%20Premium%201%20Kg_1.png",
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new//panelupload_1701874486278_Ahaar%20Masoor%20Black%20Dal%20Premium%201%20Kg_2.png"
+                ],
+                "code": "1:8901524002148"
+              },
+              "quantity": {
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                },
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "3000",
+                "maximum_value": "3200"
+              },
+              "category_id": "Atta, Flours and Sooji",
+              "location_id": "15b5f8a0-29b5-11ed-93b0-8d73fff38901",
+              "fulfillment_id": "1",
+              "@ondc/org/returnable": true,
+              "@ondc/org/cancellable": true,
+              "@ondc/org/seller_pickup_return": false,
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/time_to_ship": "PT60M",
+              "@ondc/org/contact_details_consumer_care": "ChattyBao Help, help@chattybao.com,7353256777",
+              "@ondc/org/return_window": "P1D",
+              "matched": true,
+              "tags": [
+                {
+                  "code": "origin",
+                  "list": [
+                    {
+                      "code": "country",
+                      "value": "IND"
+                    }
+                  ]
+                },
+                {
+                  "code": "image",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "back_image"
+                    },
+                    {
+                      "code": "url",
+                      "value": "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new//panelupload_1701874486278_Ahaar%20Masoor%20Black%20Dal%20Premium%201%20Kg_2.png"
+                    }
+                  ]
+                },
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ],
+              "@ondc/org/statutory_reqs_packaged_commodities": {
+                "manufacturer_or_packer_name": "refer to back image",
+                "manufacturer_or_packer_address": "refer to back image",
+                "common_or_generic_name_of_commodity": "refer to back image",
+                "net_quantity_or_measure_of_commodity_in_pkg": "refer to back image",
+                "month_year_of_manufacture_packing_import": "refer to back image"
+              }
+            },
+            {
+              "id": "ded21392-1a41-11ee-8ddd-2bac5af1417f:MlepomA3E7XUC_7MpLJgjn",
+              "time": {
+                "label": "enable",
+                "timestamp": "2024-01-05T07:33:56.432Z"
+              },
+              "descriptor": {
+                "name": "Aashirvaad Shudh Chakki Atta Whole Wheat 10 Kg",
+                "symbol": "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196846739_40127505_7-aashirvaad-shudh-chakki-atta.jpg",
+                "short_desc": "Aashirvaad Shudh Chakki Atta Whole Wheat 10 Kg",
+                "long_desc": "Aashirvaad Shudh Chakki Atta Whole Wheat 10 Kg",
+                "images": [
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196846739_40127505_7-aashirvaad-shudh-chakki-atta.jpg",
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196846964_40127505-3_8-aashirvaad-shudh-chakki-atta.jpg",
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196847065_40127506-9_2-aashirvaad-shudh-chakki-atta.jpg",
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196846983_aashirvaad-whole-wheat-atta-10-kg-legal-images-o490000041-p490000041-4-202207051337.jpg",
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196847015_40127506-4_8-aashirvaad-shudh-chakki-atta.jpg"
+                ],
+                "code": "1:8901725008895"
+              },
+              "quantity": {
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                },
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "3000",
+                "maximum_value": "3500"
+              },
+              "category_id": "Atta, Flours and Sooji",
+              "location_id": "15b5f8a0-29b5-11ed-93b0-8d73fff38901",
+              "fulfillment_id": "1",
+              "@ondc/org/returnable": true,
+              "@ondc/org/cancellable": true,
+              "@ondc/org/seller_pickup_return": false,
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/time_to_ship": "PT60M",
+              "@ondc/org/contact_details_consumer_care": "ChattyBao Help, help@chattybao.com,7353256777",
+              "@ondc/org/return_window": "P1D",
+              "matched": true,
+              "tags": [
+                {
+                  "code": "origin",
+                  "list": [
+                    {
+                      "code": "country",
+                      "value": "IND"
+                    }
+                  ]
+                },
+                {
+                  "code": "image",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "back_image"
+                    },
+                    {
+                      "code": "url",
+                      "value": "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196846964_40127505-3_8-aashirvaad-shudh-chakki-atta.jpg"
+                    }
+                  ]
+                },
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ],
+              "@ondc/org/statutory_reqs_packaged_commodities": {
+                "manufacturer_or_packer_name": "refer to back image",
+                "manufacturer_or_packer_address": "refer to back image",
+                "common_or_generic_name_of_commodity": "refer to back image",
+                "net_quantity_or_measure_of_commodity_in_pkg": "refer to back image",
+                "month_year_of_manufacture_packing_import": "refer to back image"
+              }
+            },
+            {
+              "id": "e31c8e80-1a41-11ee-8ddd-2bac5af1417f:MlepomA3E7XUC_7MpLJgjn",
+              "time": {
+                "label": "enable",
+                "timestamp": "2024-01-05T07:33:56.432Z"
+              },
+              "descriptor": {
+                "name": "Anik Ghee Carton 1 L",
+                "symbol": "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196915259_ensure000371.jpg",
+                "short_desc": "Anik Ghee Carton 1 L",
+                "long_desc": "Anik Ghee Carton 1 L",
+                "images": [
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196915259_ensure000371.jpg",
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196914855_40053315-2_5-anik-ghee.jpg",
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196916779_1-ghee-1l-tetra-1-tetrapack-anik-original-imagk7yzhcf2k5hu.jpeg",
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196915339_1-ghee-1l-tetra-1-tetrapack-anik-original-imagk7yzjqzpqazf.jpeg"
+                ],
+                "code": "1:8906002091058"
+              },
+              "quantity": {
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                },
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "3500",
+                "maximum_value": "5000"
+              },
+              "category_id": "Oil & Ghee",
+              "location_id": "15b5f8a0-29b5-11ed-93b0-8d73fff38901",
+              "fulfillment_id": "1",
+              "@ondc/org/returnable": true,
+              "@ondc/org/cancellable": true,
+              "@ondc/org/seller_pickup_return": false,
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/time_to_ship": "PT60M",
+              "@ondc/org/contact_details_consumer_care": "ChattyBao Help, help@chattybao.com,7353256777",
+              "@ondc/org/return_window": "P1D",
+              "matched": true,
+              "tags": [
+                {
+                  "code": "origin",
+                  "list": [
+                    {
+                      "code": "country",
+                      "value": "IND"
+                    }
+                  ]
+                },
+                {
+                  "code": "image",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "back_image"
+                    },
+                    {
+                      "code": "url",
+                      "value": "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196914855_40053315-2_5-anik-ghee.jpg"
+                    }
+                  ]
+                },
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ],
+              "@ondc/org/statutory_reqs_packaged_commodities": {
+                "manufacturer_or_packer_name": "refer to back image",
+                "manufacturer_or_packer_address": "refer to back image",
+                "common_or_generic_name_of_commodity": "refer to back image",
+                "net_quantity_or_measure_of_commodity_in_pkg": "refer to back image",
+                "month_year_of_manufacture_packing_import": "refer to back image"
+              }
+            },
+            {
+              "id": "278c8bf0-5dff-11ee-b94d-fbd52ac06897:MlepomA3E7XUC_7MpLJgjn",
+              "time": {
+                "label": "enable",
+                "timestamp": "2024-01-05T07:33:56.432Z"
+              },
+              "descriptor": {
+                "name": "Amul Chocolate Cookies 200 g",
+                "symbol": "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695906091745_40088518_2-amul-cookies-chocolate.jpg",
+                "short_desc": "Amul Chocolate Cookies 200 g",
+                "long_desc": "Amul Chocolate Cookies 200 g",
+                "images": [
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695906091745_40088518_2-amul-cookies-chocolate.jpg",
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695906091723_40088518-2_1-amul-cookies-chocolate.jpg",
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695906091442_40088518-4_1-amul-cookies-chocolate.jpg",
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695906091505_40088518-5_1-amul-cookies-chocolate.jpg"
+                ],
+                "code": "1:8901262220354"
+              },
+              "quantity": {
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                },
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "3400",
+                "maximum_value": "3500"
+              },
+              "category_id": "Chocolates and Biscuits",
+              "location_id": "15b5f8a0-29b5-11ed-93b0-8d73fff38901",
+              "fulfillment_id": "1",
+              "@ondc/org/returnable": true,
+              "@ondc/org/cancellable": true,
+              "@ondc/org/seller_pickup_return": false,
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/time_to_ship": "PT60M",
+              "@ondc/org/contact_details_consumer_care": "ChattyBao Help, help@chattybao.com,7353256777",
+              "@ondc/org/return_window": "P1D",
+              "matched": true,
+              "tags": [
+                {
+                  "code": "origin",
+                  "list": [
+                    {
+                      "code": "country",
+                      "value": "IND"
+                    }
+                  ]
+                },
+                {
+                  "code": "image",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "back_image"
+                    },
+                    {
+                      "code": "url",
+                      "value": "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695906091723_40088518-2_1-amul-cookies-chocolate.jpg"
+                    }
+                  ]
+                },
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ],
+              "@ondc/org/statutory_reqs_prepackaged_food": {
+                "nutritional_info": "refer to back image",
+                "additives_info": "refer to back image",
+                "brand_owner_FSSAI_license_no": "refer to back image",
+                "other_FSSAI_license_no": "refer to back image",
+                "importer_FSSAI_license_no": "refer to back image"
+              }
+            },
+            {
+              "id": "e1d875c0-1a41-11ee-8ddd-2bac5af1417f:MlepomA3E7XUC_7MpLJgjn",
+              "time": {
+                "label": "enable",
+                "timestamp": "2024-01-05T07:33:56.432Z"
+              },
+              "descriptor": {
+                "name": "Amul Pure Ghee Tin 1 L",
+                "symbol": "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196914877_214784_5-amul-amul-pure-ghee-1-l.jpg",
+                "short_desc": "Amul Pure Ghee Tin 1 L",
+                "long_desc": "Amul Pure Ghee Tin 1 L",
+                "images": [
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196914877_214784_5-amul-amul-pure-ghee-1-l.jpg",
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196914281_214784-2_5-amul-amul-pure-ghee-1-l.jpg",
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196913702_214784-3_5-amul-amul-pure-ghee-1-l.jpg",
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196916711_214784-4_5-amul-amul-pure-ghee-1-l.jpg"
+                ],
+                "code": "1:8901262030151"
+              },
+              "quantity": {
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                },
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "3800",
+                "maximum_value": "4000"
+              },
+              "category_id": "Oil & Ghee",
+              "location_id": "15b5f8a0-29b5-11ed-93b0-8d73fff38901",
+              "fulfillment_id": "1",
+              "@ondc/org/returnable": true,
+              "@ondc/org/cancellable": true,
+              "@ondc/org/seller_pickup_return": false,
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/time_to_ship": "PT60M",
+              "@ondc/org/contact_details_consumer_care": "ChattyBao Help, help@chattybao.com,7353256777",
+              "@ondc/org/return_window": "P1D",
+              "matched": true,
+              "tags": [
+                {
+                  "code": "origin",
+                  "list": [
+                    {
+                      "code": "country",
+                      "value": "IND"
+                    }
+                  ]
+                },
+                {
+                  "code": "image",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "back_image"
+                    },
+                    {
+                      "code": "url",
+                      "value": "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196914281_214784-2_5-amul-amul-pure-ghee-1-l.jpg"
+                    }
+                  ]
+                },
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ],
+              "@ondc/org/statutory_reqs_packaged_commodities": {
+                "manufacturer_or_packer_name": "refer to back image",
+                "manufacturer_or_packer_address": "refer to back image",
+                "common_or_generic_name_of_commodity": "refer to back image",
+                "net_quantity_or_measure_of_commodity_in_pkg": "refer to back image",
+                "month_year_of_manufacture_packing_import": "refer to back image"
+              }
+            },
+            {
+              "id": "e10631a0-1a41-11ee-8ddd-2bac5af1417f:MlepomA3E7XUC_7MpLJgjn",
+              "time": {
+                "label": "enable",
+                "timestamp": "2024-01-05T07:33:56.432Z"
+              },
+              "descriptor": {
+                "name": "Amul Cow Ghee Carton 1L",
+                "symbol": "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196914127_40096994_1-amul-amul-cow-ghee-1-l.jpg",
+                "short_desc": "Amul Cow Ghee Carton 1L",
+                "long_desc": "Amul Cow Ghee Carton 1L",
+                "images": [
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196914127_40096994_1-amul-amul-cow-ghee-1-l.jpg",
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196914187_40096994-2_1-amul-amul-cow-ghee-1-l.jpg",
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196914375_40096994-3_1-amul-amul-cow-ghee-1-l.jpg",
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196914005_40096994-5_1-amul-amul-cow-ghee-1-l.jpg"
+                ],
+                "code": "1:8901262030878"
+              },
+              "quantity": {
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                },
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "3200",
+                "maximum_value": "3500"
+              },
+              "category_id": "Oil & Ghee",
+              "location_id": "15b5f8a0-29b5-11ed-93b0-8d73fff38901",
+              "fulfillment_id": "1",
+              "@ondc/org/returnable": true,
+              "@ondc/org/cancellable": true,
+              "@ondc/org/seller_pickup_return": false,
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/time_to_ship": "PT60M",
+              "@ondc/org/contact_details_consumer_care": "ChattyBao Help, help@chattybao.com,7353256777",
+              "@ondc/org/return_window": "P1D",
+              "matched": true,
+              "tags": [
+                {
+                  "code": "origin",
+                  "list": [
+                    {
+                      "code": "country",
+                      "value": "IND"
+                    }
+                  ]
+                },
+                {
+                  "code": "image",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "back_image"
+                    },
+                    {
+                      "code": "url",
+                      "value": "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196914187_40096994-2_1-amul-amul-cow-ghee-1-l.jpg"
+                    }
+                  ]
+                },
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ],
+              "@ondc/org/statutory_reqs_packaged_commodities": {
+                "manufacturer_or_packer_name": "refer to back image",
+                "manufacturer_or_packer_address": "refer to back image",
+                "common_or_generic_name_of_commodity": "refer to back image",
+                "net_quantity_or_measure_of_commodity_in_pkg": "refer to back image",
+                "month_year_of_manufacture_packing_import": "refer to back image"
+              }
+            },
+            {
+              "id": "f862b941-1a41-11ee-8ddd-2bac5af1417f:MlepomA3E7XUC_7MpLJgjn",
+              "time": {
+                "label": "enable",
+                "timestamp": "2024-01-05T07:33:56.432Z"
+              },
+              "descriptor": {
+                "name": "Dhara Kachi Ghani Mustard Oil Bottle 1 L",
+                "symbol": "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196927301_212470_5-dhara-oil-mustard-kachi-ghani.jpg",
+                "short_desc": "Dhara Kachi Ghani Mustard Oil Bottle 1 L",
+                "long_desc": "Dhara Kachi Ghani Mustard Oil Bottle 1 L",
+                "images": [
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196927301_212470_5-dhara-oil-mustard-kachi-ghani.jpg",
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196927127_212470-2_3-dhara-oil-mustard-kachi-ghani.jpg",
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196927484_212470-4_2-dhara-oil-mustard-kachi-ghani.jpg",
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196927136_100005318-5_3-dhara-oil-mustard-kachi-ghani.jpg",
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196927049_212470-3_3-dhara-oil-mustard-kachi-ghani.jpg"
+                ],
+                "code": "1:8906004620263"
+              },
+              "quantity": {
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                },
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "2900",
+                "maximum_value": "3500"
+              },
+              "category_id": "Oil & Ghee",
+              "location_id": "15b5f8a0-29b5-11ed-93b0-8d73fff38901",
+              "fulfillment_id": "1",
+              "@ondc/org/returnable": true,
+              "@ondc/org/cancellable": true,
+              "@ondc/org/seller_pickup_return": false,
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/time_to_ship": "PT60M",
+              "@ondc/org/contact_details_consumer_care": "ChattyBao Help, help@chattybao.com,7353256777",
+              "@ondc/org/return_window": "P1D",
+              "matched": true,
+              "tags": [
+                {
+                  "code": "origin",
+                  "list": [
+                    {
+                      "code": "country",
+                      "value": "IND"
+                    }
+                  ]
+                },
+                {
+                  "code": "image",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "back_image"
+                    },
+                    {
+                      "code": "url",
+                      "value": "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196927127_212470-2_3-dhara-oil-mustard-kachi-ghani.jpg"
+                    }
+                  ]
+                },
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ],
+              "@ondc/org/statutory_reqs_packaged_commodities": {
+                "manufacturer_or_packer_name": "refer to back image",
+                "manufacturer_or_packer_address": "refer to back image",
+                "common_or_generic_name_of_commodity": "refer to back image",
+                "net_quantity_or_measure_of_commodity_in_pkg": "refer to back image",
+                "month_year_of_manufacture_packing_import": "refer to back image"
+              }
+            },
+            {
+              "id": "2850ed60-5dff-11ee-b94d-fbd52ac06897:MlepomA3E7XUC_7MpLJgjn",
+              "time": {
+                "label": "enable",
+                "timestamp": "2024-01-05T07:33:56.432Z"
+              },
+              "descriptor": {
+                "name": "Amul Butter Cookies 200 g",
+                "symbol": "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695906091558_40088517_2-amul-cookies-butter.jpg",
+                "short_desc": "Amul Butter Cookies 200 g",
+                "long_desc": "Amul Butter Cookies 200 g",
+                "images": [
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695906091558_40088517_2-amul-cookies-butter.jpg",
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695906092028_40088517-2_1-amul-cookies-butter.jpg",
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new2024-01-05T07:33:56.567530666Z /1695906091954_40088517-4_1-amul-cookies-butter.jpg",
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695906091489_40088517-5_1-amul-cookies-butter.jpg"
+                ],
+                "code": "1:8901262220347"
+              },
+              "quantity": {
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                },
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "1900",
+                "maximum_value": "2000"
+              },
+              "category_id": "Chocolates and Biscuits",
+              "location_id": "15b5f8a0-29b5-11ed-93b0-8d73fff38901",
+              "fulfillment_id": "1",
+              "@ondc/org/returnable": true,
+              "@ondc/org/cancellable": true,
+              "@ondc/org/seller_pickup_return": false,
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/time_to_ship": "PT60M",
+              "@ondc/org/contact_details_consumer_care": "ChattyBao Help, help@chattybao.com,7353256777",
+              "@ondc/org/return_window": "P1D",
+              "matched": true,
+              "tags": [
+                {
+                  "code": "origin",
+                  "list": [
+                    {
+                      "code": "country",
+                      "value": "IND"
+                    }
+                  ]
+                },
+                {
+                  "code": "image",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "back_image"
+                    },
+                    {
+                      "code": "url",
+                      "value": "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695906092028_40088517-2_1-amul-cookies-butter.jpg"
+                    }
+                  ]
+                },
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ],
+              "@ondc/org/statutory_reqs_prepackaged_food": {
+                "nutritional_info": "refer to back image",
+                "additives_info": "refer to back image",
+                "brand_owner_FSSAI_license_no": "refer to back image",
+                "other_FSSAI_license_no": "refer to back image",
+                "importer_FSSAI_license_no": "refer to back image"
+              }
+            },
+            {
+              "id": "e50d3af1-1a41-11ee-8ddd-2bac5af1417f:MlepomA3E7XUC_7MpLJgjn",
+              "time": {
+                "label": "enable",
+                "timestamp": "2024-01-05T07:33:56.432Z"
+              },
+              "descriptor": {
+                "name": "Bail Kolhu Kachi Ghani Mustard Oil Bottle 1 L",
+                "symbol": "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196914986_51pjk6MKaeL._SX679_.jpg",
+                "short_desc": "Bail Kolhu Kachi Ghani Mustard Oil Bottle 1 L",
+                "long_desc": "Bail Kolhu Kachi Ghani Mustard Oil Bottle 1 L",
+                "images": [
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196914986_51pjk6MKaeL._SX679_.jpg",
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196914263_51Bs6R6Q3YL._SX679_.jpg",
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196915086_61paEtFD9AL._SX679_.jpg",
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196914168_51-02wuJ9uL._SX679_.jpg",
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196913908_61gVLGJ6gPL._SX679_.jpg"
+                ],
+                "code": "1:8906015010039"
+              },
+              "quantity": {
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                },
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "5800",
+                "maximum_value": "6800"
+              },
+              "category_id": "Oil & Ghee",
+              "location_id": "15b5f8a0-29b5-11ed-93b0-8d73fff38901",
+              "fulfillment_id": "1",
+              "@ondc/org/returnable": true,
+              "@ondc/org/cancellable": true,
+              "@ondc/org/seller_pickup_return": false,
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/time_to_ship": "PT60M",
+              "@ondc/org/contact_details_consumer_care": "ChattyBao Help, help@chattybao.com,7353256777",
+              "@ondc/org/return_window": "P1D",
+              "matched": true,
+              "tags": [
+                {
+                  "code": "origin",
+                  "list": [
+                    {
+                      "code": "country",
+                      "value": "IND"
+                    }
+                  ]
+                },
+                {
+                  "code": "image",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "back_image"
+                    },
+                    {
+                      "code": "url",
+                      "value": "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196914263_51Bs6R6Q3YL._SX679_.jpg"
+                    }
+                  ]
+                },
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ],
+              "@ondc/org/statutory_reqs_packaged_commodities": {
+                "manufacturer_or_packer_name": "refer to back image",
+                "manufacturer_or_packer_address": "refer to back image",
+                "common_or_generic_name_of_commodity": "refer to back image",
+                "net_quantity_or_measure_of_commodity_in_pkg": "refer to back image",
+                "month_year_of_manufacture_packing_import": "refer to back image"
+              }
+            },
+            {
+              "id": "e5196ff0-1a41-11ee-8ddd-2bac5af1417f:MlepomA3E7XUC_7MpLJgjn",
+              "time": {
+                "label": "enable",
+                "timestamp": "2024-01-05T07:33:56.432Z"
+              },
+              "descriptor": {
+                "name": "Bail Kolhu Kachi Ghani Mustard Oil Bottle 2 L",
+                "symbol": "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196915023_61wez3G58dL._SX679_.jpg",
+                "short_desc": "Bail Kolhu Kachi Ghani Mustard Oil Bottle 2 L",
+                "long_desc": "Bail Kolhu Kachi Ghani Mustard Oil Bottle 2 L",
+                "images": [
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196915023_61wez3G58dL._SX679_.jpg",
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196914144_51jKn0ZvMIL._SX679_.jpg",
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196914748_61paEtFD9AL._SX679_.jpg",
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196915069_51-02wuJ9uL._SX679_.jpg",
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196914837_61gVLGJ6gPL._SX679_.jpg",
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196914939_61SvAOChWPL._SX679_.jpg",
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196914247_61nx6bd7%2BhL._SX679_.jpg"
+                ],
+                "code": "1:8906015010046"
+              },
+              "quantity": {
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                },
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "8000",
+                "maximum_value": "9800"
+              },
+              "category_id": "Oil & Ghee",
+              "location_id": "15b5f8a0-29b5-11ed-93b0-8d73fff38901",
+              "fulfillment_id": "1",
+              "@ondc/org/returnable": true,
+              "@ondc/org/cancellable": true,
+              "@ondc/org/seller_pickup_return": false,
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/time_to_ship": "PT60M",
+              "@ondc/org/contact_details_consumer_care": "ChattyBao Help, help@chattybao.com,7353256777",
+              "@ondc/org/return_window": "P1D",
+              "matched": true,
+              "tags": [
+                {
+                  "code": "origin",
+                  "list": [
+                    {
+                      "code": "country",
+                      "value": "IND"
+                    }
+                  ]
+                },
+                {
+                  "code": "image",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "back_image"
+                    },
+                    {
+                      "code": "url",
+                      "value": "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196914144_51jKn0ZvMIL._SX679_.jpg"
+                    }
+                  ]
+                },
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ],
+              "@ondc/org/statutory_reqs_packaged_commodities": {
+                "manufacturer_or_packer_name": "refer to back image",
+                "manufacturer_or_packer_address": "refer to back image",
+                "common_or_generic_name_of_commodity": "refer to back image",
+                "net_quantity_or_measure_of_commodity_in_pkg": "refer to back image",
+                "month_year_of_manufacture_packing_import": "refer to back image"
+              }
+            },
+            {
+              "id": "e2ee5290-1a41-11ee-8ddd-2bac5af1417f:MlepomA3E7XUC_7MpLJgjn",
+              "time": {
+                "label": "enable",
+                "timestamp": "2024-01-05T07:33:56.432Z"
+              },
+              "descriptor": {
+                "name": "Anik Ghee Tin 1 L",
+                "symbol": "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196914207_anik-ghee-1-l-tin-product-images-o490012759-p490012759-0-202203151003.jpg",
+                "short_desc": "Anik Ghee Tin 1 L",
+                "long_desc": "Anik Ghee Tin 1 L",
+                "images": [
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196914207_anik-ghee-1-l-tin-product-images-o490012759-p490012759-0-202203151003.jpg",
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196915566_1-na-tin-anik-original-imagyzd5s6nggv7s.jpeg",
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196915243_1-na-tin-anik-original-imagyzd5g3zfjheg.jpeg",
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196915317_1-na-tin-anik-original-imagyzd5d4hurhna.jpeg"
+                ],
+                "code": "1:8906002091430"
+              },
+              "quantity": {
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                },
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "2800",
+                "maximum_value": "3000"
+              },
+              "category_id": "Oil & Ghee",
+              "location_id": "15b5f8a0-29b5-11ed-93b0-8d73fff38901",
+              "fulfillment_id": "1",
+              "@ondc/org/returnable": true,
+              "@ondc/org/cancellable": true,
+              "@ondc/org/seller_pickup_return": false,
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/time_to_ship": "PT60M",
+              "@ondc/org/contact_details_consumer_care": "ChattyBao Help, help@chattybao.com,7353256777",
+              "@ondc/org/return_window": "P1D",
+              "matched": true,
+              "tags": [
+                {
+                  "code": "origin",
+                  "list": [
+                    {
+                      "code": "country",
+                      "value": "IND"
+                    }
+                  ]
+                },
+                {
+                  "code": "image",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "back_image"
+                    },
+                    {
+                      "code": "url",
+                      "value": "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196915566_1-na-tin-anik-original-imagyzd5s6nggv7s.jpeg"
+                    }
+                  ]
+                },
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ],
+              "@ondc/org/statutory_reqs_packaged_commodities": {
+                "manufacturer_or_packer_name": "refer to back image",
+                "manufacturer_or_packer_address": "refer to back image",
+                "common_or_generic_name_of_commodity": "refer to back image",
+                "net_quantity_or_measure_of_commodity_in_pkg": "refer to back image",
+                "month_year_of_manufacture_packing_import": "refer to back image"
+              }
+            },
+            {
+              "id": "276aac10-5dff-11ee-b94d-fbd52ac06897:MlepomA3E7XUC_7MpLJgjn",
+              "time": {
+                "label": "enable",
+                "timestamp": "2024-01-05T07:33:56.432Z"
+              },
+              "descriptor": {
+                "name": "Amul Chocolate Cookies 200 g",
+                "symbol": "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695906091889_40204111_1-amul-elaichi-nankhatai.jpg",
+                "short_desc": "Amul Chocolate Cookies 200 g",
+                "long_desc": "Amul Chocolate Cookies 200 g",
+                "images": [
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695906091889_40204111_1-amul-elaichi-nankhatai.jpg",
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695906091637_40204111-2_1-amul-elaichi-nankhatai.jpg",
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695906091693_40204111-4_1-amul-elaichi-nankhatai.jpg",
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695906092175_40204111-5_1-amul-elaichi-nankhatai.jpg"
+                ],
+                "code": "1:8901262220354"
+              },
+              "quantity": {
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                },
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "5900",
+                "maximum_value": "6500"
+              },
+              "category_id": "Chocolates and Biscuits",
+              "location_id": "15b5f8a0-29b5-11ed-93b0-8d73fff38901",
+              "fulfillment_id": "1",
+              "@ondc/org/returnable": true,
+              "@ondc/org/cancellable": true,
+              "@ondc/org/seller_pickup_return": false,
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/time_to_ship": "PT60M",
+              "@ondc/org/contact_details_consumer_care": "ChattyBao Help, help@chattybao.com,7353256777",
+              "@ondc/org/return_window": "P1D",
+              "matched": true,
+              "tags": [
+                {
+                  "code": "origin",
+                  "list": [
+                    {
+                      "code": "country",
+                      "value": "IND"
+                    }
+                  ]
+                },
+                {
+                  "code": "image",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "back_image"
+                    },
+                    {
+                      "code": "url",
+                      "value": "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695906091637_40204111-2_1-amul-elaichi-nankhatai.jpg"
+                    }
+                  ]
+                },
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ],
+              "@ondc/org/statutory_reqs_prepackaged_food": {
+                "nutritional_info": "refer to back image",
+                "additives_info": "refer to back image",
+                "brand_owner_FSSAI_license_no": "refer to back image",
+                "other_FSSAI_license_no": "refer to back image",
+                "importer_FSSAI_license_no": "refer to back image"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/Chattybao/Logs_Jan_05/Retail/Flow 1/on_search_incremental.json
+++ b/Chattybao/Logs_Jan_05/Retail/Flow 1/on_search_incremental.json
@@ -1,0 +1,300 @@
+{
+  "context": {
+    "domain": "ONDC:RET10",
+    "country": "IND",
+    "city": "*",
+    "action": "on_search",
+    "core_version": "1.2.0",
+    "bap_id": "mappls.com",
+    "bap_uri": "https://mappls.com/store/ondc-preprod",
+    "transaction_id": "nfh8lgte55qpn5ol2ni8sv4i43074414!inc",
+    "message_id": "9f060a4273df457fac20_1704440654",
+    "timestamp": "2024-01-05T07:44:15.102Z",
+    "ttl": "PT30S",
+    "bpp_id": "ondc-seller-preprod.chattybao.com/ondc",
+    "bpp_uri": "https://ondc-seller-preprod.chattybao.com/ondc/bpp"
+  },
+  "message": {
+    "catalog": {
+      "bpp/providers": [
+        {
+          "id": "MR8mcezPPQEA-r8EhP6UN9",
+          "items": [
+            {
+              "id": "e31c8e80-1a41-11ee-8ddd-2bac5af1417f:MR8mcezPPQEA-r8EhP6UN9",
+              "time": {
+                "label": "enable",
+                "timestamp": "2024-01-05T07:44:14.848Z"
+              },
+              "descriptor": {
+                "name": "Anik Ghee Carton 1 L",
+                "symbol": "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196915259_ensure000371.jpg",
+                "short_desc": "Anik Ghee Carton 1 L",
+                "long_desc": "Anik Ghee Carton 1 L",
+                "images": [
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196915259_ensure000371.jpg",
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196914855_40053315-2_5-anik-ghee.jpg",
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196916779_1-ghee-1l-tetra-1-tetrapack-anik-original-imagk7yzhcf2k5hu.jpeg",
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196915339_1-ghee-1l-tetra-1-tetrapack-anik-original-imagk7yzjqzpqazf.jpeg"
+                ],
+                "code": "1:8906002091058"
+              },
+              "quantity": {
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                },
+                "available": {
+                  "count": "0"
+                },
+                "maximum": {
+                  "count": "0"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "25000",
+                "maximum_value": "25000"
+              },
+              "category_id": "Oil & Ghee",
+              "location_id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042",
+              "fulfillment_id": "1",
+              "@ondc/org/returnable": true,
+              "@ondc/org/cancellable": true,
+              "@ondc/org/seller_pickup_return": false,
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/time_to_ship": "PT60M",
+              "@ondc/org/contact_details_consumer_care": "ChattyBao Help, help@chattybao.com,7353256777",
+              "@ondc/org/return_window": "P1D",
+              "matched": true,
+              "tags": [
+                {
+                  "code": "origin",
+                  "list": [
+                    {
+                      "code": "country",
+                      "value": "IND"
+                    }
+                  ]
+                },
+                {
+                  "code": "image",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "back_image"
+                    },
+                    {
+                      "code": "url",
+                      "value": "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196914855_40053315-2_5-anik-ghee.jpg"
+                    }
+                  ]
+                },
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ],
+              "@ondc/org/statutory_reqs_packaged_commodities": {
+                "manufacturer_or_packer_name": "refer to back image",
+                "manufacturer_or_packer_address": "refer to back image",
+                "common_or_generic_name_of_commodity": "refer to back image",
+                "net_quantity_or_measure_of_commodity_in_pkg": "refer to back image",
+                "month_year_of_manufacture_packing_import": "refer to back image"
+              }
+            },
+            {
+              "id": "f862b941-1a41-11ee-8ddd-2bac5af1417f:MR8mcezPPQEA-r8EhP6UN9",
+              "time": {
+                "label": "enable",
+                "timestamp": "2024-01-05T07:44:14.917Z"
+              },
+              "descriptor": {
+                "name": "Dhara Kachi Ghani Mustard Oil Bottle 1 L",
+                "symbol": "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196927301_212470_5-dhara-oil-mustard-kachi-ghani.jpg",
+                "short_desc": "Dhara Kachi Ghani Mustard Oil Bottle 1 L",
+                "long_desc": "Dhara Kachi Ghani Mustard Oil Bottle 1 L",
+                "images": [
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196927301_212470_5-dhara-oil-mustard-kachi-ghani.jpg",
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196927127_212470-2_3-dhara-oil-mustard-kachi-ghani.jpg",
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196927484_212470-4_2-dhara-oil-mustard-kachi-ghani.jpg",
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196927136_100005318-5_3-dhara-oil-mustard-kachi-ghani.jpg",
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196927049_212470-3_3-dhara-oil-mustard-kachi-ghani.jpg"
+                ],
+                "code": "1:8906004620263"
+              },
+              "quantity": {
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                },
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "13000",
+                "maximum_value": "13000"
+              },
+              "category_id": "Oil & Ghee",
+              "location_id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042",
+              "fulfillment_id": "1",
+              "@ondc/org/returnable": true,
+              "@ondc/org/cancellable": true,
+              "@ondc/org/seller_pickup_return": false,
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/time_to_ship": "PT60M",
+              "@ondc/org/contact_details_consumer_care": "ChattyBao Help, help@chattybao.com,7353256777",
+              "@ondc/org/return_window": "P1D",
+              "matched": true,
+              "tags": [
+                {
+                  "code": "origin",
+                  "list": [
+                    {
+                      "code": "country",
+                      "value": "IND"
+                    }
+                  ]
+                },
+                {
+                  "code": "image",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "back_image"
+                    },
+                    {
+                      "code": "url",
+                      "value": "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196927127_212470-2_3-dhara-oil-mustard-kachi-ghani.jpg"
+                    }
+                  ]
+                },
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ],
+              "@ondc/org/statutory_reqs_packaged_commodities": {
+                "manufacturer_or_packer_name": "refer to back image",
+                "manufacturer_or_packer_address": "refer to back image",
+                "common_or_generic_name_of_commodity": "refer to back image",
+                "net_quantity_or_measure_of_commodity_in_pkg": "refer to back image",
+                "month_year_of_manufacture_packing_import": "refer to back image"
+              }
+            },
+            {
+              "id": "e3007b00-1a41-11ee-8ddd-2bac5af1417f:MR8mcezPPQEA-r8EhP6UN9",
+              "time": {
+                "label": "enable",
+                "timestamp": "2024-01-05T07:44:14.948Z"
+              },
+              "descriptor": {
+                "name": "Amul Pure Ghee Carton 1L",
+                "symbol": "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196913862_191057_5-amul-amul-pure-ghee-1-l.jpg",
+                "short_desc": "Amul Pure Ghee Carton 1L",
+                "long_desc": "Amul Pure Ghee Carton 1L",
+                "images": [
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196913862_191057_5-amul-amul-pure-ghee-1-l.jpg",
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196913808_191057-2_5-amul-amul-pure-ghee-1-l.jpg",
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196914805_191057-4_5-amul-amul-pure-ghee-1-l.jpg",
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196913976_191057-5_5-amul-amul-pure-ghee-1-l.jpg",
+                  "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196914662_191057-3_5-amul-amul-pure-ghee-1-l.jpg"
+                ],
+                "code": "1:8901262030618"
+              },
+              "quantity": {
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                },
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "1500",
+                "maximum_value": "1500"
+              },
+              "category_id": "Oil & Ghee",
+              "location_id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042",
+              "fulfillment_id": "1",
+              "@ondc/org/returnable": true,
+              "@ondc/org/cancellable": true,
+              "@ondc/org/seller_pickup_return": false,
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/time_to_ship": "PT60M",
+              "@ondc/org/contact_details_consumer_care": "ChattyBao Help, help@chattybao.com,7353256777",
+              "@ondc/org/return_window": "P1D",
+              "matched": true,
+              "tags": [
+                {
+                  "code": "origin",
+                  "list": [
+                    {
+                      "code": "country",
+                      "value": "IND"
+                    }
+                  ]
+                },
+                {
+                  "code": "image",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "back_image"
+                    },
+                    {
+                      "code": "url",
+                      "value": "https://master-catalogs.s3.ap-south-1.amazonaws.com/Grocer_new/1695196913808_191057-2_5-amul-amul-pure-ghee-1-l.jpg"
+                    }
+                  ]
+                },
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ],
+              "@ondc/org/statutory_reqs_packaged_commodities": {
+                "manufacturer_or_packer_name": "refer to back image",
+                "manufacturer_or_packer_address": "refer to back image",
+                "common_or_generic_name_of_commodity": "refer to back image",
+                "net_quantity_or_measure_of_commodity_in_pkg": "refer to back image",
+                "month_year_of_manufacture_packing_import": "refer to back image"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/Chattybao/Logs_Jan_05/Retail/Flow 1/search_full_catalog.json
+++ b/Chattybao/Logs_Jan_05/Retail/Flow 1/search_full_catalog.json
@@ -1,0 +1,27 @@
+{
+  "context": {
+    "domain": "ONDC:RET10",
+    "country": "IND",
+    "city": "std:0522",
+    "action": "search",
+    "core_version": "1.2.0",
+    "bap_id": "mappls.com",
+    "bap_uri": "https://mappls.com/store/ondc-preprod",
+    "transaction_id": "nfh8lgte55qpn5ol2ni8sv4i43073356",
+    "message_id": "48713dca54d570ca1cd8_1704440036",
+    "timestamp": "2024-01-05T07:33:56.000Z",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "intent": {
+      "tags": [],
+      "fulfillment": {
+        "type": "Delivery"
+      },
+      "payment": {
+        "@ondc/org/buyer_app_finder_fee_type": "percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "3"
+      }
+    }
+  }
+}

--- a/Chattybao/Logs_Jan_05/Retail/Flow 1/search_incremental.json
+++ b/Chattybao/Logs_Jan_05/Retail/Flow 1/search_incremental.json
@@ -1,0 +1,41 @@
+{
+  "context": {
+    "domain": "ONDC:RET10",
+    "country": "IND",
+    "city": "*",
+    "action": "search",
+    "core_version": "1.2.0",
+    "bap_id": "mappls.com",
+    "bap_uri": "https://mappls.com/store/ondc-preprod",
+    "transaction_id": "nfh8lgte55qpn5ol2ni8sv4i43074414!inc",
+    "message_id": "9f060a4273df457fac20_1704440654",
+    "timestamp": "2024-01-05T07:44:14.000Z",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "intent": {
+      "tags": [
+        {
+          "code": "catalog_inc",
+          "list": [
+            {
+              "code": "start_time",
+              "value": "2024-01-05T06:44:14.000Z"
+            },
+            {
+              "code": "end_time",
+              "value": "2024-01-05T07:44:14.000Z"
+            }
+          ]
+        }
+      ],
+      "fulfillment": {
+        "type": "Delivery"
+      },
+      "payment": {
+        "@ondc/org/buyer_app_finder_fee_type": "percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "3"
+      }
+    }
+  }
+}

--- a/Chattybao/Logs_Jan_05/Retail/Flow 2/confirm.json
+++ b/Chattybao/Logs_Jan_05/Retail/Flow 2/confirm.json
@@ -1,0 +1,244 @@
+{
+  "context": {
+    "domain": "ONDC:RET10",
+    "country": "IND",
+    "city": "std:0522",
+    "action": "confirm",
+    "core_version": "1.2.0",
+    "bap_id": "mappls.com",
+    "bap_uri": "https://mappls.com/store/ondc-preprod",
+    "bpp_uri": "https://ondc-seller-preprod.chattybao.com/ondc/bpp",
+    "transaction_id": "evk5ilom22hsgq3u9fggvovlg3108",
+    "message_id": "db9a5cdda71c72e0280c_1704443596",
+    "timestamp": "2024-01-05T08:33:16.000Z",
+    "bpp_id": "ondc-seller-preprod.chattybao.com/ondc",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "id": "ORDevk5ilom22hsgq3u9fggvovlg3108",
+      "state": "Created",
+      "items": [
+        {
+          "id": "4e5ffc10-944d-11ee-848d-2d2b8538311e:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 1
+          },
+          "fulfillment_id": "1"
+        },
+        {
+          "id": "2e4065c0-5dff-11ee-b94d-fbd52ac06897:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 1
+          },
+          "fulfillment_id": "1"
+        },
+        {
+          "id": "e1d875c0-1a41-11ee-8ddd-2bac5af1417f:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 1
+          },
+          "fulfillment_id": "1"
+        }
+      ],
+      "provider": {
+        "id": "MR8mcezPPQEA-r8EhP6UN9",
+        "locations": [
+          {
+            "id": null
+          }
+        ]
+      },
+      "fulfillments": [
+        {
+          "id": "1",
+          "type": "Delivery",
+          "tracking": true,
+          "end": {
+            "location": {
+              "gps": "26.856159,81.004399",
+              "address": {
+                "name": "BMP",
+                "email": "balmukand@mapmyindia.co.in",
+                "building": "226010,226010, Lucknow, Uttar Pradesh",
+                "locality": "test",
+                "city": "Lucknow",
+                "state": "Uttar Pradesh",
+                "area_code": "226010",
+                "country": "IND"
+              }
+            },
+            "contact": {
+              "phone": "9999364087"
+            },
+            "person": {
+              "name": "BMP"
+            }
+          }
+        }
+      ],
+      "billing": {
+        "address": {
+          "name": "BMP",
+          "email": "balmukand@mapmyindia.co.in",
+          "building": "226010,226010, Lucknow, Uttar Pradesh",
+          "locality": "test",
+          "city": "Lucknow",
+          "state": "Uttar Pradesh",
+          "area_code": "226010",
+          "country": "IND"
+        },
+        "name": "BMP",
+        "phone": "9999364087",
+        "email": "balmukand@mapmyindia.co.in",
+        "created_at": "2024-01-05T08:30:18.000Z",
+        "updated_at": "2024-01-05T08:30:18.000Z"
+      },
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "15450"
+        },
+        "breakup": [
+          {
+            "title": "Ahaar Malka Red Dal Premium 500 g",
+            "@ondc/org/item_id": "4e5ffc10-944d-11ee-848d-2d2b8538311e:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/title_type": "item",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "price": {
+              "currency": "INR",
+              "value": "1400"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "1400"
+              }
+            }
+          },
+          {
+            "title": "Britannia 50-50 Sweet & Salty Biscuits 62.8 g",
+            "@ondc/org/item_id": "2e4065c0-5dff-11ee-b94d-fbd52ac06897:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/title_type": "item",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "price": {
+              "currency": "INR",
+              "value": "2000"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "2000"
+              }
+            }
+          },
+          {
+            "title": "Amul Pure Ghee Tin 1 L",
+            "@ondc/org/item_id": "e1d875c0-1a41-11ee-8ddd-2bac5af1417f:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/title_type": "item",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "price": {
+              "currency": "INR",
+              "value": "12000"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "12000"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "1",
+            "title": "Delivery Charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "42"
+            }
+          },
+          {
+            "@ondc/org/item_id": "1",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "8"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "quote",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "fulfillment"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "ttl": "P4D"
+      },
+      "offers": [],
+      "payment": {
+        "params": {
+          "currency": "INR",
+          "transaction_id": "NOtReceived",
+          "amount": "15450"
+        },
+        "status": "PAID",
+        "type": "ON-ORDER",
+        "collected_by": "BAP",
+        "@ondc/org/buyer_app_finder_fee_type": "percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "3",
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "seller-app",
+            "settlement_phase": "sale-amount",
+            "settlement_type": "neft",
+            "beneficiary_name": "CHATTYBAO TECHNOLOGIES PRIVATE LIMITED NODAL ACCOUNT",
+            "upi_address": "",
+            "settlement_bank_account_no": "661505602069",
+            "settlement_ifsc_code": "ICIC0006615",
+            "bank_name": "ICICI",
+            "branch_name": "Sco 31, Sector 18, Udyog Vihar, Gurgaon - 122016, Haryana"
+          }
+        ],
+        "@ondc/org/settlement_basis": "delivery",
+        "@ondc/org/withholding_amount": "99",
+        "@ondc/org/settlement_window": "P15D"
+      },
+      "tags": [
+        {
+          "code": "bpp_terms",
+          "list": [
+            {
+              "code": "tax_number",
+              "value": "07AAJCC8423B1ZW"
+            }
+          ]
+        },
+        {
+          "code": "bap_terms",
+          "list": [
+            {
+              "code": "tax_number",
+              "value": "07AAACC5585B1ZW"
+            }
+          ]
+        }
+      ],
+      "created_at": "2024-01-05T08:33:16.000Z",
+      "updated_at": "2024-01-05T08:33:16.000Z"
+    }
+  }
+}

--- a/Chattybao/Logs_Jan_05/Retail/Flow 2/init.json
+++ b/Chattybao/Logs_Jan_05/Retail/Flow 2/init.json
@@ -1,0 +1,95 @@
+{
+  "context": {
+    "domain": "ONDC:RET10",
+    "country": "IND",
+    "city": "std:0522",
+    "action": "init",
+    "core_version": "1.2.0",
+    "bap_id": "mappls.com",
+    "bap_uri": "https://mappls.com/store/ondc-preprod",
+    "bpp_uri": "https://ondc-seller-preprod.chattybao.com/ondc/bpp",
+    "transaction_id": "evk5ilom22hsgq3u9fggvovlg3108",
+    "message_id": "97afb61a75254d2de420_1704443418",
+    "timestamp": "2024-01-05T08:30:18.000Z",
+    "bpp_id": "ondc-seller-preprod.chattybao.com/ondc",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "items": [
+        {
+          "id": "4e5ffc10-944d-11ee-848d-2d2b8538311e:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 1
+          },
+          "fulfillment_id": "1"
+        },
+        {
+          "id": "2e4065c0-5dff-11ee-b94d-fbd52ac06897:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 1
+          },
+          "fulfillment_id": "1"
+        },
+        {
+          "id": "e1d875c0-1a41-11ee-8ddd-2bac5af1417f:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 1
+          },
+          "fulfillment_id": "1"
+        }
+      ],
+      "provider": {
+        "id": "MR8mcezPPQEA-r8EhP6UN9",
+        "locations": [
+          {
+            "id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042"
+          }
+        ]
+      },
+      "offers": [],
+      "fulfillments": [
+        {
+          "id": "1",
+          "type": "Delivery",
+          "tracking": true,
+          "end": {
+            "location": {
+              "gps": "26.856159,81.004399",
+              "address": {
+                "name": "BMP",
+                "email": "balmukand@mapmyindia.co.in",
+                "building": "226010,226010, Lucknow, Uttar Pradesh",
+                "locality": "test",
+                "city": "Lucknow",
+                "state": "Uttar Pradesh",
+                "area_code": "226010",
+                "country": "IND"
+              }
+            },
+            "contact": {
+              "phone": "9999364087"
+            }
+          }
+        }
+      ],
+      "billing": {
+        "address": {
+          "name": "BMP",
+          "email": "balmukand@mapmyindia.co.in",
+          "building": "226010,226010, Lucknow, Uttar Pradesh",
+          "locality": "test",
+          "city": "Lucknow",
+          "state": "Uttar Pradesh",
+          "area_code": "226010",
+          "country": "IND"
+        },
+        "name": "BMP",
+        "phone": "9999364087",
+        "email": "balmukand@mapmyindia.co.in",
+        "created_at": "2024-01-05T08:30:18.000Z",
+        "updated_at": "2024-01-05T08:30:18.000Z"
+      }
+    }
+  }
+}

--- a/Chattybao/Logs_Jan_05/Retail/Flow 2/on_confirm.json
+++ b/Chattybao/Logs_Jan_05/Retail/Flow 2/on_confirm.json
@@ -1,0 +1,288 @@
+{
+  "context": {
+    "domain": "ONDC:RET10",
+    "country": "IND",
+    "city": "std:0522",
+    "action": "on_confirm",
+    "core_version": "1.2.0",
+    "bap_id": "mappls.com",
+    "bap_uri": "https://mappls.com/store/ondc-preprod",
+    "bpp_uri": "https://ondc-seller-preprod.chattybao.com/ondc/bpp",
+    "transaction_id": "evk5ilom22hsgq3u9fggvovlg3108",
+    "message_id": "db9a5cdda71c72e0280c_1704443596",
+    "timestamp": "2024-01-05T08:33:16.953Z",
+    "bpp_id": "ondc-seller-preprod.chattybao.com/ondc",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "id": "ORDevk5ilom22hsgq3u9fggvovlg3108",
+      "state": "Accepted",
+      "items": [
+        {
+          "id": "4e5ffc10-944d-11ee-848d-2d2b8538311e:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 1
+          },
+          "fulfillment_id": "1"
+        },
+        {
+          "id": "2e4065c0-5dff-11ee-b94d-fbd52ac06897:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 1
+          },
+          "fulfillment_id": "1"
+        },
+        {
+          "id": "e1d875c0-1a41-11ee-8ddd-2bac5af1417f:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 1
+          },
+          "fulfillment_id": "1"
+        }
+      ],
+      "provider": {
+        "id": "MR8mcezPPQEA-r8EhP6UN9",
+        "locations": [
+          {
+            "id": null
+          }
+        ]
+      },
+      "fulfillments": [
+        {
+          "@ondc/org/provider_name": "tester shatrughan grocery",
+          "state": {
+            "descriptor": {
+              "code": "Pending"
+            }
+          },
+          "start": {
+            "location": {
+              "id": null,
+              "descriptor": {
+                "name": "tester shatrughan grocery"
+              },
+              "gps": "26.854719,80.998035",
+              "address": {
+                "locality": "4/267, Vivek Khand 4 Gomti Nagar",
+                "city": "Uttar Pradesh",
+                "area_code": "226010",
+                "state": "lucknow"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2024-01-05T08:33:16.948Z",
+                "end": "2024-01-05T09:03:16.948Z"
+              }
+            },
+            "instructions": {
+              "code": "2",
+              "name": "ONDC order",
+              "short_desc": "ONDC order",
+              "long_desc": "ONDC order"
+            },
+            "contact": {
+              "phone": "8840019700",
+              "email": "help@chattybao.com"
+            }
+          },
+          "id": "1",
+          "type": "Delivery",
+          "tracking": true,
+          "end": {
+            "location": {
+              "gps": "26.856159,81.004399",
+              "address": {
+                "name": "BMP",
+                "email": "balmukand@mapmyindia.co.in",
+                "building": "226010,226010, Lucknow, Uttar Pradesh",
+                "locality": "test",
+                "city": "Lucknow",
+                "state": "Uttar Pradesh",
+                "area_code": "226010",
+                "country": "IND"
+              }
+            },
+            "contact": {
+              "phone": "9999364087"
+            },
+            "person": {
+              "name": "BMP"
+            },
+            "time": {
+              "range": {
+                "start": "2024-01-05T08:33:16.948Z",
+                "end": "2024-01-05T09:33:16.948Z"
+              }
+            }
+          }
+        }
+      ],
+      "billing": {
+        "address": {
+          "name": "BMP",
+          "email": "balmukand@mapmyindia.co.in",
+          "building": "226010,226010, Lucknow, Uttar Pradesh",
+          "locality": "test",
+          "city": "Lucknow",
+          "state": "Uttar Pradesh",
+          "area_code": "226010",
+          "country": "IND"
+        },
+        "name": "BMP",
+        "phone": "9999364087",
+        "email": "balmukand@mapmyindia.co.in",
+        "created_at": "2024-01-05T08:30:18.000Z",
+        "updated_at": "2024-01-05T08:30:18.000Z"
+      },
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "15450"
+        },
+        "breakup": [
+          {
+            "title": "Ahaar Malka Red Dal Premium 500 g",
+            "@ondc/org/item_id": "4e5ffc10-944d-11ee-848d-2d2b8538311e:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/title_type": "item",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "price": {
+              "currency": "INR",
+              "value": "1400"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "1400"
+              }
+            }
+          },
+          {
+            "title": "Britannia 50-50 Sweet & Salty Biscuits 62.8 g",
+            "@ondc/org/item_id": "2e4065c0-5dff-11ee-b94d-fbd52ac06897:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/title_type": "item",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "price": {
+              "currency": "INR",
+              "value": "2000"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "2000"
+              }
+            }
+          },
+          {
+            "title": "Amul Pure Ghee Tin 1 L",
+            "@ondc/org/item_id": "e1d875c0-1a41-11ee-8ddd-2bac5af1417f:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/title_type": "item",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "price": {
+              "currency": "INR",
+              "value": "12000"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "12000"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "1",
+            "title": "Delivery Charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "42"
+            }
+          },
+          {
+            "@ondc/org/item_id": "1",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "8"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "quote",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "fulfillment"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "ttl": "P4D"
+      },
+      "offers": [],
+      "payment": {
+        "params": {
+          "currency": "INR",
+          "transaction_id": "NOtReceived",
+          "amount": "15450"
+        },
+        "status": "PAID",
+        "type": "ON-ORDER",
+        "collected_by": "BAP",
+        "@ondc/org/buyer_app_finder_fee_type": "percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "3",
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "seller-app",
+            "settlement_phase": "sale-amount",
+            "settlement_type": "neft",
+            "beneficiary_name": "CHATTYBAO TECHNOLOGIES PRIVATE LIMITED NODAL ACCOUNT",
+            "upi_address": "",
+            "settlement_bank_account_no": "661505602069",
+            "settlement_ifsc_code": "ICIC0006615",
+            "bank_name": "ICICI",
+            "branch_name": "Sco 31, Sector 18, Udyog Vihar, Gurgaon - 122016, Haryana"
+          }
+        ],
+        "@ondc/org/settlement_basis": "delivery",
+        "@ondc/org/withholding_amount": "99",
+        "@ondc/org/settlement_window": "P15D"
+      },
+      "tags": [
+        {
+          "code": "bpp_terms",
+          "list": [
+            {
+              "code": "tax_number",
+              "value": "07AAJCC8423B1ZW"
+            }
+          ]
+        },
+        {
+          "code": "bap_terms",
+          "list": [
+            {
+              "code": "tax_number",
+              "value": "07AAACC5585B1ZW"
+            }
+          ]
+        }
+      ],
+      "created_at": "2024-01-05T08:33:16.000Z",
+      "updated_at": "2024-01-05T08:33:16.953Z",
+      "rateable": true
+    }
+  }
+}

--- a/Chattybao/Logs_Jan_05/Retail/Flow 2/on_init.json
+++ b/Chattybao/Logs_Jan_05/Retail/Flow 2/on_init.json
@@ -1,0 +1,222 @@
+{
+  "context": {
+    "domain": "ONDC:RET10",
+    "country": "IND",
+    "city": "std:0522",
+    "action": "on_init",
+    "core_version": "1.2.0",
+    "bap_id": "mappls.com",
+    "bap_uri": "https://mappls.com/store/ondc-preprod",
+    "bpp_uri": "https://ondc-seller-preprod.chattybao.com/ondc/bpp",
+    "transaction_id": "evk5ilom22hsgq3u9fggvovlg3108",
+    "message_id": "97afb61a75254d2de420_1704443418",
+    "timestamp": "2024-01-05T08:30:18.863Z",
+    "bpp_id": "ondc-seller-preprod.chattybao.com/ondc",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "items": [
+        {
+          "id": "4e5ffc10-944d-11ee-848d-2d2b8538311e:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 1
+          },
+          "fulfillment_id": "1"
+        },
+        {
+          "id": "2e4065c0-5dff-11ee-b94d-fbd52ac06897:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 1
+          },
+          "fulfillment_id": "1"
+        },
+        {
+          "id": "e1d875c0-1a41-11ee-8ddd-2bac5af1417f:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 1
+          },
+          "fulfillment_id": "1"
+        }
+      ],
+      "billing": {
+        "address": {
+          "name": "BMP",
+          "email": "balmukand@mapmyindia.co.in",
+          "building": "226010,226010, Lucknow, Uttar Pradesh",
+          "locality": "test",
+          "city": "Lucknow",
+          "state": "Uttar Pradesh",
+          "area_code": "226010",
+          "country": "IND"
+        },
+        "name": "BMP",
+        "phone": "9999364087",
+        "email": "balmukand@mapmyindia.co.in",
+        "created_at": "2024-01-05T08:30:18.000Z",
+        "updated_at": "2024-01-05T08:30:18.000Z"
+      },
+      "fulfillments": [
+        {
+          "id": "1",
+          "type": "Delivery",
+          "tracking": true,
+          "end": {
+            "location": {
+              "gps": "26.856159,81.004399",
+              "address": {
+                "name": "BMP",
+                "email": "balmukand@mapmyindia.co.in",
+                "building": "226010,226010, Lucknow, Uttar Pradesh",
+                "locality": "test",
+                "city": "Lucknow",
+                "state": "Uttar Pradesh",
+                "area_code": "226010",
+                "country": "IND"
+              }
+            },
+            "contact": {
+              "phone": "9999364087"
+            }
+          }
+        }
+      ],
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "15450"
+        },
+        "breakup": [
+          {
+            "title": "Ahaar Malka Red Dal Premium 500 g",
+            "@ondc/org/item_id": "4e5ffc10-944d-11ee-848d-2d2b8538311e:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/title_type": "item",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "price": {
+              "currency": "INR",
+              "value": "1400"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "1400"
+              }
+            }
+          },
+          {
+            "title": "Britannia 50-50 Sweet & Salty Biscuits 62.8 g",
+            "@ondc/org/item_id": "2e4065c0-5dff-11ee-b94d-fbd52ac06897:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/title_type": "item",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "price": {
+              "currency": "INR",
+              "value": "2000"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "2000"
+              }
+            }
+          },
+          {
+            "title": "Amul Pure Ghee Tin 1 L",
+            "@ondc/org/item_id": "e1d875c0-1a41-11ee-8ddd-2bac5af1417f:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/title_type": "item",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "price": {
+              "currency": "INR",
+              "value": "12000"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "12000"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "1",
+            "title": "Delivery Charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "42"
+            }
+          },
+          {
+            "@ondc/org/item_id": "1",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "8"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "quote",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "fulfillment"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "ttl": "P4D"
+      },
+      "provider": {
+        "id": "MR8mcezPPQEA-r8EhP6UN9",
+        "locations": [
+          {
+            "id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042"
+          }
+        ]
+      },
+      "payment": {
+        "type": "ON-ORDER",
+        "collected_by": "BAP",
+        "status": "NOT-PAID",
+        "@ondc/org/settlement_basis": "delivery",
+        "@ondc/org/settlement_window": "P1D",
+        "@ondc/org/withholding_amount": "0.00",
+        "@ondc/org/buyer_app_finder_fee_type": "percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "3",
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "seller-app",
+            "settlement_phase": "sale-amount",
+            "settlement_type": "neft",
+            "beneficiary_name": "CHATTYBAO TECHNOLOGIES PRIVATE LIMITED NODAL ACCOUNT",
+            "upi_address": "",
+            "settlement_bank_account_no": "661505602069",
+            "settlement_ifsc_code": "ICIC0006615",
+            "bank_name": "ICICI",
+            "branch_name": "Sco 31, Sector 18, Udyog Vihar, Gurgaon - 122016, Haryana"
+          }
+        ]
+      },
+      "tags": [
+        {
+          "code": "bpp_terms",
+          "list": [
+            {
+              "code": "tax_number",
+              "value": "07AAJCC8423B1ZW"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/Chattybao/Logs_Jan_05/Retail/Flow 2/on_select.json
+++ b/Chattybao/Logs_Jan_05/Retail/Flow 2/on_select.json
@@ -1,0 +1,176 @@
+{
+  "context": {
+    "domain": "ONDC:RET10",
+    "country": "IND",
+    "city": "std:0522",
+    "action": "on_select",
+    "core_version": "1.2.0",
+    "bap_id": "mappls.com",
+    "bap_uri": "https://mappls.com/store/ondc-preprod",
+    "bpp_uri": "https://ondc-seller-preprod.chattybao.com/ondc/bpp",
+    "transaction_id": "evk5ilom22hsgq3u9fggvovlg3108",
+    "message_id": "48790770ec6bbc84aab6_1704443411",
+    "timestamp": "2024-01-05T08:30:12.775Z",
+    "bpp_id": "ondc-seller-preprod.chattybao.com/ondc",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "provider": {
+        "id": "MR8mcezPPQEA-r8EhP6UN9",
+        "locations": [
+          {
+            "id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042"
+          }
+        ]
+      },
+      "items": [
+        {
+          "fulfillment_id": "1",
+          "id": "2e4065c0-5dff-11ee-b94d-fbd52ac06897:MR8mcezPPQEA-r8EhP6UN9"
+        },
+        {
+          "fulfillment_id": "1",
+          "id": "e1d875c0-1a41-11ee-8ddd-2bac5af1417f:MR8mcezPPQEA-r8EhP6UN9"
+        },
+        {
+          "fulfillment_id": "1",
+          "id": "4e5ffc10-944d-11ee-848d-2d2b8538311e:MR8mcezPPQEA-r8EhP6UN9"
+        }
+      ],
+      "fulfillments": [
+        {
+          "id": "1",
+          "type": "Delivery",
+          "@ondc/org/provider_name": "Chattybao Logistics",
+          "tracking": true,
+          "@ondc/org/category": "Immediate Delivery",
+          "@ondc/org/TAT": "PT60M",
+          "state": {
+            "descriptor": {
+              "code": "Serviceable"
+            }
+          }
+        }
+      ],
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "15450"
+        },
+        "breakup": [
+          {
+            "@ondc/org/item_id": "2e4065c0-5dff-11ee-b94d-fbd52ac06897:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "@ondc/org/title_type": "item",
+            "title": "Britannia 50-50 Sweet & Salty Biscuits 62.8 g",
+            "price": {
+              "currency": "INR",
+              "value": "2000"
+            },
+            "item": {
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "2000"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "e1d875c0-1a41-11ee-8ddd-2bac5af1417f:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "@ondc/org/title_type": "item",
+            "title": "Amul Pure Ghee Tin 1 L",
+            "price": {
+              "currency": "INR",
+              "value": "12000"
+            },
+            "item": {
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "12000"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "4e5ffc10-944d-11ee-848d-2d2b8538311e:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "@ondc/org/title_type": "item",
+            "title": "Ahaar Malka Red Dal Premium 500 g",
+            "price": {
+              "currency": "INR",
+              "value": "1400"
+            },
+            "item": {
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "1400"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "1",
+            "title": "Delivery Charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "42"
+            }
+          },
+          {
+            "@ondc/org/item_id": "1",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "8"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "quote",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "fulfillment"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "ttl": "P4D"
+      }
+    }
+  }
+}

--- a/Chattybao/Logs_Jan_05/Retail/Flow 2/on_status_delivered.json
+++ b/Chattybao/Logs_Jan_05/Retail/Flow 2/on_status_delivered.json
@@ -1,0 +1,290 @@
+{
+  "context": {
+    "domain": "ONDC:RET10",
+    "country": "IND",
+    "city": "std:0522",
+    "action": "on_status",
+    "core_version": "1.2.0",
+    "bap_id": "mappls.com",
+    "bap_uri": "https://mappls.com/store/ondc-preprod",
+    "bpp_uri": "https://ondc-seller-preprod.chattybao.com/ondc/bpp",
+    "transaction_id": "evk5ilom22hsgq3u9fggvovlg3108",
+    "message_id": "dff87660-aba5-11ee-bcfb-b194587c2ac1",
+    "timestamp": "2024-01-05T08:39:01.062Z",
+    "bpp_id": "ondc-seller-preprod.chattybao.com/ondc",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "id": "ORDevk5ilom22hsgq3u9fggvovlg3108",
+      "state": "Completed",
+      "provider": {
+        "id": "MR8mcezPPQEA-r8EhP6UN9",
+        "locations": [
+          {
+            "id": "null"
+          }
+        ]
+      },
+      "items": [
+        {
+          "id": "4e5ffc10-944d-11ee-848d-2d2b8538311e:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 1
+          },
+          "fulfillment_id": "1"
+        },
+        {
+          "id": "2e4065c0-5dff-11ee-b94d-fbd52ac06897:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 1
+          },
+          "fulfillment_id": "1"
+        },
+        {
+          "id": "e1d875c0-1a41-11ee-8ddd-2bac5af1417f:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 1
+          },
+          "fulfillment_id": "1"
+        }
+      ],
+      "billing": {
+        "address": {
+          "name": "BMP",
+          "email": "balmukand@mapmyindia.co.in",
+          "building": "226010,226010, Lucknow, Uttar Pradesh",
+          "locality": "test",
+          "city": "Lucknow",
+          "state": "Uttar Pradesh",
+          "area_code": "226010",
+          "country": "IND"
+        },
+        "name": "BMP",
+        "phone": "9999364087",
+        "email": "help@chattybao.com",
+        "created_at": "2024-01-05T08:30:18.000Z",
+        "updated_at": "2024-01-05T08:30:18.000Z"
+      },
+      "fulfillments": [
+        {
+          "@ondc/org/provider_name": "tester shatrughan grocery",
+          "state": {
+            "descriptor": {
+              "code": "Order-delivered",
+              "name": "Order delivered"
+            }
+          },
+          "start": {
+            "location": {
+              "id": null,
+              "descriptor": {
+                "name": "tester shatrughan grocery"
+              },
+              "gps": "26.854719,80.998035",
+              "address": {
+                "locality": "4/267, Vivek Khand 4 Gomti Nagar",
+                "city": "Uttar Pradesh",
+                "area_code": "226010",
+                "state": "lucknow"
+              }
+            },
+            "time": {
+              "timestamp": "2024-01-05T08:36:19.060Z",
+              "range": {
+                "start": "2024-01-05T08:33:16.948Z",
+                "end": "2024-01-05T09:03:16.948Z"
+              }
+            },
+            "instructions": {
+              "code": "2",
+              "name": "ONDC order",
+              "short_desc": "ONDC order",
+              "long_desc": "ONDC order"
+            },
+            "contact": {
+              "phone": "8840019700",
+              "email": "help@chattybao.com"
+            }
+          },
+          "id": "1",
+          "type": "Delivery",
+          "tracking": true,
+          "end": {
+            "location": {
+              "gps": "26.856159,81.004399",
+              "address": {
+                "name": "BMP",
+                "email": "balmukand@mapmyindia.co.in",
+                "building": "226010,226010, Lucknow, Uttar Pradesh",
+                "locality": "test",
+                "city": "Lucknow",
+                "state": "Uttar Pradesh",
+                "area_code": "226010",
+                "country": "IND"
+              }
+            },
+            "contact": {
+              "phone": "9999364087"
+            },
+            "person": {
+              "name": "BMP"
+            },
+            "time": {
+              "timestamp": "2024-01-05T08:39:01.059Z",
+              "range": {
+                "start": "2024-01-05T08:33:16.948Z",
+                "end": "2024-01-05T09:33:16.948Z"
+              }
+            }
+          },
+          "@ondc/org/TAT": "PT60M",
+          "agent": {
+            "name": "Dummy1",
+            "phone": "8840019101"
+          },
+          "tags": [
+            {
+              "code": "tracking",
+              "list": [
+                {
+                  "code": "gps_enabled",
+                  "value": "yes"
+                },
+                {
+                  "code": "url_enabled",
+                  "value": "no"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "15450"
+        },
+        "breakup": [
+          {
+            "title": "Ahaar Malka Red Dal Premium 500 g",
+            "@ondc/org/item_id": "4e5ffc10-944d-11ee-848d-2d2b8538311e:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/title_type": "item",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "price": {
+              "currency": "INR",
+              "value": "1400"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "1400"
+              }
+            }
+          },
+          {
+            "title": "Britannia 50-50 Sweet & Salty Biscuits 62.8 g",
+            "@ondc/org/item_id": "2e4065c0-5dff-11ee-b94d-fbd52ac06897:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/title_type": "item",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "price": {
+              "currency": "INR",
+              "value": "2000"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "2000"
+              }
+            }
+          },
+          {
+            "title": "Amul Pure Ghee Tin 1 L",
+            "@ondc/org/item_id": "e1d875c0-1a41-11ee-8ddd-2bac5af1417f:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/title_type": "item",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "price": {
+              "currency": "INR",
+              "value": "12000"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "12000"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "1",
+            "title": "Delivery Charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "42"
+            }
+          },
+          {
+            "@ondc/org/item_id": "1",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "8"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "quote",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "fulfillment"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "ttl": "P4D"
+      },
+      "payment": {
+        "params": {
+          "currency": "INR",
+          "transaction_id": "NOtReceived",
+          "amount": "15450"
+        },
+        "status": "PAID",
+        "type": "ON-ORDER",
+        "collected_by": "BAP",
+        "@ondc/org/buyer_app_finder_fee_type": "percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "3",
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "seller-app",
+            "settlement_phase": "sale-amount",
+            "settlement_type": "neft",
+            "beneficiary_name": "CHATTYBAO TECHNOLOGIES PRIVATE LIMITED NODAL ACCOUNT",
+            "upi_address": "",
+            "settlement_bank_account_no": "661505602069",
+            "settlement_ifsc_code": "ICIC0006615",
+            "bank_name": "ICICI",
+            "branch_name": "Sco 31, Sector 18, Udyog Vihar, Gurgaon - 122016, Haryana",
+            "settlement_timestamp": "2024-01-06T09:03:16.948Z"
+          }
+        ],
+        "@ondc/org/settlement_basis": "delivery",
+        "@ondc/org/withholding_amount": "99",
+        "@ondc/org/settlement_window": "P15D"
+      },
+      "created_at": "2024-01-05T08:33:16.000Z",
+      "updated_at": "2024-01-05T08:39:01.060Z"
+    }
+  }
+}

--- a/Chattybao/Logs_Jan_05/Retail/Flow 2/on_status_out_for_delivery.json
+++ b/Chattybao/Logs_Jan_05/Retail/Flow 2/on_status_out_for_delivery.json
@@ -1,0 +1,289 @@
+{
+  "context": {
+    "domain": "ONDC:RET10",
+    "country": "IND",
+    "city": "std:0522",
+    "action": "on_status",
+    "core_version": "1.2.0",
+    "bap_id": "mappls.com",
+    "bap_uri": "https://mappls.com/store/ondc-preprod",
+    "bpp_uri": "https://ondc-seller-preprod.chattybao.com/ondc/bpp",
+    "transaction_id": "evk5ilom22hsgq3u9fggvovlg3108",
+    "message_id": "b1330b10-aba5-11ee-bcfb-b194587c2ac1",
+    "timestamp": "2024-01-05T08:37:42.593Z",
+    "bpp_id": "ondc-seller-preprod.chattybao.com/ondc",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "id": "ORDevk5ilom22hsgq3u9fggvovlg3108",
+      "state": "In-progress",
+      "provider": {
+        "id": "MR8mcezPPQEA-r8EhP6UN9",
+        "locations": [
+          {
+            "id": "null"
+          }
+        ]
+      },
+      "items": [
+        {
+          "id": "4e5ffc10-944d-11ee-848d-2d2b8538311e:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 1
+          },
+          "fulfillment_id": "1"
+        },
+        {
+          "id": "2e4065c0-5dff-11ee-b94d-fbd52ac06897:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 1
+          },
+          "fulfillment_id": "1"
+        },
+        {
+          "id": "e1d875c0-1a41-11ee-8ddd-2bac5af1417f:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 1
+          },
+          "fulfillment_id": "1"
+        }
+      ],
+      "billing": {
+        "address": {
+          "name": "BMP",
+          "email": "balmukand@mapmyindia.co.in",
+          "building": "226010,226010, Lucknow, Uttar Pradesh",
+          "locality": "test",
+          "city": "Lucknow",
+          "state": "Uttar Pradesh",
+          "area_code": "226010",
+          "country": "IND"
+        },
+        "name": "BMP",
+        "phone": "9999364087",
+        "email": "help@chattybao.com",
+        "created_at": "2024-01-05T08:30:18.000Z",
+        "updated_at": "2024-01-05T08:30:18.000Z"
+      },
+      "fulfillments": [
+        {
+          "@ondc/org/provider_name": "tester shatrughan grocery",
+          "state": {
+            "descriptor": {
+              "code": "Out-for-delivery",
+              "name": "Out for delivery"
+            }
+          },
+          "start": {
+            "location": {
+              "id": null,
+              "descriptor": {
+                "name": "tester shatrughan grocery"
+              },
+              "gps": "26.854719,80.998035",
+              "address": {
+                "locality": "4/267, Vivek Khand 4 Gomti Nagar",
+                "city": "Uttar Pradesh",
+                "area_code": "226010",
+                "state": "lucknow"
+              }
+            },
+            "time": {
+              "timestamp": "2024-01-05T08:36:19.060Z",
+              "range": {
+                "start": "2024-01-05T08:33:16.948Z",
+                "end": "2024-01-05T09:03:16.948Z"
+              }
+            },
+            "instructions": {
+              "code": "2",
+              "name": "ONDC order",
+              "short_desc": "ONDC order",
+              "long_desc": "ONDC order"
+            },
+            "contact": {
+              "phone": "8840019700",
+              "email": "help@chattybao.com"
+            }
+          },
+          "id": "1",
+          "type": "Delivery",
+          "tracking": true,
+          "end": {
+            "location": {
+              "gps": "26.856159,81.004399",
+              "address": {
+                "name": "BMP",
+                "email": "balmukand@mapmyindia.co.in",
+                "building": "226010,226010, Lucknow, Uttar Pradesh",
+                "locality": "test",
+                "city": "Lucknow",
+                "state": "Uttar Pradesh",
+                "area_code": "226010",
+                "country": "IND"
+              }
+            },
+            "contact": {
+              "phone": "9999364087"
+            },
+            "person": {
+              "name": "BMP"
+            },
+            "time": {
+              "range": {
+                "start": "2024-01-05T08:33:16.948Z",
+                "end": "2024-01-05T09:33:16.948Z"
+              }
+            }
+          },
+          "@ondc/org/TAT": "PT60M",
+          "agent": {
+            "name": "Dummy1",
+            "phone": "8840019101"
+          },
+          "tags": [
+            {
+              "code": "tracking",
+              "list": [
+                {
+                  "code": "gps_enabled",
+                  "value": "yes"
+                },
+                {
+                  "code": "url_enabled",
+                  "value": "no"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "15450"
+        },
+        "breakup": [
+          {
+            "title": "Ahaar Malka Red Dal Premium 500 g",
+            "@ondc/org/item_id": "4e5ffc10-944d-11ee-848d-2d2b8538311e:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/title_type": "item",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "price": {
+              "currency": "INR",
+              "value": "1400"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "1400"
+              }
+            }
+          },
+          {
+            "title": "Britannia 50-50 Sweet & Salty Biscuits 62.8 g",
+            "@ondc/org/item_id": "2e4065c0-5dff-11ee-b94d-fbd52ac06897:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/title_type": "item",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "price": {
+              "currency": "INR",
+              "value": "2000"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "2000"
+              }
+            }
+          },
+          {
+            "title": "Amul Pure Ghee Tin 1 L",
+            "@ondc/org/item_id": "e1d875c0-1a41-11ee-8ddd-2bac5af1417f:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/title_type": "item",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "price": {
+              "currency": "INR",
+              "value": "12000"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "12000"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "1",
+            "title": "Delivery Charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "42"
+            }
+          },
+          {
+            "@ondc/org/item_id": "1",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "8"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "quote",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "fulfillment"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "ttl": "P4D"
+      },
+      "payment": {
+        "params": {
+          "currency": "INR",
+          "transaction_id": "NOtReceived",
+          "amount": "15450"
+        },
+        "status": "PAID",
+        "type": "ON-ORDER",
+        "collected_by": "BAP",
+        "@ondc/org/buyer_app_finder_fee_type": "percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "3",
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "seller-app",
+            "settlement_phase": "sale-amount",
+            "settlement_type": "neft",
+            "beneficiary_name": "CHATTYBAO TECHNOLOGIES PRIVATE LIMITED NODAL ACCOUNT",
+            "upi_address": "",
+            "settlement_bank_account_no": "661505602069",
+            "settlement_ifsc_code": "ICIC0006615",
+            "bank_name": "ICICI",
+            "branch_name": "Sco 31, Sector 18, Udyog Vihar, Gurgaon - 122016, Haryana",
+            "settlement_timestamp": "2024-01-06T09:03:16.948Z"
+          }
+        ],
+        "@ondc/org/settlement_basis": "delivery",
+        "@ondc/org/withholding_amount": "99",
+        "@ondc/org/settlement_window": "P15D"
+      },
+      "created_at": "2024-01-05T08:33:16.000Z",
+      "updated_at": "2024-01-05T08:37:42.591Z"
+    }
+  }
+}

--- a/Chattybao/Logs_Jan_05/Retail/Flow 2/on_status_pending(packed).json
+++ b/Chattybao/Logs_Jan_05/Retail/Flow 2/on_status_pending(packed).json
@@ -1,0 +1,269 @@
+{
+  "context": {
+    "domain": "ONDC:RET10",
+    "country": "IND",
+    "city": "std:0522",
+    "action": "on_status",
+    "core_version": "1.2.0",
+    "bap_id": "mappls.com",
+    "bap_uri": "https://mappls.com/store/ondc-preprod",
+    "bpp_uri": "https://ondc-seller-preprod.chattybao.com/ondc/bpp",
+    "transaction_id": "evk5ilom22hsgq3u9fggvovlg3108",
+    "message_id": "4102a530-aba5-11ee-bcfb-b194587c2ac1",
+    "timestamp": "2024-01-05T08:34:34.370Z",
+    "bpp_id": "ondc-seller-preprod.chattybao.com/ondc",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "id": "ORDevk5ilom22hsgq3u9fggvovlg3108",
+      "state": "In-progress",
+      "provider": {
+        "id": "MR8mcezPPQEA-r8EhP6UN9",
+        "locations": [
+          {
+            "id": "null"
+          }
+        ]
+      },
+      "items": [
+        {
+          "id": "4e5ffc10-944d-11ee-848d-2d2b8538311e:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 1
+          },
+          "fulfillment_id": "1"
+        },
+        {
+          "id": "2e4065c0-5dff-11ee-b94d-fbd52ac06897:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 1
+          },
+          "fulfillment_id": "1"
+        },
+        {
+          "id": "e1d875c0-1a41-11ee-8ddd-2bac5af1417f:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 1
+          },
+          "fulfillment_id": "1"
+        }
+      ],
+      "billing": {
+        "address": {
+          "name": "BMP",
+          "email": "balmukand@mapmyindia.co.in",
+          "building": "226010,226010, Lucknow, Uttar Pradesh",
+          "locality": "test",
+          "city": "Lucknow",
+          "state": "Uttar Pradesh",
+          "area_code": "226010",
+          "country": "IND"
+        },
+        "name": "BMP",
+        "phone": "9999364087",
+        "email": "help@chattybao.com",
+        "created_at": "2024-01-05T08:30:18.000Z",
+        "updated_at": "2024-01-05T08:30:18.000Z"
+      },
+      "fulfillments": [
+        {
+          "@ondc/org/provider_name": "tester shatrughan grocery",
+          "state": {
+            "descriptor": {
+              "code": "Packed",
+              "name": "Packed"
+            }
+          },
+          "start": {
+            "location": {
+              "id": null,
+              "descriptor": {
+                "name": "tester shatrughan grocery"
+              },
+              "gps": "26.854719,80.998035",
+              "address": {
+                "locality": "4/267, Vivek Khand 4 Gomti Nagar",
+                "city": "Uttar Pradesh",
+                "area_code": "226010",
+                "state": "lucknow"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2024-01-05T08:33:16.948Z",
+                "end": "2024-01-05T09:03:16.948Z"
+              }
+            },
+            "instructions": {
+              "code": "2",
+              "name": "ONDC order",
+              "short_desc": "ONDC order",
+              "long_desc": "ONDC order"
+            },
+            "contact": {
+              "phone": "8840019700",
+              "email": "help@chattybao.com"
+            }
+          },
+          "id": "1",
+          "type": "Delivery",
+          "tracking": true,
+          "end": {
+            "location": {
+              "gps": "26.856159,81.004399",
+              "address": {
+                "name": "BMP",
+                "email": "balmukand@mapmyindia.co.in",
+                "building": "226010,226010, Lucknow, Uttar Pradesh",
+                "locality": "test",
+                "city": "Lucknow",
+                "state": "Uttar Pradesh",
+                "area_code": "226010",
+                "country": "IND"
+              }
+            },
+            "contact": {
+              "phone": "9999364087"
+            },
+            "person": {
+              "name": "BMP"
+            },
+            "time": {
+              "range": {
+                "start": "2024-01-05T08:33:16.948Z",
+                "end": "2024-01-05T09:33:16.948Z"
+              }
+            }
+          },
+          "@ondc/org/TAT": "PT60M"
+        }
+      ],
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "15450"
+        },
+        "breakup": [
+          {
+            "title": "Ahaar Malka Red Dal Premium 500 g",
+            "@ondc/org/item_id": "4e5ffc10-944d-11ee-848d-2d2b8538311e:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/title_type": "item",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "price": {
+              "currency": "INR",
+              "value": "1400"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "1400"
+              }
+            }
+          },
+          {
+            "title": "Britannia 50-50 Sweet & Salty Biscuits 62.8 g",
+            "@ondc/org/item_id": "2e4065c0-5dff-11ee-b94d-fbd52ac06897:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/title_type": "item",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "price": {
+              "currency": "INR",
+              "value": "2000"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "2000"
+              }
+            }
+          },
+          {
+            "title": "Amul Pure Ghee Tin 1 L",
+            "@ondc/org/item_id": "e1d875c0-1a41-11ee-8ddd-2bac5af1417f:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/title_type": "item",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "price": {
+              "currency": "INR",
+              "value": "12000"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "12000"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "1",
+            "title": "Delivery Charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "42"
+            }
+          },
+          {
+            "@ondc/org/item_id": "1",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "8"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "quote",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "fulfillment"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "ttl": "P4D"
+      },
+      "payment": {
+        "params": {
+          "currency": "INR",
+          "transaction_id": "NOtReceived",
+          "amount": "15450"
+        },
+        "status": "PAID",
+        "type": "ON-ORDER",
+        "collected_by": "BAP",
+        "@ondc/org/buyer_app_finder_fee_type": "percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "3",
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "seller-app",
+            "settlement_phase": "sale-amount",
+            "settlement_type": "neft",
+            "beneficiary_name": "CHATTYBAO TECHNOLOGIES PRIVATE LIMITED NODAL ACCOUNT",
+            "upi_address": "",
+            "settlement_bank_account_no": "661505602069",
+            "settlement_ifsc_code": "ICIC0006615",
+            "bank_name": "ICICI",
+            "branch_name": "Sco 31, Sector 18, Udyog Vihar, Gurgaon - 122016, Haryana",
+            "settlement_timestamp": "2024-01-06T09:03:16.948Z"
+          }
+        ],
+        "@ondc/org/settlement_basis": "delivery",
+        "@ondc/org/withholding_amount": "99",
+        "@ondc/org/settlement_window": "P15D"
+      },
+      "created_at": "2024-01-05T08:33:16.000Z",
+      "updated_at": "2024-01-05T08:34:34.368Z"
+    }
+  }
+}

--- a/Chattybao/Logs_Jan_05/Retail/Flow 2/on_status_pending.json
+++ b/Chattybao/Logs_Jan_05/Retail/Flow 2/on_status_pending.json
@@ -1,0 +1,269 @@
+{
+  "context": {
+    "domain": "ONDC:RET10",
+    "country": "IND",
+    "city": "std:0522",
+    "action": "on_status",
+    "core_version": "1.2.0",
+    "bap_id": "mappls.com",
+    "bap_uri": "https://mappls.com/store/ondc-preprod",
+    "bpp_uri": "https://ondc-seller-preprod.chattybao.com/ondc/bpp",
+    "transaction_id": "evk5ilom22hsgq3u9fggvovlg3108",
+    "message_id": "137a74d0-aba5-11ee-bcfb-b194587c2ac1",
+    "timestamp": "2024-01-05T08:33:17.981Z",
+    "bpp_id": "ondc-seller-preprod.chattybao.com/ondc",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "id": "ORDevk5ilom22hsgq3u9fggvovlg3108",
+      "state": "Accepted",
+      "provider": {
+        "id": "MR8mcezPPQEA-r8EhP6UN9",
+        "locations": [
+          {
+            "id": "null"
+          }
+        ]
+      },
+      "items": [
+        {
+          "id": "4e5ffc10-944d-11ee-848d-2d2b8538311e:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 1
+          },
+          "fulfillment_id": "1"
+        },
+        {
+          "id": "2e4065c0-5dff-11ee-b94d-fbd52ac06897:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 1
+          },
+          "fulfillment_id": "1"
+        },
+        {
+          "id": "e1d875c0-1a41-11ee-8ddd-2bac5af1417f:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 1
+          },
+          "fulfillment_id": "1"
+        }
+      ],
+      "billing": {
+        "address": {
+          "name": "BMP",
+          "email": "balmukand@mapmyindia.co.in",
+          "building": "226010,226010, Lucknow, Uttar Pradesh",
+          "locality": "test",
+          "city": "Lucknow",
+          "state": "Uttar Pradesh",
+          "area_code": "226010",
+          "country": "IND"
+        },
+        "name": "BMP",
+        "phone": "9999364087",
+        "email": "help@chattybao.com",
+        "created_at": "2024-01-05T08:30:18.000Z",
+        "updated_at": "2024-01-05T08:30:18.000Z"
+      },
+      "fulfillments": [
+        {
+          "@ondc/org/provider_name": "tester shatrughan grocery",
+          "state": {
+            "descriptor": {
+              "code": "Pending",
+              "name": "Pending"
+            }
+          },
+          "start": {
+            "location": {
+              "id": null,
+              "descriptor": {
+                "name": "tester shatrughan grocery"
+              },
+              "gps": "26.854719,80.998035",
+              "address": {
+                "locality": "4/267, Vivek Khand 4 Gomti Nagar",
+                "city": "Uttar Pradesh",
+                "area_code": "226010",
+                "state": "lucknow"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2024-01-05T08:33:16.948Z",
+                "end": "2024-01-05T09:03:16.948Z"
+              }
+            },
+            "instructions": {
+              "code": "2",
+              "name": "ONDC order",
+              "short_desc": "ONDC order",
+              "long_desc": "ONDC order"
+            },
+            "contact": {
+              "phone": "8840019700",
+              "email": "help@chattybao.com"
+            }
+          },
+          "id": "1",
+          "type": "Delivery",
+          "tracking": true,
+          "end": {
+            "location": {
+              "gps": "26.856159,81.004399",
+              "address": {
+                "name": "BMP",
+                "email": "balmukand@mapmyindia.co.in",
+                "building": "226010,226010, Lucknow, Uttar Pradesh",
+                "locality": "test",
+                "city": "Lucknow",
+                "state": "Uttar Pradesh",
+                "area_code": "226010",
+                "country": "IND"
+              }
+            },
+            "contact": {
+              "phone": "9999364087"
+            },
+            "person": {
+              "name": "BMP"
+            },
+            "time": {
+              "range": {
+                "start": "2024-01-05T08:33:16.948Z",
+                "end": "2024-01-05T09:33:16.948Z"
+              }
+            }
+          },
+          "@ondc/org/TAT": "PT60M"
+        }
+      ],
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "15450"
+        },
+        "breakup": [
+          {
+            "title": "Ahaar Malka Red Dal Premium 500 g",
+            "@ondc/org/item_id": "4e5ffc10-944d-11ee-848d-2d2b8538311e:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/title_type": "item",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "price": {
+              "currency": "INR",
+              "value": "1400"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "1400"
+              }
+            }
+          },
+          {
+            "title": "Britannia 50-50 Sweet & Salty Biscuits 62.8 g",
+            "@ondc/org/item_id": "2e4065c0-5dff-11ee-b94d-fbd52ac06897:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/title_type": "item",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "price": {
+              "currency": "INR",
+              "value": "2000"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "2000"
+              }
+            }
+          },
+          {
+            "title": "Amul Pure Ghee Tin 1 L",
+            "@ondc/org/item_id": "e1d875c0-1a41-11ee-8ddd-2bac5af1417f:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/title_type": "item",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "price": {
+              "currency": "INR",
+              "value": "12000"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "12000"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "1",
+            "title": "Delivery Charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "42"
+            }
+          },
+          {
+            "@ondc/org/item_id": "1",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "8"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "quote",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "fulfillment"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "ttl": "P4D"
+      },
+      "payment": {
+        "params": {
+          "currency": "INR",
+          "transaction_id": "NOtReceived",
+          "amount": "15450"
+        },
+        "status": "PAID",
+        "type": "ON-ORDER",
+        "collected_by": "BAP",
+        "@ondc/org/buyer_app_finder_fee_type": "percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "3",
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "seller-app",
+            "settlement_phase": "sale-amount",
+            "settlement_type": "neft",
+            "beneficiary_name": "CHATTYBAO TECHNOLOGIES PRIVATE LIMITED NODAL ACCOUNT",
+            "upi_address": "",
+            "settlement_bank_account_no": "661505602069",
+            "settlement_ifsc_code": "ICIC0006615",
+            "bank_name": "ICICI",
+            "branch_name": "Sco 31, Sector 18, Udyog Vihar, Gurgaon - 122016, Haryana",
+            "settlement_timestamp": "2024-01-06T09:03:16.948Z"
+          }
+        ],
+        "@ondc/org/settlement_basis": "delivery",
+        "@ondc/org/withholding_amount": "99",
+        "@ondc/org/settlement_window": "P15D"
+      },
+      "created_at": "2024-01-05T08:33:16.000Z",
+      "updated_at": "2024-01-05T08:33:17.980Z"
+    }
+  }
+}

--- a/Chattybao/Logs_Jan_05/Retail/Flow 2/on_status_picked.json
+++ b/Chattybao/Logs_Jan_05/Retail/Flow 2/on_status_picked.json
@@ -1,0 +1,289 @@
+{
+  "context": {
+    "domain": "ONDC:RET10",
+    "country": "IND",
+    "city": "std:0522",
+    "action": "on_status",
+    "core_version": "1.2.0",
+    "bap_id": "mappls.com",
+    "bap_uri": "https://mappls.com/store/ondc-preprod",
+    "bpp_uri": "https://ondc-seller-preprod.chattybao.com/ondc/bpp",
+    "transaction_id": "evk5ilom22hsgq3u9fggvovlg3108",
+    "message_id": "7f698780-aba5-11ee-bcfb-b194587c2ac1",
+    "timestamp": "2024-01-05T08:36:19.064Z",
+    "bpp_id": "ondc-seller-preprod.chattybao.com/ondc",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "id": "ORDevk5ilom22hsgq3u9fggvovlg3108",
+      "state": "In-progress",
+      "provider": {
+        "id": "MR8mcezPPQEA-r8EhP6UN9",
+        "locations": [
+          {
+            "id": "null"
+          }
+        ]
+      },
+      "items": [
+        {
+          "id": "4e5ffc10-944d-11ee-848d-2d2b8538311e:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 1
+          },
+          "fulfillment_id": "1"
+        },
+        {
+          "id": "2e4065c0-5dff-11ee-b94d-fbd52ac06897:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 1
+          },
+          "fulfillment_id": "1"
+        },
+        {
+          "id": "e1d875c0-1a41-11ee-8ddd-2bac5af1417f:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 1
+          },
+          "fulfillment_id": "1"
+        }
+      ],
+      "billing": {
+        "address": {
+          "name": "BMP",
+          "email": "balmukand@mapmyindia.co.in",
+          "building": "226010,226010, Lucknow, Uttar Pradesh",
+          "locality": "test",
+          "city": "Lucknow",
+          "state": "Uttar Pradesh",
+          "area_code": "226010",
+          "country": "IND"
+        },
+        "name": "BMP",
+        "phone": "9999364087",
+        "email": "help@chattybao.com",
+        "created_at": "2024-01-05T08:30:18.000Z",
+        "updated_at": "2024-01-05T08:30:18.000Z"
+      },
+      "fulfillments": [
+        {
+          "@ondc/org/provider_name": "tester shatrughan grocery",
+          "state": {
+            "descriptor": {
+              "code": "Order-picked-up",
+              "name": "Order picked up"
+            }
+          },
+          "start": {
+            "location": {
+              "id": null,
+              "descriptor": {
+                "name": "tester shatrughan grocery"
+              },
+              "gps": "26.854719,80.998035",
+              "address": {
+                "locality": "4/267, Vivek Khand 4 Gomti Nagar",
+                "city": "Uttar Pradesh",
+                "area_code": "226010",
+                "state": "lucknow"
+              }
+            },
+            "time": {
+              "timestamp": "2024-01-05T08:36:19.060Z",
+              "range": {
+                "start": "2024-01-05T08:33:16.948Z",
+                "end": "2024-01-05T09:03:16.948Z"
+              }
+            },
+            "instructions": {
+              "code": "2",
+              "name": "ONDC order",
+              "short_desc": "ONDC order",
+              "long_desc": "ONDC order"
+            },
+            "contact": {
+              "phone": "8840019700",
+              "email": "help@chattybao.com"
+            }
+          },
+          "id": "1",
+          "type": "Delivery",
+          "tracking": true,
+          "end": {
+            "location": {
+              "gps": "26.856159,81.004399",
+              "address": {
+                "name": "BMP",
+                "email": "balmukand@mapmyindia.co.in",
+                "building": "226010,226010, Lucknow, Uttar Pradesh",
+                "locality": "test",
+                "city": "Lucknow",
+                "state": "Uttar Pradesh",
+                "area_code": "226010",
+                "country": "IND"
+              }
+            },
+            "contact": {
+              "phone": "9999364087"
+            },
+            "person": {
+              "name": "BMP"
+            },
+            "time": {
+              "range": {
+                "start": "2024-01-05T08:33:16.948Z",
+                "end": "2024-01-05T09:33:16.948Z"
+              }
+            }
+          },
+          "@ondc/org/TAT": "PT60M",
+          "agent": {
+            "name": "Dummy1",
+            "phone": "8840019101"
+          },
+          "tags": [
+            {
+              "code": "tracking",
+              "list": [
+                {
+                  "code": "gps_enabled",
+                  "value": "yes"
+                },
+                {
+                  "code": "url_enabled",
+                  "value": "no"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "15450"
+        },
+        "breakup": [
+          {
+            "title": "Ahaar Malka Red Dal Premium 500 g",
+            "@ondc/org/item_id": "4e5ffc10-944d-11ee-848d-2d2b8538311e:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/title_type": "item",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "price": {
+              "currency": "INR",
+              "value": "1400"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "1400"
+              }
+            }
+          },
+          {
+            "title": "Britannia 50-50 Sweet & Salty Biscuits 62.8 g",
+            "@ondc/org/item_id": "2e4065c0-5dff-11ee-b94d-fbd52ac06897:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/title_type": "item",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "price": {
+              "currency": "INR",
+              "value": "2000"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "2000"
+              }
+            }
+          },
+          {
+            "title": "Amul Pure Ghee Tin 1 L",
+            "@ondc/org/item_id": "e1d875c0-1a41-11ee-8ddd-2bac5af1417f:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/title_type": "item",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "price": {
+              "currency": "INR",
+              "value": "12000"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "12000"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "1",
+            "title": "Delivery Charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "42"
+            }
+          },
+          {
+            "@ondc/org/item_id": "1",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "8"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "quote",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "fulfillment"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "ttl": "P4D"
+      },
+      "payment": {
+        "params": {
+          "currency": "INR",
+          "transaction_id": "NOtReceived",
+          "amount": "15450"
+        },
+        "status": "PAID",
+        "type": "ON-ORDER",
+        "collected_by": "BAP",
+        "@ondc/org/buyer_app_finder_fee_type": "percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "3",
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "seller-app",
+            "settlement_phase": "sale-amount",
+            "settlement_type": "neft",
+            "beneficiary_name": "CHATTYBAO TECHNOLOGIES PRIVATE LIMITED NODAL ACCOUNT",
+            "upi_address": "",
+            "settlement_bank_account_no": "661505602069",
+            "settlement_ifsc_code": "ICIC0006615",
+            "bank_name": "ICICI",
+            "branch_name": "Sco 31, Sector 18, Udyog Vihar, Gurgaon - 122016, Haryana",
+            "settlement_timestamp": "2024-01-06T09:03:16.948Z"
+          }
+        ],
+        "@ondc/org/settlement_basis": "delivery",
+        "@ondc/org/withholding_amount": "99",
+        "@ondc/org/settlement_window": "P15D"
+      },
+      "created_at": "2024-01-05T08:33:16.000Z",
+      "updated_at": "2024-01-05T08:36:19.063Z"
+    }
+  }
+}

--- a/Chattybao/Logs_Jan_05/Retail/Flow 2/on_track.json
+++ b/Chattybao/Logs_Jan_05/Retail/Flow 2/on_track.json
@@ -1,0 +1,30 @@
+{
+  "context": {
+    "domain": "ONDC:RET10",
+    "country": "IND",
+    "city": "std:0522",
+    "action": "on_track",
+    "core_version": "1.2.0",
+    "bap_id": "mappls.com",
+    "bap_uri": "https://mappls.com/store/ondc-preprod",
+    "bpp_uri": "https://ondc-seller-preprod.chattybao.com/ondc/bpp",
+    "transaction_id": "evk5ilom22hsgq3u9fggvovlg3108",
+    "message_id": "e0d56054fa56cc7fdd50_1704443904",
+    "timestamp": "2024-01-05T08:38:25.176Z",
+    "bpp_id": "ondc-seller-preprod.chattybao.com/ondc",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "tracking": {
+      "id": "1",
+      "status": "active",
+      "location": {
+        "gps": "26.854719,80.998035",
+        "time": {
+          "timestamp": "2024-01-05T08:37:45Z"
+        },
+        "updated_at": "2024-01-05T08:38:25.175Z"
+      }
+    }
+  }
+}

--- a/Chattybao/Logs_Jan_05/Retail/Flow 2/select.json
+++ b/Chattybao/Logs_Jan_05/Retail/Flow 2/select.json
@@ -1,0 +1,68 @@
+{
+  "context": {
+    "domain": "ONDC:RET10",
+    "country": "IND",
+    "city": "std:0522",
+    "action": "select",
+    "core_version": "1.2.0",
+    "bap_id": "mappls.com",
+    "bap_uri": "https://mappls.com/store/ondc-preprod",
+    "bpp_uri": "https://ondc-seller-preprod.chattybao.com/ondc/bpp",
+    "transaction_id": "evk5ilom22hsgq3u9fggvovlg3108",
+    "message_id": "48790770ec6bbc84aab6_1704443411",
+    "timestamp": "2024-01-05T08:30:11.000Z",
+    "bpp_id": "ondc-seller-preprod.chattybao.com/ondc",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "items": [
+        {
+          "id": "4e5ffc10-944d-11ee-848d-2d2b8538311e:MR8mcezPPQEA-r8EhP6UN9",
+          "location_id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042",
+          "quantity": {
+            "count": 1
+          }
+        },
+        {
+          "id": "2e4065c0-5dff-11ee-b94d-fbd52ac06897:MR8mcezPPQEA-r8EhP6UN9",
+          "location_id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042",
+          "quantity": {
+            "count": 1
+          }
+        },
+        {
+          "id": "e1d875c0-1a41-11ee-8ddd-2bac5af1417f:MR8mcezPPQEA-r8EhP6UN9",
+          "location_id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042",
+          "quantity": {
+            "count": 1
+          }
+        }
+      ],
+      "provider": {
+        "id": "MR8mcezPPQEA-r8EhP6UN9",
+        "locations": [
+          {
+            "id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042"
+          }
+        ]
+      },
+      "fulfillments": [
+        {
+          "end": {
+            "location": {
+              "gps": "26.856159,81.004399",
+              "address": {
+                "area_code": "226010"
+              }
+            }
+          }
+        }
+      ],
+      "offers": [],
+      "payment": {
+        "type": "ON-ORDER"
+      }
+    }
+  }
+}

--- a/Chattybao/Logs_Jan_05/Retail/Flow 2/track.json
+++ b/Chattybao/Logs_Jan_05/Retail/Flow 2/track.json
@@ -1,0 +1,20 @@
+{
+  "context": {
+    "domain": "ONDC:RET10",
+    "country": "IND",
+    "city": "std:0522",
+    "action": "track",
+    "core_version": "1.2.0",
+    "bap_id": "mappls.com",
+    "bap_uri": "https://mappls.com/store/ondc-preprod",
+    "bpp_uri": "https://ondc-seller-preprod.chattybao.com/ondc/bpp",
+    "transaction_id": "evk5ilom22hsgq3u9fggvovlg3108",
+    "message_id": "e0d56054fa56cc7fdd50_1704443904",
+    "timestamp": "2024-01-05T08:38:24.000Z",
+    "bpp_id": "ondc-seller-preprod.chattybao.com/ondc",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order_id": "ORDevk5ilom22hsgq3u9fggvovlg3108"
+  }
+}

--- a/Chattybao/Logs_Jan_05/Retail/Flow 5/confirm.json
+++ b/Chattybao/Logs_Jan_05/Retail/Flow 5/confirm.json
@@ -1,0 +1,269 @@
+{
+  "context": {
+    "domain": "ONDC:RET10",
+    "country": "IND",
+    "city": "std:0522",
+    "action": "confirm",
+    "core_version": "1.2.0",
+    "bap_id": "mappls.com",
+    "bap_uri": "https://mappls.com/store/ondc-preprod",
+    "bpp_uri": "https://ondc-seller-preprod.chattybao.com/ondc/bpp",
+    "transaction_id": "ped92me5kdliajo4v07j9vehj2108",
+    "message_id": "bdff5e19cf544ca043d3_1704444113",
+    "timestamp": "2024-01-05T08:41:53.000Z",
+    "bpp_id": "ondc-seller-preprod.chattybao.com/ondc",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "id": "ORDped92me5kdliajo4v07j9vehj2108",
+      "state": "Created",
+      "items": [
+        {
+          "id": "4e5ffc10-944d-11ee-848d-2d2b8538311e:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 1
+          },
+          "fulfillment_id": "1"
+        },
+        {
+          "id": "2e4065c0-5dff-11ee-b94d-fbd52ac06897:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 1
+          },
+          "fulfillment_id": "1"
+        },
+        {
+          "id": "e1d875c0-1a41-11ee-8ddd-2bac5af1417f:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 1
+          },
+          "fulfillment_id": "1"
+        },
+        {
+          "id": "3799b340-9448-11ee-848d-2d2b8538311e:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 1
+          },
+          "fulfillment_id": "1"
+        }
+      ],
+      "provider": {
+        "id": "MR8mcezPPQEA-r8EhP6UN9",
+        "locations": [
+          {
+            "id": null
+          }
+        ]
+      },
+      "fulfillments": [
+        {
+          "id": "1",
+          "type": "Delivery",
+          "tracking": true,
+          "end": {
+            "location": {
+              "gps": "26.856159,81.004399",
+              "address": {
+                "name": "BMP",
+                "email": "balmukand@mapmyindia.co.in",
+                "building": "226010,226010, Lucknow, Uttar Pradesh",
+                "locality": "test",
+                "city": "Lucknow",
+                "state": "Uttar Pradesh",
+                "area_code": "226010",
+                "country": "IND"
+              }
+            },
+            "contact": {
+              "phone": "9999364087"
+            },
+            "person": {
+              "name": "BMP"
+            }
+          }
+        }
+      ],
+      "billing": {
+        "address": {
+          "name": "BMP",
+          "email": "balmukand@mapmyindia.co.in",
+          "building": "226010,226010, Lucknow, Uttar Pradesh",
+          "locality": "test",
+          "city": "Lucknow",
+          "state": "Uttar Pradesh",
+          "area_code": "226010",
+          "country": "IND"
+        },
+        "name": "BMP",
+        "phone": "9999364087",
+        "email": "balmukand@mapmyindia.co.in",
+        "created_at": "2024-01-05T08:40:21.000Z",
+        "updated_at": "2024-01-05T08:40:21.000Z"
+      },
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "18450"
+        },
+        "breakup": [
+          {
+            "title": "Ahaar Malka Red Dal Premium 500 g",
+            "@ondc/org/item_id": "4e5ffc10-944d-11ee-848d-2d2b8538311e:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/title_type": "item",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "price": {
+              "currency": "INR",
+              "value": "1400"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "1400"
+              }
+            }
+          },
+          {
+            "title": "Britannia 50-50 Sweet & Salty Biscuits 62.8 g",
+            "@ondc/org/item_id": "2e4065c0-5dff-11ee-b94d-fbd52ac06897:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/title_type": "item",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "price": {
+              "currency": "INR",
+              "value": "2000"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "2000"
+              }
+            }
+          },
+          {
+            "title": "Amul Pure Ghee Tin 1 L",
+            "@ondc/org/item_id": "e1d875c0-1a41-11ee-8ddd-2bac5af1417f:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/title_type": "item",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "price": {
+              "currency": "INR",
+              "value": "12000"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "12000"
+              }
+            }
+          },
+          {
+            "title": "Ahaar Besan Micro Refined 500 g",
+            "@ondc/org/item_id": "3799b340-9448-11ee-848d-2d2b8538311e:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/title_type": "item",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "price": {
+              "currency": "INR",
+              "value": "3000"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "3000"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "1",
+            "title": "Delivery Charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "42"
+            }
+          },
+          {
+            "@ondc/org/item_id": "1",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "8"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "quote",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "fulfillment"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "ttl": "P4D"
+      },
+      "offers": [],
+      "payment": {
+        "params": {
+          "currency": "INR",
+          "transaction_id": "NOtReceived",
+          "amount": "18450"
+        },
+        "status": "PAID",
+        "type": "ON-ORDER",
+        "collected_by": "BAP",
+        "@ondc/org/buyer_app_finder_fee_type": "percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "3",
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "seller-app",
+            "settlement_phase": "sale-amount",
+            "settlement_type": "neft",
+            "beneficiary_name": "CHATTYBAO TECHNOLOGIES PRIVATE LIMITED NODAL ACCOUNT",
+            "upi_address": "",
+            "settlement_bank_account_no": "661505602069",
+            "settlement_ifsc_code": "ICIC0006615",
+            "bank_name": "ICICI",
+            "branch_name": "Sco 31, Sector 18, Udyog Vihar, Gurgaon - 122016, Haryana"
+          }
+        ],
+        "@ondc/org/settlement_basis": "delivery",
+        "@ondc/org/withholding_amount": "99",
+        "@ondc/org/settlement_window": "P15D"
+      },
+      "tags": [
+        {
+          "code": "bpp_terms",
+          "list": [
+            {
+              "code": "tax_number",
+              "value": "07AAJCC8423B1ZW"
+            }
+          ]
+        },
+        {
+          "code": "bap_terms",
+          "list": [
+            {
+              "code": "tax_number",
+              "value": "07AAACC5585B1ZW"
+            }
+          ]
+        }
+      ],
+      "created_at": "2024-01-05T08:41:53.000Z",
+      "updated_at": "2024-01-05T08:41:53.000Z"
+    }
+  }
+}

--- a/Chattybao/Logs_Jan_05/Retail/Flow 5/init.json
+++ b/Chattybao/Logs_Jan_05/Retail/Flow 5/init.json
@@ -1,0 +1,102 @@
+{
+  "context": {
+    "domain": "ONDC:RET10",
+    "country": "IND",
+    "city": "std:0522",
+    "action": "init",
+    "core_version": "1.2.0",
+    "bap_id": "mappls.com",
+    "bap_uri": "https://mappls.com/store/ondc-preprod",
+    "bpp_uri": "https://ondc-seller-preprod.chattybao.com/ondc/bpp",
+    "transaction_id": "ped92me5kdliajo4v07j9vehj2108",
+    "message_id": "92606419099a1fea67d9_1704444021",
+    "timestamp": "2024-01-05T08:40:21.000Z",
+    "bpp_id": "ondc-seller-preprod.chattybao.com/ondc",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "items": [
+        {
+          "id": "4e5ffc10-944d-11ee-848d-2d2b8538311e:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 1
+          },
+          "fulfillment_id": "1"
+        },
+        {
+          "id": "2e4065c0-5dff-11ee-b94d-fbd52ac06897:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 1
+          },
+          "fulfillment_id": "1"
+        },
+        {
+          "id": "e1d875c0-1a41-11ee-8ddd-2bac5af1417f:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 1
+          },
+          "fulfillment_id": "1"
+        },
+        {
+          "id": "3799b340-9448-11ee-848d-2d2b8538311e:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 1
+          },
+          "fulfillment_id": "1"
+        }
+      ],
+      "provider": {
+        "id": "MR8mcezPPQEA-r8EhP6UN9",
+        "locations": [
+          {
+            "id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042"
+          }
+        ]
+      },
+      "offers": [],
+      "fulfillments": [
+        {
+          "id": "1",
+          "type": "Delivery",
+          "tracking": true,
+          "end": {
+            "location": {
+              "gps": "26.856159,81.004399",
+              "address": {
+                "name": "BMP",
+                "email": "balmukand@mapmyindia.co.in",
+                "building": "226010,226010, Lucknow, Uttar Pradesh",
+                "locality": "test",
+                "city": "Lucknow",
+                "state": "Uttar Pradesh",
+                "area_code": "226010",
+                "country": "IND"
+              }
+            },
+            "contact": {
+              "phone": "9999364087"
+            }
+          }
+        }
+      ],
+      "billing": {
+        "address": {
+          "name": "BMP",
+          "email": "balmukand@mapmyindia.co.in",
+          "building": "226010,226010, Lucknow, Uttar Pradesh",
+          "locality": "test",
+          "city": "Lucknow",
+          "state": "Uttar Pradesh",
+          "area_code": "226010",
+          "country": "IND"
+        },
+        "name": "BMP",
+        "phone": "9999364087",
+        "email": "balmukand@mapmyindia.co.in",
+        "created_at": "2024-01-05T08:40:21.000Z",
+        "updated_at": "2024-01-05T08:40:21.000Z"
+      }
+    }
+  }
+}

--- a/Chattybao/Logs_Jan_05/Retail/Flow 5/on_cancel_rto.json
+++ b/Chattybao/Logs_Jan_05/Retail/Flow 5/on_cancel_rto.json
@@ -1,0 +1,503 @@
+{
+  "context": {
+    "domain": "ONDC:RET10",
+    "country": "IND",
+    "city": "std:0522",
+    "action": "on_cancel",
+    "core_version": "1.2.0",
+    "bap_id": "mappls.com",
+    "bap_uri": "https://mappls.com/store/ondc-preprod",
+    "bpp_uri": "https://ondc-seller-preprod.chattybao.com/ondc/bpp",
+    "transaction_id": "ped92me5kdliajo4v07j9vehj2108",
+    "message_id": "b17575d0-aba6-11ee-bcfb-b194587c2ac1",
+    "timestamp": "2024-01-05T08:44:52.525Z",
+    "bpp_id": "ondc-seller-preprod.chattybao.com/ondc",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "id": "ORDped92me5kdliajo4v07j9vehj2108",
+      "state": "Cancelled",
+      "provider": {
+        "id": "MR8mcezPPQEA-r8EhP6UN9",
+        "locations": [
+          {
+            "id": "null"
+          }
+        ]
+      },
+      "items": [
+        {
+          "id": "4e5ffc10-944d-11ee-848d-2d2b8538311e:MR8mcezPPQEA-r8EhP6UN9",
+          "fulfillment_id": "1",
+          "quantity": {
+            "count": 0
+          }
+        },
+        {
+          "id": "4e5ffc10-944d-11ee-848d-2d2b8538311e:MR8mcezPPQEA-r8EhP6UN9",
+          "fulfillment_id": "F1-RTO",
+          "quantity": {
+            "count": 1
+          }
+        },
+        {
+          "id": "2e4065c0-5dff-11ee-b94d-fbd52ac06897:MR8mcezPPQEA-r8EhP6UN9",
+          "fulfillment_id": "1",
+          "quantity": {
+            "count": 0
+          }
+        },
+        {
+          "id": "2e4065c0-5dff-11ee-b94d-fbd52ac06897:MR8mcezPPQEA-r8EhP6UN9",
+          "fulfillment_id": "F1-RTO",
+          "quantity": {
+            "count": 1
+          }
+        },
+        {
+          "id": "e1d875c0-1a41-11ee-8ddd-2bac5af1417f:MR8mcezPPQEA-r8EhP6UN9",
+          "fulfillment_id": "1",
+          "quantity": {
+            "count": 0
+          }
+        },
+        {
+          "id": "e1d875c0-1a41-11ee-8ddd-2bac5af1417f:MR8mcezPPQEA-r8EhP6UN9",
+          "fulfillment_id": "F1-RTO",
+          "quantity": {
+            "count": 1
+          }
+        },
+        {
+          "id": "3799b340-9448-11ee-848d-2d2b8538311e:MR8mcezPPQEA-r8EhP6UN9",
+          "fulfillment_id": "1",
+          "quantity": {
+            "count": 0
+          }
+        },
+        {
+          "id": "3799b340-9448-11ee-848d-2d2b8538311e:MR8mcezPPQEA-r8EhP6UN9",
+          "fulfillment_id": "F1-RTO",
+          "quantity": {
+            "count": 1
+          }
+        }
+      ],
+      "billing": {
+        "address": {
+          "name": "BMP",
+          "email": "balmukand@mapmyindia.co.in",
+          "building": "226010,226010, Lucknow, Uttar Pradesh",
+          "locality": "test",
+          "city": "Lucknow",
+          "state": "Uttar Pradesh",
+          "area_code": "226010",
+          "country": "IND"
+        },
+        "name": "BMP",
+        "phone": "9999364087",
+        "email": "balmukand@mapmyindia.co.in",
+        "created_at": "2024-01-05T08:40:21.000Z",
+        "updated_at": "2024-01-05T08:40:21.000Z"
+      },
+      "cancellation": {
+        "cancelled_by": "ondc-seller-preprod.chattybao.com/ondc",
+        "reason": {
+          "id": "011"
+        }
+      },
+      "fulfillments": [
+        {
+          "@ondc/org/provider_name": "tester shatrughan grocery",
+          "state": {
+            "descriptor": {
+              "code": "Cancelled",
+              "name": "Cancelled"
+            }
+          },
+          "start": {
+            "location": {
+              "id": null,
+              "descriptor": {
+                "name": "tester shatrughan grocery"
+              },
+              "gps": "26.854719,80.998035",
+              "address": {
+                "locality": "4/267, Vivek Khand 4 Gomti Nagar",
+                "city": "Uttar Pradesh",
+                "area_code": "226010",
+                "state": "lucknow"
+              }
+            },
+            "time": {
+              "timestamp": "2024-01-05T08:43:23.994Z",
+              "range": {
+                "start": "2024-01-05T08:41:54.204Z",
+                "end": "2024-01-05T09:11:54.204Z"
+              }
+            },
+            "instructions": {
+              "code": "2",
+              "name": "ONDC order",
+              "short_desc": "ONDC order",
+              "long_desc": "ONDC order"
+            },
+            "contact": {
+              "phone": "8840019700",
+              "email": "help@chattybao.com"
+            }
+          },
+          "id": "1",
+          "type": "Delivery",
+          "tracking": true,
+          "end": {
+            "location": {
+              "gps": "26.856159,81.004399",
+              "address": {
+                "name": "BMP",
+                "email": "balmukand@mapmyindia.co.in",
+                "building": "226010,226010, Lucknow, Uttar Pradesh",
+                "locality": "test",
+                "city": "Lucknow",
+                "state": "Uttar Pradesh",
+                "area_code": "226010",
+                "country": "IND"
+              }
+            },
+            "contact": {
+              "phone": "9999364087"
+            },
+            "person": {
+              "name": "BMP"
+            },
+            "time": {
+              "range": {
+                "start": "2024-01-05T08:41:54.204Z",
+                "end": "2024-01-05T09:41:54.204Z"
+              }
+            }
+          },
+          "@ondc/org/TAT": "PT60M",
+          "agent": {
+            "name": "Dummy1",
+            "phone": "8840019101"
+          },
+          "tags": [
+            {
+              "code": "cancel_request",
+              "list": [
+                {
+                  "code": "reason_id",
+                  "value": "011"
+                },
+                {
+                  "code": "initiated_by",
+                  "value": "ondc-seller-preprod.chattybao.com/ondc"
+                },
+                {
+                  "code": "retry_count",
+                  "value": "3"
+                },
+                {
+                  "code": "rto_id",
+                  "value": "F1-RTO"
+                }
+              ]
+            },
+            {
+              "code": "precancel_state",
+              "list": [
+                {
+                  "code": "fulfillment_state",
+                  "value": "Out-for-delivery"
+                },
+                {
+                  "code": "updated_at",
+                  "value": "2024-01-05T08:44:52.523Z"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "id": "F1-RTO",
+          "type": "RTO",
+          "state": {
+            "descriptor": {
+              "code": "RTO-Disposed"
+            }
+          },
+          "start": {
+            "time": {
+              "timestamp": "2024-01-05T08:44:52.524Z"
+            }
+          },
+          "end": {
+            "time": {
+              "timestamp": "2024-01-05T08:44:52.524Z"
+            }
+          },
+          "tags": [
+            {
+              "code": "quote_trail",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "item"
+                },
+                {
+                  "code": "id",
+                  "value": "4e5ffc10-944d-11ee-848d-2d2b8538311e:MR8mcezPPQEA-r8EhP6UN9"
+                },
+                {
+                  "code": "currency",
+                  "value": "INR"
+                },
+                {
+                  "code": "value",
+                  "value": "-1400"
+                }
+              ]
+            },
+            {
+              "code": "quote_trail",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "item"
+                },
+                {
+                  "code": "id",
+                  "value": "2e4065c0-5dff-11ee-b94d-fbd52ac06897:MR8mcezPPQEA-r8EhP6UN9"
+                },
+                {
+                  "code": "currency",
+                  "value": "INR"
+                },
+                {
+                  "code": "value",
+                  "value": "-2000"
+                }
+              ]
+            },
+            {
+              "code": "quote_trail",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "item"
+                },
+                {
+                  "code": "id",
+                  "value": "e1d875c0-1a41-11ee-8ddd-2bac5af1417f:MR8mcezPPQEA-r8EhP6UN9"
+                },
+                {
+                  "code": "currency",
+                  "value": "INR"
+                },
+                {
+                  "code": "value",
+                  "value": "-12000"
+                }
+              ]
+            },
+            {
+              "code": "quote_trail",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "item"
+                },
+                {
+                  "code": "id",
+                  "value": "3799b340-9448-11ee-848d-2d2b8538311e:MR8mcezPPQEA-r8EhP6UN9"
+                },
+                {
+                  "code": "currency",
+                  "value": "INR"
+                },
+                {
+                  "code": "value",
+                  "value": "-3000"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "50"
+        },
+        "breakup": [
+          {
+            "title": "Ahaar Malka Red Dal Premium 500 g",
+            "@ondc/org/item_id": "4e5ffc10-944d-11ee-848d-2d2b8538311e:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/title_type": "item",
+            "@ondc/org/item_quantity": {
+              "count": 0
+            },
+            "price": {
+              "currency": "INR",
+              "value": "0.00"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "1400"
+              }
+            }
+          },
+          {
+            "title": "Britannia 50-50 Sweet & Salty Biscuits 62.8 g",
+            "@ondc/org/item_id": "2e4065c0-5dff-11ee-b94d-fbd52ac06897:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/title_type": "item",
+            "@ondc/org/item_quantity": {
+              "count": 0
+            },
+            "price": {
+              "currency": "INR",
+              "value": "0.00"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "2000"
+              }
+            }
+          },
+          {
+            "title": "Amul Pure Ghee Tin 1 L",
+            "@ondc/org/item_id": "e1d875c0-1a41-11ee-8ddd-2bac5af1417f:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/title_type": "item",
+            "@ondc/org/item_quantity": {
+              "count": 0
+            },
+            "price": {
+              "currency": "INR",
+              "value": "0.00"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "12000"
+              }
+            }
+          },
+          {
+            "title": "Ahaar Besan Micro Refined 500 g",
+            "@ondc/org/item_id": "3799b340-9448-11ee-848d-2d2b8538311e:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/title_type": "item",
+            "@ondc/org/item_quantity": {
+              "count": 0
+            },
+            "price": {
+              "currency": "INR",
+              "value": "0.00"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "3000"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "1",
+            "title": "Delivery Charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "42"
+            }
+          },
+          {
+            "@ondc/org/item_id": "1",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "8"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "quote",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "fulfillment"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "F1-RTO",
+            "title": "Delivery charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "0.00"
+            }
+          },
+          {
+            "@ondc/org/item_id": "F1-RTO",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "0.00"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "quote",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "fulfillment"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "payment": {
+        "params": {
+          "currency": "INR",
+          "transaction_id": "NOtReceived",
+          "amount": "18450"
+        },
+        "status": "PAID",
+        "type": "ON-ORDER",
+        "collected_by": "BAP",
+        "@ondc/org/buyer_app_finder_fee_type": "percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "3",
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "seller-app",
+            "settlement_phase": "sale-amount",
+            "settlement_type": "neft",
+            "beneficiary_name": "CHATTYBAO TECHNOLOGIES PRIVATE LIMITED NODAL ACCOUNT",
+            "upi_address": "",
+            "settlement_bank_account_no": "661505602069",
+            "settlement_ifsc_code": "ICIC0006615",
+            "bank_name": "ICICI",
+            "branch_name": "Sco 31, Sector 18, Udyog Vihar, Gurgaon - 122016, Haryana"
+          }
+        ],
+        "@ondc/org/settlement_basis": "delivery",
+        "@ondc/org/withholding_amount": "99",
+        "@ondc/org/settlement_window": "P15D"
+      },
+      "created_at": "2024-01-05T08:41:53.000Z",
+      "updated_at": "2024-01-05T08:44:52.524Z"
+    }
+  }
+}

--- a/Chattybao/Logs_Jan_05/Retail/Flow 5/on_confirm.json
+++ b/Chattybao/Logs_Jan_05/Retail/Flow 5/on_confirm.json
@@ -1,0 +1,313 @@
+{
+  "context": {
+    "domain": "ONDC:RET10",
+    "country": "IND",
+    "city": "std:0522",
+    "action": "on_confirm",
+    "core_version": "1.2.0",
+    "bap_id": "mappls.com",
+    "bap_uri": "https://mappls.com/store/ondc-preprod",
+    "bpp_uri": "https://ondc-seller-preprod.chattybao.com/ondc/bpp",
+    "transaction_id": "ped92me5kdliajo4v07j9vehj2108",
+    "message_id": "bdff5e19cf544ca043d3_1704444113",
+    "timestamp": "2024-01-05T08:41:54.212Z",
+    "bpp_id": "ondc-seller-preprod.chattybao.com/ondc",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "id": "ORDped92me5kdliajo4v07j9vehj2108",
+      "state": "Accepted",
+      "items": [
+        {
+          "id": "4e5ffc10-944d-11ee-848d-2d2b8538311e:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 1
+          },
+          "fulfillment_id": "1"
+        },
+        {
+          "id": "2e4065c0-5dff-11ee-b94d-fbd52ac06897:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 1
+          },
+          "fulfillment_id": "1"
+        },
+        {
+          "id": "e1d875c0-1a41-11ee-8ddd-2bac5af1417f:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 1
+          },
+          "fulfillment_id": "1"
+        },
+        {
+          "id": "3799b340-9448-11ee-848d-2d2b8538311e:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 1
+          },
+          "fulfillment_id": "1"
+        }
+      ],
+      "provider": {
+        "id": "MR8mcezPPQEA-r8EhP6UN9",
+        "locations": [
+          {
+            "id": null
+          }
+        ]
+      },
+      "fulfillments": [
+        {
+          "@ondc/org/provider_name": "tester shatrughan grocery",
+          "state": {
+            "descriptor": {
+              "code": "Pending"
+            }
+          },
+          "start": {
+            "location": {
+              "id": null,
+              "descriptor": {
+                "name": "tester shatrughan grocery"
+              },
+              "gps": "26.854719,80.998035",
+              "address": {
+                "locality": "4/267, Vivek Khand 4 Gomti Nagar",
+                "city": "Uttar Pradesh",
+                "area_code": "226010",
+                "state": "lucknow"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2024-01-05T08:41:54.204Z",
+                "end": "2024-01-05T09:11:54.204Z"
+              }
+            },
+            "instructions": {
+              "code": "2",
+              "name": "ONDC order",
+              "short_desc": "ONDC order",
+              "long_desc": "ONDC order"
+            },
+            "contact": {
+              "phone": "8840019700",
+              "email": "help@chattybao.com"
+            }
+          },
+          "id": "1",
+          "type": "Delivery",
+          "tracking": true,
+          "end": {
+            "location": {
+              "gps": "26.856159,81.004399",
+              "address": {
+                "name": "BMP",
+                "email": "balmukand@mapmyindia.co.in",
+                "building": "226010,226010, Lucknow, Uttar Pradesh",
+                "locality": "test",
+                "city": "Lucknow",
+                "state": "Uttar Pradesh",
+                "area_code": "226010",
+                "country": "IND"
+              }
+            },
+            "contact": {
+              "phone": "9999364087"
+            },
+            "person": {
+              "name": "BMP"
+            },
+            "time": {
+              "range": {
+                "start": "2024-01-05T08:41:54.204Z",
+                "end": "2024-01-05T09:41:54.204Z"
+              }
+            }
+          }
+        }
+      ],
+      "billing": {
+        "address": {
+          "name": "BMP",
+          "email": "balmukand@mapmyindia.co.in",
+          "building": "226010,226010, Lucknow, Uttar Pradesh",
+          "locality": "test",
+          "city": "Lucknow",
+          "state": "Uttar Pradesh",
+          "area_code": "226010",
+          "country": "IND"
+        },
+        "name": "BMP",
+        "phone": "9999364087",
+        "email": "balmukand@mapmyindia.co.in",
+        "created_at": "2024-01-05T08:40:21.000Z",
+        "updated_at": "2024-01-05T08:40:21.000Z"
+      },
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "18450"
+        },
+        "breakup": [
+          {
+            "title": "Ahaar Malka Red Dal Premium 500 g",
+            "@ondc/org/item_id": "4e5ffc10-944d-11ee-848d-2d2b8538311e:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/title_type": "item",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "price": {
+              "currency": "INR",
+              "value": "1400"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "1400"
+              }
+            }
+          },
+          {
+            "title": "Britannia 50-50 Sweet & Salty Biscuits 62.8 g",
+            "@ondc/org/item_id": "2e4065c0-5dff-11ee-b94d-fbd52ac06897:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/title_type": "item",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "price": {
+              "currency": "INR",
+              "value": "2000"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "2000"
+              }
+            }
+          },
+          {
+            "title": "Amul Pure Ghee Tin 1 L",
+            "@ondc/org/item_id": "e1d875c0-1a41-11ee-8ddd-2bac5af1417f:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/title_type": "item",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "price": {
+              "currency": "INR",
+              "value": "12000"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "12000"
+              }
+            }
+          },
+          {
+            "title": "Ahaar Besan Micro Refined 500 g",
+            "@ondc/org/item_id": "3799b340-9448-11ee-848d-2d2b8538311e:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/title_type": "item",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "price": {
+              "currency": "INR",
+              "value": "3000"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "3000"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "1",
+            "title": "Delivery Charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "42"
+            }
+          },
+          {
+            "@ondc/org/item_id": "1",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "8"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "quote",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "fulfillment"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "ttl": "P4D"
+      },
+      "offers": [],
+      "payment": {
+        "params": {
+          "currency": "INR",
+          "transaction_id": "NOtReceived",
+          "amount": "18450"
+        },
+        "status": "PAID",
+        "type": "ON-ORDER",
+        "collected_by": "BAP",
+        "@ondc/org/buyer_app_finder_fee_type": "percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "3",
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "seller-app",
+            "settlement_phase": "sale-amount",
+            "settlement_type": "neft",
+            "beneficiary_name": "CHATTYBAO TECHNOLOGIES PRIVATE LIMITED NODAL ACCOUNT",
+            "upi_address": "",
+            "settlement_bank_account_no": "661505602069",
+            "settlement_ifsc_code": "ICIC0006615",
+            "bank_name": "ICICI",
+            "branch_name": "Sco 31, Sector 18, Udyog Vihar, Gurgaon - 122016, Haryana"
+          }
+        ],
+        "@ondc/org/settlement_basis": "delivery",
+        "@ondc/org/withholding_amount": "99",
+        "@ondc/org/settlement_window": "P15D"
+      },
+      "tags": [
+        {
+          "code": "bpp_terms",
+          "list": [
+            {
+              "code": "tax_number",
+              "value": "07AAJCC8423B1ZW"
+            }
+          ]
+        },
+        {
+          "code": "bap_terms",
+          "list": [
+            {
+              "code": "tax_number",
+              "value": "07AAACC5585B1ZW"
+            }
+          ]
+        }
+      ],
+      "created_at": "2024-01-05T08:41:53.000Z",
+      "updated_at": "2024-01-05T08:41:54.212Z",
+      "rateable": true
+    }
+  }
+}

--- a/Chattybao/Logs_Jan_05/Retail/Flow 5/on_init.json
+++ b/Chattybao/Logs_Jan_05/Retail/Flow 5/on_init.json
@@ -1,0 +1,247 @@
+{
+  "context": {
+    "domain": "ONDC:RET10",
+    "country": "IND",
+    "city": "std:0522",
+    "action": "on_init",
+    "core_version": "1.2.0",
+    "bap_id": "mappls.com",
+    "bap_uri": "https://mappls.com/store/ondc-preprod",
+    "bpp_uri": "https://ondc-seller-preprod.chattybao.com/ondc/bpp",
+    "transaction_id": "ped92me5kdliajo4v07j9vehj2108",
+    "message_id": "92606419099a1fea67d9_1704444021",
+    "timestamp": "2024-01-05T08:40:21.758Z",
+    "bpp_id": "ondc-seller-preprod.chattybao.com/ondc",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "items": [
+        {
+          "id": "4e5ffc10-944d-11ee-848d-2d2b8538311e:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 1
+          },
+          "fulfillment_id": "1"
+        },
+        {
+          "id": "2e4065c0-5dff-11ee-b94d-fbd52ac06897:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 1
+          },
+          "fulfillment_id": "1"
+        },
+        {
+          "id": "e1d875c0-1a41-11ee-8ddd-2bac5af1417f:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 1
+          },
+          "fulfillment_id": "1"
+        },
+        {
+          "id": "3799b340-9448-11ee-848d-2d2b8538311e:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 1
+          },
+          "fulfillment_id": "1"
+        }
+      ],
+      "billing": {
+        "address": {
+          "name": "BMP",
+          "email": "balmukand@mapmyindia.co.in",
+          "building": "226010,226010, Lucknow, Uttar Pradesh",
+          "locality": "test",
+          "city": "Lucknow",
+          "state": "Uttar Pradesh",
+          "area_code": "226010",
+          "country": "IND"
+        },
+        "name": "BMP",
+        "phone": "9999364087",
+        "email": "balmukand@mapmyindia.co.in",
+        "created_at": "2024-01-05T08:40:21.000Z",
+        "updated_at": "2024-01-05T08:40:21.000Z"
+      },
+      "fulfillments": [
+        {
+          "id": "1",
+          "type": "Delivery",
+          "tracking": true,
+          "end": {
+            "location": {
+              "gps": "26.856159,81.004399",
+              "address": {
+                "name": "BMP",
+                "email": "balmukand@mapmyindia.co.in",
+                "building": "226010,226010, Lucknow, Uttar Pradesh",
+                "locality": "test",
+                "city": "Lucknow",
+                "state": "Uttar Pradesh",
+                "area_code": "226010",
+                "country": "IND"
+              }
+            },
+            "contact": {
+              "phone": "9999364087"
+            }
+          }
+        }
+      ],
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "18450"
+        },
+        "breakup": [
+          {
+            "title": "Ahaar Malka Red Dal Premium 500 g",
+            "@ondc/org/item_id": "4e5ffc10-944d-11ee-848d-2d2b8538311e:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/title_type": "item",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "price": {
+              "currency": "INR",
+              "value": "1400"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "1400"
+              }
+            }
+          },
+          {
+            "title": "Britannia 50-50 Sweet & Salty Biscuits 62.8 g",
+            "@ondc/org/item_id": "2e4065c0-5dff-11ee-b94d-fbd52ac06897:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/title_type": "item",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "price": {
+              "currency": "INR",
+              "value": "2000"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "2000"
+              }
+            }
+          },
+          {
+            "title": "Amul Pure Ghee Tin 1 L",
+            "@ondc/org/item_id": "e1d875c0-1a41-11ee-8ddd-2bac5af1417f:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/title_type": "item",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "price": {
+              "currency": "INR",
+              "value": "12000"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "12000"
+              }
+            }
+          },
+          {
+            "title": "Ahaar Besan Micro Refined 500 g",
+            "@ondc/org/item_id": "3799b340-9448-11ee-848d-2d2b8538311e:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/title_type": "item",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "price": {
+              "currency": "INR",
+              "value": "3000"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "3000"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "1",
+            "title": "Delivery Charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "42"
+            }
+          },
+          {
+            "@ondc/org/item_id": "1",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "8"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "quote",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "fulfillment"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "ttl": "P4D"
+      },
+      "provider": {
+        "id": "MR8mcezPPQEA-r8EhP6UN9",
+        "locations": [
+          {
+            "id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042"
+          }
+        ]
+      },
+      "payment": {
+        "type": "ON-ORDER",
+        "collected_by": "BAP",
+        "status": "NOT-PAID",
+        "@ondc/org/settlement_basis": "delivery",
+        "@ondc/org/settlement_window": "P1D",
+        "@ondc/org/withholding_amount": "0.00",
+        "@ondc/org/buyer_app_finder_fee_type": "percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "3",
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "seller-app",
+            "settlement_phase": "sale-amount",
+            "settlement_type": "neft",
+            "beneficiary_name": "CHATTYBAO TECHNOLOGIES PRIVATE LIMITED NODAL ACCOUNT",
+            "upi_address": "",
+            "settlement_bank_account_no": "661505602069",
+            "settlement_ifsc_code": "ICIC0006615",
+            "bank_name": "ICICI",
+            "branch_name": "Sco 31, Sector 18, Udyog Vihar, Gurgaon - 122016, Haryana"
+          }
+        ]
+      },
+      "tags": [
+        {
+          "code": "bpp_terms",
+          "list": [
+            {
+              "code": "tax_number",
+              "value": "07AAJCC8423B1ZW"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/Chattybao/Logs_Jan_05/Retail/Flow 5/on_select.json
+++ b/Chattybao/Logs_Jan_05/Retail/Flow 5/on_select.json
@@ -1,0 +1,206 @@
+{
+  "context": {
+    "domain": "ONDC:RET10",
+    "country": "IND",
+    "city": "std:0522",
+    "action": "on_select",
+    "core_version": "1.2.0",
+    "bap_id": "mappls.com",
+    "bap_uri": "https://mappls.com/store/ondc-preprod",
+    "bpp_uri": "https://ondc-seller-preprod.chattybao.com/ondc/bpp",
+    "transaction_id": "ped92me5kdliajo4v07j9vehj2108",
+    "message_id": "312535de59c3c17342ef_1704444014",
+    "timestamp": "2024-01-05T08:40:15.697Z",
+    "bpp_id": "ondc-seller-preprod.chattybao.com/ondc",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "provider": {
+        "id": "MR8mcezPPQEA-r8EhP6UN9",
+        "locations": [
+          {
+            "id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042"
+          }
+        ]
+      },
+      "items": [
+        {
+          "fulfillment_id": "1",
+          "id": "2e4065c0-5dff-11ee-b94d-fbd52ac06897:MR8mcezPPQEA-r8EhP6UN9"
+        },
+        {
+          "fulfillment_id": "1",
+          "id": "4e5ffc10-944d-11ee-848d-2d2b8538311e:MR8mcezPPQEA-r8EhP6UN9"
+        },
+        {
+          "fulfillment_id": "1",
+          "id": "e1d875c0-1a41-11ee-8ddd-2bac5af1417f:MR8mcezPPQEA-r8EhP6UN9"
+        },
+        {
+          "fulfillment_id": "1",
+          "id": "3799b340-9448-11ee-848d-2d2b8538311e:MR8mcezPPQEA-r8EhP6UN9"
+        }
+      ],
+      "fulfillments": [
+        {
+          "id": "1",
+          "type": "Delivery",
+          "@ondc/org/provider_name": "Chattybao Logistics",
+          "tracking": true,
+          "@ondc/org/category": "Immediate Delivery",
+          "@ondc/org/TAT": "PT60M",
+          "state": {
+            "descriptor": {
+              "code": "Serviceable"
+            }
+          }
+        }
+      ],
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "18450"
+        },
+        "breakup": [
+          {
+            "@ondc/org/item_id": "2e4065c0-5dff-11ee-b94d-fbd52ac06897:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "@ondc/org/title_type": "item",
+            "title": "Britannia 50-50 Sweet & Salty Biscuits 62.8 g",
+            "price": {
+              "currency": "INR",
+              "value": "2000"
+            },
+            "item": {
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "2000"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "4e5ffc10-944d-11ee-848d-2d2b8538311e:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "@ondc/org/title_type": "item",
+            "title": "Ahaar Malka Red Dal Premium 500 g",
+            "price": {
+              "currency": "INR",
+              "value": "1400"
+            },
+            "item": {
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "1400"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "e1d875c0-1a41-11ee-8ddd-2bac5af1417f:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "@ondc/org/title_type": "item",
+            "title": "Amul Pure Ghee Tin 1 L",
+            "price": {
+              "currency": "INR",
+              "value": "12000"
+            },
+            "item": {
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "12000"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "3799b340-9448-11ee-848d-2d2b8538311e:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "@ondc/org/title_type": "item",
+            "title": "Ahaar Besan Micro Refined 500 g",
+            "price": {
+              "currency": "INR",
+              "value": "3000"
+            },
+            "item": {
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "3000"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "1",
+            "title": "Delivery Charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "42"
+            }
+          },
+          {
+            "@ondc/org/item_id": "1",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "8"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "quote",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "fulfillment"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "ttl": "P4D"
+      }
+    }
+  }
+}

--- a/Chattybao/Logs_Jan_05/Retail/Flow 5/on_status_cancelled.json
+++ b/Chattybao/Logs_Jan_05/Retail/Flow 5/on_status_cancelled.json
@@ -1,0 +1,503 @@
+{
+  "context": {
+    "domain": "ONDC:RET10",
+    "country": "IND",
+    "city": "std:0522",
+    "action": "on_status",
+    "core_version": "1.2.0",
+    "bap_id": "mappls.com",
+    "bap_uri": "https://mappls.com/store/ondc-preprod",
+    "bpp_uri": "https://ondc-seller-preprod.chattybao.com/ondc/bpp",
+    "transaction_id": "ped92me5kdliajo4v07j9vehj2108",
+    "message_id": "99edaa397f5181b4914a_1704444358",
+    "timestamp": "2024-01-05T08:45:58.573Z",
+    "bpp_id": "ondc-seller-preprod.chattybao.com/ondc",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "id": "ORDped92me5kdliajo4v07j9vehj2108",
+      "state": "Cancelled",
+      "provider": {
+        "id": "MR8mcezPPQEA-r8EhP6UN9",
+        "locations": [
+          {
+            "id": "null"
+          }
+        ]
+      },
+      "items": [
+        {
+          "id": "4e5ffc10-944d-11ee-848d-2d2b8538311e:MR8mcezPPQEA-r8EhP6UN9",
+          "fulfillment_id": "1",
+          "quantity": {
+            "count": 0
+          }
+        },
+        {
+          "id": "4e5ffc10-944d-11ee-848d-2d2b8538311e:MR8mcezPPQEA-r8EhP6UN9",
+          "fulfillment_id": "F1-RTO",
+          "quantity": {
+            "count": 1
+          }
+        },
+        {
+          "id": "2e4065c0-5dff-11ee-b94d-fbd52ac06897:MR8mcezPPQEA-r8EhP6UN9",
+          "fulfillment_id": "1",
+          "quantity": {
+            "count": 0
+          }
+        },
+        {
+          "id": "2e4065c0-5dff-11ee-b94d-fbd52ac06897:MR8mcezPPQEA-r8EhP6UN9",
+          "fulfillment_id": "F1-RTO",
+          "quantity": {
+            "count": 1
+          }
+        },
+        {
+          "id": "e1d875c0-1a41-11ee-8ddd-2bac5af1417f:MR8mcezPPQEA-r8EhP6UN9",
+          "fulfillment_id": "1",
+          "quantity": {
+            "count": 0
+          }
+        },
+        {
+          "id": "e1d875c0-1a41-11ee-8ddd-2bac5af1417f:MR8mcezPPQEA-r8EhP6UN9",
+          "fulfillment_id": "F1-RTO",
+          "quantity": {
+            "count": 1
+          }
+        },
+        {
+          "id": "3799b340-9448-11ee-848d-2d2b8538311e:MR8mcezPPQEA-r8EhP6UN9",
+          "fulfillment_id": "1",
+          "quantity": {
+            "count": 0
+          }
+        },
+        {
+          "id": "3799b340-9448-11ee-848d-2d2b8538311e:MR8mcezPPQEA-r8EhP6UN9",
+          "fulfillment_id": "F1-RTO",
+          "quantity": {
+            "count": 1
+          }
+        }
+      ],
+      "billing": {
+        "address": {
+          "name": "BMP",
+          "email": "balmukand@mapmyindia.co.in",
+          "building": "226010,226010, Lucknow, Uttar Pradesh",
+          "locality": "test",
+          "city": "Lucknow",
+          "state": "Uttar Pradesh",
+          "area_code": "226010",
+          "country": "IND"
+        },
+        "name": "BMP",
+        "phone": "9999364087",
+        "email": "balmukand@mapmyindia.co.in",
+        "created_at": "2024-01-05T08:40:21.000Z",
+        "updated_at": "2024-01-05T08:40:21.000Z"
+      },
+      "cancellation": {
+        "cancelled_by": "ondc-seller-preprod.chattybao.com/ondc",
+        "reason": {
+          "id": "011"
+        }
+      },
+      "fulfillments": [
+        {
+          "@ondc/org/provider_name": "tester shatrughan grocery",
+          "state": {
+            "descriptor": {
+              "code": "Cancelled",
+              "name": "Cancelled"
+            }
+          },
+          "start": {
+            "location": {
+              "id": null,
+              "descriptor": {
+                "name": "tester shatrughan grocery"
+              },
+              "gps": "26.854719,80.998035",
+              "address": {
+                "locality": "4/267, Vivek Khand 4 Gomti Nagar",
+                "city": "Uttar Pradesh",
+                "area_code": "226010",
+                "state": "lucknow"
+              }
+            },
+            "time": {
+              "timestamp": "2024-01-05T08:43:23.994Z",
+              "range": {
+                "start": "2024-01-05T08:41:54.204Z",
+                "end": "2024-01-05T09:11:54.204Z"
+              }
+            },
+            "instructions": {
+              "code": "2",
+              "name": "ONDC order",
+              "short_desc": "ONDC order",
+              "long_desc": "ONDC order"
+            },
+            "contact": {
+              "phone": "8840019700",
+              "email": "help@chattybao.com"
+            }
+          },
+          "id": "1",
+          "type": "Delivery",
+          "tracking": true,
+          "end": {
+            "location": {
+              "gps": "26.856159,81.004399",
+              "address": {
+                "name": "BMP",
+                "email": "balmukand@mapmyindia.co.in",
+                "building": "226010,226010, Lucknow, Uttar Pradesh",
+                "locality": "test",
+                "city": "Lucknow",
+                "state": "Uttar Pradesh",
+                "area_code": "226010",
+                "country": "IND"
+              }
+            },
+            "contact": {
+              "phone": "9999364087"
+            },
+            "person": {
+              "name": "BMP"
+            },
+            "time": {
+              "range": {
+                "start": "2024-01-05T08:41:54.204Z",
+                "end": "2024-01-05T09:41:54.204Z"
+              }
+            }
+          },
+          "@ondc/org/TAT": "PT60M",
+          "agent": {
+            "name": "Dummy1",
+            "phone": "8840019101"
+          },
+          "tags": [
+            {
+              "code": "cancel_request",
+              "list": [
+                {
+                  "code": "reason_id",
+                  "value": "011"
+                },
+                {
+                  "code": "initiated_by",
+                  "value": "ondc-seller-preprod.chattybao.com/ondc"
+                },
+                {
+                  "code": "retry_count",
+                  "value": "3"
+                },
+                {
+                  "code": "rto_id",
+                  "value": "F1-RTO"
+                }
+              ]
+            },
+            {
+              "code": "precancel_state",
+              "list": [
+                {
+                  "code": "fulfillment_state",
+                  "value": "Out-for-delivery"
+                },
+                {
+                  "code": "updated_at",
+                  "value": "2024-01-05T08:44:52.523Z"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "id": "F1-RTO",
+          "type": "RTO",
+          "state": {
+            "descriptor": {
+              "code": "RTO-Disposed"
+            }
+          },
+          "start": {
+            "time": {
+              "timestamp": "2024-01-05T08:44:52.524Z"
+            }
+          },
+          "end": {
+            "time": {
+              "timestamp": "2024-01-05T08:44:52.524Z"
+            }
+          },
+          "tags": [
+            {
+              "code": "quote_trail",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "item"
+                },
+                {
+                  "code": "id",
+                  "value": "4e5ffc10-944d-11ee-848d-2d2b8538311e:MR8mcezPPQEA-r8EhP6UN9"
+                },
+                {
+                  "code": "currency",
+                  "value": "INR"
+                },
+                {
+                  "code": "value",
+                  "value": "-1400"
+                }
+              ]
+            },
+            {
+              "code": "quote_trail",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "item"
+                },
+                {
+                  "code": "id",
+                  "value": "2e4065c0-5dff-11ee-b94d-fbd52ac06897:MR8mcezPPQEA-r8EhP6UN9"
+                },
+                {
+                  "code": "currency",
+                  "value": "INR"
+                },
+                {
+                  "code": "value",
+                  "value": "-2000"
+                }
+              ]
+            },
+            {
+              "code": "quote_trail",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "item"
+                },
+                {
+                  "code": "id",
+                  "value": "e1d875c0-1a41-11ee-8ddd-2bac5af1417f:MR8mcezPPQEA-r8EhP6UN9"
+                },
+                {
+                  "code": "currency",
+                  "value": "INR"
+                },
+                {
+                  "code": "value",
+                  "value": "-12000"
+                }
+              ]
+            },
+            {
+              "code": "quote_trail",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "item"
+                },
+                {
+                  "code": "id",
+                  "value": "3799b340-9448-11ee-848d-2d2b8538311e:MR8mcezPPQEA-r8EhP6UN9"
+                },
+                {
+                  "code": "currency",
+                  "value": "INR"
+                },
+                {
+                  "code": "value",
+                  "value": "-3000"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "50"
+        },
+        "breakup": [
+          {
+            "title": "Ahaar Malka Red Dal Premium 500 g",
+            "@ondc/org/item_id": "4e5ffc10-944d-11ee-848d-2d2b8538311e:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/title_type": "item",
+            "@ondc/org/item_quantity": {
+              "count": 0
+            },
+            "price": {
+              "currency": "INR",
+              "value": "0.00"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "1400"
+              }
+            }
+          },
+          {
+            "title": "Britannia 50-50 Sweet & Salty Biscuits 62.8 g",
+            "@ondc/org/item_id": "2e4065c0-5dff-11ee-b94d-fbd52ac06897:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/title_type": "item",
+            "@ondc/org/item_quantity": {
+              "count": 0
+            },
+            "price": {
+              "currency": "INR",
+              "value": "0.00"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "2000"
+              }
+            }
+          },
+          {
+            "title": "Amul Pure Ghee Tin 1 L",
+            "@ondc/org/item_id": "e1d875c0-1a41-11ee-8ddd-2bac5af1417f:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/title_type": "item",
+            "@ondc/org/item_quantity": {
+              "count": 0
+            },
+            "price": {
+              "currency": "INR",
+              "value": "0.00"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "12000"
+              }
+            }
+          },
+          {
+            "title": "Ahaar Besan Micro Refined 500 g",
+            "@ondc/org/item_id": "3799b340-9448-11ee-848d-2d2b8538311e:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/title_type": "item",
+            "@ondc/org/item_quantity": {
+              "count": 0
+            },
+            "price": {
+              "currency": "INR",
+              "value": "0.00"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "3000"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "1",
+            "title": "Delivery Charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "42"
+            }
+          },
+          {
+            "@ondc/org/item_id": "1",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "8"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "quote",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "fulfillment"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "F1-RTO",
+            "title": "Delivery charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "0.00"
+            }
+          },
+          {
+            "@ondc/org/item_id": "F1-RTO",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "0.00"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "quote",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "fulfillment"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "payment": {
+        "params": {
+          "currency": "INR",
+          "transaction_id": "NOtReceived",
+          "amount": "18450"
+        },
+        "status": "PAID",
+        "type": "ON-ORDER",
+        "collected_by": "BAP",
+        "@ondc/org/buyer_app_finder_fee_type": "percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "3",
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "seller-app",
+            "settlement_phase": "sale-amount",
+            "settlement_type": "neft",
+            "beneficiary_name": "CHATTYBAO TECHNOLOGIES PRIVATE LIMITED NODAL ACCOUNT",
+            "upi_address": "",
+            "settlement_bank_account_no": "661505602069",
+            "settlement_ifsc_code": "ICIC0006615",
+            "bank_name": "ICICI",
+            "branch_name": "Sco 31, Sector 18, Udyog Vihar, Gurgaon - 122016, Haryana"
+          }
+        ],
+        "@ondc/org/settlement_basis": "delivery",
+        "@ondc/org/withholding_amount": "99",
+        "@ondc/org/settlement_window": "P15D"
+      },
+      "created_at": "2024-01-05T08:41:53.000Z",
+      "updated_at": "2024-01-05T08:44:52.524Z"
+    }
+  }
+}

--- a/Chattybao/Logs_Jan_05/Retail/Flow 5/on_status_out_for_delivery.json
+++ b/Chattybao/Logs_Jan_05/Retail/Flow 5/on_status_out_for_delivery.json
@@ -1,0 +1,314 @@
+{
+  "context": {
+    "domain": "ONDC:RET10",
+    "country": "IND",
+    "city": "std:0522",
+    "action": "on_status",
+    "core_version": "1.2.0",
+    "bap_id": "mappls.com",
+    "bap_uri": "https://mappls.com/store/ondc-preprod",
+    "bpp_uri": "https://ondc-seller-preprod.chattybao.com/ondc/bpp",
+    "transaction_id": "ped92me5kdliajo4v07j9vehj2108",
+    "message_id": "8179fb80-aba6-11ee-bcfb-b194587c2ac1",
+    "timestamp": "2024-01-05T08:43:32.024Z",
+    "bpp_id": "ondc-seller-preprod.chattybao.com/ondc",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "id": "ORDped92me5kdliajo4v07j9vehj2108",
+      "state": "In-progress",
+      "provider": {
+        "id": "MR8mcezPPQEA-r8EhP6UN9",
+        "locations": [
+          {
+            "id": "null"
+          }
+        ]
+      },
+      "items": [
+        {
+          "id": "4e5ffc10-944d-11ee-848d-2d2b8538311e:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 1
+          },
+          "fulfillment_id": "1"
+        },
+        {
+          "id": "2e4065c0-5dff-11ee-b94d-fbd52ac06897:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 1
+          },
+          "fulfillment_id": "1"
+        },
+        {
+          "id": "e1d875c0-1a41-11ee-8ddd-2bac5af1417f:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 1
+          },
+          "fulfillment_id": "1"
+        },
+        {
+          "id": "3799b340-9448-11ee-848d-2d2b8538311e:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 1
+          },
+          "fulfillment_id": "1"
+        }
+      ],
+      "billing": {
+        "address": {
+          "name": "BMP",
+          "email": "balmukand@mapmyindia.co.in",
+          "building": "226010,226010, Lucknow, Uttar Pradesh",
+          "locality": "test",
+          "city": "Lucknow",
+          "state": "Uttar Pradesh",
+          "area_code": "226010",
+          "country": "IND"
+        },
+        "name": "BMP",
+        "phone": "9999364087",
+        "email": "help@chattybao.com",
+        "created_at": "2024-01-05T08:40:21.000Z",
+        "updated_at": "2024-01-05T08:40:21.000Z"
+      },
+      "fulfillments": [
+        {
+          "@ondc/org/provider_name": "tester shatrughan grocery",
+          "state": {
+            "descriptor": {
+              "code": "Out-for-delivery",
+              "name": "Out for delivery"
+            }
+          },
+          "start": {
+            "location": {
+              "id": null,
+              "descriptor": {
+                "name": "tester shatrughan grocery"
+              },
+              "gps": "26.854719,80.998035",
+              "address": {
+                "locality": "4/267, Vivek Khand 4 Gomti Nagar",
+                "city": "Uttar Pradesh",
+                "area_code": "226010",
+                "state": "lucknow"
+              }
+            },
+            "time": {
+              "timestamp": "2024-01-05T08:43:23.994Z",
+              "range": {
+                "start": "2024-01-05T08:41:54.204Z",
+                "end": "2024-01-05T09:11:54.204Z"
+              }
+            },
+            "instructions": {
+              "code": "2",
+              "name": "ONDC order",
+              "short_desc": "ONDC order",
+              "long_desc": "ONDC order"
+            },
+            "contact": {
+              "phone": "8840019700",
+              "email": "help@chattybao.com"
+            }
+          },
+          "id": "1",
+          "type": "Delivery",
+          "tracking": true,
+          "end": {
+            "location": {
+              "gps": "26.856159,81.004399",
+              "address": {
+                "name": "BMP",
+                "email": "balmukand@mapmyindia.co.in",
+                "building": "226010,226010, Lucknow, Uttar Pradesh",
+                "locality": "test",
+                "city": "Lucknow",
+                "state": "Uttar Pradesh",
+                "area_code": "226010",
+                "country": "IND"
+              }
+            },
+            "contact": {
+              "phone": "9999364087"
+            },
+            "person": {
+              "name": "BMP"
+            },
+            "time": {
+              "range": {
+                "start": "2024-01-05T08:41:54.204Z",
+                "end": "2024-01-05T09:41:54.204Z"
+              }
+            }
+          },
+          "@ondc/org/TAT": "PT60M",
+          "agent": {
+            "name": "Dummy1",
+            "phone": "8840019101"
+          },
+          "tags": [
+            {
+              "code": "tracking",
+              "list": [
+                {
+                  "code": "gps_enabled",
+                  "value": "yes"
+                },
+                {
+                  "code": "url_enabled",
+                  "value": "no"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "18450"
+        },
+        "breakup": [
+          {
+            "title": "Ahaar Malka Red Dal Premium 500 g",
+            "@ondc/org/item_id": "4e5ffc10-944d-11ee-848d-2d2b8538311e:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/title_type": "item",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "price": {
+              "currency": "INR",
+              "value": "1400"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "1400"
+              }
+            }
+          },
+          {
+            "title": "Britannia 50-50 Sweet & Salty Biscuits 62.8 g",
+            "@ondc/org/item_id": "2e4065c0-5dff-11ee-b94d-fbd52ac06897:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/title_type": "item",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "price": {
+              "currency": "INR",
+              "value": "2000"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "2000"
+              }
+            }
+          },
+          {
+            "title": "Amul Pure Ghee Tin 1 L",
+            "@ondc/org/item_id": "e1d875c0-1a41-11ee-8ddd-2bac5af1417f:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/title_type": "item",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "price": {
+              "currency": "INR",
+              "value": "12000"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "12000"
+              }
+            }
+          },
+          {
+            "title": "Ahaar Besan Micro Refined 500 g",
+            "@ondc/org/item_id": "3799b340-9448-11ee-848d-2d2b8538311e:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/title_type": "item",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "price": {
+              "currency": "INR",
+              "value": "3000"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "3000"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "1",
+            "title": "Delivery Charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "42"
+            }
+          },
+          {
+            "@ondc/org/item_id": "1",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "8"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "quote",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "fulfillment"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "ttl": "P4D"
+      },
+      "payment": {
+        "params": {
+          "currency": "INR",
+          "transaction_id": "NOtReceived",
+          "amount": "18450"
+        },
+        "status": "PAID",
+        "type": "ON-ORDER",
+        "collected_by": "BAP",
+        "@ondc/org/buyer_app_finder_fee_type": "percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "3",
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "seller-app",
+            "settlement_phase": "sale-amount",
+            "settlement_type": "neft",
+            "beneficiary_name": "CHATTYBAO TECHNOLOGIES PRIVATE LIMITED NODAL ACCOUNT",
+            "upi_address": "",
+            "settlement_bank_account_no": "661505602069",
+            "settlement_ifsc_code": "ICIC0006615",
+            "bank_name": "ICICI",
+            "branch_name": "Sco 31, Sector 18, Udyog Vihar, Gurgaon - 122016, Haryana",
+            "settlement_timestamp": "2024-01-06T09:11:54.204Z"
+          }
+        ],
+        "@ondc/org/settlement_basis": "delivery",
+        "@ondc/org/withholding_amount": "99",
+        "@ondc/org/settlement_window": "P15D"
+      },
+      "created_at": "2024-01-05T08:41:53.000Z",
+      "updated_at": "2024-01-05T08:43:32.023Z"
+    }
+  }
+}

--- a/Chattybao/Logs_Jan_05/Retail/Flow 5/on_status_pending(packed).json
+++ b/Chattybao/Logs_Jan_05/Retail/Flow 5/on_status_pending(packed).json
@@ -1,0 +1,294 @@
+{
+  "context": {
+    "domain": "ONDC:RET10",
+    "country": "IND",
+    "city": "std:0522",
+    "action": "on_status",
+    "core_version": "1.2.0",
+    "bap_id": "mappls.com",
+    "bap_uri": "https://mappls.com/store/ondc-preprod",
+    "bpp_uri": "https://ondc-seller-preprod.chattybao.com/ondc/bpp",
+    "transaction_id": "ped92me5kdliajo4v07j9vehj2108",
+    "message_id": "670cff90-aba6-11ee-bcfb-b194587c2ac1",
+    "timestamp": "2024-01-05T08:42:47.689Z",
+    "bpp_id": "ondc-seller-preprod.chattybao.com/ondc",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "id": "ORDped92me5kdliajo4v07j9vehj2108",
+      "state": "In-progress",
+      "provider": {
+        "id": "MR8mcezPPQEA-r8EhP6UN9",
+        "locations": [
+          {
+            "id": "null"
+          }
+        ]
+      },
+      "items": [
+        {
+          "id": "4e5ffc10-944d-11ee-848d-2d2b8538311e:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 1
+          },
+          "fulfillment_id": "1"
+        },
+        {
+          "id": "2e4065c0-5dff-11ee-b94d-fbd52ac06897:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 1
+          },
+          "fulfillment_id": "1"
+        },
+        {
+          "id": "e1d875c0-1a41-11ee-8ddd-2bac5af1417f:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 1
+          },
+          "fulfillment_id": "1"
+        },
+        {
+          "id": "3799b340-9448-11ee-848d-2d2b8538311e:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 1
+          },
+          "fulfillment_id": "1"
+        }
+      ],
+      "billing": {
+        "address": {
+          "name": "BMP",
+          "email": "balmukand@mapmyindia.co.in",
+          "building": "226010,226010, Lucknow, Uttar Pradesh",
+          "locality": "test",
+          "city": "Lucknow",
+          "state": "Uttar Pradesh",
+          "area_code": "226010",
+          "country": "IND"
+        },
+        "name": "BMP",
+        "phone": "9999364087",
+        "email": "help@chattybao.com",
+        "created_at": "2024-01-05T08:40:21.000Z",
+        "updated_at": "2024-01-05T08:40:21.000Z"
+      },
+      "fulfillments": [
+        {
+          "@ondc/org/provider_name": "tester shatrughan grocery",
+          "state": {
+            "descriptor": {
+              "code": "Packed",
+              "name": "Packed"
+            }
+          },
+          "start": {
+            "location": {
+              "id": null,
+              "descriptor": {
+                "name": "tester shatrughan grocery"
+              },
+              "gps": "26.854719,80.998035",
+              "address": {
+                "locality": "4/267, Vivek Khand 4 Gomti Nagar",
+                "city": "Uttar Pradesh",
+                "area_code": "226010",
+                "state": "lucknow"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2024-01-05T08:41:54.204Z",
+                "end": "2024-01-05T09:11:54.204Z"
+              }
+            },
+            "instructions": {
+              "code": "2",
+              "name": "ONDC order",
+              "short_desc": "ONDC order",
+              "long_desc": "ONDC order"
+            },
+            "contact": {
+              "phone": "8840019700",
+              "email": "help@chattybao.com"
+            }
+          },
+          "id": "1",
+          "type": "Delivery",
+          "tracking": true,
+          "end": {
+            "location": {
+              "gps": "26.856159,81.004399",
+              "address": {
+                "name": "BMP",
+                "email": "balmukand@mapmyindia.co.in",
+                "building": "226010,226010, Lucknow, Uttar Pradesh",
+                "locality": "test",
+                "city": "Lucknow",
+                "state": "Uttar Pradesh",
+                "area_code": "226010",
+                "country": "IND"
+              }
+            },
+            "contact": {
+              "phone": "9999364087"
+            },
+            "person": {
+              "name": "BMP"
+            },
+            "time": {
+              "range": {
+                "start": "2024-01-05T08:41:54.204Z",
+                "end": "2024-01-05T09:41:54.204Z"
+              }
+            }
+          },
+          "@ondc/org/TAT": "PT60M"
+        }
+      ],
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "18450"
+        },
+        "breakup": [
+          {
+            "title": "Ahaar Malka Red Dal Premium 500 g",
+            "@ondc/org/item_id": "4e5ffc10-944d-11ee-848d-2d2b8538311e:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/title_type": "item",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "price": {
+              "currency": "INR",
+              "value": "1400"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "1400"
+              }
+            }
+          },
+          {
+            "title": "Britannia 50-50 Sweet & Salty Biscuits 62.8 g",
+            "@ondc/org/item_id": "2e4065c0-5dff-11ee-b94d-fbd52ac06897:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/title_type": "item",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "price": {
+              "currency": "INR",
+              "value": "2000"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "2000"
+              }
+            }
+          },
+          {
+            "title": "Amul Pure Ghee Tin 1 L",
+            "@ondc/org/item_id": "e1d875c0-1a41-11ee-8ddd-2bac5af1417f:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/title_type": "item",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "price": {
+              "currency": "INR",
+              "value": "12000"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "12000"
+              }
+            }
+          },
+          {
+            "title": "Ahaar Besan Micro Refined 500 g",
+            "@ondc/org/item_id": "3799b340-9448-11ee-848d-2d2b8538311e:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/title_type": "item",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "price": {
+              "currency": "INR",
+              "value": "3000"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "3000"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "1",
+            "title": "Delivery Charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "42"
+            }
+          },
+          {
+            "@ondc/org/item_id": "1",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "8"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "quote",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "fulfillment"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "ttl": "P4D"
+      },
+      "payment": {
+        "params": {
+          "currency": "INR",
+          "transaction_id": "NOtReceived",
+          "amount": "18450"
+        },
+        "status": "PAID",
+        "type": "ON-ORDER",
+        "collected_by": "BAP",
+        "@ondc/org/buyer_app_finder_fee_type": "percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "3",
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "seller-app",
+            "settlement_phase": "sale-amount",
+            "settlement_type": "neft",
+            "beneficiary_name": "CHATTYBAO TECHNOLOGIES PRIVATE LIMITED NODAL ACCOUNT",
+            "upi_address": "",
+            "settlement_bank_account_no": "661505602069",
+            "settlement_ifsc_code": "ICIC0006615",
+            "bank_name": "ICICI",
+            "branch_name": "Sco 31, Sector 18, Udyog Vihar, Gurgaon - 122016, Haryana",
+            "settlement_timestamp": "2024-01-06T09:11:54.204Z"
+          }
+        ],
+        "@ondc/org/settlement_basis": "delivery",
+        "@ondc/org/withholding_amount": "99",
+        "@ondc/org/settlement_window": "P15D"
+      },
+      "created_at": "2024-01-05T08:41:53.000Z",
+      "updated_at": "2024-01-05T08:42:47.687Z"
+    }
+  }
+}

--- a/Chattybao/Logs_Jan_05/Retail/Flow 5/on_status_pending.json
+++ b/Chattybao/Logs_Jan_05/Retail/Flow 5/on_status_pending.json
@@ -1,0 +1,294 @@
+{
+  "context": {
+    "domain": "ONDC:RET10",
+    "country": "IND",
+    "city": "std:0522",
+    "action": "on_status",
+    "core_version": "1.2.0",
+    "bap_id": "mappls.com",
+    "bap_uri": "https://mappls.com/store/ondc-preprod",
+    "bpp_uri": "https://ondc-seller-preprod.chattybao.com/ondc/bpp",
+    "transaction_id": "ped92me5kdliajo4v07j9vehj2108",
+    "message_id": "47be03a0-aba6-11ee-bcfb-b194587c2ac1",
+    "timestamp": "2024-01-05T08:41:55.162Z",
+    "bpp_id": "ondc-seller-preprod.chattybao.com/ondc",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "id": "ORDped92me5kdliajo4v07j9vehj2108",
+      "state": "Accepted",
+      "provider": {
+        "id": "MR8mcezPPQEA-r8EhP6UN9",
+        "locations": [
+          {
+            "id": "null"
+          }
+        ]
+      },
+      "items": [
+        {
+          "id": "4e5ffc10-944d-11ee-848d-2d2b8538311e:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 1
+          },
+          "fulfillment_id": "1"
+        },
+        {
+          "id": "2e4065c0-5dff-11ee-b94d-fbd52ac06897:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 1
+          },
+          "fulfillment_id": "1"
+        },
+        {
+          "id": "e1d875c0-1a41-11ee-8ddd-2bac5af1417f:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 1
+          },
+          "fulfillment_id": "1"
+        },
+        {
+          "id": "3799b340-9448-11ee-848d-2d2b8538311e:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 1
+          },
+          "fulfillment_id": "1"
+        }
+      ],
+      "billing": {
+        "address": {
+          "name": "BMP",
+          "email": "balmukand@mapmyindia.co.in",
+          "building": "226010,226010, Lucknow, Uttar Pradesh",
+          "locality": "test",
+          "city": "Lucknow",
+          "state": "Uttar Pradesh",
+          "area_code": "226010",
+          "country": "IND"
+        },
+        "name": "BMP",
+        "phone": "9999364087",
+        "email": "help@chattybao.com",
+        "created_at": "2024-01-05T08:40:21.000Z",
+        "updated_at": "2024-01-05T08:40:21.000Z"
+      },
+      "fulfillments": [
+        {
+          "@ondc/org/provider_name": "tester shatrughan grocery",
+          "state": {
+            "descriptor": {
+              "code": "Pending",
+              "name": "Pending"
+            }
+          },
+          "start": {
+            "location": {
+              "id": null,
+              "descriptor": {
+                "name": "tester shatrughan grocery"
+              },
+              "gps": "26.854719,80.998035",
+              "address": {
+                "locality": "4/267, Vivek Khand 4 Gomti Nagar",
+                "city": "Uttar Pradesh",
+                "area_code": "226010",
+                "state": "lucknow"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2024-01-05T08:41:54.204Z",
+                "end": "2024-01-05T09:11:54.204Z"
+              }
+            },
+            "instructions": {
+              "code": "2",
+              "name": "ONDC order",
+              "short_desc": "ONDC order",
+              "long_desc": "ONDC order"
+            },
+            "contact": {
+              "phone": "8840019700",
+              "email": "help@chattybao.com"
+            }
+          },
+          "id": "1",
+          "type": "Delivery",
+          "tracking": true,
+          "end": {
+            "location": {
+              "gps": "26.856159,81.004399",
+              "address": {
+                "name": "BMP",
+                "email": "balmukand@mapmyindia.co.in",
+                "building": "226010,226010, Lucknow, Uttar Pradesh",
+                "locality": "test",
+                "city": "Lucknow",
+                "state": "Uttar Pradesh",
+                "area_code": "226010",
+                "country": "IND"
+              }
+            },
+            "contact": {
+              "phone": "9999364087"
+            },
+            "person": {
+              "name": "BMP"
+            },
+            "time": {
+              "range": {
+                "start": "2024-01-05T08:41:54.204Z",
+                "end": "2024-01-05T09:41:54.204Z"
+              }
+            }
+          },
+          "@ondc/org/TAT": "PT60M"
+        }
+      ],
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "18450"
+        },
+        "breakup": [
+          {
+            "title": "Ahaar Malka Red Dal Premium 500 g",
+            "@ondc/org/item_id": "4e5ffc10-944d-11ee-848d-2d2b8538311e:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/title_type": "item",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "price": {
+              "currency": "INR",
+              "value": "1400"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "1400"
+              }
+            }
+          },
+          {
+            "title": "Britannia 50-50 Sweet & Salty Biscuits 62.8 g",
+            "@ondc/org/item_id": "2e4065c0-5dff-11ee-b94d-fbd52ac06897:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/title_type": "item",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "price": {
+              "currency": "INR",
+              "value": "2000"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "2000"
+              }
+            }
+          },
+          {
+            "title": "Amul Pure Ghee Tin 1 L",
+            "@ondc/org/item_id": "e1d875c0-1a41-11ee-8ddd-2bac5af1417f:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/title_type": "item",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "price": {
+              "currency": "INR",
+              "value": "12000"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "12000"
+              }
+            }
+          },
+          {
+            "title": "Ahaar Besan Micro Refined 500 g",
+            "@ondc/org/item_id": "3799b340-9448-11ee-848d-2d2b8538311e:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/title_type": "item",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "price": {
+              "currency": "INR",
+              "value": "3000"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "3000"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "1",
+            "title": "Delivery Charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "42"
+            }
+          },
+          {
+            "@ondc/org/item_id": "1",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "8"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "quote",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "fulfillment"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "ttl": "P4D"
+      },
+      "payment": {
+        "params": {
+          "currency": "INR",
+          "transaction_id": "NOtReceived",
+          "amount": "18450"
+        },
+        "status": "PAID",
+        "type": "ON-ORDER",
+        "collected_by": "BAP",
+        "@ondc/org/buyer_app_finder_fee_type": "percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "3",
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "seller-app",
+            "settlement_phase": "sale-amount",
+            "settlement_type": "neft",
+            "beneficiary_name": "CHATTYBAO TECHNOLOGIES PRIVATE LIMITED NODAL ACCOUNT",
+            "upi_address": "",
+            "settlement_bank_account_no": "661505602069",
+            "settlement_ifsc_code": "ICIC0006615",
+            "bank_name": "ICICI",
+            "branch_name": "Sco 31, Sector 18, Udyog Vihar, Gurgaon - 122016, Haryana",
+            "settlement_timestamp": "2024-01-06T09:11:54.204Z"
+          }
+        ],
+        "@ondc/org/settlement_basis": "delivery",
+        "@ondc/org/withholding_amount": "99",
+        "@ondc/org/settlement_window": "P15D"
+      },
+      "created_at": "2024-01-05T08:41:53.000Z",
+      "updated_at": "2024-01-05T08:41:55.161Z"
+    }
+  }
+}

--- a/Chattybao/Logs_Jan_05/Retail/Flow 5/on_status_picked.json
+++ b/Chattybao/Logs_Jan_05/Retail/Flow 5/on_status_picked.json
@@ -1,0 +1,314 @@
+{
+  "context": {
+    "domain": "ONDC:RET10",
+    "country": "IND",
+    "city": "std:0522",
+    "action": "on_status",
+    "core_version": "1.2.0",
+    "bap_id": "mappls.com",
+    "bap_uri": "https://mappls.com/store/ondc-preprod",
+    "bpp_uri": "https://ondc-seller-preprod.chattybao.com/ondc/bpp",
+    "transaction_id": "ped92me5kdliajo4v07j9vehj2108",
+    "message_id": "7cb101c0-aba6-11ee-bcfb-b194587c2ac1",
+    "timestamp": "2024-01-05T08:43:23.996Z",
+    "bpp_id": "ondc-seller-preprod.chattybao.com/ondc",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "id": "ORDped92me5kdliajo4v07j9vehj2108",
+      "state": "In-progress",
+      "provider": {
+        "id": "MR8mcezPPQEA-r8EhP6UN9",
+        "locations": [
+          {
+            "id": "null"
+          }
+        ]
+      },
+      "items": [
+        {
+          "id": "4e5ffc10-944d-11ee-848d-2d2b8538311e:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 1
+          },
+          "fulfillment_id": "1"
+        },
+        {
+          "id": "2e4065c0-5dff-11ee-b94d-fbd52ac06897:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 1
+          },
+          "fulfillment_id": "1"
+        },
+        {
+          "id": "e1d875c0-1a41-11ee-8ddd-2bac5af1417f:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 1
+          },
+          "fulfillment_id": "1"
+        },
+        {
+          "id": "3799b340-9448-11ee-848d-2d2b8538311e:MR8mcezPPQEA-r8EhP6UN9",
+          "quantity": {
+            "count": 1
+          },
+          "fulfillment_id": "1"
+        }
+      ],
+      "billing": {
+        "address": {
+          "name": "BMP",
+          "email": "balmukand@mapmyindia.co.in",
+          "building": "226010,226010, Lucknow, Uttar Pradesh",
+          "locality": "test",
+          "city": "Lucknow",
+          "state": "Uttar Pradesh",
+          "area_code": "226010",
+          "country": "IND"
+        },
+        "name": "BMP",
+        "phone": "9999364087",
+        "email": "help@chattybao.com",
+        "created_at": "2024-01-05T08:40:21.000Z",
+        "updated_at": "2024-01-05T08:40:21.000Z"
+      },
+      "fulfillments": [
+        {
+          "@ondc/org/provider_name": "tester shatrughan grocery",
+          "state": {
+            "descriptor": {
+              "code": "Order-picked-up",
+              "name": "Order picked up"
+            }
+          },
+          "start": {
+            "location": {
+              "id": null,
+              "descriptor": {
+                "name": "tester shatrughan grocery"
+              },
+              "gps": "26.854719,80.998035",
+              "address": {
+                "locality": "4/267, Vivek Khand 4 Gomti Nagar",
+                "city": "Uttar Pradesh",
+                "area_code": "226010",
+                "state": "lucknow"
+              }
+            },
+            "time": {
+              "timestamp": "2024-01-05T08:43:23.994Z",
+              "range": {
+                "start": "2024-01-05T08:41:54.204Z",
+                "end": "2024-01-05T09:11:54.204Z"
+              }
+            },
+            "instructions": {
+              "code": "2",
+              "name": "ONDC order",
+              "short_desc": "ONDC order",
+              "long_desc": "ONDC order"
+            },
+            "contact": {
+              "phone": "8840019700",
+              "email": "help@chattybao.com"
+            }
+          },
+          "id": "1",
+          "type": "Delivery",
+          "tracking": true,
+          "end": {
+            "location": {
+              "gps": "26.856159,81.004399",
+              "address": {
+                "name": "BMP",
+                "email": "balmukand@mapmyindia.co.in",
+                "building": "226010,226010, Lucknow, Uttar Pradesh",
+                "locality": "test",
+                "city": "Lucknow",
+                "state": "Uttar Pradesh",
+                "area_code": "226010",
+                "country": "IND"
+              }
+            },
+            "contact": {
+              "phone": "9999364087"
+            },
+            "person": {
+              "name": "BMP"
+            },
+            "time": {
+              "range": {
+                "start": "2024-01-05T08:41:54.204Z",
+                "end": "2024-01-05T09:41:54.204Z"
+              }
+            }
+          },
+          "@ondc/org/TAT": "PT60M",
+          "agent": {
+            "name": "Dummy1",
+            "phone": "8840019101"
+          },
+          "tags": [
+            {
+              "code": "tracking",
+              "list": [
+                {
+                  "code": "gps_enabled",
+                  "value": "yes"
+                },
+                {
+                  "code": "url_enabled",
+                  "value": "no"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "18450"
+        },
+        "breakup": [
+          {
+            "title": "Ahaar Malka Red Dal Premium 500 g",
+            "@ondc/org/item_id": "4e5ffc10-944d-11ee-848d-2d2b8538311e:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/title_type": "item",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "price": {
+              "currency": "INR",
+              "value": "1400"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "1400"
+              }
+            }
+          },
+          {
+            "title": "Britannia 50-50 Sweet & Salty Biscuits 62.8 g",
+            "@ondc/org/item_id": "2e4065c0-5dff-11ee-b94d-fbd52ac06897:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/title_type": "item",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "price": {
+              "currency": "INR",
+              "value": "2000"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "2000"
+              }
+            }
+          },
+          {
+            "title": "Amul Pure Ghee Tin 1 L",
+            "@ondc/org/item_id": "e1d875c0-1a41-11ee-8ddd-2bac5af1417f:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/title_type": "item",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "price": {
+              "currency": "INR",
+              "value": "12000"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "12000"
+              }
+            }
+          },
+          {
+            "title": "Ahaar Besan Micro Refined 500 g",
+            "@ondc/org/item_id": "3799b340-9448-11ee-848d-2d2b8538311e:MR8mcezPPQEA-r8EhP6UN9",
+            "@ondc/org/title_type": "item",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "price": {
+              "currency": "INR",
+              "value": "3000"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "3000"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "1",
+            "title": "Delivery Charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "42"
+            }
+          },
+          {
+            "@ondc/org/item_id": "1",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "8"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "quote",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "fulfillment"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "ttl": "P4D"
+      },
+      "payment": {
+        "params": {
+          "currency": "INR",
+          "transaction_id": "NOtReceived",
+          "amount": "18450"
+        },
+        "status": "PAID",
+        "type": "ON-ORDER",
+        "collected_by": "BAP",
+        "@ondc/org/buyer_app_finder_fee_type": "percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "3",
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "seller-app",
+            "settlement_phase": "sale-amount",
+            "settlement_type": "neft",
+            "beneficiary_name": "CHATTYBAO TECHNOLOGIES PRIVATE LIMITED NODAL ACCOUNT",
+            "upi_address": "",
+            "settlement_bank_account_no": "661505602069",
+            "settlement_ifsc_code": "ICIC0006615",
+            "bank_name": "ICICI",
+            "branch_name": "Sco 31, Sector 18, Udyog Vihar, Gurgaon - 122016, Haryana",
+            "settlement_timestamp": "2024-01-06T09:11:54.204Z"
+          }
+        ],
+        "@ondc/org/settlement_basis": "delivery",
+        "@ondc/org/withholding_amount": "99",
+        "@ondc/org/settlement_window": "P15D"
+      },
+      "created_at": "2024-01-05T08:41:53.000Z",
+      "updated_at": "2024-01-05T08:43:23.995Z"
+    }
+  }
+}

--- a/Chattybao/Logs_Jan_05/Retail/Flow 5/select.json
+++ b/Chattybao/Logs_Jan_05/Retail/Flow 5/select.json
@@ -1,0 +1,75 @@
+{
+  "context": {
+    "domain": "ONDC:RET10",
+    "country": "IND",
+    "city": "std:0522",
+    "action": "select",
+    "core_version": "1.2.0",
+    "bap_id": "mappls.com",
+    "bap_uri": "https://mappls.com/store/ondc-preprod",
+    "bpp_uri": "https://ondc-seller-preprod.chattybao.com/ondc/bpp",
+    "transaction_id": "ped92me5kdliajo4v07j9vehj2108",
+    "message_id": "312535de59c3c17342ef_1704444014",
+    "timestamp": "2024-01-05T08:40:14.000Z",
+    "bpp_id": "ondc-seller-preprod.chattybao.com/ondc",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "items": [
+        {
+          "id": "4e5ffc10-944d-11ee-848d-2d2b8538311e:MR8mcezPPQEA-r8EhP6UN9",
+          "location_id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042",
+          "quantity": {
+            "count": 1
+          }
+        },
+        {
+          "id": "2e4065c0-5dff-11ee-b94d-fbd52ac06897:MR8mcezPPQEA-r8EhP6UN9",
+          "location_id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042",
+          "quantity": {
+            "count": 1
+          }
+        },
+        {
+          "id": "e1d875c0-1a41-11ee-8ddd-2bac5af1417f:MR8mcezPPQEA-r8EhP6UN9",
+          "location_id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042",
+          "quantity": {
+            "count": 1
+          }
+        },
+        {
+          "id": "3799b340-9448-11ee-848d-2d2b8538311e:MR8mcezPPQEA-r8EhP6UN9",
+          "location_id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042",
+          "quantity": {
+            "count": 1
+          }
+        }
+      ],
+      "provider": {
+        "id": "MR8mcezPPQEA-r8EhP6UN9",
+        "locations": [
+          {
+            "id": "33b5d8f0-b265-11ed-b3f2-ed62b63ba042"
+          }
+        ]
+      },
+      "fulfillments": [
+        {
+          "end": {
+            "location": {
+              "gps": "26.856159,81.004399",
+              "address": {
+                "area_code": "226010"
+              }
+            }
+          }
+        }
+      ],
+      "offers": [],
+      "payment": {
+        "type": "ON-ORDER"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Flow 1

    /on_search:

    close_timing to be sent only if the store was previously sent as closed using full or incremental pull;
    remove accept_bap_terms (as static terms aren't yet enabled);
    for grocery packaged items (e.g. item ded21392-1a41-11ee-8ddd-2bac5af1417f:MlepomA3E7XUC_7MpLJgjn), pls also send EAN code in item.descriptor.code;
    item unitized measure should show 10 kg for the above item;
    pls use updated categories from [this](https://docs.google.com/spreadsheets/d/1APAvavF_BNbTA89benAlGtv0GuFvpn2b6XXi4lSdTTw/edit#gid=0) list;

    /on_search_incremental:

    pls share logs for common grocery use cases such as item out of stock, change in price;

Flow 2

    /on_init:

    remove provider_location, cancellation_terms;

    /on_confirm:

    structure for bpp_terms is invalid;

Flow 5

    /on_cancel_rto:

    for grocery, item costs are generally refunded in full and items are sent back to the store for resale; why not make your RTO fulfillment, quote trail & quote realistic?

for all flows with quote trail, pls check that there is no object with 0 value;

Flow 3, 4, 6 - ok;


Above feedback changes are done. And as discussed, for the below one, we'll do it within a month and update you.
- item unitized measure should show 10 kg for the above item;

@BLR-0118 