### PR TITLE
Tipplr SA - added logs as per new compliance

### DIFF
--- a/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow1/1. search_full_catalog_refresh.json
+++ b/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow1/1. search_full_catalog_refresh.json
@@ -1,0 +1,26 @@
+{
+  "context": {
+    "domain": "ONDC:RET11",
+    "action": "search",
+    "country": "IND",
+    "city": "std:080",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "transaction_id": "ceb00867-b6d5-44ad-a581-08cac6ed432e",
+    "message_id": "9d1a5ccc-5e54-4c93-a1e9-efcb06412299",
+    "timestamp": "2024-06-14T12:00:01.700Z",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "intent": {
+      "fulfillment": {
+        "type": "Delivery"
+      },
+      "payment": {
+        "@ondc/org/buyer_app_finder_fee_type": "percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "3"
+      }
+    }
+  }
+}

--- a/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow1/2. on_search_full_catalog_refresh.json
+++ b/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow1/2. on_search_full_catalog_refresh.json
@@ -1,0 +1,1009 @@
+{
+  "context": {
+    "domain": "ONDC:RET11",
+    "action": "on_search",
+    "country": "IND",
+    "city": "std:080",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "transaction_id": "ceb00867-b6d5-44ad-a581-08cac6ed432e",
+    "message_id": "9d1a5ccc-5e54-4c93-a1e9-efcb06412299",
+    "timestamp": "2024-06-14T12:00:03.700Z",
+    "bpp_id": "preprod.tipplr.in",
+    "bpp_uri": "https://preprod.tipplr.in/ondc/v2"
+  },
+  "message": {
+    "catalog": {
+      "bpp/descriptor": {
+        "name": "Tipplr",
+        "short_desc": "Tipplr for ONDC",
+        "long_desc": "Tipplr is a food and beverage discounting platform that connects diners to Dine-in or Order-in from your favorite local and national restaurants.",
+        "images": [
+          "https://tipplr.in/wp-content/uploads/2021/09/Tipplr-violet-2-190x72.png"
+        ],
+        "symbol": "https://tipplr.in/wp-content/uploads/2021/09/Tipplr-violet-2-190x72.png",
+        "tags": [
+          {
+            "code": "bpp_terms",
+            "list": [
+              {
+                "code": "np_type",
+                "value": "ISN"
+              }
+            ]
+          }
+        ]
+      },
+      "bpp/fulfillments": [
+        {
+          "id": "1",
+          "type": "Delivery"
+        }
+      ],
+      "bpp/providers": [
+        {
+          "@ondc/org/fssai_license_no": "52436745498216",
+          "id": "merchant-167714647372249847",
+          "descriptor": {
+            "name": "Tipplr-swathi d",
+            "symbol": "https://res.cloudinary.com/tipplr/image/upload/v1638530136/App%20Banners/Delivery%20Banners/Empire_Restaurant_r6hrx6.jpg",
+            "short_desc": "Tipplr-swathi d",
+            "long_desc": "Tipplr-swathi d-Vasanth Nagar",
+            "images": [
+              "https://res.cloudinary.com/tipplr-server/image/upload/fl_lossy,f_auto,q_auto,c_fill,w_512,h_256/v1656567653/gqy2lg8rhx7xjo7zyzgk.jpg"
+            ]
+          },
+          "ttl": "PT24H",
+          "categories": [
+            {
+              "id": "XFDQR84HV0",
+              "parent_category_id": "",
+              "descriptor": {
+                "name": "F&B",
+                "images": [
+                  "https://res.cloudinary.com/tipplr-server/image/upload/fl_lossy,f_auto,q_auto,c_fill,w_512,h_256/v1656567529/zhpfawowfu51xzvkia0b.jpg"
+                ],
+                "short_desc": "This is f&b",
+                "long_desc": "This is related to f&b category in ondc"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "custom_menu"
+                    }
+                  ]
+                },
+                {
+                  "code": "display",
+                  "list": [
+                    {
+                      "code": "rank",
+                      "value": "1"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "76859436",
+              "descriptor": {
+                "name": "Select Quantity"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "custom_group"
+                    }
+                  ]
+                },
+                {
+                  "code": "config",
+                  "list": [
+                    {
+                      "code": "min",
+                      "value": "1"
+                    },
+                    {
+                      "code": "max",
+                      "value": "1"
+                    },
+                    {
+                      "code": "input",
+                      "value": "select"
+                    },
+                    {
+                      "code": "seq",
+                      "value": "1"
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "locations": [
+            {
+              "id": "merchant-167714647372249847",
+              "gps": "12.979612,77.590846",
+              "address": {
+                "city": "Bengaluru",
+                "state": "KA",
+                "locality": "Vasanth Nagar",
+                "area_code": "560001",
+                "street": "Ambedkar Bheedhi, XHHR+R8X, Sampangi Rama Nagara, Bengaluru, Karnataka 560001, India"
+              },
+              "circle": {
+                "gps": "12.979612,77.590846",
+                "radius": {
+                  "unit": "km",
+                  "value": "7"
+                }
+              },
+              "time": {
+                "label": "enable",
+                "timestamp": "2024-06-13T13:12:19.258Z",
+                "days": "1,2,3,4,5,6,7",
+                "schedule": {
+                  "holidays": [
+                    "2024-10-02",
+                    "2024-06-17"
+                  ],
+                  "frequency": "PT4H",
+                  "times": [
+                    "1100",
+                    "2200"
+                  ]
+                }
+              }
+            }
+          ],
+          "time": {
+            "label": "enable",
+            "timestamp": "2024-04-29T05:52:04.466Z"
+          },
+          "offers": [
+            {
+              "id": "FLAT150",
+              "descriptor": {
+                "code": "disc_amt",
+                "images": [
+                  "https://res.cloudinary.com/tipplr/image/upload/v1714656252/App%20Banners/Cover%20Banners/smmjilsewtxpgadojgcp.png",
+                  "https://res.cloudinary.com/tipplr/image/upload/v1714656368/App%20Banners/Cover%20Banners/zqs7klrry5llglt7f9lb.png"
+                ]
+              },
+              "location_ids": [
+                "merchant-167714647372249847"
+              ],
+              "item_ids": [
+                "food_item-170383210555845413",
+                "food_item-170383210588937185",
+                "food_item-170383210568816554",
+                "food_item-170383210579428251",
+                "food_item-170383210597342600",
+                "food_item-170383210607141862",
+                "food_item-170383210627835789",
+                "food_item-170383210639513742"
+              ],
+              "time": {
+                "label": "valid",
+                "range": {
+                  "start": "2024-03-22T16:00:00.000Z",
+                  "end": "2024-06-22T23:00:00.000Z"
+                }
+              },
+              "tags": [
+                {
+                  "code": "cart",
+                  "list": [
+                    {
+                      "code": "min_value",
+                      "value": "299.00"
+                    }
+                  ]
+                },
+                {
+                  "code": "variable",
+                  "list": [
+                    {
+                      "code": "value_type",
+                      "value": "amount"
+                    },
+                    {
+                      "code": "value",
+                      "value": "-50.00"
+                    }
+                  ]
+                },
+                {
+                  "code": "definition",
+                  "list": [
+                    {
+                      "code": "additive",
+                      "value": "no"
+                    },
+                    {
+                      "code": "auto",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "fulfillments": [
+            {
+              "id": "1",
+              "type": "Delivery",
+              "contact": {
+                "phone": "8553957123",
+                "email": "tech@tipplr.in"
+              }
+            }
+          ],
+          "tags": [
+            {
+              "code": "serviceability",
+              "list": [
+                {
+                  "code": "location",
+                  "value": "merchant-167714647372249847"
+                },
+                {
+                  "code": "category",
+                  "value": "F&B"
+                },
+                {
+                  "code": "type",
+                  "value": "10"
+                },
+                {
+                  "code": "unit",
+                  "value": "km"
+                },
+                {
+                  "code": "val",
+                  "value": "7"
+                }
+              ]
+            },
+            {
+              "code": "timing",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "Delivery"
+                },
+                {
+                  "code": "location",
+                  "value": "merchant-167714647372249847"
+                },
+                {
+                  "code": "day_from",
+                  "value": "1"
+                },
+                {
+                  "code": "day_to",
+                  "value": "7"
+                },
+                {
+                  "code": "time_from",
+                  "value": "1000"
+                },
+                {
+                  "code": "time_to",
+                  "value": "2200"
+                }
+              ]
+            },
+            {
+              "code": "timing",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "Order"
+                },
+                {
+                  "code": "location",
+                  "value": "merchant-167714647372249847"
+                },
+                {
+                  "code": "day_from",
+                  "value": "1"
+                },
+                {
+                  "code": "day_to",
+                  "value": "7"
+                },
+                {
+                  "code": "time_from",
+                  "value": "1000"
+                },
+                {
+                  "code": "time_to",
+                  "value": "2200"
+                }
+              ]
+            }
+          ],
+          "items": [
+            {
+              "id": "food_item-170383210555845413",
+              "time": {
+                "label": "enable",
+                "timestamp": "2024-06-13T13:12:19.548Z"
+              },
+              "descriptor": {
+                "name": "Rava Idli",
+                "symbol": "",
+                "short_desc": "This is Rava Idli",
+                "long_desc": "This is Rava Idli. It tastes really great",
+                "images": [
+                  "https://res.cloudinary.com/tipplr-server/image/upload/fl_lossy,f_auto,q_auto,c_fill,w_512,h_256/v1698306432/ydzuhfgubyj4mpibutum.jpg"
+                ]
+              },
+              "quantity": {
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                },
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "10"
+                }
+              },
+              "category_ids": [
+                "XFDQR84HV0:1"
+              ],
+              "category_id": "F&B",
+              "location_id": "merchant-167714647372249847",
+              "fulfillment_id": "1",
+              "price": {
+                "currency": "INR",
+                "value": "45.00",
+                "maximum_value": "45.00"
+              },
+              "@ondc/org/returnable": true,
+              "@ondc/org/cancellable": false,
+              "@ondc/org/return_window": "P0D",
+              "@ondc/org/seller_pickup_return": false,
+              "@ondc/org/time_to_ship": "PT45M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "Support,hello@tipplr.in,8929221233",
+              "related": false,
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "food_item-170383210588937185:603230",
+              "descriptor": {
+                "name": "Regular"
+              },
+              "quantity": {
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                },
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "10"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "259",
+                "maximum_value": "259"
+              },
+              "category_id": "F&B",
+              "related": true,
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "76859436"
+                    },
+                    {
+                      "code": "default",
+                      "value": "no"
+                    }
+                  ]
+                },
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "food_item-170383210588937185:603232",
+              "descriptor": {
+                "name": "Medium"
+              },
+              "quantity": {
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                },
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "10"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "549",
+                "maximum_value": "549"
+              },
+              "category_id": "F&B",
+              "related": true,
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "76859436"
+                    },
+                    {
+                      "code": "default",
+                      "value": "no"
+                    }
+                  ]
+                },
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "food_item-170383210588937185:603233",
+              "descriptor": {
+                "name": "Large"
+              },
+              "quantity": {
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                },
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "10"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "749",
+                "maximum_value": "749"
+              },
+              "category_id": "F&B",
+              "related": true,
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "76859436"
+                    },
+                    {
+                      "code": "default",
+                      "value": "no"
+                    }
+                  ]
+                },
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "food_item-170383210588937185",
+              "time": {
+                "label": "enable",
+                "timestamp": "2024-06-13T13:12:19.549Z"
+              },
+              "descriptor": {
+                "name": "Chicken pizza",
+                "symbol": "",
+                "short_desc": "This is Chicken pizza",
+                "long_desc": "This is Chicken pizza. It tastes really great",
+                "images": [
+                  "https://res.cloudinary.com/tipplr-server/image/upload/fl_lossy,f_auto,q_auto,c_fill,w_512,h_256/v1698306432/ydzuhfgubyj4mpibutum.jpg"
+                ]
+              },
+              "quantity": {
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                },
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "10"
+                }
+              },
+              "category_ids": [
+                "XFDQR84HV0:2"
+              ],
+              "category_id": "F&B",
+              "location_id": "merchant-167714647372249847",
+              "fulfillment_id": "1",
+              "price": {
+                "currency": "INR",
+                "value": "1.00",
+                "maximum_value": "1.00"
+              },
+              "@ondc/org/returnable": true,
+              "@ondc/org/cancellable": true,
+              "@ondc/org/return_window": "P0D",
+              "@ondc/org/seller_pickup_return": false,
+              "@ondc/org/time_to_ship": "PT45M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "Support,hello@tipplr.in,8929221233",
+              "related": false,
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "non_veg",
+                      "value": "yes"
+                    }
+                  ]
+                },
+                {
+                  "code": "custom_group",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "76859436"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "food_item-170383210568816554",
+              "time": {
+                "label": "enable",
+                "timestamp": "2024-06-13T13:12:19.549Z"
+              },
+              "descriptor": {
+                "name": "Idli 2",
+                "symbol": "",
+                "short_desc": "This is Idli 2",
+                "long_desc": "This is Idli 2. It tastes really great",
+                "images": [
+                  "https://res.cloudinary.com/tipplr-server/image/upload/fl_lossy,f_auto,q_auto,c_fill,w_512,h_256/v1698306432/ydzuhfgubyj4mpibutum.jpg"
+                ]
+              },
+              "quantity": {
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                },
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "10"
+                }
+              },
+              "category_ids": [
+                "XFDQR84HV0:3"
+              ],
+              "category_id": "F&B",
+              "location_id": "merchant-167714647372249847",
+              "fulfillment_id": "1",
+              "price": {
+                "currency": "INR",
+                "value": "40.00",
+                "maximum_value": "40.00"
+              },
+              "@ondc/org/returnable": true,
+              "@ondc/org/cancellable": true,
+              "@ondc/org/return_window": "P0D",
+              "@ondc/org/seller_pickup_return": false,
+              "@ondc/org/time_to_ship": "PT45M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "Support,hello@tipplr.in,8929221233",
+              "related": false,
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "food_item-170383210579428251",
+              "time": {
+                "label": "enable",
+                "timestamp": "2024-06-13T13:12:19.549Z"
+              },
+              "descriptor": {
+                "name": "2 Idli 1 Vada",
+                "symbol": "",
+                "short_desc": "This is 2 Idli 1 Vada",
+                "long_desc": "This is 2 Idli 1 Vada. It tastes really great",
+                "images": [
+                  "https://res.cloudinary.com/tipplr-server/image/upload/fl_lossy,f_auto,q_auto,c_fill,w_512,h_256/v1698306432/ydzuhfgubyj4mpibutum.jpg"
+                ]
+              },
+              "quantity": {
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                },
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "10"
+                }
+              },
+              "category_ids": [
+                "XFDQR84HV0:4"
+              ],
+              "category_id": "F&B",
+              "location_id": "merchant-167714647372249847",
+              "fulfillment_id": "1",
+              "price": {
+                "currency": "INR",
+                "value": "70.00",
+                "maximum_value": "70.00"
+              },
+              "@ondc/org/returnable": true,
+              "@ondc/org/cancellable": true,
+              "@ondc/org/return_window": "P0D",
+              "@ondc/org/seller_pickup_return": false,
+              "@ondc/org/time_to_ship": "PT45M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "Support,hello@tipplr.in,8929221233",
+              "related": false,
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "food_item-170383210597342600",
+              "time": {
+                "label": "enable",
+                "timestamp": "2024-06-13T13:12:19.549Z"
+              },
+              "descriptor": {
+                "name": "1 Idli 1 Vada",
+                "symbol": "",
+                "short_desc": "This is 1 Idli 1 Vada",
+                "long_desc": "This is 1 Idli 1 Vada. It tastes really great",
+                "images": [
+                  "https://res.cloudinary.com/tipplr-server/image/upload/fl_lossy,f_auto,q_auto,c_fill,w_512,h_256/v1698306432/ydzuhfgubyj4mpibutum.jpg"
+                ]
+              },
+              "quantity": {
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                },
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "10"
+                }
+              },
+              "category_ids": [
+                "XFDQR84HV0:5"
+              ],
+              "category_id": "F&B",
+              "location_id": "merchant-167714647372249847",
+              "fulfillment_id": "1",
+              "price": {
+                "currency": "INR",
+                "value": "55.00",
+                "maximum_value": "55.00"
+              },
+              "@ondc/org/returnable": true,
+              "@ondc/org/cancellable": true,
+              "@ondc/org/return_window": "P0D",
+              "@ondc/org/seller_pickup_return": false,
+              "@ondc/org/time_to_ship": "PT45M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "Support,hello@tipplr.in,8929221233",
+              "related": false,
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "food_item-170383210607141862",
+              "time": {
+                "label": "enable",
+                "timestamp": "2024-06-13T13:12:19.549Z"
+              },
+              "descriptor": {
+                "name": "Kesari Bath",
+                "symbol": "",
+                "short_desc": "This is Kesari Bath",
+                "long_desc": "This is Kesari Bath. It tastes really great",
+                "images": [
+                  "https://res.cloudinary.com/tipplr-server/image/upload/fl_lossy,f_auto,q_auto,c_fill,w_512,h_256/v1698306432/ydzuhfgubyj4mpibutum.jpg"
+                ]
+              },
+              "quantity": {
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                },
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "10"
+                }
+              },
+              "category_ids": [
+                "XFDQR84HV0:6"
+              ],
+              "category_id": "F&B",
+              "location_id": "merchant-167714647372249847",
+              "fulfillment_id": "1",
+              "price": {
+                "currency": "INR",
+                "value": "35.00",
+                "maximum_value": "35.00"
+              },
+              "@ondc/org/returnable": true,
+              "@ondc/org/cancellable": true,
+              "@ondc/org/return_window": "P0D",
+              "@ondc/org/seller_pickup_return": false,
+              "@ondc/org/time_to_ship": "PT45M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "Support,hello@tipplr.in,8929221233",
+              "related": false,
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "food_item-170383210627835789",
+              "time": {
+                "label": "enable",
+                "timestamp": "2024-06-13T13:12:19.549Z"
+              },
+              "descriptor": {
+                "name": "Poori Kurma",
+                "symbol": "",
+                "short_desc": "This is Poori Kurma",
+                "long_desc": "This is Poori Kurma. It tastes really great",
+                "images": [
+                  "https://res.cloudinary.com/tipplr-server/image/upload/fl_lossy,f_auto,q_auto,c_fill,w_512,h_256/v1698306432/ydzuhfgubyj4mpibutum.jpg"
+                ]
+              },
+              "quantity": {
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                },
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "10"
+                }
+              },
+              "category_ids": [
+                "XFDQR84HV0:7"
+              ],
+              "category_id": "F&B",
+              "location_id": "merchant-167714647372249847",
+              "fulfillment_id": "1",
+              "price": {
+                "currency": "INR",
+                "value": "70.00",
+                "maximum_value": "70.00"
+              },
+              "@ondc/org/returnable": true,
+              "@ondc/org/cancellable": true,
+              "@ondc/org/return_window": "P0D",
+              "@ondc/org/seller_pickup_return": false,
+              "@ondc/org/time_to_ship": "PT45M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "Support,hello@tipplr.in,8929221233",
+              "related": false,
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "food_item-170383210639513742",
+              "time": {
+                "label": "enable",
+                "timestamp": "2024-06-13T13:12:19.549Z"
+              },
+              "descriptor": {
+                "name": "Gulab Jamun 1pc",
+                "symbol": "",
+                "short_desc": "This is Gulab Jamun 1pc",
+                "long_desc": "This is Gulab Jamun 1pc. It tastes really great",
+                "images": [
+                  "https://res.cloudinary.com/tipplr-server/image/upload/fl_lossy,f_auto,q_auto,c_fill,w_512,h_256/v1698306432/ydzuhfgubyj4mpibutum.jpg"
+                ]
+              },
+              "quantity": {
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                },
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "10"
+                }
+              },
+              "category_ids": [
+                "XFDQR84HV0:8"
+              ],
+              "category_id": "F&B",
+              "location_id": "merchant-167714647372249847",
+              "fulfillment_id": "1",
+              "price": {
+                "currency": "INR",
+                "value": "25.00",
+                "maximum_value": "25.00"
+              },
+              "@ondc/org/returnable": true,
+              "@ondc/org/cancellable": true,
+              "@ondc/org/return_window": "P0D",
+              "@ondc/org/seller_pickup_return": false,
+              "@ondc/org/time_to_ship": "PT45M",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "Support,hello@tipplr.in,8929221233",
+              "related": false,
+              "tags": [
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow1/3. search_inc_refresh.json
+++ b/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow1/3. search_inc_refresh.json
@@ -1,0 +1,55 @@
+{
+  "context": {
+    "domain": "ONDC:RET11",
+    "action": "search",
+    "country": "IND",
+    "city": "*",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "transaction_id": "a597f768-6f96-4cc7-9121-bc66dabecbf0",
+    "message_id": "ed118139-ecc8-4c18-a246-f9f3ca9567e3",
+    "timestamp": "2024-06-14T12:04:03.700Z",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "intent": {
+      "payment": {
+        "@ondc/org/buyer_app_finder_fee_type": "percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "3"
+      },
+      "tags": [
+        {
+          "code": "catalog_inc",
+          "list": [
+            {
+              "code": "start_time",
+              "value": "2024-06-06T06:03:56.550Z"
+            },
+            {
+              "code": "end_time",
+              "value": "2024-06-06T07:01:56.550Z"
+            }
+          ]
+        },
+        {
+          "code": "bap_terms",
+          "list": [
+            {
+              "code": "static_terms",
+              "value": ""
+            },
+            {
+              "code": "static_terms_new",
+              "value": "https://github.com/ONDC-Official/NP-Static-Terms/buyerNP_BNP/1.0/tc.pdf"
+            },
+            {
+              "code": "effective_date",
+              "value": "2023-12-01T00:00:00.000Z"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow1/4. on_search_inc_refresh.json
+++ b/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow1/4. on_search_inc_refresh.json
@@ -1,0 +1,72 @@
+{
+  "context": {
+    "domain": "ONDC:RET11",
+    "action": "on_search",
+    "country": "IND",
+    "city": "*",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "transaction_id": "a597f768-6f96-4cc7-9121-bc66dabecbf0",
+    "message_id": "ed118139-ecc8-4c18-a246-f9f3ca9567e3",
+    "timestamp": "2024-06-14T12:04:05.700Z",
+    "ttl": "PT30S",
+    "bpp_id": "preprod.tipplr.in",
+    "bpp_uri": "https://preprod.tipplr.in/ondc/v2"
+  },
+  "message": {
+    "catalog": {
+      "bpp/providers": [
+        {
+          "id": "merchant-167714647372249847",
+          "locations": [
+            {
+              "id": "merchant-167714647372249847",
+              "time": {
+                "label": "close",
+                "timestamp": "2024-06-06T07:01:56.550Z",
+                "range": {
+                  "start": "2024-06-06T10:03:56.550Z",
+                  "end": "2024-06-06T14:03:56.550Z"
+                },
+                "schedule": {
+                  "holidays": [
+                    "2024-10-02",
+                    "2024-06-17"
+                  ]
+                }
+              }
+            }
+          ]
+        },
+        {
+          "id": "merchant-16470689776923676",
+          "locations": [
+            {
+              "id": "merchant-16470689776923676",
+              "time": {
+                "label": "close",
+                "timestamp": "2024-06-06T07:01:56.550Z",
+                "range": {
+                  "start": "2024-06-06T10:03:56.550Z",
+                  "end": "2024-06-06T14:03:56.550Z"
+                },
+                "schedule": {
+                  "holidays": [
+                    "2024-10-02",
+                    "2024-06-17"
+                  ],
+                  "frequency": "PT4H",
+                  "times": [
+                    "1100",
+                    "2200"
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow2/1. select.json
+++ b/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow2/1. select.json
@@ -1,0 +1,86 @@
+{
+  "context": {
+    "domain": "ONDC:RET11",
+    "country": "IND",
+    "city": "std:080",
+    "action": "select",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_uri": "https://preprod.tipplr.in/ondc/v2",
+    "transaction_id": "f17e9b49-7799-4624-974d-8c413b41a12b",
+    "message_id": "3886f7db-68de-464a-8edf-11602c2f8073",
+    "timestamp": "2024-06-14T06:32:40.565Z",
+    "bpp_id": "preprod.tipplr.in",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "items": [
+        {
+          "id": "food_item-170383210555845413",
+          "quantity": {
+            "count": 2
+          },
+          "location_id": "merchant-167714647372249847"
+        },
+        {
+          "id": "food_item-170383210588937185",
+          "quantity": {
+            "count": 2
+          },
+          "location_id": "merchant-167714647372249847",
+          "parent_item_id": "DI1"
+        },
+        {
+          "id": "food_item-170383210588937185:603230",
+          "quantity": {
+            "count": 2
+          },
+          "location_id": "merchant-167714647372249847",
+          "tags": [
+            {
+              "code": "type",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "customization"
+                }
+              ]
+            },
+            {
+              "code": "parent",
+              "list": [
+                {
+                  "code": "id",
+                  "value": "76859436"
+                }
+              ]
+            }
+          ],
+          "parent_item_id": "DI1"
+        }
+      ],
+      "provider": {
+        "id": "merchant-167714647372249847",
+        "locations": [
+          {
+            "id": "merchant-167714647372249847"
+          }
+        ]
+      },
+      "fulfillments": [
+        {
+          "end": {
+            "location": {
+              "gps": "12.988908115944769,77.58893609046937",
+              "address": {
+                "area_code": "560052"
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow2/10. on_status_out_for_delivery.json
+++ b/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow2/10. on_status_out_for_delivery.json
@@ -1,0 +1,381 @@
+{
+  "message": {
+    "order": {
+      "id": "2024-06-14-828136",
+      "state": "In-progress",
+      "billing": {
+        "address": {
+          "name": "test",
+          "building": "Office",
+          "locality": "Palace Road",
+          "city": "Bengaluru",
+          "state": "Karnataka",
+          "country": "IND",
+          "area_code": "560052"
+        },
+        "phone": "9999999999",
+        "name": "test",
+        "email": "test@gmail.com",
+        "created_at": "2024-06-14T06:32:51.134Z",
+        "updated_at": "2024-06-14T06:32:51.134Z"
+      },
+      "items": [
+        {
+          "id": "food_item-170383210555845413",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "merchant-167714647372249847"
+        },
+        {
+          "id": "food_item-170383210588937185",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "merchant-167714647372249847",
+          "parent_item_id": "DI1"
+        },
+        {
+          "id": "food_item-170383210588937185:603230",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "merchant-167714647372249847",
+          "tags": [
+            {
+              "code": "type",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "customization"
+                }
+              ]
+            },
+            {
+              "code": "parent",
+              "list": [
+                {
+                  "code": "id",
+                  "value": "76859436"
+                }
+              ]
+            }
+          ],
+          "parent_item_id": "DI1"
+        }
+      ],
+      "provider": {
+        "id": "merchant-167714647372249847",
+        "locations": [
+          {
+            "id": "merchant-167714647372249847"
+          }
+        ]
+      },
+      "fulfillments": [
+        {
+          "@ondc/org/TAT": "PT45M",
+          "id": "merchant-167714647372249847",
+          "tracking": false,
+          "end": {
+            "contact": {
+              "email": "test@gmail.com",
+              "phone": "9999999999"
+            },
+            "person": {
+              "name": "test"
+            },
+            "location": {
+              "gps": "12.988908115944769,77.58893609046937",
+              "address": {
+                "name": "test",
+                "building": "Office",
+                "locality": "Palace Road",
+                "city": "Bengaluru",
+                "state": "Karnataka",
+                "country": "IND",
+                "area_code": "560052"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2024-06-14T06:33:15.363Z",
+                "end": "2024-06-14T07:18:15.363Z"
+              }
+            }
+          },
+          "type": "Delivery",
+          "start": {
+            "location": {
+              "id": "merchant-167714647372249847",
+              "descriptor": {
+                "name": "Tipplr-swathi d"
+              },
+              "gps": "12.979612,77.590846",
+              "address": {
+                "city": "Bengaluru",
+                "area_code": "560001",
+                "locality": "Vasanth Nagar",
+                "state": "KA"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2024-06-14T06:33:15.363Z",
+                "end": "2024-06-14T07:18:15.363Z"
+              },
+              "timestamp": "2024-06-14T06:34:50.338Z"
+            },
+            "contact": {
+              "phone": "8929221233",
+              "email": "support@tipplr.in"
+            }
+          },
+          "@ondc/org/provider_name": "TIPPLR_DELIVERY",
+          "state": {
+            "descriptor": {
+              "code": "Out-for-delivery"
+            }
+          },
+          "tags": [
+            {
+              "code": "routing",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "P2P"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "payment": {
+        "uri": "https://razorpay.com/",
+        "tl_method": "http/get",
+        "params": {
+          "amount": "700.50",
+          "currency": "INR",
+          "transaction_id": "order_OMXjoNk6JZVsrc"
+        },
+        "status": "PAID",
+        "type": "ON-ORDER",
+        "collected_by": "BAP",
+        "@ondc/org/buyer_app_finder_fee_type": "percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+        "@ondc/org/settlement_basis": "return_window_expiry",
+        "@ondc/org/settlement_window": "P1D",
+        "@ondc/org/withholding_amount": "21.02",
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "seller-app",
+            "settlement_phase": "sale-amount",
+            "settlement_type": "neft",
+            "upi_address": "9900818181@upi",
+            "settlement_bank_account_no": "50200053531451",
+            "settlement_ifsc_code": "HDFC0004051",
+            "beneficiary_name": "FOOD SPACE TECHNOLOGY PRIVATE LIMITED",
+            "bank_name": "HDFC Bank",
+            "branch_name": "CNN"
+          }
+        ]
+      },
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "700.50"
+        },
+        "breakup": [
+          {
+            "@ondc/org/item_id": "food_item-170383210555845413",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "title": "Rava Idli",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "90"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "45"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210555845413",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "4.50"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210588937185",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "title": "Chicken pizza",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "2"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "1"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ],
+              "parent_item_id": "DI1"
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210588937185:603230",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "title": "Regular",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "518"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "259"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "76859436"
+                    }
+                  ]
+                }
+              ],
+              "fulfillment_id": "merchant-167714647372249847",
+              "parent_item_id": "DI1"
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210588937185",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "26.00"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ],
+              "parent_item_id": "DI1"
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Packing charges",
+            "@ondc/org/title_type": "packing",
+            "price": {
+              "currency": "INR",
+              "value": "10.5"
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Delivery charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "39"
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Convenience Fee",
+            "@ondc/org/title_type": "misc",
+            "price": {
+              "currency": "INR",
+              "value": "10.50"
+            }
+          }
+        ],
+        "ttl": "P1D"
+      },
+      "created_at": "2024-06-14T06:33:15.103Z",
+      "updated_at": "2024-06-14T06:34:50.338Z"
+    }
+  },
+  "context": {
+    "domain": "ONDC:RET11",
+    "country": "IND",
+    "city": "std:080",
+    "action": "on_status",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_uri": "https://preprod.tipplr.in/ondc/v2",
+    "transaction_id": "f17e9b49-7799-4624-974d-8c413b41a12b",
+    "message_id": "a8509e02-0113-4183-9db0-cd7911674b3f",
+    "timestamp": "2024-06-14T06:34:50.377Z",
+    "bpp_id": "preprod.tipplr.in"
+  }
+}

--- a/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow2/11. track.json
+++ b/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow2/11. track.json
@@ -1,0 +1,20 @@
+{
+  "context": {
+    "domain": "ONDC:RET11",
+    "country": "IND",
+    "city": "std:080",
+    "action": "track",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_uri": "https://preprod.tipplr.in/ondc/v2",
+    "transaction_id": "f17e9b49-7799-4624-974d-8c413b41a12b",
+    "message_id": "f485dfb4-a500-4425-8488-e4d9951bc434",
+    "timestamp": "2024-06-14T06:35:07.629Z",
+    "bpp_id": "preprod.tipplr.in",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order_id": "2024-06-14-828136"
+  }
+}

--- a/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow2/12. on_track.json
+++ b/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow2/12. on_track.json
@@ -1,0 +1,30 @@
+{
+  "context": {
+    "domain": "ONDC:RET11",
+    "country": "IND",
+    "city": "std:080",
+    "action": "on_track",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_uri": "https://preprod.tipplr.in/ondc/v2",
+    "transaction_id": "f17e9b49-7799-4624-974d-8c413b41a12b",
+    "message_id": "f485dfb4-a500-4425-8488-e4d9951bc434",
+    "timestamp": "2024-06-14T06:35:09.629Z",
+    "bpp_id": "preprod.tipplr.in",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "tracking": {
+      "id": "2024-06-14-828136",
+      "location": {
+        "gps": "12.974002,77.613458",
+        "time": {
+          "timestamp": "2024-06-14T06:35:07.719Z"
+        },
+        "updated_at": "2024-06-14T06:35:07.719Z"
+      },
+      "status": "active"
+    }
+  }
+}

--- a/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow2/13. on_status_delivered.json
+++ b/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow2/13. on_status_delivered.json
@@ -1,0 +1,392 @@
+{
+  "message": {
+    "order": {
+      "id": "2024-06-14-828136",
+      "state": "Completed",
+      "billing": {
+        "address": {
+          "name": "test",
+          "building": "Office",
+          "locality": "Palace Road",
+          "city": "Bengaluru",
+          "state": "Karnataka",
+          "country": "IND",
+          "area_code": "560052"
+        },
+        "phone": "9999999999",
+        "name": "test",
+        "email": "test@gmail.com",
+        "created_at": "2024-06-14T06:32:51.134Z",
+        "updated_at": "2024-06-14T06:32:51.134Z"
+      },
+      "items": [
+        {
+          "id": "food_item-170383210555845413",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "merchant-167714647372249847"
+        },
+        {
+          "id": "food_item-170383210588937185",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "merchant-167714647372249847",
+          "parent_item_id": "DI1"
+        },
+        {
+          "id": "food_item-170383210588937185:603230",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "merchant-167714647372249847",
+          "tags": [
+            {
+              "code": "type",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "customization"
+                }
+              ]
+            },
+            {
+              "code": "parent",
+              "list": [
+                {
+                  "code": "id",
+                  "value": "76859436"
+                }
+              ]
+            }
+          ],
+          "parent_item_id": "DI1"
+        }
+      ],
+      "provider": {
+        "id": "merchant-167714647372249847",
+        "locations": [
+          {
+            "id": "merchant-167714647372249847"
+          }
+        ]
+      },
+      "fulfillments": [
+        {
+          "@ondc/org/TAT": "PT45M",
+          "id": "merchant-167714647372249847",
+          "tracking": false,
+          "end": {
+            "contact": {
+              "email": "test@gmail.com",
+              "phone": "9999999999"
+            },
+            "person": {
+              "name": "test"
+            },
+            "location": {
+              "gps": "12.988908115944769,77.58893609046937",
+              "address": {
+                "name": "test",
+                "building": "Office",
+                "locality": "Palace Road",
+                "city": "Bengaluru",
+                "state": "Karnataka",
+                "country": "IND",
+                "area_code": "560052"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2024-06-14T06:33:15.363Z",
+                "end": "2024-06-14T07:18:15.363Z"
+              },
+              "timestamp": "2024-06-14T06:40:46.392Z"
+            },
+            "instructions": {
+              "code": "2",
+              "name": "Proof of delivery",
+              "short_desc": "order delivered",
+              "long_desc": "delivery completed",
+              "images": [
+                "https://res.cloudinary.com/tipplr/image/upload/v1717656844/Common%20Images/testing/Image_3_gmvamz.jpg",
+                "https://res.cloudinary.com/tipplr/image/upload/v1717656844/Common%20Images/testing/Image_4_e5lywo.jpg"
+              ]
+            }
+          },
+          "type": "Delivery",
+          "start": {
+            "location": {
+              "id": "merchant-167714647372249847",
+              "descriptor": {
+                "name": "Tipplr-swathi d"
+              },
+              "gps": "12.979612,77.590846",
+              "address": {
+                "city": "Bengaluru",
+                "area_code": "560001",
+                "locality": "Vasanth Nagar",
+                "state": "KA"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2024-06-14T06:33:15.363Z",
+                "end": "2024-06-14T07:18:15.363Z"
+              },
+              "timestamp": "2024-06-14T06:34:50.338Z"
+            },
+            "contact": {
+              "phone": "8929221233",
+              "email": "support@tipplr.in"
+            }
+          },
+          "@ondc/org/provider_name": "TIPPLR_DELIVERY",
+          "state": {
+            "descriptor": {
+              "code": "Order-delivered"
+            }
+          },
+          "tags": [
+            {
+              "code": "routing",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "P2P"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "payment": {
+        "uri": "https://razorpay.com/",
+        "tl_method": "http/get",
+        "params": {
+          "amount": "700.50",
+          "currency": "INR",
+          "transaction_id": "order_OMXjoNk6JZVsrc"
+        },
+        "status": "PAID",
+        "type": "ON-ORDER",
+        "collected_by": "BAP",
+        "@ondc/org/buyer_app_finder_fee_type": "percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+        "@ondc/org/settlement_basis": "return_window_expiry",
+        "@ondc/org/settlement_window": "P1D",
+        "@ondc/org/withholding_amount": "21.02",
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "seller-app",
+            "settlement_phase": "sale-amount",
+            "settlement_type": "neft",
+            "upi_address": "9900818181@upi",
+            "settlement_bank_account_no": "50200053531451",
+            "settlement_ifsc_code": "HDFC0004051",
+            "beneficiary_name": "FOOD SPACE TECHNOLOGY PRIVATE LIMITED",
+            "bank_name": "HDFC Bank",
+            "branch_name": "CNN"
+          }
+        ]
+      },
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "700.50"
+        },
+        "breakup": [
+          {
+            "@ondc/org/item_id": "food_item-170383210555845413",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "title": "Rava Idli",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "90"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "45"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210555845413",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "4.50"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210588937185",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "title": "Chicken pizza",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "2"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "1"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ],
+              "parent_item_id": "DI1"
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210588937185:603230",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "title": "Regular",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "518"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "259"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "76859436"
+                    }
+                  ]
+                }
+              ],
+              "fulfillment_id": "merchant-167714647372249847",
+              "parent_item_id": "DI1"
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210588937185",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "26.00"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ],
+              "parent_item_id": "DI1"
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Packing charges",
+            "@ondc/org/title_type": "packing",
+            "price": {
+              "currency": "INR",
+              "value": "10.5"
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Delivery charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "39"
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Convenience Fee",
+            "@ondc/org/title_type": "misc",
+            "price": {
+              "currency": "INR",
+              "value": "10.50"
+            }
+          }
+        ],
+        "ttl": "P1D"
+      },
+      "created_at": "2024-06-14T06:33:15.103Z",
+      "updated_at": "2024-06-14T06:40:46.392Z"
+    }
+  },
+  "context": {
+    "domain": "ONDC:RET11",
+    "country": "IND",
+    "city": "std:080",
+    "action": "on_status",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_uri": "https://preprod.tipplr.in/ondc/v2",
+    "transaction_id": "f17e9b49-7799-4624-974d-8c413b41a12b",
+    "message_id": "2516e7d7-7348-4566-9a92-0434a27c8754",
+    "timestamp": "2024-06-14T06:40:46.392Z",
+    "bpp_id": "preprod.tipplr.in"
+  }
+}

--- a/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow2/2. on_select.json
+++ b/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow2/2. on_select.json
@@ -1,0 +1,283 @@
+{
+  "context": {
+    "domain": "ONDC:RET11",
+    "country": "IND",
+    "city": "std:080",
+    "action": "on_select",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_uri": "https://preprod.tipplr.in/ondc/v2",
+    "transaction_id": "f17e9b49-7799-4624-974d-8c413b41a12b",
+    "message_id": "3886f7db-68de-464a-8edf-11602c2f8073",
+    "timestamp": "2024-06-14T06:32:42.565Z",
+    "bpp_id": "preprod.tipplr.in"
+  },
+  "message": {
+    "order": {
+      "provider": {
+        "id": "merchant-167714647372249847",
+        "locations": [
+          {
+            "id": "merchant-167714647372249847"
+          }
+        ]
+      },
+      "fulfillments": [
+        {
+          "id": "merchant-167714647372249847",
+          "@ondc/org/provider_name": "TIPPLR_DELIVERY",
+          "tracking": false,
+          "@ondc/org/category": "Immediate Delivery",
+          "type": "Delivery",
+          "@ondc/org/TAT": "PT60M",
+          "state": {
+            "descriptor": {
+              "code": "Serviceable"
+            }
+          }
+        }
+      ],
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "700.50"
+        },
+        "breakup": [
+          {
+            "@ondc/org/item_id": "food_item-170383210555845413",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "title": "Rava Idli",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "90"
+            },
+            "item": {
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "10"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "45"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210555845413",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "4.50"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210588937185",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "title": "Chicken pizza",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "2"
+            },
+            "item": {
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "10"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "1"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ],
+              "parent_item_id": "DI1"
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210588937185:603230",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "title": "Regular",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "518"
+            },
+            "item": {
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "10"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "259"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "76859436"
+                    }
+                  ]
+                }
+              ],
+              "fulfillment_id": "merchant-167714647372249847",
+              "parent_item_id": "DI1"
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210588937185",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "26.00"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ],
+              "parent_item_id": "DI1"
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Packing charges",
+            "@ondc/org/title_type": "packing",
+            "price": {
+              "currency": "INR",
+              "value": "10.5"
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Delivery charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "39"
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Convenience Fee",
+            "@ondc/org/title_type": "misc",
+            "price": {
+              "currency": "INR",
+              "value": "10.50"
+            }
+          }
+        ],
+        "ttl": "P1D"
+      },
+      "items": [
+        {
+          "id": "food_item-170383210555845413",
+          "fulfillment_id": "merchant-167714647372249847"
+        },
+        {
+          "id": "food_item-170383210588937185",
+          "fulfillment_id": "merchant-167714647372249847",
+          "parent_item_id": "DI1"
+        },
+        {
+          "id": "food_item-170383210588937185:603230",
+          "tags": [
+            {
+              "code": "type",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "customization"
+                }
+              ]
+            },
+            {
+              "code": "parent",
+              "list": [
+                {
+                  "code": "id",
+                  "value": "76859436"
+                }
+              ]
+            }
+          ],
+          "fulfillment_id": "merchant-167714647372249847",
+          "parent_item_id": "DI1"
+        }
+      ]
+    }
+  }
+}

--- a/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow2/3. init.json
+++ b/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow2/3. init.json
@@ -1,0 +1,117 @@
+{
+  "context": {
+    "domain": "ONDC:RET11",
+    "country": "IND",
+    "city": "std:080",
+    "action": "init",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_uri": "https://preprod.tipplr.in/ondc/v2",
+    "transaction_id": "f17e9b49-7799-4624-974d-8c413b41a12b",
+    "message_id": "65998a85-4ea1-4d39-aa23-977409c9be07",
+    "timestamp": "2024-06-14T06:32:51.134Z",
+    "bpp_id": "preprod.tipplr.in",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "provider": {
+        "id": "merchant-167714647372249847",
+        "locations": [
+          {
+            "id": "merchant-167714647372249847"
+          }
+        ]
+      },
+      "items": [
+        {
+          "id": "food_item-170383210555845413",
+          "quantity": {
+            "count": 2
+          },
+          "location_id": "merchant-167714647372249847",
+          "fulfillment_id": "merchant-167714647372249847"
+        },
+        {
+          "id": "food_item-170383210588937185",
+          "quantity": {
+            "count": 2
+          },
+          "location_id": "merchant-167714647372249847",
+          "parent_item_id": "DI1",
+          "fulfillment_id": "merchant-167714647372249847"
+        },
+        {
+          "id": "food_item-170383210588937185:603230",
+          "quantity": {
+            "count": 2
+          },
+          "location_id": "merchant-167714647372249847",
+          "tags": [
+            {
+              "code": "type",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "customization"
+                }
+              ]
+            },
+            {
+              "code": "parent",
+              "list": [
+                {
+                  "code": "id",
+                  "value": "76859436"
+                }
+              ]
+            }
+          ],
+          "fulfillment_id": "merchant-167714647372249847",
+          "parent_item_id": "DI1"
+        }
+      ],
+      "billing": {
+        "address": {
+          "building": "Office",
+          "city": "Bengaluru",
+          "state": "Karnataka",
+          "country": "IND",
+          "area_code": "560052",
+          "locality": "Palace Road",
+          "name": "test"
+        },
+        "phone": "9999999999",
+        "name": "test",
+        "email": "test@gmail.com",
+        "created_at": "2024-06-14T06:32:51.134Z",
+        "updated_at": "2024-06-14T06:32:51.134Z"
+      },
+      "fulfillments": [
+        {
+          "id": "merchant-167714647372249847",
+          "type": "Delivery",
+          "end": {
+            "contact": {
+              "email": "test@gmail.com",
+              "phone": "9999999999"
+            },
+            "location": {
+              "gps": "12.988908115944769,77.58893609046937",
+              "address": {
+                "building": "Office",
+                "city": "Bengaluru",
+                "state": "Karnataka",
+                "country": "IND",
+                "area_code": "560052",
+                "locality": "Palace Road",
+                "name": "test"
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow2/4. on_init.json
+++ b/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow2/4. on_init.json
@@ -1,0 +1,340 @@
+{
+  "context": {
+    "domain": "ONDC:RET11",
+    "country": "IND",
+    "city": "std:080",
+    "action": "on_init",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_uri": "https://preprod.tipplr.in/ondc/v2",
+    "transaction_id": "f17e9b49-7799-4624-974d-8c413b41a12b",
+    "message_id": "65998a85-4ea1-4d39-aa23-977409c9be07",
+    "timestamp": "2024-06-14T06:32:53.134Z",
+    "bpp_id": "preprod.tipplr.in",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "provider": {
+        "id": "merchant-167714647372249847",
+        "locations": [
+          {
+            "id": "merchant-167714647372249847"
+          }
+        ]
+      },
+      "items": [
+        {
+          "id": "food_item-170383210555845413",
+          "quantity": {
+            "count": 2
+          },
+          "location_id": "merchant-167714647372249847",
+          "fulfillment_id": "merchant-167714647372249847"
+        },
+        {
+          "id": "food_item-170383210588937185",
+          "quantity": {
+            "count": 2
+          },
+          "location_id": "merchant-167714647372249847",
+          "parent_item_id": "DI1",
+          "fulfillment_id": "merchant-167714647372249847"
+        },
+        {
+          "id": "food_item-170383210588937185:603230",
+          "quantity": {
+            "count": 2
+          },
+          "location_id": "merchant-167714647372249847",
+          "tags": [
+            {
+              "code": "type",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "customization"
+                }
+              ]
+            },
+            {
+              "code": "parent",
+              "list": [
+                {
+                  "code": "id",
+                  "value": "76859436"
+                }
+              ]
+            }
+          ],
+          "fulfillment_id": "merchant-167714647372249847",
+          "parent_item_id": "DI1"
+        }
+      ],
+      "billing": {
+        "address": {
+          "building": "Office",
+          "city": "Bengaluru",
+          "state": "Karnataka",
+          "country": "IND",
+          "area_code": "560052",
+          "locality": "Palace Road",
+          "name": "test"
+        },
+        "phone": "9999999999",
+        "name": "test",
+        "email": "test@gmail.com",
+        "created_at": "2024-06-14T06:32:51.134Z",
+        "updated_at": "2024-06-14T06:32:51.134Z"
+      },
+      "fulfillments": [
+        {
+          "id": "merchant-167714647372249847",
+          "type": "Delivery",
+          "end": {
+            "contact": {
+              "email": "test@gmail.com",
+              "phone": "9999999999"
+            },
+            "location": {
+              "gps": "12.988908115944769,77.58893609046937",
+              "address": {
+                "building": "Office",
+                "city": "Bengaluru",
+                "state": "Karnataka",
+                "country": "IND",
+                "area_code": "560052",
+                "locality": "Palace Road",
+                "name": "test"
+              }
+            }
+          },
+          "tracking": false
+        }
+      ],
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "700.50"
+        },
+        "breakup": [
+          {
+            "@ondc/org/item_id": "food_item-170383210555845413",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "title": "Rava Idli",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "90"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "45"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210555845413",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "4.50"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210588937185",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "title": "Chicken pizza",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "2"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "1"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ],
+              "parent_item_id": "DI1"
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210588937185:603230",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "title": "Regular",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "518"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "259"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "76859436"
+                    }
+                  ]
+                }
+              ],
+              "fulfillment_id": "merchant-167714647372249847",
+              "parent_item_id": "DI1"
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210588937185",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "26.00"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ],
+              "parent_item_id": "DI1"
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Packing charges",
+            "@ondc/org/title_type": "packing",
+            "price": {
+              "currency": "INR",
+              "value": "10.5"
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Delivery charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "39"
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Convenience Fee",
+            "@ondc/org/title_type": "misc",
+            "price": {
+              "currency": "INR",
+              "value": "10.50"
+            }
+          }
+        ],
+        "ttl": "P1D"
+      },
+      "payment": {
+        "type": "ON-ORDER",
+        "collected_by": "BAP",
+        "status": "NOT-PAID",
+        "@ondc/org/buyer_app_finder_fee_type": "percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "3",
+        "@ondc/org/settlement_basis": "return_window_expiry",
+        "@ondc/org/settlement_window": "P1D",
+        "@ondc/org/withholding_amount": "21.02",
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "seller-app",
+            "settlement_phase": "sale-amount",
+            "settlement_type": "neft",
+            "upi_address": "9900818181@upi",
+            "settlement_bank_account_no": "50200053531451",
+            "settlement_ifsc_code": "HDFC0004051",
+            "beneficiary_name": "FOOD SPACE TECHNOLOGY PRIVATE LIMITED",
+            "bank_name": "HDFC Bank",
+            "branch_name": "CNN"
+          }
+        ]
+      },
+      "tags": [
+        {
+          "code": "bpp_terms",
+          "list": [
+            {
+              "code": "tax_number",
+              "value": "29AAECF1747N1Z6"
+            },
+            {
+              "code": "provider_tax_number",
+              "value": "AAECF1747N"
+            },
+            {
+              "code": "np_type",
+              "value": "ISN"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow2/5. confirm.json
+++ b/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow2/5. confirm.json
@@ -1,0 +1,361 @@
+{
+  "context": {
+    "domain": "ONDC:RET11",
+    "country": "IND",
+    "city": "std:080",
+    "action": "confirm",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_uri": "https://preprod.tipplr.in/ondc/v2",
+    "transaction_id": "f17e9b49-7799-4624-974d-8c413b41a12b",
+    "message_id": "10b913a0-668d-4e6a-b73f-7c9ab91c5215",
+    "timestamp": "2024-06-14T06:33:15.103Z",
+    "bpp_id": "preprod.tipplr.in",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "id": "2024-06-14-828136",
+      "state": "Created",
+      "billing": {
+        "address": {
+          "name": "test",
+          "building": "Office",
+          "locality": "Palace Road",
+          "city": "Bengaluru",
+          "state": "Karnataka",
+          "country": "IND",
+          "area_code": "560052"
+        },
+        "phone": "9999999999",
+        "name": "test",
+        "email": "test@gmail.com",
+        "created_at": "2024-06-14T06:32:51.134Z",
+        "updated_at": "2024-06-14T06:32:51.134Z"
+      },
+      "items": [
+        {
+          "id": "food_item-170383210555845413",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "merchant-167714647372249847"
+        },
+        {
+          "id": "food_item-170383210588937185",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "merchant-167714647372249847",
+          "parent_item_id": "DI1"
+        },
+        {
+          "id": "food_item-170383210588937185:603230",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "merchant-167714647372249847",
+          "tags": [
+            {
+              "code": "type",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "customization"
+                }
+              ]
+            },
+            {
+              "code": "parent",
+              "list": [
+                {
+                  "code": "id",
+                  "value": "76859436"
+                }
+              ]
+            }
+          ],
+          "parent_item_id": "DI1"
+        }
+      ],
+      "provider": {
+        "id": "merchant-167714647372249847",
+        "locations": [
+          {
+            "id": "merchant-167714647372249847"
+          }
+        ]
+      },
+      "fulfillments": [
+        {
+          "@ondc/org/TAT": "PT60M",
+          "id": "merchant-167714647372249847",
+          "tracking": false,
+          "end": {
+            "contact": {
+              "email": "test@gmail.com",
+              "phone": "9999999999"
+            },
+            "person": {
+              "name": "test"
+            },
+            "location": {
+              "gps": "12.988908115944769,77.58893609046937",
+              "address": {
+                "name": "test",
+                "building": "Office",
+                "locality": "Palace Road",
+                "city": "Bengaluru",
+                "state": "Karnataka",
+                "country": "IND",
+                "area_code": "560052"
+              }
+            }
+          },
+          "type": "Delivery"
+        }
+      ],
+      "payment": {
+        "uri": "https://razorpay.com/",
+        "tl_method": "http/get",
+        "params": {
+          "amount": "700.50",
+          "currency": "INR",
+          "transaction_id": "order_OMXjoNk6JZVsrc"
+        },
+        "status": "PAID",
+        "type": "ON-ORDER",
+        "collected_by": "BAP",
+        "@ondc/org/buyer_app_finder_fee_type": "percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+        "@ondc/org/settlement_basis": "return_window_expiry",
+        "@ondc/org/settlement_window": "P1D",
+        "@ondc/org/withholding_amount": "21.02",
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "seller-app",
+            "settlement_phase": "sale-amount",
+            "settlement_type": "neft",
+            "upi_address": "9900818181@upi",
+            "settlement_bank_account_no": "50200053531451",
+            "settlement_ifsc_code": "HDFC0004051",
+            "beneficiary_name": "FOOD SPACE TECHNOLOGY PRIVATE LIMITED",
+            "bank_name": "HDFC Bank",
+            "branch_name": "CNN"
+          }
+        ]
+      },
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "700.50"
+        },
+        "breakup": [
+          {
+            "@ondc/org/item_id": "food_item-170383210555845413",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "title": "Rava Idli",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "90"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "45"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210555845413",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "4.50"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210588937185",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "title": "Chicken pizza",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "2"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "1"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ],
+              "parent_item_id": "DI1"
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210588937185:603230",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "title": "Regular",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "518"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "259"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "76859436"
+                    }
+                  ]
+                }
+              ],
+              "fulfillment_id": "merchant-167714647372249847",
+              "parent_item_id": "DI1"
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210588937185",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "26.00"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ],
+              "parent_item_id": "DI1"
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Packing charges",
+            "@ondc/org/title_type": "packing",
+            "price": {
+              "currency": "INR",
+              "value": "10.5"
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Delivery charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "39"
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Convenience Fee",
+            "@ondc/org/title_type": "misc",
+            "price": {
+              "currency": "INR",
+              "value": "10.50"
+            }
+          }
+        ],
+        "ttl": "P1D"
+      },
+      "tags": [
+        {
+          "code": "bpp_terms",
+          "list": [
+            {
+              "code": "tax_number",
+              "value": "29AAECF1747N1Z6"
+            },
+            {
+              "code": "provider_tax_number",
+              "value": "AAECF1747N"
+            },
+            {
+              "code": "np_type",
+              "value": "ISN"
+            }
+          ]
+        },
+        {
+          "code": "bap_terms",
+          "list": [
+            {
+              "code": "tax_number",
+              "value": "GSTIN1234567890"
+            }
+          ]
+        }
+      ],
+      "created_at": "2024-06-14T06:33:15.103Z",
+      "updated_at": "2024-06-14T06:33:15.103Z"
+    }
+  }
+}

--- a/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow2/6. on_confirm.json
+++ b/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow2/6. on_confirm.json
@@ -1,0 +1,391 @@
+{
+  "context": {
+    "domain": "ONDC:RET11",
+    "country": "IND",
+    "city": "std:080",
+    "action": "on_confirm",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_uri": "https://preprod.tipplr.in/ondc/v2",
+    "transaction_id": "f17e9b49-7799-4624-974d-8c413b41a12b",
+    "message_id": "10b913a0-668d-4e6a-b73f-7c9ab91c5215",
+    "timestamp": "2024-06-14T06:33:17.103Z",
+    "bpp_id": "preprod.tipplr.in"
+  },
+  "message": {
+    "order": {
+      "id": "2024-06-14-828136",
+      "state": "Created",
+      "billing": {
+        "address": {
+          "name": "test",
+          "building": "Office",
+          "locality": "Palace Road",
+          "city": "Bengaluru",
+          "state": "Karnataka",
+          "country": "IND",
+          "area_code": "560052"
+        },
+        "phone": "9999999999",
+        "name": "test",
+        "email": "test@gmail.com",
+        "created_at": "2024-06-14T06:32:51.134Z",
+        "updated_at": "2024-06-14T06:32:51.134Z"
+      },
+      "items": [
+        {
+          "id": "food_item-170383210555845413",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "merchant-167714647372249847"
+        },
+        {
+          "id": "food_item-170383210588937185",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "merchant-167714647372249847",
+          "parent_item_id": "DI1"
+        },
+        {
+          "id": "food_item-170383210588937185:603230",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "merchant-167714647372249847",
+          "tags": [
+            {
+              "code": "type",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "customization"
+                }
+              ]
+            },
+            {
+              "code": "parent",
+              "list": [
+                {
+                  "code": "id",
+                  "value": "76859436"
+                }
+              ]
+            }
+          ],
+          "parent_item_id": "DI1"
+        }
+      ],
+      "provider": {
+        "id": "merchant-167714647372249847",
+        "locations": [
+          {
+            "id": "merchant-167714647372249847"
+          }
+        ]
+      },
+      "fulfillments": [
+        {
+          "@ondc/org/TAT": "PT60M",
+          "id": "merchant-167714647372249847",
+          "tracking": false,
+          "end": {
+            "contact": {
+              "email": "test@gmail.com",
+              "phone": "9999999999"
+            },
+            "person": {
+              "name": "test"
+            },
+            "location": {
+              "gps": "12.988908115944769,77.58893609046937",
+              "address": {
+                "name": "test",
+                "building": "Office",
+                "locality": "Palace Road",
+                "city": "Bengaluru",
+                "state": "Karnataka",
+                "country": "IND",
+                "area_code": "560052"
+              }
+            }
+          },
+          "type": "Delivery",
+          "start": {
+            "location": {
+              "id": "merchant-167714647372249847",
+              "descriptor": {
+                "name": "Tipplr-swathi d"
+              },
+              "gps": "12.979612,77.590846",
+              "address": {
+                "city": "Bengaluru",
+                "area_code": "560001",
+                "locality": "Vasanth Nagar",
+                "state": "KA"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2024-06-14T06:33:15.363Z",
+                "end": "2024-06-14T07:18:15.363Z"
+              }
+            },
+            "contact": {
+              "phone": "8929221233",
+              "email": "support@tipplr.in"
+            }
+          },
+          "@ondc/org/provider_name": "TIPPLR_DELIVERY",
+          "state": {
+            "descriptor": {
+              "code": "Pending"
+            }
+          }
+        }
+      ],
+      "payment": {
+        "uri": "https://razorpay.com/",
+        "tl_method": "http/get",
+        "params": {
+          "amount": "700.50",
+          "currency": "INR",
+          "transaction_id": "order_OMXjoNk6JZVsrc"
+        },
+        "status": "PAID",
+        "type": "ON-ORDER",
+        "collected_by": "BAP",
+        "@ondc/org/buyer_app_finder_fee_type": "percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+        "@ondc/org/settlement_basis": "return_window_expiry",
+        "@ondc/org/settlement_window": "P1D",
+        "@ondc/org/withholding_amount": "21.02",
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "seller-app",
+            "settlement_phase": "sale-amount",
+            "settlement_type": "neft",
+            "upi_address": "9900818181@upi",
+            "settlement_bank_account_no": "50200053531451",
+            "settlement_ifsc_code": "HDFC0004051",
+            "beneficiary_name": "FOOD SPACE TECHNOLOGY PRIVATE LIMITED",
+            "bank_name": "HDFC Bank",
+            "branch_name": "CNN"
+          }
+        ]
+      },
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "700.50"
+        },
+        "breakup": [
+          {
+            "@ondc/org/item_id": "food_item-170383210555845413",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "title": "Rava Idli",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "90"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "45"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210555845413",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "4.50"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210588937185",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "title": "Chicken pizza",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "2"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "1"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ],
+              "parent_item_id": "DI1"
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210588937185:603230",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "title": "Regular",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "518"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "259"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "76859436"
+                    }
+                  ]
+                }
+              ],
+              "fulfillment_id": "merchant-167714647372249847",
+              "parent_item_id": "DI1"
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210588937185",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "26.00"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ],
+              "parent_item_id": "DI1"
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Packing charges",
+            "@ondc/org/title_type": "packing",
+            "price": {
+              "currency": "INR",
+              "value": "10.5"
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Delivery charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "39"
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Convenience Fee",
+            "@ondc/org/title_type": "misc",
+            "price": {
+              "currency": "INR",
+              "value": "10.50"
+            }
+          }
+        ],
+        "ttl": "P1D"
+      },
+      "tags": [
+        {
+          "code": "bpp_terms",
+          "list": [
+            {
+              "code": "tax_number",
+              "value": "29AAECF1747N1Z6"
+            },
+            {
+              "code": "provider_tax_number",
+              "value": "AAECF1747N"
+            },
+            {
+              "code": "np_type",
+              "value": "ISN"
+            }
+          ]
+        },
+        {
+          "code": "bap_terms",
+          "list": [
+            {
+              "code": "tax_number",
+              "value": "GSTIN1234567890"
+            }
+          ]
+        }
+      ],
+      "created_at": "2024-06-14T06:33:15.103Z",
+      "updated_at": "2024-06-14T06:33:17.103Z"
+    }
+  }
+}

--- a/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow2/7. on_status_pending.json
+++ b/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow2/7. on_status_pending.json
@@ -1,0 +1,386 @@
+{
+  "message": {
+    "order": {
+      "id": "2024-06-14-828136",
+      "state": "Accepted",
+      "billing": {
+        "address": {
+          "name": "test",
+          "building": "Office",
+          "locality": "Palace Road",
+          "city": "Bengaluru",
+          "state": "Karnataka",
+          "country": "IND",
+          "area_code": "560052"
+        },
+        "phone": "9999999999",
+        "name": "test",
+        "email": "test@gmail.com",
+        "created_at": "2024-06-14T06:32:51.134Z",
+        "updated_at": "2024-06-14T06:32:51.134Z"
+      },
+      "items": [
+        {
+          "id": "food_item-170383210555845413",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "merchant-167714647372249847"
+        },
+        {
+          "id": "food_item-170383210588937185",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "merchant-167714647372249847",
+          "parent_item_id": "DI1"
+        },
+        {
+          "id": "food_item-170383210588937185:603230",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "merchant-167714647372249847",
+          "tags": [
+            {
+              "code": "type",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "customization"
+                }
+              ]
+            },
+            {
+              "code": "parent",
+              "list": [
+                {
+                  "code": "id",
+                  "value": "76859436"
+                }
+              ]
+            }
+          ],
+          "parent_item_id": "DI1"
+        }
+      ],
+      "provider": {
+        "id": "merchant-167714647372249847",
+        "locations": [
+          {
+            "id": "merchant-167714647372249847"
+          }
+        ]
+      },
+      "fulfillments": [
+        {
+          "@ondc/org/TAT": "PT45M",
+          "id": "merchant-167714647372249847",
+          "tracking": false,
+          "end": {
+            "contact": {
+              "email": "test@gmail.com",
+              "phone": "9999999999"
+            },
+            "person": {
+              "name": "test"
+            },
+            "location": {
+              "gps": "12.988908115944769,77.58893609046937",
+              "address": {
+                "name": "test",
+                "building": "Office",
+                "locality": "Palace Road",
+                "city": "Bengaluru",
+                "state": "Karnataka",
+                "country": "IND",
+                "area_code": "560052"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2024-06-14T06:33:51.690Z",
+                "end": "2024-06-14T07:18:51.690Z"
+              }
+            }
+          },
+          "type": "Delivery",
+          "start": {
+            "location": {
+              "id": "merchant-167714647372249847",
+              "descriptor": {
+                "name": "Tipplr-swathi d"
+              },
+              "gps": "12.979612,77.590846",
+              "address": {
+                "city": "Bengaluru",
+                "area_code": "560001",
+                "locality": "Vasanth Nagar",
+                "state": "KA"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2024-06-14T06:33:15.363Z",
+                "end": "2024-06-14T07:18:15.363Z"
+              }
+            },
+            "contact": {
+              "phone": "8929221233",
+              "email": "support@tipplr.in"
+            }
+          },
+          "@ondc/org/provider_name": "TIPPLR_DELIVERY",
+          "state": {
+            "descriptor": {
+              "code": "Pending"
+            }
+          },
+          "tags": [
+            {
+              "code": "routing",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "P2P"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "payment": {
+        "uri": "https://razorpay.com/",
+        "tl_method": "http/get",
+        "params": {
+          "amount": "700.50",
+          "currency": "INR",
+          "transaction_id": "order_OMXjoNk6JZVsrc"
+        },
+        "status": "PAID",
+        "type": "ON-ORDER",
+        "collected_by": "BAP",
+        "@ondc/org/buyer_app_finder_fee_type": "percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+        "@ondc/org/settlement_basis": "return_window_expiry",
+        "@ondc/org/settlement_window": "P1D",
+        "@ondc/org/withholding_amount": "21.02",
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "seller-app",
+            "settlement_phase": "sale-amount",
+            "settlement_type": "neft",
+            "upi_address": "9900818181@upi",
+            "settlement_bank_account_no": "50200053531451",
+            "settlement_ifsc_code": "HDFC0004051",
+            "beneficiary_name": "FOOD SPACE TECHNOLOGY PRIVATE LIMITED",
+            "bank_name": "HDFC Bank",
+            "branch_name": "CNN"
+          }
+        ]
+      },
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "700.50"
+        },
+        "breakup": [
+          {
+            "@ondc/org/item_id": "food_item-170383210555845413",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "title": "Rava Idli",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "90"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "45"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210555845413",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "4.50"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210588937185",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "title": "Chicken pizza",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "2"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "1"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ],
+              "parent_item_id": "DI1"
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210588937185:603230",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "title": "Regular",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "518"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "259"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "76859436"
+                    }
+                  ]
+                }
+              ],
+              "fulfillment_id": "merchant-167714647372249847",
+              "parent_item_id": "DI1"
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210588937185",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "26.00"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ],
+              "parent_item_id": "DI1"
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Packing charges",
+            "@ondc/org/title_type": "packing",
+            "price": {
+              "currency": "INR",
+              "value": "10.5"
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Delivery charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "39"
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Convenience Fee",
+            "@ondc/org/title_type": "misc",
+            "price": {
+              "currency": "INR",
+              "value": "10.50"
+            }
+          }
+        ],
+        "ttl": "P1D"
+      },
+      "created_at": "2024-06-14T06:33:15.103Z",
+      "updated_at": "2024-06-14T06:33:51.690Z",
+      "documents": [
+        {
+          "url": "https://tipplr-media.s3.ap-south-1.amazonaws.com/images/Invoice-IZJYPFBHAIC46NS.pdf",
+          "label": "Invoice"
+        }
+      ]
+    }
+  },
+  "context": {
+    "domain": "ONDC:RET11",
+    "country": "IND",
+    "city": "std:080",
+    "action": "on_status",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_uri": "https://preprod.tipplr.in/ondc/v2",
+    "transaction_id": "f17e9b49-7799-4624-974d-8c413b41a12b",
+    "message_id": "37478295-26b5-4315-ab70-c5daef980a09",
+    "timestamp": "2024-06-14T06:33:51.690Z",
+    "bpp_id": "preprod.tipplr.in"
+  }
+}

--- a/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow2/8. on_status_packed.json
+++ b/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow2/8. on_status_packed.json
@@ -1,0 +1,380 @@
+{
+  "message": {
+    "order": {
+      "id": "2024-06-14-828136",
+      "state": "In-progress",
+      "billing": {
+        "address": {
+          "name": "test",
+          "building": "Office",
+          "locality": "Palace Road",
+          "city": "Bengaluru",
+          "state": "Karnataka",
+          "country": "IND",
+          "area_code": "560052"
+        },
+        "phone": "9999999999",
+        "name": "test",
+        "email": "test@gmail.com",
+        "created_at": "2024-06-14T06:32:51.134Z",
+        "updated_at": "2024-06-14T06:32:51.134Z"
+      },
+      "items": [
+        {
+          "id": "food_item-170383210555845413",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "merchant-167714647372249847"
+        },
+        {
+          "id": "food_item-170383210588937185",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "merchant-167714647372249847",
+          "parent_item_id": "DI1"
+        },
+        {
+          "id": "food_item-170383210588937185:603230",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "merchant-167714647372249847",
+          "tags": [
+            {
+              "code": "type",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "customization"
+                }
+              ]
+            },
+            {
+              "code": "parent",
+              "list": [
+                {
+                  "code": "id",
+                  "value": "76859436"
+                }
+              ]
+            }
+          ],
+          "parent_item_id": "DI1"
+        }
+      ],
+      "provider": {
+        "id": "merchant-167714647372249847",
+        "locations": [
+          {
+            "id": "merchant-167714647372249847"
+          }
+        ]
+      },
+      "fulfillments": [
+        {
+          "@ondc/org/TAT": "PT45M",
+          "id": "merchant-167714647372249847",
+          "tracking": false,
+          "end": {
+            "contact": {
+              "email": "test@gmail.com",
+              "phone": "9999999999"
+            },
+            "person": {
+              "name": "test"
+            },
+            "location": {
+              "gps": "12.988908115944769,77.58893609046937",
+              "address": {
+                "name": "test",
+                "building": "Office",
+                "locality": "Palace Road",
+                "city": "Bengaluru",
+                "state": "Karnataka",
+                "country": "IND",
+                "area_code": "560052"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2024-06-14T06:33:15.363Z",
+                "end": "2024-06-14T07:18:15.363Z"
+              }
+            }
+          },
+          "type": "Delivery",
+          "start": {
+            "location": {
+              "id": "merchant-167714647372249847",
+              "descriptor": {
+                "name": "Tipplr-swathi d"
+              },
+              "gps": "12.979612,77.590846",
+              "address": {
+                "city": "Bengaluru",
+                "area_code": "560001",
+                "locality": "Vasanth Nagar",
+                "state": "KA"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2024-06-14T06:33:15.363Z",
+                "end": "2024-06-14T07:18:15.363Z"
+              }
+            },
+            "contact": {
+              "phone": "8929221233",
+              "email": "support@tipplr.in"
+            }
+          },
+          "@ondc/org/provider_name": "TIPPLR_DELIVERY",
+          "state": {
+            "descriptor": {
+              "code": "Packed"
+            }
+          },
+          "tags": [
+            {
+              "code": "routing",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "P2P"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "payment": {
+        "uri": "https://razorpay.com/",
+        "tl_method": "http/get",
+        "params": {
+          "amount": "700.50",
+          "currency": "INR",
+          "transaction_id": "order_OMXjoNk6JZVsrc"
+        },
+        "status": "PAID",
+        "type": "ON-ORDER",
+        "collected_by": "BAP",
+        "@ondc/org/buyer_app_finder_fee_type": "percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+        "@ondc/org/settlement_basis": "return_window_expiry",
+        "@ondc/org/settlement_window": "P1D",
+        "@ondc/org/withholding_amount": "21.02",
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "seller-app",
+            "settlement_phase": "sale-amount",
+            "settlement_type": "neft",
+            "upi_address": "9900818181@upi",
+            "settlement_bank_account_no": "50200053531451",
+            "settlement_ifsc_code": "HDFC0004051",
+            "beneficiary_name": "FOOD SPACE TECHNOLOGY PRIVATE LIMITED",
+            "bank_name": "HDFC Bank",
+            "branch_name": "CNN"
+          }
+        ]
+      },
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "700.50"
+        },
+        "breakup": [
+          {
+            "@ondc/org/item_id": "food_item-170383210555845413",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "title": "Rava Idli",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "90"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "45"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210555845413",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "4.50"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210588937185",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "title": "Chicken pizza",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "2"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "1"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ],
+              "parent_item_id": "DI1"
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210588937185:603230",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "title": "Regular",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "518"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "259"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "76859436"
+                    }
+                  ]
+                }
+              ],
+              "fulfillment_id": "merchant-167714647372249847",
+              "parent_item_id": "DI1"
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210588937185",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "26.00"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ],
+              "parent_item_id": "DI1"
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Packing charges",
+            "@ondc/org/title_type": "packing",
+            "price": {
+              "currency": "INR",
+              "value": "10.5"
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Delivery charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "39"
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Convenience Fee",
+            "@ondc/org/title_type": "misc",
+            "price": {
+              "currency": "INR",
+              "value": "10.50"
+            }
+          }
+        ],
+        "ttl": "P1D"
+      },
+      "created_at": "2024-06-14T06:33:15.103Z",
+      "updated_at": "2024-06-14T06:34:14.742Z"
+    }
+  },
+  "context": {
+    "domain": "ONDC:RET11",
+    "country": "IND",
+    "city": "std:080",
+    "action": "on_status",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_uri": "https://preprod.tipplr.in/ondc/v2",
+    "transaction_id": "f17e9b49-7799-4624-974d-8c413b41a12b",
+    "message_id": "606571ea-6798-49d3-b915-84a7fe1f6511",
+    "timestamp": "2024-06-14T06:34:14.742Z",
+    "bpp_id": "preprod.tipplr.in"
+  }
+}

--- a/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow2/9. on_status_picked.json
+++ b/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow2/9. on_status_picked.json
@@ -1,0 +1,381 @@
+{
+  "message": {
+    "order": {
+      "id": "2024-06-14-828136",
+      "state": "In-progress",
+      "billing": {
+        "address": {
+          "name": "test",
+          "building": "Office",
+          "locality": "Palace Road",
+          "city": "Bengaluru",
+          "state": "Karnataka",
+          "country": "IND",
+          "area_code": "560052"
+        },
+        "phone": "9999999999",
+        "name": "test",
+        "email": "test@gmail.com",
+        "created_at": "2024-06-14T06:32:51.134Z",
+        "updated_at": "2024-06-14T06:32:51.134Z"
+      },
+      "items": [
+        {
+          "id": "food_item-170383210555845413",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "merchant-167714647372249847"
+        },
+        {
+          "id": "food_item-170383210588937185",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "merchant-167714647372249847",
+          "parent_item_id": "DI1"
+        },
+        {
+          "id": "food_item-170383210588937185:603230",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "merchant-167714647372249847",
+          "tags": [
+            {
+              "code": "type",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "customization"
+                }
+              ]
+            },
+            {
+              "code": "parent",
+              "list": [
+                {
+                  "code": "id",
+                  "value": "76859436"
+                }
+              ]
+            }
+          ],
+          "parent_item_id": "DI1"
+        }
+      ],
+      "provider": {
+        "id": "merchant-167714647372249847",
+        "locations": [
+          {
+            "id": "merchant-167714647372249847"
+          }
+        ]
+      },
+      "fulfillments": [
+        {
+          "@ondc/org/TAT": "PT45M",
+          "id": "merchant-167714647372249847",
+          "tracking": false,
+          "end": {
+            "contact": {
+              "email": "test@gmail.com",
+              "phone": "9999999999"
+            },
+            "person": {
+              "name": "test"
+            },
+            "location": {
+              "gps": "12.988908115944769,77.58893609046937",
+              "address": {
+                "name": "test",
+                "building": "Office",
+                "locality": "Palace Road",
+                "city": "Bengaluru",
+                "state": "Karnataka",
+                "country": "IND",
+                "area_code": "560052"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2024-06-14T06:33:15.363Z",
+                "end": "2024-06-14T07:18:15.363Z"
+              }
+            }
+          },
+          "type": "Delivery",
+          "start": {
+            "location": {
+              "id": "merchant-167714647372249847",
+              "descriptor": {
+                "name": "Tipplr-swathi d"
+              },
+              "gps": "12.979612,77.590846",
+              "address": {
+                "city": "Bengaluru",
+                "area_code": "560001",
+                "locality": "Vasanth Nagar",
+                "state": "KA"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2024-06-14T06:33:15.363Z",
+                "end": "2024-06-14T07:18:15.363Z"
+              },
+              "timestamp": "2024-06-14T06:34:50.338Z"
+            },
+            "contact": {
+              "phone": "8929221233",
+              "email": "support@tipplr.in"
+            }
+          },
+          "@ondc/org/provider_name": "TIPPLR_DELIVERY",
+          "state": {
+            "descriptor": {
+              "code": "Order-picked-up"
+            }
+          },
+          "tags": [
+            {
+              "code": "routing",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "P2P"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "payment": {
+        "uri": "https://razorpay.com/",
+        "tl_method": "http/get",
+        "params": {
+          "amount": "700.50",
+          "currency": "INR",
+          "transaction_id": "order_OMXjoNk6JZVsrc"
+        },
+        "status": "PAID",
+        "type": "ON-ORDER",
+        "collected_by": "BAP",
+        "@ondc/org/buyer_app_finder_fee_type": "percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+        "@ondc/org/settlement_basis": "return_window_expiry",
+        "@ondc/org/settlement_window": "P1D",
+        "@ondc/org/withholding_amount": "21.02",
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "seller-app",
+            "settlement_phase": "sale-amount",
+            "settlement_type": "neft",
+            "upi_address": "9900818181@upi",
+            "settlement_bank_account_no": "50200053531451",
+            "settlement_ifsc_code": "HDFC0004051",
+            "beneficiary_name": "FOOD SPACE TECHNOLOGY PRIVATE LIMITED",
+            "bank_name": "HDFC Bank",
+            "branch_name": "CNN"
+          }
+        ]
+      },
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "700.50"
+        },
+        "breakup": [
+          {
+            "@ondc/org/item_id": "food_item-170383210555845413",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "title": "Rava Idli",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "90"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "45"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210555845413",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "4.50"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210588937185",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "title": "Chicken pizza",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "2"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "1"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ],
+              "parent_item_id": "DI1"
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210588937185:603230",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "title": "Regular",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "518"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "259"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "76859436"
+                    }
+                  ]
+                }
+              ],
+              "fulfillment_id": "merchant-167714647372249847",
+              "parent_item_id": "DI1"
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210588937185",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "26.00"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ],
+              "parent_item_id": "DI1"
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Packing charges",
+            "@ondc/org/title_type": "packing",
+            "price": {
+              "currency": "INR",
+              "value": "10.5"
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Delivery charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "39"
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Convenience Fee",
+            "@ondc/org/title_type": "misc",
+            "price": {
+              "currency": "INR",
+              "value": "10.50"
+            }
+          }
+        ],
+        "ttl": "P1D"
+      },
+      "created_at": "2024-06-14T06:33:15.103Z",
+      "updated_at": "2024-06-14T06:34:50.338Z"
+    }
+  },
+  "context": {
+    "domain": "ONDC:RET11",
+    "country": "IND",
+    "city": "std:080",
+    "action": "on_status",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_uri": "https://preprod.tipplr.in/ondc/v2",
+    "transaction_id": "f17e9b49-7799-4624-974d-8c413b41a12b",
+    "message_id": "47a84d2c-116e-40ab-bf8c-2678c219d241",
+    "timestamp": "2024-06-14T06:34:50.338Z",
+    "bpp_id": "preprod.tipplr.in"
+  }
+}

--- a/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow3/1. select_out_of_stock.json
+++ b/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow3/1. select_out_of_stock.json
@@ -1,0 +1,93 @@
+{
+  "context": {
+    "domain": "ONDC:RET11",
+    "country": "IND",
+    "city": "std:080",
+    "action": "select",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_uri": "https://preprod.tipplr.in/ondc/v2",
+    "transaction_id": "f4a9c6fe-a9c2-4a39-99b7-4a2667c8991c",
+    "message_id": "c86e692f-2105-452e-9097-b6b6ffae4c6f",
+    "timestamp": "2024-06-14T07:12:43.792Z",
+    "bpp_id": "preprod.tipplr.in",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "items": [
+        {
+          "id": "food_item-170383210597342600",
+          "quantity": {
+            "count": 1
+          },
+          "location_id": "merchant-167714647372249847"
+        },
+        {
+          "id": "food_item-170383210627835789",
+          "quantity": {
+            "count": 1
+          },
+          "location_id": "merchant-167714647372249847"
+        },
+        {
+          "id": "food_item-170383210588937185",
+          "quantity": {
+            "count": 1
+          },
+          "location_id": "merchant-167714647372249847",
+          "parent_item_id": "DI2"
+        },
+        {
+          "id": "food_item-170383210588937185:603230",
+          "quantity": {
+            "count": 1
+          },
+          "location_id": "merchant-167714647372249847",
+          "tags": [
+            {
+              "code": "type",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "customization"
+                }
+              ]
+            },
+            {
+              "code": "parent",
+              "list": [
+                {
+                  "code": "id",
+                  "value": "76859436"
+                }
+              ]
+            }
+          ],
+          "parent_item_id": "DI2"
+        }
+      ],
+      "provider": {
+        "id": "merchant-167714647372249847",
+        "locations": [
+          {
+            "id": "merchant-167714647372249847"
+          }
+        ]
+      },
+      "fulfillments": [
+        {
+          "end": {
+            "location": {
+              "gps": "12.97943084572564,77.59098932147026",
+              "address": {
+                "area_code": "560001"
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow3/10. on_status_packed.json
+++ b/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow3/10. on_status_packed.json
@@ -1,0 +1,315 @@
+{
+  "message": {
+    "order": {
+      "id": "2024-06-14-816815",
+      "state": "In-progress",
+      "billing": {
+        "address": {
+          "name": "Nithin",
+          "building": "building",
+          "locality": "Dr Ambedkar Road",
+          "city": "Bengaluru",
+          "state": "Karnataka",
+          "country": "IND",
+          "area_code": "560001"
+        },
+        "phone": "8951440205",
+        "name": "Nithin",
+        "email": "nithin@gmail.com",
+        "created_at": "2024-06-14T07:12:59.507Z",
+        "updated_at": "2024-06-14T07:12:59.507Z"
+      },
+      "items": [
+        {
+          "id": "food_item-170383210597342600",
+          "quantity": {
+            "count": 1
+          },
+          "fulfillment_id": "merchant-167714647372249847"
+        },
+        {
+          "id": "food_item-170383210627835789",
+          "quantity": {
+            "count": 1
+          },
+          "fulfillment_id": "merchant-167714647372249847"
+        }
+      ],
+      "provider": {
+        "id": "merchant-167714647372249847",
+        "locations": [
+          {
+            "id": "merchant-167714647372249847"
+          }
+        ]
+      },
+      "fulfillments": [
+        {
+          "@ondc/org/TAT": "PT45M",
+          "id": "merchant-167714647372249847",
+          "tracking": false,
+          "end": {
+            "contact": {
+              "email": "nithin@gmail.com",
+              "phone": "8951440205"
+            },
+            "person": {
+              "name": "Nithin"
+            },
+            "location": {
+              "gps": "12.97943084572564,77.59098932147026",
+              "address": {
+                "name": "Nithin",
+                "building": "building",
+                "locality": "Dr Ambedkar Road",
+                "city": "Bengaluru",
+                "state": "Karnataka",
+                "country": "IND",
+                "area_code": "560001"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2024-06-14T07:13:20.343Z",
+                "end": "2024-06-14T07:58:20.343Z"
+              }
+            }
+          },
+          "type": "Delivery",
+          "start": {
+            "location": {
+              "id": "merchant-167714647372249847",
+              "descriptor": {
+                "name": "Tipplr-swathi d"
+              },
+              "gps": "12.979612,77.590846",
+              "address": {
+                "city": "Bengaluru",
+                "area_code": "560001",
+                "locality": "Vasanth Nagar",
+                "state": "KA"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2024-06-14T07:13:20.343Z",
+                "end": "2024-06-14T07:58:20.343Z"
+              }
+            },
+            "contact": {
+              "phone": "8929221233",
+              "email": "support@tipplr.in"
+            }
+          },
+          "@ondc/org/provider_name": "TIPPLR_DELIVERY",
+          "state": {
+            "descriptor": {
+              "code": "Packed"
+            }
+          },
+          "tags": [
+            {
+              "code": "routing",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "P2P"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "payment": {
+        "uri": "https://razorpay.com/",
+        "tl_method": "http/get",
+        "params": {
+          "amount": "191.25",
+          "currency": "INR",
+          "transaction_id": "order_OMYQCvGJXOmSWt"
+        },
+        "status": "PAID",
+        "type": "ON-ORDER",
+        "collected_by": "BAP",
+        "@ondc/org/buyer_app_finder_fee_type": "percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+        "@ondc/org/settlement_basis": "return_window_expiry",
+        "@ondc/org/settlement_window": "P1D",
+        "@ondc/org/withholding_amount": "5.74",
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "seller-app",
+            "settlement_phase": "sale-amount",
+            "settlement_type": "neft",
+            "upi_address": "9900818181@upi",
+            "settlement_bank_account_no": "50200053531451",
+            "settlement_ifsc_code": "HDFC0004051",
+            "beneficiary_name": "FOOD SPACE TECHNOLOGY PRIVATE LIMITED",
+            "bank_name": "HDFC Bank",
+            "branch_name": "CNN"
+          }
+        ]
+      },
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "191.25"
+        },
+        "breakup": [
+          {
+            "@ondc/org/item_id": "food_item-170383210597342600",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "title": "1 Idli 1 Vada",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "55"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "55"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210597342600",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "2.75"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210627835789",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "title": "Poori Kurma",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "70"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "70"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210627835789",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "3.50"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Packing charges",
+            "@ondc/org/title_type": "packing",
+            "price": {
+              "currency": "INR",
+              "value": "10.5"
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Delivery charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "39"
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Convenience Fee",
+            "@ondc/org/title_type": "misc",
+            "price": {
+              "currency": "INR",
+              "value": "10.50"
+            }
+          }
+        ],
+        "ttl": "P1D"
+      },
+      "created_at": "2024-06-14T07:13:19.999Z",
+      "updated_at": "2024-06-14T07:14:43.620Z",
+      "documents": [
+        {
+          "url": "https://tipplr-media.s3.ap-south-1.amazonaws.com/images/Invoice-A9MOS924C9JKYSQ.pdf",
+          "label": "Invoice"
+        }
+      ]
+    }
+  },
+  "context": {
+    "domain": "ONDC:RET11",
+    "country": "IND",
+    "city": "std:080",
+    "action": "on_status",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_uri": "https://preprod.tipplr.in/ondc/v2",
+    "transaction_id": "f4a9c6fe-a9c2-4a39-99b7-4a2667c8991c",
+    "message_id": "08def002-b019-42bd-a2fb-301ecc886146",
+    "timestamp": "2024-06-14T07:14:43.620Z",
+    "bpp_id": "preprod.tipplr.in"
+  }
+}

--- a/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow3/12. on_status_picked.json
+++ b/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow3/12. on_status_picked.json
@@ -1,0 +1,316 @@
+{
+  "message": {
+    "order": {
+      "id": "2024-06-14-816815",
+      "state": "In-progress",
+      "billing": {
+        "address": {
+          "name": "Nithin",
+          "building": "building",
+          "locality": "Dr Ambedkar Road",
+          "city": "Bengaluru",
+          "state": "Karnataka",
+          "country": "IND",
+          "area_code": "560001"
+        },
+        "phone": "8951440205",
+        "name": "Nithin",
+        "email": "nithin@gmail.com",
+        "created_at": "2024-06-14T07:12:59.507Z",
+        "updated_at": "2024-06-14T07:12:59.507Z"
+      },
+      "items": [
+        {
+          "id": "food_item-170383210597342600",
+          "quantity": {
+            "count": 1
+          },
+          "fulfillment_id": "merchant-167714647372249847"
+        },
+        {
+          "id": "food_item-170383210627835789",
+          "quantity": {
+            "count": 1
+          },
+          "fulfillment_id": "merchant-167714647372249847"
+        }
+      ],
+      "provider": {
+        "id": "merchant-167714647372249847",
+        "locations": [
+          {
+            "id": "merchant-167714647372249847"
+          }
+        ]
+      },
+      "fulfillments": [
+        {
+          "@ondc/org/TAT": "PT45M",
+          "id": "merchant-167714647372249847",
+          "tracking": false,
+          "end": {
+            "contact": {
+              "email": "nithin@gmail.com",
+              "phone": "8951440205"
+            },
+            "person": {
+              "name": "Nithin"
+            },
+            "location": {
+              "gps": "12.97943084572564,77.59098932147026",
+              "address": {
+                "name": "Nithin",
+                "building": "building",
+                "locality": "Dr Ambedkar Road",
+                "city": "Bengaluru",
+                "state": "Karnataka",
+                "country": "IND",
+                "area_code": "560001"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2024-06-14T07:13:20.343Z",
+                "end": "2024-06-14T07:58:20.343Z"
+              }
+            }
+          },
+          "type": "Delivery",
+          "start": {
+            "location": {
+              "id": "merchant-167714647372249847",
+              "descriptor": {
+                "name": "Tipplr-swathi d"
+              },
+              "gps": "12.979612,77.590846",
+              "address": {
+                "city": "Bengaluru",
+                "area_code": "560001",
+                "locality": "Vasanth Nagar",
+                "state": "KA"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2024-06-14T07:13:20.343Z",
+                "end": "2024-06-14T07:58:20.343Z"
+              },
+              "timestamp": "2024-06-14T07:15:08.826Z"
+            },
+            "contact": {
+              "phone": "8929221233",
+              "email": "support@tipplr.in"
+            }
+          },
+          "@ondc/org/provider_name": "TIPPLR_DELIVERY",
+          "state": {
+            "descriptor": {
+              "code": "Order-picked-up"
+            }
+          },
+          "tags": [
+            {
+              "code": "routing",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "P2P"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "payment": {
+        "uri": "https://razorpay.com/",
+        "tl_method": "http/get",
+        "params": {
+          "amount": "191.25",
+          "currency": "INR",
+          "transaction_id": "order_OMYQCvGJXOmSWt"
+        },
+        "status": "PAID",
+        "type": "ON-ORDER",
+        "collected_by": "BAP",
+        "@ondc/org/buyer_app_finder_fee_type": "percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+        "@ondc/org/settlement_basis": "return_window_expiry",
+        "@ondc/org/settlement_window": "P1D",
+        "@ondc/org/withholding_amount": "5.74",
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "seller-app",
+            "settlement_phase": "sale-amount",
+            "settlement_type": "neft",
+            "upi_address": "9900818181@upi",
+            "settlement_bank_account_no": "50200053531451",
+            "settlement_ifsc_code": "HDFC0004051",
+            "beneficiary_name": "FOOD SPACE TECHNOLOGY PRIVATE LIMITED",
+            "bank_name": "HDFC Bank",
+            "branch_name": "CNN"
+          }
+        ]
+      },
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "191.25"
+        },
+        "breakup": [
+          {
+            "@ondc/org/item_id": "food_item-170383210597342600",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "title": "1 Idli 1 Vada",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "55"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "55"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210597342600",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "2.75"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210627835789",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "title": "Poori Kurma",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "70"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "70"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210627835789",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "3.50"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Packing charges",
+            "@ondc/org/title_type": "packing",
+            "price": {
+              "currency": "INR",
+              "value": "10.5"
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Delivery charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "39"
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Convenience Fee",
+            "@ondc/org/title_type": "misc",
+            "price": {
+              "currency": "INR",
+              "value": "10.50"
+            }
+          }
+        ],
+        "ttl": "P1D"
+      },
+      "created_at": "2024-06-14T07:13:19.999Z",
+      "updated_at": "2024-06-14T07:15:08.826Z",
+      "documents": [
+        {
+          "url": "https://tipplr-media.s3.ap-south-1.amazonaws.com/images/Invoice-A9MOS924C9JKYSQ.pdf",
+          "label": "Invoice"
+        }
+      ]
+    }
+  },
+  "context": {
+    "domain": "ONDC:RET11",
+    "country": "IND",
+    "city": "std:080",
+    "action": "on_status",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_uri": "https://preprod.tipplr.in/ondc/v2",
+    "transaction_id": "f4a9c6fe-a9c2-4a39-99b7-4a2667c8991c",
+    "message_id": "a6781df5-5605-46e1-9e9a-ac0ea1fb10fb",
+    "timestamp": "2024-06-14T07:15:08.826Z",
+    "bpp_id": "preprod.tipplr.in"
+  }
+}

--- a/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow3/13. on_status_out_for_delivery.json
+++ b/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow3/13. on_status_out_for_delivery.json
@@ -1,0 +1,316 @@
+{
+  "message": {
+    "order": {
+      "id": "2024-06-14-816815",
+      "state": "In-progress",
+      "billing": {
+        "address": {
+          "name": "Nithin",
+          "building": "building",
+          "locality": "Dr Ambedkar Road",
+          "city": "Bengaluru",
+          "state": "Karnataka",
+          "country": "IND",
+          "area_code": "560001"
+        },
+        "phone": "8951440205",
+        "name": "Nithin",
+        "email": "nithin@gmail.com",
+        "created_at": "2024-06-14T07:12:59.507Z",
+        "updated_at": "2024-06-14T07:12:59.507Z"
+      },
+      "items": [
+        {
+          "id": "food_item-170383210597342600",
+          "quantity": {
+            "count": 1
+          },
+          "fulfillment_id": "merchant-167714647372249847"
+        },
+        {
+          "id": "food_item-170383210627835789",
+          "quantity": {
+            "count": 1
+          },
+          "fulfillment_id": "merchant-167714647372249847"
+        }
+      ],
+      "provider": {
+        "id": "merchant-167714647372249847",
+        "locations": [
+          {
+            "id": "merchant-167714647372249847"
+          }
+        ]
+      },
+      "fulfillments": [
+        {
+          "@ondc/org/TAT": "PT45M",
+          "id": "merchant-167714647372249847",
+          "tracking": false,
+          "end": {
+            "contact": {
+              "email": "nithin@gmail.com",
+              "phone": "8951440205"
+            },
+            "person": {
+              "name": "Nithin"
+            },
+            "location": {
+              "gps": "12.97943084572564,77.59098932147026",
+              "address": {
+                "name": "Nithin",
+                "building": "building",
+                "locality": "Dr Ambedkar Road",
+                "city": "Bengaluru",
+                "state": "Karnataka",
+                "country": "IND",
+                "area_code": "560001"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2024-06-14T07:13:20.343Z",
+                "end": "2024-06-14T07:58:20.343Z"
+              }
+            }
+          },
+          "type": "Delivery",
+          "start": {
+            "location": {
+              "id": "merchant-167714647372249847",
+              "descriptor": {
+                "name": "Tipplr-swathi d"
+              },
+              "gps": "12.979612,77.590846",
+              "address": {
+                "city": "Bengaluru",
+                "area_code": "560001",
+                "locality": "Vasanth Nagar",
+                "state": "KA"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2024-06-14T07:13:20.343Z",
+                "end": "2024-06-14T07:58:20.343Z"
+              },
+              "timestamp": "2024-06-14T07:15:08.826Z"
+            },
+            "contact": {
+              "phone": "8929221233",
+              "email": "support@tipplr.in"
+            }
+          },
+          "@ondc/org/provider_name": "TIPPLR_DELIVERY",
+          "state": {
+            "descriptor": {
+              "code": "Out-for-delivery"
+            }
+          },
+          "tags": [
+            {
+              "code": "routing",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "P2P"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "payment": {
+        "uri": "https://razorpay.com/",
+        "tl_method": "http/get",
+        "params": {
+          "amount": "191.25",
+          "currency": "INR",
+          "transaction_id": "order_OMYQCvGJXOmSWt"
+        },
+        "status": "PAID",
+        "type": "ON-ORDER",
+        "collected_by": "BAP",
+        "@ondc/org/buyer_app_finder_fee_type": "percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+        "@ondc/org/settlement_basis": "return_window_expiry",
+        "@ondc/org/settlement_window": "P1D",
+        "@ondc/org/withholding_amount": "5.74",
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "seller-app",
+            "settlement_phase": "sale-amount",
+            "settlement_type": "neft",
+            "upi_address": "9900818181@upi",
+            "settlement_bank_account_no": "50200053531451",
+            "settlement_ifsc_code": "HDFC0004051",
+            "beneficiary_name": "FOOD SPACE TECHNOLOGY PRIVATE LIMITED",
+            "bank_name": "HDFC Bank",
+            "branch_name": "CNN"
+          }
+        ]
+      },
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "191.25"
+        },
+        "breakup": [
+          {
+            "@ondc/org/item_id": "food_item-170383210597342600",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "title": "1 Idli 1 Vada",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "55"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "55"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210597342600",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "2.75"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210627835789",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "title": "Poori Kurma",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "70"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "70"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210627835789",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "3.50"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Packing charges",
+            "@ondc/org/title_type": "packing",
+            "price": {
+              "currency": "INR",
+              "value": "10.5"
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Delivery charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "39"
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Convenience Fee",
+            "@ondc/org/title_type": "misc",
+            "price": {
+              "currency": "INR",
+              "value": "10.50"
+            }
+          }
+        ],
+        "ttl": "P1D"
+      },
+      "created_at": "2024-06-14T07:13:19.999Z",
+      "updated_at": "2024-06-14T07:15:08.826Z",
+      "documents": [
+        {
+          "url": "https://tipplr-media.s3.ap-south-1.amazonaws.com/images/Invoice-A9MOS924C9JKYSQ.pdf",
+          "label": "Invoice"
+        }
+      ]
+    }
+  },
+  "context": {
+    "domain": "ONDC:RET11",
+    "country": "IND",
+    "city": "std:080",
+    "action": "on_status",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_uri": "https://preprod.tipplr.in/ondc/v2",
+    "transaction_id": "f4a9c6fe-a9c2-4a39-99b7-4a2667c8991c",
+    "message_id": "05db4038-8ed0-4018-b72c-a1e40bc14a26",
+    "timestamp": "2024-06-14T07:15:08.870Z",
+    "bpp_id": "preprod.tipplr.in"
+  }
+}

--- a/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow3/14. on_status_order_delivered.json
+++ b/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow3/14. on_status_order_delivered.json
@@ -1,0 +1,327 @@
+{
+  "message": {
+    "order": {
+      "id": "2024-06-14-816815",
+      "state": "Completed",
+      "billing": {
+        "address": {
+          "name": "Nithin",
+          "building": "building",
+          "locality": "Dr Ambedkar Road",
+          "city": "Bengaluru",
+          "state": "Karnataka",
+          "country": "IND",
+          "area_code": "560001"
+        },
+        "phone": "8951440205",
+        "name": "Nithin",
+        "email": "nithin@gmail.com",
+        "created_at": "2024-06-14T07:12:59.507Z",
+        "updated_at": "2024-06-14T07:12:59.507Z"
+      },
+      "items": [
+        {
+          "id": "food_item-170383210597342600",
+          "quantity": {
+            "count": 1
+          },
+          "fulfillment_id": "merchant-167714647372249847"
+        },
+        {
+          "id": "food_item-170383210627835789",
+          "quantity": {
+            "count": 1
+          },
+          "fulfillment_id": "merchant-167714647372249847"
+        }
+      ],
+      "provider": {
+        "id": "merchant-167714647372249847",
+        "locations": [
+          {
+            "id": "merchant-167714647372249847"
+          }
+        ]
+      },
+      "fulfillments": [
+        {
+          "@ondc/org/TAT": "PT45M",
+          "id": "merchant-167714647372249847",
+          "tracking": false,
+          "end": {
+            "contact": {
+              "email": "nithin@gmail.com",
+              "phone": "8951440205"
+            },
+            "person": {
+              "name": "Nithin"
+            },
+            "location": {
+              "gps": "12.97943084572564,77.59098932147026",
+              "address": {
+                "name": "Nithin",
+                "building": "building",
+                "locality": "Dr Ambedkar Road",
+                "city": "Bengaluru",
+                "state": "Karnataka",
+                "country": "IND",
+                "area_code": "560001"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2024-06-14T07:13:20.343Z",
+                "end": "2024-06-14T07:58:20.343Z"
+              },
+              "timestamp": "2024-06-14T07:20:15.401Z"
+            },
+            "instructions": {
+              "code": "2",
+              "name": "Proof of delivery",
+              "short_desc": "order delivered",
+              "long_desc": "delivery completed",
+              "images": [
+                "https://res.cloudinary.com/tipplr/image/upload/v1717656844/Common%20Images/testing/Image_3_gmvamz.jpg",
+                "https://res.cloudinary.com/tipplr/image/upload/v1717656844/Common%20Images/testing/Image_4_e5lywo.jpg"
+              ]
+            }
+          },
+          "type": "Delivery",
+          "start": {
+            "location": {
+              "id": "merchant-167714647372249847",
+              "descriptor": {
+                "name": "Tipplr-swathi d"
+              },
+              "gps": "12.979612,77.590846",
+              "address": {
+                "city": "Bengaluru",
+                "area_code": "560001",
+                "locality": "Vasanth Nagar",
+                "state": "KA"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2024-06-14T07:13:20.343Z",
+                "end": "2024-06-14T07:58:20.343Z"
+              },
+              "timestamp": "2024-06-14T07:15:08.826Z"
+            },
+            "contact": {
+              "phone": "8929221233",
+              "email": "support@tipplr.in"
+            }
+          },
+          "@ondc/org/provider_name": "TIPPLR_DELIVERY",
+          "state": {
+            "descriptor": {
+              "code": "Order-delivered"
+            }
+          },
+          "tags": [
+            {
+              "code": "routing",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "P2P"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "payment": {
+        "uri": "https://razorpay.com/",
+        "tl_method": "http/get",
+        "params": {
+          "amount": "191.25",
+          "currency": "INR",
+          "transaction_id": "order_OMYQCvGJXOmSWt"
+        },
+        "status": "PAID",
+        "type": "ON-ORDER",
+        "collected_by": "BAP",
+        "@ondc/org/buyer_app_finder_fee_type": "percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+        "@ondc/org/settlement_basis": "return_window_expiry",
+        "@ondc/org/settlement_window": "P1D",
+        "@ondc/org/withholding_amount": "5.74",
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "seller-app",
+            "settlement_phase": "sale-amount",
+            "settlement_type": "neft",
+            "upi_address": "9900818181@upi",
+            "settlement_bank_account_no": "50200053531451",
+            "settlement_ifsc_code": "HDFC0004051",
+            "beneficiary_name": "FOOD SPACE TECHNOLOGY PRIVATE LIMITED",
+            "bank_name": "HDFC Bank",
+            "branch_name": "CNN"
+          }
+        ]
+      },
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "191.25"
+        },
+        "breakup": [
+          {
+            "@ondc/org/item_id": "food_item-170383210597342600",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "title": "1 Idli 1 Vada",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "55"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "55"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210597342600",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "2.75"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210627835789",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "title": "Poori Kurma",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "70"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "70"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210627835789",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "3.50"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Packing charges",
+            "@ondc/org/title_type": "packing",
+            "price": {
+              "currency": "INR",
+              "value": "10.5"
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Delivery charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "39"
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Convenience Fee",
+            "@ondc/org/title_type": "misc",
+            "price": {
+              "currency": "INR",
+              "value": "10.50"
+            }
+          }
+        ],
+        "ttl": "P1D"
+      },
+      "created_at": "2024-06-14T07:13:19.999Z",
+      "updated_at": "2024-06-14T07:20:15.401Z",
+      "documents": [
+        {
+          "url": "https://tipplr-media.s3.ap-south-1.amazonaws.com/images/Invoice-A9MOS924C9JKYSQ.pdf",
+          "label": "Invoice"
+        }
+      ]
+    }
+  },
+  "context": {
+    "domain": "ONDC:RET11",
+    "country": "IND",
+    "city": "std:080",
+    "action": "on_status",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_uri": "https://preprod.tipplr.in/ondc/v2",
+    "transaction_id": "f4a9c6fe-a9c2-4a39-99b7-4a2667c8991c",
+    "message_id": "bd51a394-08c0-4267-9fc1-d16b37092934",
+    "timestamp": "2024-06-14T07:20:15.401Z",
+    "bpp_id": "preprod.tipplr.in"
+  }
+}

--- a/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow3/2. on_select_out_of_stock.json
+++ b/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow3/2. on_select_out_of_stock.json
@@ -1,0 +1,317 @@
+{
+  "context": {
+    "domain": "ONDC:RET11",
+    "country": "IND",
+    "city": "std:080",
+    "action": "on_select",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_uri": "https://preprod.tipplr.in/ondc/v2",
+    "transaction_id": "f4a9c6fe-a9c2-4a39-99b7-4a2667c8991c",
+    "message_id": "c86e692f-2105-452e-9097-b6b6ffae4c6f",
+    "timestamp": "2024-06-14T07:12:45.792Z",
+    "bpp_id": "preprod.tipplr.in"
+  },
+  "message": {
+    "order": {
+      "provider": {
+        "id": "merchant-167714647372249847",
+        "locations": [
+          {
+            "id": "merchant-167714647372249847"
+          }
+        ]
+      },
+      "fulfillments": [
+        {
+          "id": "merchant-167714647372249847",
+          "@ondc/org/provider_name": "TIPPLR_DELIVERY",
+          "tracking": false,
+          "@ondc/org/category": "Immediate Delivery",
+          "type": "Delivery",
+          "@ondc/org/TAT": "PT60M",
+          "state": {
+            "descriptor": {
+              "code": "Serviceable"
+            }
+          }
+        }
+      ],
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "450.25"
+        },
+        "breakup": [
+          {
+            "@ondc/org/item_id": "food_item-170383210588937185",
+            "@ondc/org/item_quantity": {
+              "count": 0
+            },
+            "title": "Chicken pizza",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "0"
+            },
+            "item": {
+              "quantity": {
+                "available": {
+                  "count": "0"
+                },
+                "maximum": {
+                  "count": "0"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "1"
+              },
+              "parent_item_id": "DI2"
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210588937185:603230",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "title": "Regular",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "259"
+            },
+            "item": {
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "10"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "259"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "76859436"
+                    }
+                  ]
+                }
+              ],
+              "fulfillment_id": "merchant-167714647372249847",
+              "parent_item_id": "DI2"
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210597342600",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "title": "1 Idli 1 Vada",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "55"
+            },
+            "item": {
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "10"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "55"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210597342600",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "2.75"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210627835789",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "title": "Poori Kurma",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "70"
+            },
+            "item": {
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "10"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "70"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210627835789",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "3.50"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Packing charges",
+            "@ondc/org/title_type": "packing",
+            "price": {
+              "currency": "INR",
+              "value": "10.5"
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Delivery charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "39"
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Convenience Fee",
+            "@ondc/org/title_type": "misc",
+            "price": {
+              "currency": "INR",
+              "value": "10.50"
+            }
+          }
+        ],
+        "ttl": "P1D"
+      },
+      "items": [
+        {
+          "id": "food_item-170383210588937185",
+          "fulfillment_id": "merchant-167714647372249847",
+          "parent_item_id": "DI2"
+        },
+        {
+          "id": "food_item-170383210588937185:603230",
+          "tags": [
+            {
+              "code": "type",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "customization"
+                }
+              ]
+            },
+            {
+              "code": "parent",
+              "list": [
+                {
+                  "code": "id",
+                  "value": "76859436"
+                }
+              ]
+            }
+          ],
+          "fulfillment_id": "merchant-167714647372249847",
+          "parent_item_id": "DI2"
+        },
+        {
+          "id": "food_item-170383210597342600",
+          "fulfillment_id": "merchant-167714647372249847"
+        },
+        {
+          "id": "food_item-170383210627835789",
+          "fulfillment_id": "merchant-167714647372249847"
+        }
+      ]
+    }
+  },
+  "error": {
+    "type": "DOMAIN-ERROR",
+    "code": "40002",
+    "message": "[{\"item_id\":\"food_item-170383210588937185\",\"dynamic_item_id\":\"DI2\",\"error\":\"40002\"},{\"dynamic_item_id\":\"DI2\",\"customization_id\":\"food_item-170383210588937185:603230\",\"custom_group_id\":\"76859436\",\"error\":\"40002\"}]"
+  }
+}

--- a/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow3/3. select.json
+++ b/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow3/3. select.json
@@ -1,0 +1,57 @@
+{
+  "context": {
+    "domain": "ONDC:RET11",
+    "country": "IND",
+    "city": "std:080",
+    "action": "select",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_uri": "https://preprod.tipplr.in/ondc/v2",
+    "transaction_id": "f4a9c6fe-a9c2-4a39-99b7-4a2667c8991c",
+    "message_id": "5bace504-e0b2-4f84-b677-8a0f4833b069",
+    "timestamp": "2024-06-14T07:12:51.094Z",
+    "bpp_id": "preprod.tipplr.in",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "items": [
+        {
+          "id": "food_item-170383210597342600",
+          "quantity": {
+            "count": 1
+          },
+          "location_id": "merchant-167714647372249847"
+        },
+        {
+          "id": "food_item-170383210627835789",
+          "quantity": {
+            "count": 1
+          },
+          "location_id": "merchant-167714647372249847"
+        }
+      ],
+      "provider": {
+        "id": "merchant-167714647372249847",
+        "locations": [
+          {
+            "id": "merchant-167714647372249847"
+          }
+        ]
+      },
+      "fulfillments": [
+        {
+          "end": {
+            "location": {
+              "gps": "12.97943084572564,77.59098932147026",
+              "address": {
+                "area_code": "560001"
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow3/4. on_select.json
+++ b/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow3/4. on_select.json
@@ -1,0 +1,207 @@
+{
+  "context": {
+    "domain": "ONDC:RET11",
+    "country": "IND",
+    "city": "std:080",
+    "action": "on_select",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_uri": "https://preprod.tipplr.in/ondc/v2",
+    "transaction_id": "f4a9c6fe-a9c2-4a39-99b7-4a2667c8991c",
+    "message_id": "5bace504-e0b2-4f84-b677-8a0f4833b069",
+    "timestamp": "2024-06-14T07:12:53.094Z",
+    "bpp_id": "preprod.tipplr.in"
+  },
+  "message": {
+    "order": {
+      "provider": {
+        "id": "merchant-167714647372249847",
+        "locations": [
+          {
+            "id": "merchant-167714647372249847"
+          }
+        ]
+      },
+      "fulfillments": [
+        {
+          "id": "merchant-167714647372249847",
+          "@ondc/org/provider_name": "TIPPLR_DELIVERY",
+          "tracking": false,
+          "@ondc/org/category": "Immediate Delivery",
+          "type": "Delivery",
+          "@ondc/org/TAT": "PT60M",
+          "state": {
+            "descriptor": {
+              "code": "Serviceable"
+            }
+          }
+        }
+      ],
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "191.25"
+        },
+        "breakup": [
+          {
+            "@ondc/org/item_id": "food_item-170383210597342600",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "title": "1 Idli 1 Vada",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "55"
+            },
+            "item": {
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "10"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "55"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210597342600",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "2.75"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210627835789",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "title": "Poori Kurma",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "70"
+            },
+            "item": {
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "10"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "70"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210627835789",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "3.50"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Packing charges",
+            "@ondc/org/title_type": "packing",
+            "price": {
+              "currency": "INR",
+              "value": "10.5"
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Delivery charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "39"
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Convenience Fee",
+            "@ondc/org/title_type": "misc",
+            "price": {
+              "currency": "INR",
+              "value": "10.50"
+            }
+          }
+        ],
+        "ttl": "P1D"
+      },
+      "items": [
+        {
+          "id": "food_item-170383210597342600",
+          "fulfillment_id": "merchant-167714647372249847"
+        },
+        {
+          "id": "food_item-170383210627835789",
+          "fulfillment_id": "merchant-167714647372249847"
+        }
+      ]
+    }
+  }
+}

--- a/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow3/5. init.json
+++ b/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow3/5. init.json
@@ -1,0 +1,87 @@
+{
+  "context": {
+    "domain": "ONDC:RET11",
+    "country": "IND",
+    "city": "std:080",
+    "action": "init",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_uri": "https://preprod.tipplr.in/ondc/v2",
+    "transaction_id": "f4a9c6fe-a9c2-4a39-99b7-4a2667c8991c",
+    "message_id": "4de3ec96-6ed8-4680-98dc-3a53c325f1dd",
+    "timestamp": "2024-06-14T07:12:59.507Z",
+    "bpp_id": "preprod.tipplr.in",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "provider": {
+        "id": "merchant-167714647372249847",
+        "locations": [
+          {
+            "id": "merchant-167714647372249847"
+          }
+        ]
+      },
+      "items": [
+        {
+          "id": "food_item-170383210597342600",
+          "quantity": {
+            "count": 1
+          },
+          "location_id": "merchant-167714647372249847",
+          "fulfillment_id": "merchant-167714647372249847"
+        },
+        {
+          "id": "food_item-170383210627835789",
+          "quantity": {
+            "count": 1
+          },
+          "location_id": "merchant-167714647372249847",
+          "fulfillment_id": "merchant-167714647372249847"
+        }
+      ],
+      "billing": {
+        "address": {
+          "building": "building",
+          "city": "Bengaluru",
+          "state": "Karnataka",
+          "country": "IND",
+          "area_code": "560001",
+          "locality": "Dr Ambedkar Road",
+          "name": "Nithin"
+        },
+        "phone": "8951440205",
+        "name": "Nithin",
+        "email": "nithin@gmail.com",
+        "created_at": "2024-06-14T07:12:59.507Z",
+        "updated_at": "2024-06-14T07:12:59.507Z"
+      },
+      "fulfillments": [
+        {
+          "id": "merchant-167714647372249847",
+          "type": "Delivery",
+          "end": {
+            "contact": {
+              "email": "nithin@gmail.com",
+              "phone": "8951440205"
+            },
+            "location": {
+              "gps": "12.97943084572564,77.59098932147026",
+              "address": {
+                "building": "building",
+                "city": "Bengaluru",
+                "state": "Karnataka",
+                "country": "IND",
+                "area_code": "560001",
+                "locality": "Dr Ambedkar Road",
+                "name": "Nithin"
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow3/6. on_init.json
+++ b/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow3/6. on_init.json
@@ -1,0 +1,268 @@
+{
+  "context": {
+    "domain": "ONDC:RET11",
+    "country": "IND",
+    "city": "std:080",
+    "action": "on_init",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_uri": "https://preprod.tipplr.in/ondc/v2",
+    "transaction_id": "f4a9c6fe-a9c2-4a39-99b7-4a2667c8991c",
+    "message_id": "4de3ec96-6ed8-4680-98dc-3a53c325f1dd",
+    "timestamp": "2024-06-14T07:13:01.507Z",
+    "bpp_id": "preprod.tipplr.in",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "provider": {
+        "id": "merchant-167714647372249847",
+        "locations": [
+          {
+            "id": "merchant-167714647372249847"
+          }
+        ]
+      },
+      "items": [
+        {
+          "id": "food_item-170383210597342600",
+          "quantity": {
+            "count": 1
+          },
+          "location_id": "merchant-167714647372249847",
+          "fulfillment_id": "merchant-167714647372249847"
+        },
+        {
+          "id": "food_item-170383210627835789",
+          "quantity": {
+            "count": 1
+          },
+          "location_id": "merchant-167714647372249847",
+          "fulfillment_id": "merchant-167714647372249847"
+        }
+      ],
+      "billing": {
+        "address": {
+          "building": "building",
+          "city": "Bengaluru",
+          "state": "Karnataka",
+          "country": "IND",
+          "area_code": "560001",
+          "locality": "Dr Ambedkar Road",
+          "name": "Nithin"
+        },
+        "phone": "8951440205",
+        "name": "Nithin",
+        "email": "nithin@gmail.com",
+        "created_at": "2024-06-14T07:12:59.507Z",
+        "updated_at": "2024-06-14T07:12:59.507Z"
+      },
+      "fulfillments": [
+        {
+          "id": "merchant-167714647372249847",
+          "type": "Delivery",
+          "end": {
+            "contact": {
+              "email": "nithin@gmail.com",
+              "phone": "8951440205"
+            },
+            "location": {
+              "gps": "12.97943084572564,77.59098932147026",
+              "address": {
+                "building": "building",
+                "city": "Bengaluru",
+                "state": "Karnataka",
+                "country": "IND",
+                "area_code": "560001",
+                "locality": "Dr Ambedkar Road",
+                "name": "Nithin"
+              }
+            }
+          },
+          "tracking": false
+        }
+      ],
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "191.25"
+        },
+        "breakup": [
+          {
+            "@ondc/org/item_id": "food_item-170383210597342600",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "title": "1 Idli 1 Vada",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "55"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "55"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210597342600",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "2.75"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210627835789",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "title": "Poori Kurma",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "70"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "70"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210627835789",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "3.50"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Packing charges",
+            "@ondc/org/title_type": "packing",
+            "price": {
+              "currency": "INR",
+              "value": "10.5"
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Delivery charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "39"
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Convenience Fee",
+            "@ondc/org/title_type": "misc",
+            "price": {
+              "currency": "INR",
+              "value": "10.50"
+            }
+          }
+        ],
+        "ttl": "P1D"
+      },
+      "payment": {
+        "type": "ON-ORDER",
+        "collected_by": "BAP",
+        "status": "NOT-PAID",
+        "@ondc/org/buyer_app_finder_fee_type": "percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "3",
+        "@ondc/org/settlement_basis": "return_window_expiry",
+        "@ondc/org/settlement_window": "P1D",
+        "@ondc/org/withholding_amount": "5.74",
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "seller-app",
+            "settlement_phase": "sale-amount",
+            "settlement_type": "neft",
+            "upi_address": "9900818181@upi",
+            "settlement_bank_account_no": "50200053531451",
+            "settlement_ifsc_code": "HDFC0004051",
+            "beneficiary_name": "FOOD SPACE TECHNOLOGY PRIVATE LIMITED",
+            "bank_name": "HDFC Bank",
+            "branch_name": "CNN"
+          }
+        ]
+      },
+      "tags": [
+        {
+          "code": "bpp_terms",
+          "list": [
+            {
+              "code": "tax_number",
+              "value": "29AAECF1747N1Z6"
+            },
+            {
+              "code": "provider_tax_number",
+              "value": "AAECF1747N"
+            },
+            {
+              "code": "np_type",
+              "value": "ISN"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow3/7. confirm.json
+++ b/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow3/7. confirm.json
@@ -1,0 +1,290 @@
+{
+  "context": {
+    "domain": "ONDC:RET11",
+    "country": "IND",
+    "city": "std:080",
+    "action": "confirm",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_uri": "https://preprod.tipplr.in/ondc/v2",
+    "transaction_id": "f4a9c6fe-a9c2-4a39-99b7-4a2667c8991c",
+    "message_id": "7082fd94-bf5b-43e5-a2ba-796a8a5b2a5e",
+    "timestamp": "2024-06-14T07:13:19.999Z",
+    "bpp_id": "preprod.tipplr.in",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "id": "2024-06-14-816815",
+      "state": "Created",
+      "billing": {
+        "address": {
+          "name": "Nithin",
+          "building": "building",
+          "locality": "Dr Ambedkar Road",
+          "city": "Bengaluru",
+          "state": "Karnataka",
+          "country": "IND",
+          "area_code": "560001"
+        },
+        "phone": "8951440205",
+        "name": "Nithin",
+        "email": "nithin@gmail.com",
+        "created_at": "2024-06-14T07:12:59.507Z",
+        "updated_at": "2024-06-14T07:12:59.507Z"
+      },
+      "items": [
+        {
+          "id": "food_item-170383210597342600",
+          "quantity": {
+            "count": 1
+          },
+          "fulfillment_id": "merchant-167714647372249847"
+        },
+        {
+          "id": "food_item-170383210627835789",
+          "quantity": {
+            "count": 1
+          },
+          "fulfillment_id": "merchant-167714647372249847"
+        }
+      ],
+      "provider": {
+        "id": "merchant-167714647372249847",
+        "locations": [
+          {
+            "id": "merchant-167714647372249847"
+          }
+        ]
+      },
+      "fulfillments": [
+        {
+          "@ondc/org/TAT": "PT60M",
+          "id": "merchant-167714647372249847",
+          "tracking": false,
+          "end": {
+            "contact": {
+              "email": "nithin@gmail.com",
+              "phone": "8951440205"
+            },
+            "person": {
+              "name": "Nithin"
+            },
+            "location": {
+              "gps": "12.97943084572564,77.59098932147026",
+              "address": {
+                "name": "Nithin",
+                "building": "building",
+                "locality": "Dr Ambedkar Road",
+                "city": "Bengaluru",
+                "state": "Karnataka",
+                "country": "IND",
+                "area_code": "560001"
+              }
+            }
+          },
+          "type": "Delivery"
+        }
+      ],
+      "payment": {
+        "uri": "https://razorpay.com/",
+        "tl_method": "http/get",
+        "params": {
+          "amount": "191.25",
+          "currency": "INR",
+          "transaction_id": "order_OMYQCvGJXOmSWt"
+        },
+        "status": "PAID",
+        "type": "ON-ORDER",
+        "collected_by": "BAP",
+        "@ondc/org/buyer_app_finder_fee_type": "percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+        "@ondc/org/settlement_basis": "return_window_expiry",
+        "@ondc/org/settlement_window": "P1D",
+        "@ondc/org/withholding_amount": "5.74",
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "seller-app",
+            "settlement_phase": "sale-amount",
+            "settlement_type": "neft",
+            "upi_address": "9900818181@upi",
+            "settlement_bank_account_no": "50200053531451",
+            "settlement_ifsc_code": "HDFC0004051",
+            "beneficiary_name": "FOOD SPACE TECHNOLOGY PRIVATE LIMITED",
+            "bank_name": "HDFC Bank",
+            "branch_name": "CNN"
+          }
+        ]
+      },
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "191.25"
+        },
+        "breakup": [
+          {
+            "@ondc/org/item_id": "food_item-170383210597342600",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "title": "1 Idli 1 Vada",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "55"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "55"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210597342600",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "2.75"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210627835789",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "title": "Poori Kurma",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "70"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "70"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210627835789",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "3.50"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Packing charges",
+            "@ondc/org/title_type": "packing",
+            "price": {
+              "currency": "INR",
+              "value": "10.5"
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Delivery charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "39"
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Convenience Fee",
+            "@ondc/org/title_type": "misc",
+            "price": {
+              "currency": "INR",
+              "value": "10.50"
+            }
+          }
+        ],
+        "ttl": "P1D"
+      },
+      "tags": [
+        {
+          "code": "bpp_terms",
+          "list": [
+            {
+              "code": "tax_number",
+              "value": "29AAECF1747N1Z6"
+            },
+            {
+              "code": "provider_tax_number",
+              "value": "AAECF1747N"
+            },
+            {
+              "code": "np_type",
+              "value": "ISN"
+            }
+          ]
+        },
+        {
+          "code": "bap_terms",
+          "list": [
+            {
+              "code": "tax_number",
+              "value": "GSTIN1234567890"
+            }
+          ]
+        }
+      ],
+      "created_at": "2024-06-14T07:13:19.999Z",
+      "updated_at": "2024-06-14T07:13:19.999Z"
+    }
+  }
+}

--- a/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow3/8. on_confirm.json
+++ b/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow3/8. on_confirm.json
@@ -1,0 +1,320 @@
+{
+  "context": {
+    "domain": "ONDC:RET11",
+    "country": "IND",
+    "city": "std:080",
+    "action": "on_confirm",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_uri": "https://preprod.tipplr.in/ondc/v2",
+    "transaction_id": "f4a9c6fe-a9c2-4a39-99b7-4a2667c8991c",
+    "message_id": "7082fd94-bf5b-43e5-a2ba-796a8a5b2a5e",
+    "timestamp": "2024-06-14T07:13:21.999Z",
+    "bpp_id": "preprod.tipplr.in"
+  },
+  "message": {
+    "order": {
+      "id": "2024-06-14-816815",
+      "state": "Created",
+      "billing": {
+        "address": {
+          "name": "Nithin",
+          "building": "building",
+          "locality": "Dr Ambedkar Road",
+          "city": "Bengaluru",
+          "state": "Karnataka",
+          "country": "IND",
+          "area_code": "560001"
+        },
+        "phone": "8951440205",
+        "name": "Nithin",
+        "email": "nithin@gmail.com",
+        "created_at": "2024-06-14T07:12:59.507Z",
+        "updated_at": "2024-06-14T07:12:59.507Z"
+      },
+      "items": [
+        {
+          "id": "food_item-170383210597342600",
+          "quantity": {
+            "count": 1
+          },
+          "fulfillment_id": "merchant-167714647372249847"
+        },
+        {
+          "id": "food_item-170383210627835789",
+          "quantity": {
+            "count": 1
+          },
+          "fulfillment_id": "merchant-167714647372249847"
+        }
+      ],
+      "provider": {
+        "id": "merchant-167714647372249847",
+        "locations": [
+          {
+            "id": "merchant-167714647372249847"
+          }
+        ]
+      },
+      "fulfillments": [
+        {
+          "@ondc/org/TAT": "PT60M",
+          "id": "merchant-167714647372249847",
+          "tracking": false,
+          "end": {
+            "contact": {
+              "email": "nithin@gmail.com",
+              "phone": "8951440205"
+            },
+            "person": {
+              "name": "Nithin"
+            },
+            "location": {
+              "gps": "12.97943084572564,77.59098932147026",
+              "address": {
+                "name": "Nithin",
+                "building": "building",
+                "locality": "Dr Ambedkar Road",
+                "city": "Bengaluru",
+                "state": "Karnataka",
+                "country": "IND",
+                "area_code": "560001"
+              }
+            }
+          },
+          "type": "Delivery",
+          "start": {
+            "location": {
+              "id": "merchant-167714647372249847",
+              "descriptor": {
+                "name": "Tipplr-swathi d"
+              },
+              "gps": "12.979612,77.590846",
+              "address": {
+                "city": "Bengaluru",
+                "area_code": "560001",
+                "locality": "Vasanth Nagar",
+                "state": "KA"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2024-06-14T07:13:20.343Z",
+                "end": "2024-06-14T07:58:20.343Z"
+              }
+            },
+            "contact": {
+              "phone": "8929221233",
+              "email": "support@tipplr.in"
+            }
+          },
+          "@ondc/org/provider_name": "TIPPLR_DELIVERY",
+          "state": {
+            "descriptor": {
+              "code": "Pending"
+            }
+          }
+        }
+      ],
+      "payment": {
+        "uri": "https://razorpay.com/",
+        "tl_method": "http/get",
+        "params": {
+          "amount": "191.25",
+          "currency": "INR",
+          "transaction_id": "order_OMYQCvGJXOmSWt"
+        },
+        "status": "PAID",
+        "type": "ON-ORDER",
+        "collected_by": "BAP",
+        "@ondc/org/buyer_app_finder_fee_type": "percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+        "@ondc/org/settlement_basis": "return_window_expiry",
+        "@ondc/org/settlement_window": "P1D",
+        "@ondc/org/withholding_amount": "5.74",
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "seller-app",
+            "settlement_phase": "sale-amount",
+            "settlement_type": "neft",
+            "upi_address": "9900818181@upi",
+            "settlement_bank_account_no": "50200053531451",
+            "settlement_ifsc_code": "HDFC0004051",
+            "beneficiary_name": "FOOD SPACE TECHNOLOGY PRIVATE LIMITED",
+            "bank_name": "HDFC Bank",
+            "branch_name": "CNN"
+          }
+        ]
+      },
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "191.25"
+        },
+        "breakup": [
+          {
+            "@ondc/org/item_id": "food_item-170383210597342600",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "title": "1 Idli 1 Vada",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "55"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "55"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210597342600",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "2.75"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210627835789",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "title": "Poori Kurma",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "70"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "70"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210627835789",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "3.50"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Packing charges",
+            "@ondc/org/title_type": "packing",
+            "price": {
+              "currency": "INR",
+              "value": "10.5"
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Delivery charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "39"
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Convenience Fee",
+            "@ondc/org/title_type": "misc",
+            "price": {
+              "currency": "INR",
+              "value": "10.50"
+            }
+          }
+        ],
+        "ttl": "P1D"
+      },
+      "tags": [
+        {
+          "code": "bpp_terms",
+          "list": [
+            {
+              "code": "tax_number",
+              "value": "29AAECF1747N1Z6"
+            },
+            {
+              "code": "provider_tax_number",
+              "value": "AAECF1747N"
+            },
+            {
+              "code": "np_type",
+              "value": "ISN"
+            }
+          ]
+        },
+        {
+          "code": "bap_terms",
+          "list": [
+            {
+              "code": "tax_number",
+              "value": "GSTIN1234567890"
+            }
+          ]
+        }
+      ],
+      "created_at": "2024-06-14T07:13:19.999Z",
+      "updated_at": "2024-06-14T07:13:21.999Z"
+    }
+  }
+}

--- a/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow3/9. on_status_pending.json
+++ b/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow3/9. on_status_pending.json
@@ -1,0 +1,315 @@
+{
+  "message": {
+    "order": {
+      "id": "2024-06-14-816815",
+      "state": "Accepted",
+      "billing": {
+        "address": {
+          "name": "Nithin",
+          "building": "building",
+          "locality": "Dr Ambedkar Road",
+          "city": "Bengaluru",
+          "state": "Karnataka",
+          "country": "IND",
+          "area_code": "560001"
+        },
+        "phone": "8951440205",
+        "name": "Nithin",
+        "email": "nithin@gmail.com",
+        "created_at": "2024-06-14T07:12:59.507Z",
+        "updated_at": "2024-06-14T07:12:59.507Z"
+      },
+      "items": [
+        {
+          "id": "food_item-170383210597342600",
+          "quantity": {
+            "count": 1
+          },
+          "fulfillment_id": "merchant-167714647372249847"
+        },
+        {
+          "id": "food_item-170383210627835789",
+          "quantity": {
+            "count": 1
+          },
+          "fulfillment_id": "merchant-167714647372249847"
+        }
+      ],
+      "provider": {
+        "id": "merchant-167714647372249847",
+        "locations": [
+          {
+            "id": "merchant-167714647372249847"
+          }
+        ]
+      },
+      "fulfillments": [
+        {
+          "@ondc/org/TAT": "PT45M",
+          "id": "merchant-167714647372249847",
+          "tracking": false,
+          "end": {
+            "contact": {
+              "email": "nithin@gmail.com",
+              "phone": "8951440205"
+            },
+            "person": {
+              "name": "Nithin"
+            },
+            "location": {
+              "gps": "12.97943084572564,77.59098932147026",
+              "address": {
+                "name": "Nithin",
+                "building": "building",
+                "locality": "Dr Ambedkar Road",
+                "city": "Bengaluru",
+                "state": "Karnataka",
+                "country": "IND",
+                "area_code": "560001"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2024-06-14T07:13:43.216Z",
+                "end": "2024-06-14T07:58:43.216Z"
+              }
+            }
+          },
+          "type": "Delivery",
+          "start": {
+            "location": {
+              "id": "merchant-167714647372249847",
+              "descriptor": {
+                "name": "Tipplr-swathi d"
+              },
+              "gps": "12.979612,77.590846",
+              "address": {
+                "city": "Bengaluru",
+                "area_code": "560001",
+                "locality": "Vasanth Nagar",
+                "state": "KA"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2024-06-14T07:13:20.343Z",
+                "end": "2024-06-14T07:58:20.343Z"
+              }
+            },
+            "contact": {
+              "phone": "8929221233",
+              "email": "support@tipplr.in"
+            }
+          },
+          "@ondc/org/provider_name": "TIPPLR_DELIVERY",
+          "state": {
+            "descriptor": {
+              "code": "Pending"
+            }
+          },
+          "tags": [
+            {
+              "code": "routing",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "P2P"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "payment": {
+        "uri": "https://razorpay.com/",
+        "tl_method": "http/get",
+        "params": {
+          "amount": "191.25",
+          "currency": "INR",
+          "transaction_id": "order_OMYQCvGJXOmSWt"
+        },
+        "status": "PAID",
+        "type": "ON-ORDER",
+        "collected_by": "BAP",
+        "@ondc/org/buyer_app_finder_fee_type": "percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+        "@ondc/org/settlement_basis": "return_window_expiry",
+        "@ondc/org/settlement_window": "P1D",
+        "@ondc/org/withholding_amount": "5.74",
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "seller-app",
+            "settlement_phase": "sale-amount",
+            "settlement_type": "neft",
+            "upi_address": "9900818181@upi",
+            "settlement_bank_account_no": "50200053531451",
+            "settlement_ifsc_code": "HDFC0004051",
+            "beneficiary_name": "FOOD SPACE TECHNOLOGY PRIVATE LIMITED",
+            "bank_name": "HDFC Bank",
+            "branch_name": "CNN"
+          }
+        ]
+      },
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "191.25"
+        },
+        "breakup": [
+          {
+            "@ondc/org/item_id": "food_item-170383210597342600",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "title": "1 Idli 1 Vada",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "55"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "55"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210597342600",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "2.75"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210627835789",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "title": "Poori Kurma",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "70"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "70"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210627835789",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "3.50"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Packing charges",
+            "@ondc/org/title_type": "packing",
+            "price": {
+              "currency": "INR",
+              "value": "10.5"
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Delivery charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "39"
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Convenience Fee",
+            "@ondc/org/title_type": "misc",
+            "price": {
+              "currency": "INR",
+              "value": "10.50"
+            }
+          }
+        ],
+        "ttl": "P1D"
+      },
+      "created_at": "2024-06-14T07:13:19.999Z",
+      "updated_at": "2024-06-14T07:13:43.216Z",
+      "documents": [
+        {
+          "url": "https://tipplr-media.s3.ap-south-1.amazonaws.com/images/Invoice-A9MOS924C9JKYSQ.pdf",
+          "label": "Invoice"
+        }
+      ]
+    }
+  },
+  "context": {
+    "domain": "ONDC:RET11",
+    "country": "IND",
+    "city": "std:080",
+    "action": "on_status",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_uri": "https://preprod.tipplr.in/ondc/v2",
+    "transaction_id": "f4a9c6fe-a9c2-4a39-99b7-4a2667c8991c",
+    "message_id": "b58bf50e-3366-458c-aa88-36ec7ae10dca",
+    "timestamp": "2024-06-14T07:13:43.217Z",
+    "bpp_id": "preprod.tipplr.in"
+  }
+}

--- a/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow4/1. select.json
+++ b/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow4/1. select.json
@@ -1,0 +1,93 @@
+{
+  "context": {
+    "domain": "ONDC:RET11",
+    "country": "IND",
+    "city": "std:080",
+    "action": "select",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_uri": "https://preprod.tipplr.in/ondc/v2",
+    "transaction_id": "1df9f9f2-f2ee-4c75-b981-d6675d7dc664",
+    "message_id": "25629d5a-5aa8-43da-af1e-3fefe48f166e",
+    "timestamp": "2024-06-14T10:57:20.577Z",
+    "bpp_id": "preprod.tipplr.in",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "items": [
+        {
+          "id": "food_item-170383210597342600",
+          "quantity": {
+            "count": 1
+          },
+          "location_id": "merchant-167714647372249847"
+        },
+        {
+          "id": "food_item-170383210588937185",
+          "quantity": {
+            "count": 1
+          },
+          "location_id": "merchant-167714647372249847",
+          "parent_item_id": "DI1"
+        },
+        {
+          "id": "food_item-170383210588937185:603232",
+          "quantity": {
+            "count": 1
+          },
+          "location_id": "merchant-167714647372249847",
+          "tags": [
+            {
+              "code": "type",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "customization"
+                }
+              ]
+            },
+            {
+              "code": "parent",
+              "list": [
+                {
+                  "code": "id",
+                  "value": "76859436"
+                }
+              ]
+            }
+          ],
+          "parent_item_id": "DI1"
+        },
+        {
+          "id": "food_item-170383210627835789",
+          "quantity": {
+            "count": 1
+          },
+          "location_id": "merchant-167714647372249847"
+        }
+      ],
+      "provider": {
+        "id": "merchant-167714647372249847",
+        "locations": [
+          {
+            "id": "merchant-167714647372249847"
+          }
+        ]
+      },
+      "fulfillments": [
+        {
+          "end": {
+            "location": {
+              "gps": "12.97943084572564,77.59098932147026",
+              "address": {
+                "area_code": "560001"
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow4/2. on_select.json
+++ b/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow4/2. on_select.json
@@ -1,0 +1,346 @@
+{
+  "context": {
+    "domain": "ONDC:RET11",
+    "country": "IND",
+    "city": "std:080",
+    "action": "on_select",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_uri": "https://preprod.tipplr.in/ondc/v2",
+    "transaction_id": "1df9f9f2-f2ee-4c75-b981-d6675d7dc664",
+    "message_id": "25629d5a-5aa8-43da-af1e-3fefe48f166e",
+    "timestamp": "2024-06-14T10:57:22.577Z",
+    "bpp_id": "preprod.tipplr.in"
+  },
+  "message": {
+    "order": {
+      "provider": {
+        "id": "merchant-167714647372249847",
+        "locations": [
+          {
+            "id": "merchant-167714647372249847"
+          }
+        ]
+      },
+      "fulfillments": [
+        {
+          "id": "merchant-167714647372249847",
+          "@ondc/org/provider_name": "TIPPLR_DELIVERY",
+          "tracking": true,
+          "@ondc/org/category": "Immediate Delivery",
+          "type": "Delivery",
+          "@ondc/org/TAT": "PT60M",
+          "state": {
+            "descriptor": {
+              "code": "Serviceable"
+            }
+          }
+        }
+      ],
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "768.75"
+        },
+        "breakup": [
+          {
+            "@ondc/org/item_id": "food_item-170383210588937185",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "title": "Chicken pizza",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "1"
+            },
+            "item": {
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "10"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "1"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ],
+              "parent_item_id": "DI1"
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210588937185:603232",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "title": "Medium",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "549"
+            },
+            "item": {
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "10"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "549"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "76859436"
+                    }
+                  ]
+                }
+              ],
+              "fulfillment_id": "merchant-167714647372249847",
+              "parent_item_id": "DI1"
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210588937185",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "27.50"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ],
+              "parent_item_id": "DI1"
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210597342600",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "title": "1 Idli 1 Vada",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "55"
+            },
+            "item": {
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "10"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "55"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210597342600",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "2.75"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210627835789",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "title": "Poori Kurma",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "70"
+            },
+            "item": {
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "10"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "70"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210627835789",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "3.50"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Packing charges",
+            "@ondc/org/title_type": "packing",
+            "price": {
+              "currency": "INR",
+              "value": "10.5"
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Delivery charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "39"
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Convenience Fee",
+            "@ondc/org/title_type": "misc",
+            "price": {
+              "currency": "INR",
+              "value": "10.50"
+            }
+          }
+        ],
+        "ttl": "P1D"
+      },
+      "items": [
+        {
+          "id": "food_item-170383210588937185",
+          "fulfillment_id": "merchant-167714647372249847",
+          "parent_item_id": "DI1"
+        },
+        {
+          "id": "food_item-170383210588937185:603232",
+          "tags": [
+            {
+              "code": "type",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "customization"
+                }
+              ]
+            },
+            {
+              "code": "parent",
+              "list": [
+                {
+                  "code": "id",
+                  "value": "76859436"
+                }
+              ]
+            }
+          ],
+          "fulfillment_id": "merchant-167714647372249847",
+          "parent_item_id": "DI1"
+        },
+        {
+          "id": "food_item-170383210597342600",
+          "fulfillment_id": "merchant-167714647372249847"
+        },
+        {
+          "id": "food_item-170383210627835789",
+          "fulfillment_id": "merchant-167714647372249847"
+        }
+      ]
+    }
+  }
+}

--- a/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow4/3. init.json
+++ b/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow4/3. init.json
@@ -1,0 +1,125 @@
+{
+  "context": {
+    "domain": "ONDC:RET11",
+    "country": "IND",
+    "city": "std:080",
+    "action": "init",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_uri": "https://preprod.tipplr.in/ondc/v2",
+    "transaction_id": "1df9f9f2-f2ee-4c75-b981-d6675d7dc664",
+    "message_id": "a07388c3-6eb6-410e-9965-7c6a94488779",
+    "timestamp": "2024-06-14T10:57:30.243Z",
+    "bpp_id": "preprod.tipplr.in",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "provider": {
+        "id": "merchant-167714647372249847",
+        "locations": [
+          {
+            "id": "merchant-167714647372249847"
+          }
+        ]
+      },
+      "items": [
+        {
+          "id": "food_item-170383210597342600",
+          "quantity": {
+            "count": 1
+          },
+          "location_id": "merchant-167714647372249847",
+          "fulfillment_id": "merchant-167714647372249847"
+        },
+        {
+          "id": "food_item-170383210588937185",
+          "quantity": {
+            "count": 1
+          },
+          "location_id": "merchant-167714647372249847",
+          "parent_item_id": "DI1",
+          "fulfillment_id": "merchant-167714647372249847"
+        },
+        {
+          "id": "food_item-170383210588937185:603232",
+          "quantity": {
+            "count": 1
+          },
+          "location_id": "merchant-167714647372249847",
+          "tags": [
+            {
+              "code": "type",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "customization"
+                }
+              ]
+            },
+            {
+              "code": "parent",
+              "list": [
+                {
+                  "code": "id",
+                  "value": "76859436"
+                }
+              ]
+            }
+          ],
+          "fulfillment_id": "merchant-167714647372249847",
+          "parent_item_id": "DI1"
+        },
+        {
+          "id": "food_item-170383210627835789",
+          "quantity": {
+            "count": 1
+          },
+          "location_id": "merchant-167714647372249847",
+          "fulfillment_id": "merchant-167714647372249847"
+        }
+      ],
+      "billing": {
+        "address": {
+          "building": "building",
+          "city": "Bengaluru",
+          "state": "Karnataka",
+          "country": "IND",
+          "area_code": "560001",
+          "locality": "Dr Ambedkar Road",
+          "name": "Nithin"
+        },
+        "phone": "8951440205",
+        "name": "Nithin",
+        "email": "nithin@gmail.com",
+        "created_at": "2024-06-14T10:57:30.243Z",
+        "updated_at": "2024-06-14T10:57:30.243Z"
+      },
+      "fulfillments": [
+        {
+          "id": "merchant-167714647372249847",
+          "type": "Delivery",
+          "end": {
+            "contact": {
+              "email": "nithin@gmail.com",
+              "phone": "8951440205"
+            },
+            "location": {
+              "gps": "12.97943084572564,77.59098932147026",
+              "address": {
+                "building": "building",
+                "city": "Bengaluru",
+                "state": "Karnataka",
+                "country": "IND",
+                "area_code": "560001",
+                "locality": "Dr Ambedkar Road",
+                "name": "Nithin"
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow4/4. on_init.json
+++ b/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow4/4. on_init.json
@@ -1,0 +1,399 @@
+{
+  "context": {
+    "domain": "ONDC:RET11",
+    "country": "IND",
+    "city": "std:080",
+    "action": "on_init",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_uri": "https://preprod.tipplr.in/ondc/v2",
+    "transaction_id": "1df9f9f2-f2ee-4c75-b981-d6675d7dc664",
+    "message_id": "a07388c3-6eb6-410e-9965-7c6a94488779",
+    "timestamp": "2024-06-14T10:57:32.243Z",
+    "bpp_id": "preprod.tipplr.in",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "provider": {
+        "id": "merchant-167714647372249847",
+        "locations": [
+          {
+            "id": "merchant-167714647372249847"
+          }
+        ]
+      },
+      "items": [
+        {
+          "id": "food_item-170383210597342600",
+          "quantity": {
+            "count": 1
+          },
+          "location_id": "merchant-167714647372249847",
+          "fulfillment_id": "merchant-167714647372249847"
+        },
+        {
+          "id": "food_item-170383210588937185",
+          "quantity": {
+            "count": 1
+          },
+          "location_id": "merchant-167714647372249847",
+          "parent_item_id": "DI1",
+          "fulfillment_id": "merchant-167714647372249847"
+        },
+        {
+          "id": "food_item-170383210588937185:603232",
+          "quantity": {
+            "count": 1
+          },
+          "location_id": "merchant-167714647372249847",
+          "tags": [
+            {
+              "code": "type",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "customization"
+                }
+              ]
+            },
+            {
+              "code": "parent",
+              "list": [
+                {
+                  "code": "id",
+                  "value": "76859436"
+                }
+              ]
+            }
+          ],
+          "fulfillment_id": "merchant-167714647372249847",
+          "parent_item_id": "DI1"
+        },
+        {
+          "id": "food_item-170383210627835789",
+          "quantity": {
+            "count": 1
+          },
+          "location_id": "merchant-167714647372249847",
+          "fulfillment_id": "merchant-167714647372249847"
+        }
+      ],
+      "billing": {
+        "address": {
+          "building": "building",
+          "city": "Bengaluru",
+          "state": "Karnataka",
+          "country": "IND",
+          "area_code": "560001",
+          "locality": "Dr Ambedkar Road",
+          "name": "Nithin"
+        },
+        "phone": "8951440205",
+        "name": "Nithin",
+        "email": "nithin@gmail.com",
+        "created_at": "2024-06-14T10:57:30.243Z",
+        "updated_at": "2024-06-14T10:57:30.243Z"
+      },
+      "fulfillments": [
+        {
+          "id": "merchant-167714647372249847",
+          "type": "Delivery",
+          "end": {
+            "contact": {
+              "email": "nithin@gmail.com",
+              "phone": "8951440205"
+            },
+            "location": {
+              "gps": "12.97943084572564,77.59098932147026",
+              "address": {
+                "building": "building",
+                "city": "Bengaluru",
+                "state": "Karnataka",
+                "country": "IND",
+                "area_code": "560001",
+                "locality": "Dr Ambedkar Road",
+                "name": "Nithin"
+              }
+            }
+          },
+          "tracking": true
+        }
+      ],
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "768.75"
+        },
+        "breakup": [
+          {
+            "@ondc/org/item_id": "food_item-170383210588937185",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "title": "Chicken pizza",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "1"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "1"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ],
+              "parent_item_id": "DI1"
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210588937185:603232",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "title": "Medium",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "549"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "549"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "76859436"
+                    }
+                  ]
+                }
+              ],
+              "fulfillment_id": "merchant-167714647372249847",
+              "parent_item_id": "DI1"
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210588937185",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "27.50"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ],
+              "parent_item_id": "DI1"
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210597342600",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "title": "1 Idli 1 Vada",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "55"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "55"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210597342600",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "2.75"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210627835789",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "title": "Poori Kurma",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "70"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "70"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210627835789",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "3.50"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Packing charges",
+            "@ondc/org/title_type": "packing",
+            "price": {
+              "currency": "INR",
+              "value": "10.5"
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Delivery charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "39"
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Convenience Fee",
+            "@ondc/org/title_type": "misc",
+            "price": {
+              "currency": "INR",
+              "value": "10.50"
+            }
+          }
+        ],
+        "ttl": "P1D"
+      },
+      "payment": {
+        "type": "ON-ORDER",
+        "collected_by": "BAP",
+        "status": "NOT-PAID",
+        "@ondc/org/buyer_app_finder_fee_type": "percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "3",
+        "@ondc/org/settlement_basis": "return_window_expiry",
+        "@ondc/org/settlement_window": "P1D",
+        "@ondc/org/withholding_amount": "23.06",
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "seller-app",
+            "settlement_phase": "sale-amount",
+            "settlement_type": "neft",
+            "upi_address": "9900818181@upi",
+            "settlement_bank_account_no": "50200053531451",
+            "settlement_ifsc_code": "HDFC0004051",
+            "beneficiary_name": "FOOD SPACE TECHNOLOGY PRIVATE LIMITED",
+            "bank_name": "HDFC Bank",
+            "branch_name": "CNN"
+          }
+        ]
+      },
+      "tags": [
+        {
+          "code": "bpp_terms",
+          "list": [
+            {
+              "code": "tax_number",
+              "value": "29AAECF1747N1Z6"
+            },
+            {
+              "code": "provider_tax_number",
+              "value": "AAECF1747N"
+            },
+            {
+              "code": "np_type",
+              "value": "ISN"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow4/5. confirm.json
+++ b/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow4/5. confirm.json
@@ -1,0 +1,419 @@
+{
+  "context": {
+    "domain": "ONDC:RET11",
+    "country": "IND",
+    "city": "std:080",
+    "action": "confirm",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_uri": "https://preprod.tipplr.in/ondc/v2",
+    "transaction_id": "1df9f9f2-f2ee-4c75-b981-d6675d7dc664",
+    "message_id": "4c1a17a8-9063-4943-9e40-4cd47340c5d9",
+    "timestamp": "2024-06-14T10:57:49.779Z",
+    "bpp_id": "preprod.tipplr.in",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "id": "2024-06-14-313355",
+      "state": "Created",
+      "billing": {
+        "address": {
+          "name": "Nithin",
+          "building": "building",
+          "locality": "Dr Ambedkar Road",
+          "city": "Bengaluru",
+          "state": "Karnataka",
+          "country": "IND",
+          "area_code": "560001"
+        },
+        "phone": "8951440205",
+        "name": "Nithin",
+        "email": "nithin@gmail.com",
+        "created_at": "2024-06-14T10:57:30.243Z",
+        "updated_at": "2024-06-14T10:57:30.243Z"
+      },
+      "items": [
+        {
+          "id": "food_item-170383210597342600",
+          "quantity": {
+            "count": 1
+          },
+          "fulfillment_id": "merchant-167714647372249847"
+        },
+        {
+          "id": "food_item-170383210588937185",
+          "quantity": {
+            "count": 1
+          },
+          "fulfillment_id": "merchant-167714647372249847",
+          "parent_item_id": "DI1"
+        },
+        {
+          "id": "food_item-170383210588937185:603232",
+          "quantity": {
+            "count": 1
+          },
+          "fulfillment_id": "merchant-167714647372249847",
+          "tags": [
+            {
+              "code": "type",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "customization"
+                }
+              ]
+            },
+            {
+              "code": "parent",
+              "list": [
+                {
+                  "code": "id",
+                  "value": "76859436"
+                }
+              ]
+            }
+          ],
+          "parent_item_id": "DI1"
+        },
+        {
+          "id": "food_item-170383210627835789",
+          "quantity": {
+            "count": 1
+          },
+          "fulfillment_id": "merchant-167714647372249847"
+        }
+      ],
+      "provider": {
+        "id": "merchant-167714647372249847",
+        "locations": [
+          {
+            "id": "merchant-167714647372249847"
+          }
+        ]
+      },
+      "fulfillments": [
+        {
+          "@ondc/org/TAT": "PT60M",
+          "id": "merchant-167714647372249847",
+          "tracking": true,
+          "end": {
+            "contact": {
+              "email": "nithin@gmail.com",
+              "phone": "8951440205"
+            },
+            "person": {
+              "name": "Nithin"
+            },
+            "location": {
+              "gps": "12.97943084572564,77.59098932147026",
+              "address": {
+                "name": "Nithin",
+                "building": "building",
+                "locality": "Dr Ambedkar Road",
+                "city": "Bengaluru",
+                "state": "Karnataka",
+                "country": "IND",
+                "area_code": "560001"
+              }
+            }
+          },
+          "type": "Delivery"
+        }
+      ],
+      "payment": {
+        "uri": "https://razorpay.com/",
+        "tl_method": "http/get",
+        "params": {
+          "amount": "768.75",
+          "currency": "INR",
+          "transaction_id": "order_OMcFNHHGd3N1L5"
+        },
+        "status": "PAID",
+        "type": "ON-ORDER",
+        "collected_by": "BAP",
+        "@ondc/org/buyer_app_finder_fee_type": "percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+        "@ondc/org/settlement_basis": "return_window_expiry",
+        "@ondc/org/settlement_window": "P1D",
+        "@ondc/org/withholding_amount": "23.06",
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "seller-app",
+            "settlement_phase": "sale-amount",
+            "settlement_type": "neft",
+            "upi_address": "9900818181@upi",
+            "settlement_bank_account_no": "50200053531451",
+            "settlement_ifsc_code": "HDFC0004051",
+            "beneficiary_name": "FOOD SPACE TECHNOLOGY PRIVATE LIMITED",
+            "bank_name": "HDFC Bank",
+            "branch_name": "CNN"
+          }
+        ]
+      },
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "768.75"
+        },
+        "breakup": [
+          {
+            "@ondc/org/item_id": "food_item-170383210588937185",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "title": "Chicken pizza",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "1"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "1"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ],
+              "parent_item_id": "DI1"
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210588937185:603232",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "title": "Medium",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "549"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "549"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "76859436"
+                    }
+                  ]
+                }
+              ],
+              "fulfillment_id": "merchant-167714647372249847",
+              "parent_item_id": "DI1"
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210588937185",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "27.50"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ],
+              "parent_item_id": "DI1"
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210597342600",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "title": "1 Idli 1 Vada",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "55"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "55"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210597342600",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "2.75"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210627835789",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "title": "Poori Kurma",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "70"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "70"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210627835789",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "3.50"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Packing charges",
+            "@ondc/org/title_type": "packing",
+            "price": {
+              "currency": "INR",
+              "value": "10.5"
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Delivery charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "39"
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Convenience Fee",
+            "@ondc/org/title_type": "misc",
+            "price": {
+              "currency": "INR",
+              "value": "10.50"
+            }
+          }
+        ],
+        "ttl": "P1D"
+      },
+      "tags": [
+        {
+          "code": "bpp_terms",
+          "list": [
+            {
+              "code": "tax_number",
+              "value": "29AAECF1747N1Z6"
+            },
+            {
+              "code": "provider_tax_number",
+              "value": "AAECF1747N"
+            },
+            {
+              "code": "np_type",
+              "value": "ISN"
+            }
+          ]
+        },
+        {
+          "code": "bap_terms",
+          "list": [
+            {
+              "code": "tax_number",
+              "value": "GSTIN1234567890"
+            }
+          ]
+        }
+      ],
+      "created_at": "2024-06-14T10:57:49.779Z",
+      "updated_at": "2024-06-14T10:57:49.779Z"
+    }
+  }
+}

--- a/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow4/6. on_confirm.json
+++ b/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow4/6. on_confirm.json
@@ -1,0 +1,449 @@
+{
+  "context": {
+    "domain": "ONDC:RET11",
+    "country": "IND",
+    "city": "std:080",
+    "action": "on_confirm",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_uri": "https://preprod.tipplr.in/ondc/v2",
+    "transaction_id": "1df9f9f2-f2ee-4c75-b981-d6675d7dc664",
+    "message_id": "4c1a17a8-9063-4943-9e40-4cd47340c5d9",
+    "timestamp": "2024-06-14T10:57:51.779Z",
+    "bpp_id": "preprod.tipplr.in"
+  },
+  "message": {
+    "order": {
+      "id": "2024-06-14-313355",
+      "state": "Created",
+      "billing": {
+        "address": {
+          "name": "Nithin",
+          "building": "building",
+          "locality": "Dr Ambedkar Road",
+          "city": "Bengaluru",
+          "state": "Karnataka",
+          "country": "IND",
+          "area_code": "560001"
+        },
+        "phone": "8951440205",
+        "name": "Nithin",
+        "email": "nithin@gmail.com",
+        "created_at": "2024-06-14T10:57:30.243Z",
+        "updated_at": "2024-06-14T10:57:30.243Z"
+      },
+      "items": [
+        {
+          "id": "food_item-170383210597342600",
+          "quantity": {
+            "count": 1
+          },
+          "fulfillment_id": "merchant-167714647372249847"
+        },
+        {
+          "id": "food_item-170383210588937185",
+          "quantity": {
+            "count": 1
+          },
+          "fulfillment_id": "merchant-167714647372249847",
+          "parent_item_id": "DI1"
+        },
+        {
+          "id": "food_item-170383210588937185:603232",
+          "quantity": {
+            "count": 1
+          },
+          "fulfillment_id": "merchant-167714647372249847",
+          "tags": [
+            {
+              "code": "type",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "customization"
+                }
+              ]
+            },
+            {
+              "code": "parent",
+              "list": [
+                {
+                  "code": "id",
+                  "value": "76859436"
+                }
+              ]
+            }
+          ],
+          "parent_item_id": "DI1"
+        },
+        {
+          "id": "food_item-170383210627835789",
+          "quantity": {
+            "count": 1
+          },
+          "fulfillment_id": "merchant-167714647372249847"
+        }
+      ],
+      "provider": {
+        "id": "merchant-167714647372249847",
+        "locations": [
+          {
+            "id": "merchant-167714647372249847"
+          }
+        ]
+      },
+      "fulfillments": [
+        {
+          "@ondc/org/TAT": "PT60M",
+          "id": "merchant-167714647372249847",
+          "tracking": true,
+          "end": {
+            "contact": {
+              "email": "nithin@gmail.com",
+              "phone": "8951440205"
+            },
+            "person": {
+              "name": "Nithin"
+            },
+            "location": {
+              "gps": "12.97943084572564,77.59098932147026",
+              "address": {
+                "name": "Nithin",
+                "building": "building",
+                "locality": "Dr Ambedkar Road",
+                "city": "Bengaluru",
+                "state": "Karnataka",
+                "country": "IND",
+                "area_code": "560001"
+              }
+            }
+          },
+          "type": "Delivery",
+          "start": {
+            "location": {
+              "id": "merchant-167714647372249847",
+              "descriptor": {
+                "name": "Tipplr-swathi d"
+              },
+              "gps": "12.979612,77.590846",
+              "address": {
+                "city": "Bengaluru",
+                "area_code": "560001",
+                "locality": "Vasanth Nagar",
+                "state": "KA"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2024-06-14T10:57:50.070Z",
+                "end": "2024-06-14T11:42:50.070Z"
+              }
+            },
+            "contact": {
+              "phone": "8929221233",
+              "email": "support@tipplr.in"
+            }
+          },
+          "@ondc/org/provider_name": "TIPPLR_DELIVERY",
+          "state": {
+            "descriptor": {
+              "code": "Pending"
+            }
+          }
+        }
+      ],
+      "payment": {
+        "uri": "https://razorpay.com/",
+        "tl_method": "http/get",
+        "params": {
+          "amount": "768.75",
+          "currency": "INR",
+          "transaction_id": "order_OMcFNHHGd3N1L5"
+        },
+        "status": "PAID",
+        "type": "ON-ORDER",
+        "collected_by": "BAP",
+        "@ondc/org/buyer_app_finder_fee_type": "percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+        "@ondc/org/settlement_basis": "return_window_expiry",
+        "@ondc/org/settlement_window": "P1D",
+        "@ondc/org/withholding_amount": "23.06",
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "seller-app",
+            "settlement_phase": "sale-amount",
+            "settlement_type": "neft",
+            "upi_address": "9900818181@upi",
+            "settlement_bank_account_no": "50200053531451",
+            "settlement_ifsc_code": "HDFC0004051",
+            "beneficiary_name": "FOOD SPACE TECHNOLOGY PRIVATE LIMITED",
+            "bank_name": "HDFC Bank",
+            "branch_name": "CNN"
+          }
+        ]
+      },
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "768.75"
+        },
+        "breakup": [
+          {
+            "@ondc/org/item_id": "food_item-170383210588937185",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "title": "Chicken pizza",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "1"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "1"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ],
+              "parent_item_id": "DI1"
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210588937185:603232",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "title": "Medium",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "549"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "549"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "76859436"
+                    }
+                  ]
+                }
+              ],
+              "fulfillment_id": "merchant-167714647372249847",
+              "parent_item_id": "DI1"
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210588937185",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "27.50"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ],
+              "parent_item_id": "DI1"
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210597342600",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "title": "1 Idli 1 Vada",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "55"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "55"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210597342600",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "2.75"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210627835789",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "title": "Poori Kurma",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "70"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "70"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210627835789",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "3.50"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Packing charges",
+            "@ondc/org/title_type": "packing",
+            "price": {
+              "currency": "INR",
+              "value": "10.5"
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Delivery charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "39"
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Convenience Fee",
+            "@ondc/org/title_type": "misc",
+            "price": {
+              "currency": "INR",
+              "value": "10.50"
+            }
+          }
+        ],
+        "ttl": "P1D"
+      },
+      "tags": [
+        {
+          "code": "bpp_terms",
+          "list": [
+            {
+              "code": "tax_number",
+              "value": "29AAECF1747N1Z6"
+            },
+            {
+              "code": "provider_tax_number",
+              "value": "AAECF1747N"
+            },
+            {
+              "code": "np_type",
+              "value": "ISN"
+            }
+          ]
+        },
+        {
+          "code": "bap_terms",
+          "list": [
+            {
+              "code": "tax_number",
+              "value": "GSTIN1234567890"
+            }
+          ]
+        }
+      ],
+      "created_at": "2024-06-14T10:57:49.779Z",
+      "updated_at": "2024-06-14T10:57:51.779Z"
+    }
+  }
+}

--- a/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow4/7. cancel.json
+++ b/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow4/7. cancel.json
@@ -1,0 +1,21 @@
+{
+  "context": {
+    "domain": "ONDC:RET11",
+    "country": "IND",
+    "city": "std:080",
+    "action": "cancel",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_uri": "https://preprod.tipplr.in/ondc/v2",
+    "transaction_id": "1df9f9f2-f2ee-4c75-b981-d6675d7dc664",
+    "message_id": "09e5fa37-bc3c-4144-9f48-dbb2f279c3c5",
+    "timestamp": "2024-06-14T10:58:05.630Z",
+    "bpp_id": "preprod.tipplr.in",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order_id": "2024-06-14-313355",
+    "cancellation_reason_id": "003"
+  }
+}

--- a/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow4/8. on_cancel.json
+++ b/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow4/8. on_cancel.json
@@ -1,0 +1,721 @@
+{
+  "context": {
+    "domain": "ONDC:RET11",
+    "country": "IND",
+    "city": "std:080",
+    "action": "on_cancel",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_uri": "https://preprod.tipplr.in/ondc/v2",
+    "transaction_id": "1df9f9f2-f2ee-4c75-b981-d6675d7dc664",
+    "message_id": "09e5fa37-bc3c-4144-9f48-dbb2f279c3c5",
+    "timestamp": "2024-06-14T10:58:05.630Z",
+    "bpp_id": "preprod.tipplr.in",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "id": "2024-06-14-313355",
+      "state": "Cancelled",
+      "provider": {
+        "id": "merchant-167714647372249847",
+        "locations": [
+          {
+            "id": "merchant-167714647372249847"
+          }
+        ]
+      },
+      "items": [
+        {
+          "id": "food_item-170383210597342600",
+          "quantity": {
+            "count": 0
+          },
+          "fulfillment_id": "merchant-167714647372249847"
+        },
+        {
+          "id": "food_item-170383210597342600",
+          "quantity": {
+            "count": 1
+          },
+          "fulfillment_id": "C1"
+        },
+        {
+          "id": "food_item-170383210588937185",
+          "quantity": {
+            "count": 0
+          },
+          "fulfillment_id": "merchant-167714647372249847"
+        },
+        {
+          "id": "food_item-170383210588937185",
+          "quantity": {
+            "count": 1
+          },
+          "fulfillment_id": "C1"
+        },
+        {
+          "id": "food_item-170383210588937185:603232",
+          "quantity": {
+            "count": 0
+          },
+          "fulfillment_id": "merchant-167714647372249847"
+        },
+        {
+          "id": "food_item-170383210588937185:603232",
+          "quantity": {
+            "count": 1
+          },
+          "fulfillment_id": "C1",
+          "tags": [
+            {
+              "code": "type",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "customization"
+                }
+              ]
+            },
+            {
+              "code": "parent",
+              "list": [
+                {
+                  "code": "id",
+                  "value": "76859436"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "id": "food_item-170383210627835789",
+          "quantity": {
+            "count": 0
+          },
+          "fulfillment_id": "merchant-167714647372249847"
+        },
+        {
+          "id": "food_item-170383210627835789",
+          "quantity": {
+            "count": 1
+          },
+          "fulfillment_id": "C1"
+        }
+      ],
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "0.00"
+        },
+        "breakup": [
+          {
+            "@ondc/org/item_id": "food_item-170383210588937185",
+            "@ondc/org/item_quantity": {
+              "count": 0
+            },
+            "title": "Chicken pizza",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "0"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "1"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ],
+              "parent_item_id": "DI1"
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210588937185:603232",
+            "@ondc/org/item_quantity": {
+              "count": 0
+            },
+            "title": "Medium",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "0"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "549"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "76859436"
+                    }
+                  ]
+                }
+              ],
+              "fulfillment_id": "merchant-167714647372249847",
+              "parent_item_id": "DI1"
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210588937185",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "0"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ],
+              "parent_item_id": "DI1",
+              "price": {
+                "currency": "INR",
+                "value": "0"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210597342600",
+            "@ondc/org/item_quantity": {
+              "count": 0
+            },
+            "title": "1 Idli 1 Vada",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "0"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "55"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210597342600",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "0"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ],
+              "price": {
+                "currency": "INR",
+                "value": "0"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210627835789",
+            "@ondc/org/item_quantity": {
+              "count": 0
+            },
+            "title": "Poori Kurma",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "0"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "70"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210627835789",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "0"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ],
+              "price": {
+                "currency": "INR",
+                "value": "0"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Packing charges",
+            "@ondc/org/title_type": "packing",
+            "price": {
+              "currency": "INR",
+              "value": "0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Delivery charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Convenience Fee",
+            "@ondc/org/title_type": "misc",
+            "price": {
+              "currency": "INR",
+              "value": "0"
+            }
+          }
+        ],
+        "ttl": "P1D"
+      },
+      "billing": {
+        "address": {
+          "name": "Nithin",
+          "building": "building",
+          "locality": "Dr Ambedkar Road",
+          "city": "Bengaluru",
+          "state": "Karnataka",
+          "country": "IND",
+          "area_code": "560001"
+        },
+        "phone": "8951440205",
+        "name": "Nithin",
+        "email": "nithin@gmail.com",
+        "created_at": "2024-06-14T10:57:30.243Z",
+        "updated_at": "2024-06-14T10:57:30.243Z"
+      },
+      "payment": {
+        "uri": "https://razorpay.com/",
+        "tl_method": "http/get",
+        "params": {
+          "amount": "768.75",
+          "currency": "INR",
+          "transaction_id": "order_OMcFNHHGd3N1L5"
+        },
+        "status": "PAID",
+        "type": "ON-ORDER",
+        "collected_by": "BAP",
+        "@ondc/org/buyer_app_finder_fee_type": "percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+        "@ondc/org/settlement_basis": "return_window_expiry",
+        "@ondc/org/settlement_window": "P1D",
+        "@ondc/org/withholding_amount": "23.06",
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "seller-app",
+            "settlement_phase": "sale-amount",
+            "settlement_type": "neft",
+            "upi_address": "9900818181@upi",
+            "settlement_bank_account_no": "50200053531451",
+            "settlement_ifsc_code": "HDFC0004051",
+            "beneficiary_name": "FOOD SPACE TECHNOLOGY PRIVATE LIMITED",
+            "bank_name": "HDFC Bank",
+            "branch_name": "CNN"
+          }
+        ]
+      },
+      "fulfillments": [
+        {
+          "@ondc/org/TAT": "PT60M",
+          "id": "merchant-167714647372249847",
+          "tracking": true,
+          "end": {
+            "contact": {
+              "email": "nithin@gmail.com",
+              "phone": "8951440205"
+            },
+            "person": {
+              "name": "Nithin"
+            },
+            "location": {
+              "gps": "12.97943084572564,77.59098932147026",
+              "address": {
+                "name": "Nithin",
+                "building": "building",
+                "locality": "Dr Ambedkar Road",
+                "city": "Bengaluru",
+                "state": "Karnataka",
+                "country": "IND",
+                "area_code": "560001"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2024-06-14T10:57:50.070Z",
+                "end": "2024-06-14T11:42:50.070Z"
+              }
+            }
+          },
+          "type": "Delivery",
+          "start": {
+            "location": {
+              "id": "merchant-167714647372249847",
+              "descriptor": {
+                "name": "Tipplr-swathi d"
+              },
+              "gps": "12.979612,77.590846",
+              "address": {
+                "city": "Bengaluru",
+                "area_code": "560001",
+                "locality": "Vasanth Nagar",
+                "state": "KA"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2024-06-14T10:57:50.070Z",
+                "end": "2024-06-14T11:42:50.070Z"
+              }
+            },
+            "contact": {
+              "phone": "8929221233",
+              "email": "support@tipplr.in"
+            }
+          },
+          "@ondc/org/provider_name": "TIPPLR_DELIVERY",
+          "state": {
+            "descriptor": {
+              "code": "Cancelled"
+            }
+          },
+          "tags": [
+            {
+              "code": "cancel_request",
+              "list": [
+                {
+                  "code": "reason_id",
+                  "value": "003"
+                },
+                {
+                  "code": "initiated_by",
+                  "value": "buyer-app-preprod-v2.ondc.org"
+                }
+              ]
+            },
+            {
+              "code": "precancel_state",
+              "list": [
+                {
+                  "code": "fulfillment_state",
+                  "value": "Created"
+                },
+                {
+                  "code": "updated_at",
+                  "value": "2024-06-14T10:57:51.779Z"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "id": "C1",
+          "state": {
+            "descriptor": {
+              "code": "Cancelled"
+            }
+          },
+          "type": "Cancel",
+          "tags": [
+            {
+              "code": "quote_trail",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "item"
+                },
+                {
+                  "code": "id",
+                  "value": "food_item-170383210588937185"
+                },
+                {
+                  "code": "currency",
+                  "value": "INR"
+                },
+                {
+                  "code": "value",
+                  "value": "-1"
+                }
+              ]
+            },
+            {
+              "code": "quote_trail",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "item"
+                },
+                {
+                  "code": "id",
+                  "value": "food_item-170383210588937185:603232"
+                },
+                {
+                  "code": "currency",
+                  "value": "INR"
+                },
+                {
+                  "code": "value",
+                  "value": "-549"
+                }
+              ]
+            },
+            {
+              "code": "quote_trail",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "tax"
+                },
+                {
+                  "code": "id",
+                  "value": "food_item-170383210588937185"
+                },
+                {
+                  "code": "currency",
+                  "value": "INR"
+                },
+                {
+                  "code": "value",
+                  "value": "-27.50"
+                }
+              ]
+            },
+            {
+              "code": "quote_trail",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "item"
+                },
+                {
+                  "code": "id",
+                  "value": "food_item-170383210597342600"
+                },
+                {
+                  "code": "currency",
+                  "value": "INR"
+                },
+                {
+                  "code": "value",
+                  "value": "-55"
+                }
+              ]
+            },
+            {
+              "code": "quote_trail",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "tax"
+                },
+                {
+                  "code": "id",
+                  "value": "food_item-170383210597342600"
+                },
+                {
+                  "code": "currency",
+                  "value": "INR"
+                },
+                {
+                  "code": "value",
+                  "value": "-2.75"
+                }
+              ]
+            },
+            {
+              "code": "quote_trail",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "item"
+                },
+                {
+                  "code": "id",
+                  "value": "food_item-170383210627835789"
+                },
+                {
+                  "code": "currency",
+                  "value": "INR"
+                },
+                {
+                  "code": "value",
+                  "value": "-70"
+                }
+              ]
+            },
+            {
+              "code": "quote_trail",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "tax"
+                },
+                {
+                  "code": "id",
+                  "value": "food_item-170383210627835789"
+                },
+                {
+                  "code": "currency",
+                  "value": "INR"
+                },
+                {
+                  "code": "value",
+                  "value": "-3.50"
+                }
+              ]
+            },
+            {
+              "code": "quote_trail",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "packing"
+                },
+                {
+                  "code": "id",
+                  "value": "merchant-167714647372249847"
+                },
+                {
+                  "code": "currency",
+                  "value": "INR"
+                },
+                {
+                  "code": "value",
+                  "value": "-10.5"
+                }
+              ]
+            },
+            {
+              "code": "quote_trail",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "delivery"
+                },
+                {
+                  "code": "id",
+                  "value": "merchant-167714647372249847"
+                },
+                {
+                  "code": "currency",
+                  "value": "INR"
+                },
+                {
+                  "code": "value",
+                  "value": "-39"
+                }
+              ]
+            },
+            {
+              "code": "quote_trail",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "misc"
+                },
+                {
+                  "code": "id",
+                  "value": "merchant-167714647372249847"
+                },
+                {
+                  "code": "currency",
+                  "value": "INR"
+                },
+                {
+                  "code": "value",
+                  "value": "-10.50"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "cancellation": {
+        "cancelled_by": "buyer-app-preprod-v2.ondc.org",
+        "reason": {
+          "id": "003"
+        }
+      },
+      "created_at": "2024-06-14T10:57:49.779Z",
+      "updated_at": "2024-06-14T10:58:03.756Z"
+    }
+  }
+}

--- a/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow5/1. select.json
+++ b/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow5/1. select.json
@@ -1,0 +1,86 @@
+{
+  "context": {
+    "domain": "ONDC:RET11",
+    "country": "IND",
+    "city": "std:080",
+    "action": "select",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_uri": "https://preprod.tipplr.in/ondc/v2",
+    "transaction_id": "a39edcc0-0455-445d-90b4-e5eb80a103c3",
+    "message_id": "1681a24f-fa7b-4fda-b9fc-ed22ee75006d",
+    "timestamp": "2024-06-14T11:22:53.095Z",
+    "bpp_id": "preprod.tipplr.in",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "items": [
+        {
+          "id": "food_item-170383210597342600",
+          "quantity": {
+            "count": 2
+          },
+          "location_id": "merchant-167714647372249847"
+        },
+        {
+          "id": "food_item-170383210588937185",
+          "quantity": {
+            "count": 2
+          },
+          "location_id": "merchant-167714647372249847",
+          "parent_item_id": "DI1"
+        },
+        {
+          "id": "food_item-170383210588937185:603232",
+          "quantity": {
+            "count": 2
+          },
+          "location_id": "merchant-167714647372249847",
+          "tags": [
+            {
+              "code": "type",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "customization"
+                }
+              ]
+            },
+            {
+              "code": "parent",
+              "list": [
+                {
+                  "code": "id",
+                  "value": "76859436"
+                }
+              ]
+            }
+          ],
+          "parent_item_id": "DI1"
+        }
+      ],
+      "provider": {
+        "id": "merchant-167714647372249847",
+        "locations": [
+          {
+            "id": "merchant-167714647372249847"
+          }
+        ]
+      },
+      "fulfillments": [
+        {
+          "end": {
+            "location": {
+              "gps": "12.97943084572564,77.59098932147026",
+              "address": {
+                "area_code": "560001"
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow5/10. on_status_out_for_delivery.json
+++ b/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow5/10. on_status_out_for_delivery.json
@@ -1,0 +1,391 @@
+{
+  "message": {
+    "order": {
+      "id": "2024-06-14-220594",
+      "state": "In-progress",
+      "billing": {
+        "address": {
+          "name": "Nithin",
+          "building": "building",
+          "locality": "Dr Ambedkar Road",
+          "city": "Bengaluru",
+          "state": "Karnataka",
+          "country": "IND",
+          "area_code": "560001"
+        },
+        "phone": "8951440205",
+        "name": "Nithin",
+        "email": "nithin@gmail.com",
+        "created_at": "2024-06-14T11:23:03.080Z",
+        "updated_at": "2024-06-14T11:23:03.080Z"
+      },
+      "items": [
+        {
+          "id": "food_item-170383210597342600",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "merchant-167714647372249847"
+        },
+        {
+          "id": "food_item-170383210588937185",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "merchant-167714647372249847",
+          "parent_item_id": "DI1"
+        },
+        {
+          "id": "food_item-170383210588937185:603232",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "merchant-167714647372249847",
+          "tags": [
+            {
+              "code": "type",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "customization"
+                }
+              ]
+            },
+            {
+              "code": "parent",
+              "list": [
+                {
+                  "code": "id",
+                  "value": "76859436"
+                }
+              ]
+            }
+          ],
+          "parent_item_id": "DI1"
+        }
+      ],
+      "provider": {
+        "id": "merchant-167714647372249847",
+        "locations": [
+          {
+            "id": "merchant-167714647372249847"
+          }
+        ]
+      },
+      "fulfillments": [
+        {
+          "@ondc/org/TAT": "PT45M",
+          "id": "merchant-167714647372249847",
+          "tracking": true,
+          "end": {
+            "contact": {
+              "email": "nithin@gmail.com",
+              "phone": "8951440205"
+            },
+            "person": {
+              "name": "Nithin"
+            },
+            "location": {
+              "gps": "12.97943084572564,77.59098932147026",
+              "address": {
+                "name": "Nithin",
+                "building": "building",
+                "locality": "Dr Ambedkar Road",
+                "city": "Bengaluru",
+                "state": "Karnataka",
+                "country": "IND",
+                "area_code": "560001"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2024-06-14T11:23:24.387Z",
+                "end": "2024-06-14T12:08:24.387Z"
+              }
+            }
+          },
+          "type": "Delivery",
+          "start": {
+            "location": {
+              "id": "merchant-167714647372249847",
+              "descriptor": {
+                "name": "Tipplr-swathi d"
+              },
+              "gps": "12.979612,77.590846",
+              "address": {
+                "city": "Bengaluru",
+                "area_code": "560001",
+                "locality": "Vasanth Nagar",
+                "state": "KA"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2024-06-14T11:23:24.387Z",
+                "end": "2024-06-14T12:08:24.387Z"
+              },
+              "timestamp": "2024-06-14T11:24:09.053Z"
+            },
+            "contact": {
+              "phone": "8929221233",
+              "email": "support@tipplr.in"
+            }
+          },
+          "@ondc/org/provider_name": "TIPPLR_DELIVERY",
+          "state": {
+            "descriptor": {
+              "code": "Out-for-delivery"
+            }
+          },
+          "tags": [
+            {
+              "code": "routing",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "P2P"
+                }
+              ]
+            }
+          ],
+          "agent": {
+            "name": "Channappa",
+            "phone": "8310422896"
+          }
+        }
+      ],
+      "payment": {
+        "uri": "https://razorpay.com/",
+        "tl_method": "http/get",
+        "params": {
+          "amount": "1330.50",
+          "currency": "INR",
+          "transaction_id": "order_OMcgM99vweLceE"
+        },
+        "status": "PAID",
+        "type": "ON-ORDER",
+        "collected_by": "BAP",
+        "@ondc/org/buyer_app_finder_fee_type": "percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+        "@ondc/org/settlement_basis": "return_window_expiry",
+        "@ondc/org/settlement_window": "P1D",
+        "@ondc/org/withholding_amount": "39.91",
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "seller-app",
+            "settlement_phase": "sale-amount",
+            "settlement_type": "neft",
+            "upi_address": "9900818181@upi",
+            "settlement_bank_account_no": "50200053531451",
+            "settlement_ifsc_code": "HDFC0004051",
+            "beneficiary_name": "FOOD SPACE TECHNOLOGY PRIVATE LIMITED",
+            "bank_name": "HDFC Bank",
+            "branch_name": "CNN"
+          }
+        ]
+      },
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "1330.50"
+        },
+        "breakup": [
+          {
+            "@ondc/org/item_id": "food_item-170383210588937185",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "title": "Chicken pizza",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "2"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "1"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ],
+              "parent_item_id": "DI1"
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210588937185:603232",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "title": "Medium",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "1098"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "549"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "76859436"
+                    }
+                  ]
+                }
+              ],
+              "fulfillment_id": "merchant-167714647372249847",
+              "parent_item_id": "DI1"
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210588937185",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "55.00"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ],
+              "parent_item_id": "DI1"
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210597342600",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "title": "1 Idli 1 Vada",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "110"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "55"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210597342600",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "5.50"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Packing charges",
+            "@ondc/org/title_type": "packing",
+            "price": {
+              "currency": "INR",
+              "value": "10.5"
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Delivery charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "39"
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Convenience Fee",
+            "@ondc/org/title_type": "misc",
+            "price": {
+              "currency": "INR",
+              "value": "10.50"
+            }
+          }
+        ],
+        "ttl": "P1D"
+      },
+      "created_at": "2024-06-14T11:23:24.147Z",
+      "updated_at": "2024-06-14T11:24:09.053Z",
+      "documents": [
+        {
+          "url": "https://tipplr-media.s3.ap-south-1.amazonaws.com/images/Invoice-BNWV79ZYI2CP6WL.pdf",
+          "label": "Invoice"
+        }
+      ]
+    }
+  },
+  "context": {
+    "domain": "ONDC:RET11",
+    "country": "IND",
+    "city": "std:080",
+    "action": "on_status",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_uri": "https://preprod.tipplr.in/ondc/v2",
+    "transaction_id": "a39edcc0-0455-445d-90b4-e5eb80a103c3",
+    "message_id": "817a4619-f914-4ee1-b273-2bd120b038aa",
+    "timestamp": "2024-06-14T11:24:09.092Z",
+    "bpp_id": "preprod.tipplr.in"
+  }
+}

--- a/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow5/11. on_cancel.json
+++ b/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow5/11. on_cancel.json
@@ -1,0 +1,644 @@
+{
+  "message": {
+    "order": {
+      "id": "2024-06-14-220594",
+      "state": "Cancelled",
+      "provider": {
+        "id": "merchant-167714647372249847",
+        "locations": [
+          {
+            "id": "merchant-167714647372249847"
+          }
+        ]
+      },
+      "items": [
+        {
+          "id": "food_item-170383210597342600",
+          "quantity": {
+            "count": 0
+          },
+          "fulfillment_id": "merchant-167714647372249847"
+        },
+        {
+          "id": "food_item-170383210597342600",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "C1"
+        },
+        {
+          "id": "food_item-170383210588937185",
+          "quantity": {
+            "count": 0
+          },
+          "fulfillment_id": "merchant-167714647372249847"
+        },
+        {
+          "id": "food_item-170383210588937185",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "C1"
+        },
+        {
+          "id": "food_item-170383210588937185:603232",
+          "quantity": {
+            "count": 0
+          },
+          "fulfillment_id": "merchant-167714647372249847"
+        },
+        {
+          "id": "food_item-170383210588937185:603232",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "C1"
+        }
+      ],
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "0"
+        },
+        "breakup": [
+          {
+            "@ondc/org/item_id": "food_item-170383210588937185",
+            "@ondc/org/item_quantity": {
+              "count": 0
+            },
+            "title": "Chicken pizza",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "0"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "1"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ],
+              "parent_item_id": "DI1"
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210588937185:603232",
+            "@ondc/org/item_quantity": {
+              "count": 0
+            },
+            "title": "Medium",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "0"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "549"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "76859436"
+                    }
+                  ]
+                }
+              ],
+              "fulfillment_id": "merchant-167714647372249847",
+              "parent_item_id": "DI1"
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210588937185",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "0"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ],
+              "parent_item_id": "DI1",
+              "price": {
+                "currency": "INR",
+                "value": "0"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210597342600",
+            "@ondc/org/item_quantity": {
+              "count": 0
+            },
+            "title": "1 Idli 1 Vada",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "0"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "55"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210597342600",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "0"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ],
+              "price": {
+                "currency": "INR",
+                "value": "0"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Packing charges",
+            "@ondc/org/title_type": "packing",
+            "price": {
+              "currency": "INR",
+              "value": "0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Delivery charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Convenience Fee",
+            "@ondc/org/title_type": "misc",
+            "price": {
+              "currency": "INR",
+              "value": "0"
+            }
+          }
+        ],
+        "ttl": "P1D"
+      },
+      "billing": {
+        "address": {
+          "name": "Nithin",
+          "building": "building",
+          "locality": "Dr Ambedkar Road",
+          "city": "Bengaluru",
+          "state": "Karnataka",
+          "country": "IND",
+          "area_code": "560001"
+        },
+        "phone": "8951440205",
+        "name": "Nithin",
+        "email": "nithin@gmail.com",
+        "created_at": "2024-06-14T11:23:03.080Z",
+        "updated_at": "2024-06-14T11:23:03.080Z"
+      },
+      "payment": {
+        "uri": "https://razorpay.com/",
+        "tl_method": "http/get",
+        "params": {
+          "amount": "1330.50",
+          "currency": "INR",
+          "transaction_id": "order_OMcgM99vweLceE"
+        },
+        "status": "PAID",
+        "type": "ON-ORDER",
+        "collected_by": "BAP",
+        "@ondc/org/buyer_app_finder_fee_type": "percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+        "@ondc/org/settlement_basis": "return_window_expiry",
+        "@ondc/org/settlement_window": "P1D",
+        "@ondc/org/withholding_amount": "39.91",
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "seller-app",
+            "settlement_phase": "sale-amount",
+            "settlement_type": "neft",
+            "upi_address": "9900818181@upi",
+            "settlement_bank_account_no": "50200053531451",
+            "settlement_ifsc_code": "HDFC0004051",
+            "beneficiary_name": "FOOD SPACE TECHNOLOGY PRIVATE LIMITED",
+            "bank_name": "HDFC Bank",
+            "branch_name": "CNN"
+          }
+        ]
+      },
+      "fulfillments": [
+        {
+          "@ondc/org/TAT": "PT60M",
+          "id": "merchant-167714647372249847",
+          "tracking": true,
+          "end": {
+            "contact": {
+              "email": "nithin@gmail.com",
+              "phone": "8951440205"
+            },
+            "person": {
+              "name": "Nithin"
+            },
+            "location": {
+              "gps": "12.97943084572564,77.59098932147026",
+              "address": {
+                "name": "Nithin",
+                "building": "building",
+                "locality": "Dr Ambedkar Road",
+                "city": "Bengaluru",
+                "state": "Karnataka",
+                "country": "IND",
+                "area_code": "560001"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2024-06-14T11:23:24.387Z",
+                "end": "2024-06-14T12:08:24.387Z"
+              }
+            }
+          },
+          "type": "Delivery",
+          "start": {
+            "location": {
+              "id": "merchant-167714647372249847",
+              "descriptor": {
+                "name": "Tipplr-swathi d"
+              },
+              "gps": "12.979612,77.590846",
+              "address": {
+                "city": "Bengaluru",
+                "area_code": "560001",
+                "locality": "Vasanth Nagar",
+                "state": "KA"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2024-06-14T11:23:24.387Z",
+                "end": "2024-06-14T12:08:24.387Z"
+              }
+            },
+            "contact": {
+              "phone": "8929221233",
+              "email": "support@tipplr.in"
+            }
+          },
+          "@ondc/org/provider_name": "TIPPLR_DELIVERY",
+          "state": {
+            "descriptor": {
+              "code": "Cancelled"
+            }
+          },
+          "tags": [
+            {
+              "code": "cancel_request",
+              "list": [
+                {
+                  "code": "retry_count",
+                  "value": "2"
+                },
+                {
+                  "code": "reason_id",
+                  "value": "005"
+                },
+                {
+                  "code": "initiated_by",
+                  "value": "preprod.tipplr.in"
+                },
+                {
+                  "code": "rto_id",
+                  "value": "C1"
+                }
+              ]
+            },
+            {
+              "code": "precancel_state",
+              "list": [
+                {
+                  "code": "fulfillment_state",
+                  "value": "Out-for-delivery"
+                },
+                {
+                  "code": "updated_at",
+                  "value": "2024-06-14T11:24:09.053Z"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "id": "C1",
+          "state": {
+            "descriptor": {
+              "code": "RTO-Initiated"
+            }
+          },
+          "type": "RTO",
+          "tags": [
+            {
+              "code": "quote_trail",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "item"
+                },
+                {
+                  "code": "id",
+                  "value": "food_item-170383210588937185"
+                },
+                {
+                  "code": "currency",
+                  "value": "INR"
+                },
+                {
+                  "code": "value",
+                  "value": "-2"
+                }
+              ]
+            },
+            {
+              "code": "quote_trail",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "item"
+                },
+                {
+                  "code": "id",
+                  "value": "food_item-170383210588937185:603232"
+                },
+                {
+                  "code": "currency",
+                  "value": "INR"
+                },
+                {
+                  "code": "value",
+                  "value": "-1098"
+                }
+              ]
+            },
+            {
+              "code": "quote_trail",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "tax"
+                },
+                {
+                  "code": "id",
+                  "value": "food_item-170383210588937185"
+                },
+                {
+                  "code": "currency",
+                  "value": "INR"
+                },
+                {
+                  "code": "value",
+                  "value": "-55.00"
+                }
+              ]
+            },
+            {
+              "code": "quote_trail",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "item"
+                },
+                {
+                  "code": "id",
+                  "value": "food_item-170383210597342600"
+                },
+                {
+                  "code": "currency",
+                  "value": "INR"
+                },
+                {
+                  "code": "value",
+                  "value": "-110"
+                }
+              ]
+            },
+            {
+              "code": "quote_trail",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "tax"
+                },
+                {
+                  "code": "id",
+                  "value": "food_item-170383210597342600"
+                },
+                {
+                  "code": "currency",
+                  "value": "INR"
+                },
+                {
+                  "code": "value",
+                  "value": "-5.50"
+                }
+              ]
+            },
+            {
+              "code": "quote_trail",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "packing"
+                },
+                {
+                  "code": "id",
+                  "value": "merchant-167714647372249847"
+                },
+                {
+                  "code": "currency",
+                  "value": "INR"
+                },
+                {
+                  "code": "value",
+                  "value": "-10.5"
+                }
+              ]
+            },
+            {
+              "code": "quote_trail",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "delivery"
+                },
+                {
+                  "code": "id",
+                  "value": "merchant-167714647372249847"
+                },
+                {
+                  "code": "currency",
+                  "value": "INR"
+                },
+                {
+                  "code": "value",
+                  "value": "-39"
+                }
+              ]
+            },
+            {
+              "code": "quote_trail",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "misc"
+                },
+                {
+                  "code": "id",
+                  "value": "merchant-167714647372249847"
+                },
+                {
+                  "code": "currency",
+                  "value": "INR"
+                },
+                {
+                  "code": "value",
+                  "value": "-10.50"
+                }
+              ]
+            }
+          ],
+          "start": {
+            "contact": {
+              "email": "nithin@gmail.com",
+              "phone": "8951440205"
+            },
+            "person": {
+              "name": "Nithin"
+            },
+            "location": {
+              "gps": "12.97943084572564,77.59098932147026",
+              "address": {
+                "name": "Nithin",
+                "building": "building",
+                "locality": "Dr Ambedkar Road",
+                "city": "Bengaluru",
+                "state": "Karnataka",
+                "country": "IND",
+                "area_code": "560001"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2024-06-14T11:23:24.387Z",
+                "end": "2024-06-14T12:08:24.387Z"
+              }
+            }
+          },
+          "end": {
+            "location": {
+              "id": "merchant-167714647372249847",
+              "descriptor": {
+                "name": "Tipplr-swathi d"
+              },
+              "gps": "12.979612,77.590846",
+              "address": {
+                "city": "Bengaluru",
+                "area_code": "560001",
+                "locality": "Vasanth Nagar",
+                "state": "KA"
+              }
+            },
+            "contact": {
+              "phone": "8929221233",
+              "email": "support@tipplr.in"
+            }
+          }
+        }
+      ],
+      "cancellation": {
+        "cancelled_by": "preprod.tipplr.in",
+        "reason": {
+          "id": "005"
+        }
+      },
+      "created_at": "2024-06-14T11:23:24.147Z",
+      "updated_at": "2024-06-14T11:24:19.171Z"
+    }
+  },
+  "context": {
+    "domain": "ONDC:RET11",
+    "country": "IND",
+    "city": "std:080",
+    "action": "on_cancel",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_uri": "https://preprod.tipplr.in/ondc/v2",
+    "transaction_id": "a39edcc0-0455-445d-90b4-e5eb80a103c3",
+    "message_id": "35b0ecbc-0540-4a5d-922f-2d294e715213",
+    "timestamp": "2024-06-14T11:24:19.173Z",
+    "bpp_id": "preprod.tipplr.in",
+    "ttl": "PT30S"
+  }
+}

--- a/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow5/12. on_status.json
+++ b/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow5/12. on_status.json
@@ -1,0 +1,645 @@
+{
+  "context": {
+    "domain": "ONDC:RET11",
+    "country": "IND",
+    "city": "std:080",
+    "action": "on_status",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_uri": "https://preprod.tipplr.in/ondc/v2",
+    "transaction_id": "a39edcc0-0455-445d-90b4-e5eb80a103c3",
+    "message_id": "35b0ecbc-0540-4a5d-922f-2d294e715213",
+    "timestamp": "2024-06-14T11:24:19.173Z",
+    "bpp_id": "preprod.tipplr.in",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "id": "2024-06-14-220594",
+      "state": "Cancelled",
+      "provider": {
+        "id": "merchant-167714647372249847",
+        "locations": [
+          {
+            "id": "merchant-167714647372249847"
+          }
+        ]
+      },
+      "items": [
+        {
+          "id": "food_item-170383210597342600",
+          "quantity": {
+            "count": 0
+          },
+          "fulfillment_id": "merchant-167714647372249847"
+        },
+        {
+          "id": "food_item-170383210597342600",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "C1"
+        },
+        {
+          "id": "food_item-170383210588937185",
+          "quantity": {
+            "count": 0
+          },
+          "fulfillment_id": "merchant-167714647372249847"
+        },
+        {
+          "id": "food_item-170383210588937185",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "C1"
+        },
+        {
+          "id": "food_item-170383210588937185:603232",
+          "quantity": {
+            "count": 0
+          },
+          "fulfillment_id": "merchant-167714647372249847"
+        },
+        {
+          "id": "food_item-170383210588937185:603232",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "C1"
+        }
+      ],
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "0"
+        },
+        "breakup": [
+          {
+            "@ondc/org/item_id": "food_item-170383210588937185",
+            "@ondc/org/item_quantity": {
+              "count": 0
+            },
+            "title": "Chicken pizza",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "0"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "1"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ],
+              "parent_item_id": "DI1"
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210588937185:603232",
+            "@ondc/org/item_quantity": {
+              "count": 0
+            },
+            "title": "Medium",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "0"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "549"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "76859436"
+                    }
+                  ]
+                }
+              ],
+              "fulfillment_id": "merchant-167714647372249847",
+              "parent_item_id": "DI1"
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210588937185",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "0"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ],
+              "parent_item_id": "DI1",
+              "price": {
+                "currency": "INR",
+                "value": "0"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210597342600",
+            "@ondc/org/item_quantity": {
+              "count": 0
+            },
+            "title": "1 Idli 1 Vada",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "0"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "55"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210597342600",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "0"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ],
+              "price": {
+                "currency": "INR",
+                "value": "0"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Packing charges",
+            "@ondc/org/title_type": "packing",
+            "price": {
+              "currency": "INR",
+              "value": "0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Delivery charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Convenience Fee",
+            "@ondc/org/title_type": "misc",
+            "price": {
+              "currency": "INR",
+              "value": "0"
+            }
+          }
+        ],
+        "ttl": "P1D"
+      },
+      "billing": {
+        "address": {
+          "name": "Nithin",
+          "building": "building",
+          "locality": "Dr Ambedkar Road",
+          "city": "Bengaluru",
+          "state": "Karnataka",
+          "country": "IND",
+          "area_code": "560001"
+        },
+        "phone": "8951440205",
+        "name": "Nithin",
+        "email": "nithin@gmail.com",
+        "created_at": "2024-06-14T11:23:03.080Z",
+        "updated_at": "2024-06-14T11:23:03.080Z"
+      },
+      "payment": {
+        "uri": "https://razorpay.com/",
+        "tl_method": "http/get",
+        "params": {
+          "amount": "1330.50",
+          "currency": "INR",
+          "transaction_id": "order_OMcgM99vweLceE"
+        },
+        "status": "PAID",
+        "type": "ON-ORDER",
+        "collected_by": "BAP",
+        "@ondc/org/buyer_app_finder_fee_type": "percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+        "@ondc/org/settlement_basis": "return_window_expiry",
+        "@ondc/org/settlement_window": "P1D",
+        "@ondc/org/withholding_amount": "39.91",
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "seller-app",
+            "settlement_phase": "sale-amount",
+            "settlement_type": "neft",
+            "upi_address": "9900818181@upi",
+            "settlement_bank_account_no": "50200053531451",
+            "settlement_ifsc_code": "HDFC0004051",
+            "beneficiary_name": "FOOD SPACE TECHNOLOGY PRIVATE LIMITED",
+            "bank_name": "HDFC Bank",
+            "branch_name": "CNN"
+          }
+        ]
+      },
+      "fulfillments": [
+        {
+          "@ondc/org/TAT": "PT60M",
+          "id": "merchant-167714647372249847",
+          "tracking": true,
+          "end": {
+            "contact": {
+              "email": "nithin@gmail.com",
+              "phone": "8951440205"
+            },
+            "person": {
+              "name": "Nithin"
+            },
+            "location": {
+              "gps": "12.97943084572564,77.59098932147026",
+              "address": {
+                "name": "Nithin",
+                "building": "building",
+                "locality": "Dr Ambedkar Road",
+                "city": "Bengaluru",
+                "state": "Karnataka",
+                "country": "IND",
+                "area_code": "560001"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2024-06-14T11:23:24.387Z",
+                "end": "2024-06-14T12:08:24.387Z"
+              }
+            }
+          },
+          "type": "Delivery",
+          "start": {
+            "location": {
+              "id": "merchant-167714647372249847",
+              "descriptor": {
+                "name": "Tipplr-swathi d"
+              },
+              "gps": "12.979612,77.590846",
+              "address": {
+                "city": "Bengaluru",
+                "area_code": "560001",
+                "locality": "Vasanth Nagar",
+                "state": "KA"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2024-06-14T11:23:24.387Z",
+                "end": "2024-06-14T12:08:24.387Z"
+              }
+            },
+            "contact": {
+              "phone": "8929221233",
+              "email": "support@tipplr.in"
+            }
+          },
+          "@ondc/org/provider_name": "TIPPLR_DELIVERY",
+          "state": {
+            "descriptor": {
+              "code": "Cancelled"
+            }
+          },
+          "tags": [
+            {
+              "code": "cancel_request",
+              "list": [
+                {
+                  "code": "retry_count",
+                  "value": "2"
+                },
+                {
+                  "code": "reason_id",
+                  "value": "005"
+                },
+                {
+                  "code": "initiated_by",
+                  "value": "preprod.tipplr.in"
+                },
+                {
+                  "code": "rto_id",
+                  "value": "C1"
+                }
+              ]
+            },
+            {
+              "code": "precancel_state",
+              "list": [
+                {
+                  "code": "fulfillment_state",
+                  "value": "Out-for-delivery"
+                },
+                {
+                  "code": "updated_at",
+                  "value": "2024-06-14T11:24:09.053Z"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "id": "C1",
+          "state": {
+            "descriptor": {
+              "code": "RTO-Disposed"
+            }
+          },
+          "type": "RTO",
+          "tags": [
+            {
+              "code": "quote_trail",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "item"
+                },
+                {
+                  "code": "id",
+                  "value": "food_item-170383210588937185"
+                },
+                {
+                  "code": "currency",
+                  "value": "INR"
+                },
+                {
+                  "code": "value",
+                  "value": "-2"
+                }
+              ]
+            },
+            {
+              "code": "quote_trail",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "item"
+                },
+                {
+                  "code": "id",
+                  "value": "food_item-170383210588937185:603232"
+                },
+                {
+                  "code": "currency",
+                  "value": "INR"
+                },
+                {
+                  "code": "value",
+                  "value": "-1098"
+                }
+              ]
+            },
+            {
+              "code": "quote_trail",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "tax"
+                },
+                {
+                  "code": "id",
+                  "value": "food_item-170383210588937185"
+                },
+                {
+                  "code": "currency",
+                  "value": "INR"
+                },
+                {
+                  "code": "value",
+                  "value": "-55.00"
+                }
+              ]
+            },
+            {
+              "code": "quote_trail",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "item"
+                },
+                {
+                  "code": "id",
+                  "value": "food_item-170383210597342600"
+                },
+                {
+                  "code": "currency",
+                  "value": "INR"
+                },
+                {
+                  "code": "value",
+                  "value": "-110"
+                }
+              ]
+            },
+            {
+              "code": "quote_trail",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "tax"
+                },
+                {
+                  "code": "id",
+                  "value": "food_item-170383210597342600"
+                },
+                {
+                  "code": "currency",
+                  "value": "INR"
+                },
+                {
+                  "code": "value",
+                  "value": "-5.50"
+                }
+              ]
+            },
+            {
+              "code": "quote_trail",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "packing"
+                },
+                {
+                  "code": "id",
+                  "value": "merchant-167714647372249847"
+                },
+                {
+                  "code": "currency",
+                  "value": "INR"
+                },
+                {
+                  "code": "value",
+                  "value": "-10.5"
+                }
+              ]
+            },
+            {
+              "code": "quote_trail",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "delivery"
+                },
+                {
+                  "code": "id",
+                  "value": "merchant-167714647372249847"
+                },
+                {
+                  "code": "currency",
+                  "value": "INR"
+                },
+                {
+                  "code": "value",
+                  "value": "-39"
+                }
+              ]
+            },
+            {
+              "code": "quote_trail",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "misc"
+                },
+                {
+                  "code": "id",
+                  "value": "merchant-167714647372249847"
+                },
+                {
+                  "code": "currency",
+                  "value": "INR"
+                },
+                {
+                  "code": "value",
+                  "value": "-10.50"
+                }
+              ]
+            }
+          ],
+          "start": {
+            "contact": {
+              "email": "nithin@gmail.com",
+              "phone": "8951440205"
+            },
+            "person": {
+              "name": "Nithin"
+            },
+            "location": {
+              "gps": "12.97943084572564,77.59098932147026",
+              "address": {
+                "name": "Nithin",
+                "building": "building",
+                "locality": "Dr Ambedkar Road",
+                "city": "Bengaluru",
+                "state": "Karnataka",
+                "country": "IND",
+                "area_code": "560001"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2024-06-14T11:23:24.387Z",
+                "end": "2024-06-14T12:08:24.387Z"
+              }
+            }
+          },
+          "end": {
+            "location": {
+              "id": "merchant-167714647372249847",
+              "descriptor": {
+                "name": "Tipplr-swathi d"
+              },
+              "gps": "12.979612,77.590846",
+              "address": {
+                "city": "Bengaluru",
+                "area_code": "560001",
+                "locality": "Vasanth Nagar",
+                "state": "KA"
+              }
+            },
+            "contact": {
+              "phone": "8929221233",
+              "email": "support@tipplr.in"
+            }
+          },
+          "@ondc/org/provider_name": "TIPPLR_DELIVERY"
+        }
+      ],
+      "cancellation": {
+        "cancelled_by": "preprod.tipplr.in",
+        "reason": {
+          "id": "005"
+        }
+      },
+      "created_at": "2024-06-14T11:23:24.147Z",
+      "updated_at": "2024-06-14T11:24:19.171Z"
+    }
+  }
+}

--- a/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow5/2. on_select.json
+++ b/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow5/2. on_select.json
@@ -1,0 +1,283 @@
+{
+  "context": {
+    "domain": "ONDC:RET11",
+    "country": "IND",
+    "city": "std:080",
+    "action": "on_select",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_uri": "https://preprod.tipplr.in/ondc/v2",
+    "transaction_id": "a39edcc0-0455-445d-90b4-e5eb80a103c3",
+    "message_id": "1681a24f-fa7b-4fda-b9fc-ed22ee75006d",
+    "timestamp": "2024-06-14T11:22:55.095Z",
+    "bpp_id": "preprod.tipplr.in"
+  },
+  "message": {
+    "order": {
+      "provider": {
+        "id": "merchant-167714647372249847",
+        "locations": [
+          {
+            "id": "merchant-167714647372249847"
+          }
+        ]
+      },
+      "fulfillments": [
+        {
+          "id": "merchant-167714647372249847",
+          "@ondc/org/provider_name": "TIPPLR_DELIVERY",
+          "tracking": true,
+          "@ondc/org/category": "Immediate Delivery",
+          "type": "Delivery",
+          "@ondc/org/TAT": "PT60M",
+          "state": {
+            "descriptor": {
+              "code": "Serviceable"
+            }
+          }
+        }
+      ],
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "1330.50"
+        },
+        "breakup": [
+          {
+            "@ondc/org/item_id": "food_item-170383210588937185",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "title": "Chicken pizza",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "2"
+            },
+            "item": {
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "10"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "1"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ],
+              "parent_item_id": "DI1"
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210588937185:603232",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "title": "Medium",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "1098"
+            },
+            "item": {
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "10"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "549"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "76859436"
+                    }
+                  ]
+                }
+              ],
+              "fulfillment_id": "merchant-167714647372249847",
+              "parent_item_id": "DI1"
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210588937185",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "55.00"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ],
+              "parent_item_id": "DI1"
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210597342600",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "title": "1 Idli 1 Vada",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "110"
+            },
+            "item": {
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "10"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "55"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210597342600",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "5.50"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Packing charges",
+            "@ondc/org/title_type": "packing",
+            "price": {
+              "currency": "INR",
+              "value": "10.5"
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Delivery charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "39"
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Convenience Fee",
+            "@ondc/org/title_type": "misc",
+            "price": {
+              "currency": "INR",
+              "value": "10.50"
+            }
+          }
+        ],
+        "ttl": "P1D"
+      },
+      "items": [
+        {
+          "id": "food_item-170383210588937185",
+          "fulfillment_id": "merchant-167714647372249847",
+          "parent_item_id": "DI1"
+        },
+        {
+          "id": "food_item-170383210588937185:603232",
+          "tags": [
+            {
+              "code": "type",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "customization"
+                }
+              ]
+            },
+            {
+              "code": "parent",
+              "list": [
+                {
+                  "code": "id",
+                  "value": "76859436"
+                }
+              ]
+            }
+          ],
+          "fulfillment_id": "merchant-167714647372249847",
+          "parent_item_id": "DI1"
+        },
+        {
+          "id": "food_item-170383210597342600",
+          "fulfillment_id": "merchant-167714647372249847"
+        }
+      ]
+    }
+  }
+}

--- a/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow5/3. init.json
+++ b/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow5/3. init.json
@@ -1,0 +1,117 @@
+{
+  "context": {
+    "domain": "ONDC:RET11",
+    "country": "IND",
+    "city": "std:080",
+    "action": "init",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_uri": "https://preprod.tipplr.in/ondc/v2",
+    "transaction_id": "a39edcc0-0455-445d-90b4-e5eb80a103c3",
+    "message_id": "d0015033-6605-45ec-8f44-f47a9e90b53c",
+    "timestamp": "2024-06-14T11:23:03.080Z",
+    "bpp_id": "preprod.tipplr.in",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "provider": {
+        "id": "merchant-167714647372249847",
+        "locations": [
+          {
+            "id": "merchant-167714647372249847"
+          }
+        ]
+      },
+      "items": [
+        {
+          "id": "food_item-170383210597342600",
+          "quantity": {
+            "count": 2
+          },
+          "location_id": "merchant-167714647372249847",
+          "fulfillment_id": "merchant-167714647372249847"
+        },
+        {
+          "id": "food_item-170383210588937185",
+          "quantity": {
+            "count": 2
+          },
+          "location_id": "merchant-167714647372249847",
+          "parent_item_id": "DI1",
+          "fulfillment_id": "merchant-167714647372249847"
+        },
+        {
+          "id": "food_item-170383210588937185:603232",
+          "quantity": {
+            "count": 2
+          },
+          "location_id": "merchant-167714647372249847",
+          "tags": [
+            {
+              "code": "type",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "customization"
+                }
+              ]
+            },
+            {
+              "code": "parent",
+              "list": [
+                {
+                  "code": "id",
+                  "value": "76859436"
+                }
+              ]
+            }
+          ],
+          "fulfillment_id": "merchant-167714647372249847",
+          "parent_item_id": "DI1"
+        }
+      ],
+      "billing": {
+        "address": {
+          "building": "building",
+          "city": "Bengaluru",
+          "state": "Karnataka",
+          "country": "IND",
+          "area_code": "560001",
+          "locality": "Dr Ambedkar Road",
+          "name": "Nithin"
+        },
+        "phone": "8951440205",
+        "name": "Nithin",
+        "email": "nithin@gmail.com",
+        "created_at": "2024-06-14T11:23:03.080Z",
+        "updated_at": "2024-06-14T11:23:03.080Z"
+      },
+      "fulfillments": [
+        {
+          "id": "merchant-167714647372249847",
+          "type": "Delivery",
+          "end": {
+            "contact": {
+              "email": "nithin@gmail.com",
+              "phone": "8951440205"
+            },
+            "location": {
+              "gps": "12.97943084572564,77.59098932147026",
+              "address": {
+                "building": "building",
+                "city": "Bengaluru",
+                "state": "Karnataka",
+                "country": "IND",
+                "area_code": "560001",
+                "locality": "Dr Ambedkar Road",
+                "name": "Nithin"
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow5/4. on_init.json
+++ b/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow5/4. on_init.json
@@ -1,0 +1,340 @@
+{
+  "context": {
+    "domain": "ONDC:RET11",
+    "country": "IND",
+    "city": "std:080",
+    "action": "on_init",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_uri": "https://preprod.tipplr.in/ondc/v2",
+    "transaction_id": "a39edcc0-0455-445d-90b4-e5eb80a103c3",
+    "message_id": "d0015033-6605-45ec-8f44-f47a9e90b53c",
+    "timestamp": "2024-06-14T11:23:05.080Z",
+    "bpp_id": "preprod.tipplr.in",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "provider": {
+        "id": "merchant-167714647372249847",
+        "locations": [
+          {
+            "id": "merchant-167714647372249847"
+          }
+        ]
+      },
+      "items": [
+        {
+          "id": "food_item-170383210597342600",
+          "quantity": {
+            "count": 2
+          },
+          "location_id": "merchant-167714647372249847",
+          "fulfillment_id": "merchant-167714647372249847"
+        },
+        {
+          "id": "food_item-170383210588937185",
+          "quantity": {
+            "count": 2
+          },
+          "location_id": "merchant-167714647372249847",
+          "parent_item_id": "DI1",
+          "fulfillment_id": "merchant-167714647372249847"
+        },
+        {
+          "id": "food_item-170383210588937185:603232",
+          "quantity": {
+            "count": 2
+          },
+          "location_id": "merchant-167714647372249847",
+          "tags": [
+            {
+              "code": "type",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "customization"
+                }
+              ]
+            },
+            {
+              "code": "parent",
+              "list": [
+                {
+                  "code": "id",
+                  "value": "76859436"
+                }
+              ]
+            }
+          ],
+          "fulfillment_id": "merchant-167714647372249847",
+          "parent_item_id": "DI1"
+        }
+      ],
+      "billing": {
+        "address": {
+          "building": "building",
+          "city": "Bengaluru",
+          "state": "Karnataka",
+          "country": "IND",
+          "area_code": "560001",
+          "locality": "Dr Ambedkar Road",
+          "name": "Nithin"
+        },
+        "phone": "8951440205",
+        "name": "Nithin",
+        "email": "nithin@gmail.com",
+        "created_at": "2024-06-14T11:23:03.080Z",
+        "updated_at": "2024-06-14T11:23:03.080Z"
+      },
+      "fulfillments": [
+        {
+          "id": "merchant-167714647372249847",
+          "type": "Delivery",
+          "end": {
+            "contact": {
+              "email": "nithin@gmail.com",
+              "phone": "8951440205"
+            },
+            "location": {
+              "gps": "12.97943084572564,77.59098932147026",
+              "address": {
+                "building": "building",
+                "city": "Bengaluru",
+                "state": "Karnataka",
+                "country": "IND",
+                "area_code": "560001",
+                "locality": "Dr Ambedkar Road",
+                "name": "Nithin"
+              }
+            }
+          },
+          "tracking": true
+        }
+      ],
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "1330.50"
+        },
+        "breakup": [
+          {
+            "@ondc/org/item_id": "food_item-170383210588937185",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "title": "Chicken pizza",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "2"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "1"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ],
+              "parent_item_id": "DI1"
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210588937185:603232",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "title": "Medium",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "1098"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "549"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "76859436"
+                    }
+                  ]
+                }
+              ],
+              "fulfillment_id": "merchant-167714647372249847",
+              "parent_item_id": "DI1"
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210588937185",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "55.00"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ],
+              "parent_item_id": "DI1"
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210597342600",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "title": "1 Idli 1 Vada",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "110"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "55"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210597342600",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "5.50"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Packing charges",
+            "@ondc/org/title_type": "packing",
+            "price": {
+              "currency": "INR",
+              "value": "10.5"
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Delivery charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "39"
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Convenience Fee",
+            "@ondc/org/title_type": "misc",
+            "price": {
+              "currency": "INR",
+              "value": "10.50"
+            }
+          }
+        ],
+        "ttl": "P1D"
+      },
+      "payment": {
+        "type": "ON-ORDER",
+        "collected_by": "BAP",
+        "status": "NOT-PAID",
+        "@ondc/org/buyer_app_finder_fee_type": "percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "3",
+        "@ondc/org/settlement_basis": "return_window_expiry",
+        "@ondc/org/settlement_window": "P1D",
+        "@ondc/org/withholding_amount": "39.91",
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "seller-app",
+            "settlement_phase": "sale-amount",
+            "settlement_type": "neft",
+            "upi_address": "9900818181@upi",
+            "settlement_bank_account_no": "50200053531451",
+            "settlement_ifsc_code": "HDFC0004051",
+            "beneficiary_name": "FOOD SPACE TECHNOLOGY PRIVATE LIMITED",
+            "bank_name": "HDFC Bank",
+            "branch_name": "CNN"
+          }
+        ]
+      },
+      "tags": [
+        {
+          "code": "bpp_terms",
+          "list": [
+            {
+              "code": "tax_number",
+              "value": "29AAECF1747N1Z6"
+            },
+            {
+              "code": "provider_tax_number",
+              "value": "AAECF1747N"
+            },
+            {
+              "code": "np_type",
+              "value": "ISN"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow5/5. confirm.json
+++ b/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow5/5. confirm.json
@@ -1,0 +1,361 @@
+{
+  "context": {
+    "domain": "ONDC:RET11",
+    "country": "IND",
+    "city": "std:080",
+    "action": "confirm",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_uri": "https://preprod.tipplr.in/ondc/v2",
+    "transaction_id": "a39edcc0-0455-445d-90b4-e5eb80a103c3",
+    "message_id": "95337a61-b63e-4cbe-9186-64b7444bbdde",
+    "timestamp": "2024-06-14T11:23:24.147Z",
+    "bpp_id": "preprod.tipplr.in",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "id": "2024-06-14-220594",
+      "state": "Created",
+      "billing": {
+        "address": {
+          "name": "Nithin",
+          "building": "building",
+          "locality": "Dr Ambedkar Road",
+          "city": "Bengaluru",
+          "state": "Karnataka",
+          "country": "IND",
+          "area_code": "560001"
+        },
+        "phone": "8951440205",
+        "name": "Nithin",
+        "email": "nithin@gmail.com",
+        "created_at": "2024-06-14T11:23:03.080Z",
+        "updated_at": "2024-06-14T11:23:03.080Z"
+      },
+      "items": [
+        {
+          "id": "food_item-170383210597342600",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "merchant-167714647372249847"
+        },
+        {
+          "id": "food_item-170383210588937185",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "merchant-167714647372249847",
+          "parent_item_id": "DI1"
+        },
+        {
+          "id": "food_item-170383210588937185:603232",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "merchant-167714647372249847",
+          "tags": [
+            {
+              "code": "type",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "customization"
+                }
+              ]
+            },
+            {
+              "code": "parent",
+              "list": [
+                {
+                  "code": "id",
+                  "value": "76859436"
+                }
+              ]
+            }
+          ],
+          "parent_item_id": "DI1"
+        }
+      ],
+      "provider": {
+        "id": "merchant-167714647372249847",
+        "locations": [
+          {
+            "id": "merchant-167714647372249847"
+          }
+        ]
+      },
+      "fulfillments": [
+        {
+          "@ondc/org/TAT": "PT60M",
+          "id": "merchant-167714647372249847",
+          "tracking": true,
+          "end": {
+            "contact": {
+              "email": "nithin@gmail.com",
+              "phone": "8951440205"
+            },
+            "person": {
+              "name": "Nithin"
+            },
+            "location": {
+              "gps": "12.97943084572564,77.59098932147026",
+              "address": {
+                "name": "Nithin",
+                "building": "building",
+                "locality": "Dr Ambedkar Road",
+                "city": "Bengaluru",
+                "state": "Karnataka",
+                "country": "IND",
+                "area_code": "560001"
+              }
+            }
+          },
+          "type": "Delivery"
+        }
+      ],
+      "payment": {
+        "uri": "https://razorpay.com/",
+        "tl_method": "http/get",
+        "params": {
+          "amount": "1330.50",
+          "currency": "INR",
+          "transaction_id": "order_OMcgM99vweLceE"
+        },
+        "status": "PAID",
+        "type": "ON-ORDER",
+        "collected_by": "BAP",
+        "@ondc/org/buyer_app_finder_fee_type": "percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+        "@ondc/org/settlement_basis": "return_window_expiry",
+        "@ondc/org/settlement_window": "P1D",
+        "@ondc/org/withholding_amount": "39.91",
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "seller-app",
+            "settlement_phase": "sale-amount",
+            "settlement_type": "neft",
+            "upi_address": "9900818181@upi",
+            "settlement_bank_account_no": "50200053531451",
+            "settlement_ifsc_code": "HDFC0004051",
+            "beneficiary_name": "FOOD SPACE TECHNOLOGY PRIVATE LIMITED",
+            "bank_name": "HDFC Bank",
+            "branch_name": "CNN"
+          }
+        ]
+      },
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "1330.50"
+        },
+        "breakup": [
+          {
+            "@ondc/org/item_id": "food_item-170383210588937185",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "title": "Chicken pizza",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "2"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "1"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ],
+              "parent_item_id": "DI1"
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210588937185:603232",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "title": "Medium",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "1098"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "549"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "76859436"
+                    }
+                  ]
+                }
+              ],
+              "fulfillment_id": "merchant-167714647372249847",
+              "parent_item_id": "DI1"
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210588937185",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "55.00"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ],
+              "parent_item_id": "DI1"
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210597342600",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "title": "1 Idli 1 Vada",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "110"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "55"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210597342600",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "5.50"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Packing charges",
+            "@ondc/org/title_type": "packing",
+            "price": {
+              "currency": "INR",
+              "value": "10.5"
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Delivery charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "39"
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Convenience Fee",
+            "@ondc/org/title_type": "misc",
+            "price": {
+              "currency": "INR",
+              "value": "10.50"
+            }
+          }
+        ],
+        "ttl": "P1D"
+      },
+      "tags": [
+        {
+          "code": "bpp_terms",
+          "list": [
+            {
+              "code": "tax_number",
+              "value": "29AAECF1747N1Z6"
+            },
+            {
+              "code": "provider_tax_number",
+              "value": "AAECF1747N"
+            },
+            {
+              "code": "np_type",
+              "value": "ISN"
+            }
+          ]
+        },
+        {
+          "code": "bap_terms",
+          "list": [
+            {
+              "code": "tax_number",
+              "value": "GSTIN1234567890"
+            }
+          ]
+        }
+      ],
+      "created_at": "2024-06-14T11:23:24.147Z",
+      "updated_at": "2024-06-14T11:23:24.147Z"
+    }
+  }
+}

--- a/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow5/6. on_confirm.json
+++ b/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow5/6. on_confirm.json
@@ -1,0 +1,391 @@
+{
+  "context": {
+    "domain": "ONDC:RET11",
+    "country": "IND",
+    "city": "std:080",
+    "action": "on_confirm",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_uri": "https://preprod.tipplr.in/ondc/v2",
+    "transaction_id": "a39edcc0-0455-445d-90b4-e5eb80a103c3",
+    "message_id": "95337a61-b63e-4cbe-9186-64b7444bbdde",
+    "timestamp": "2024-06-14T11:23:26.147Z",
+    "bpp_id": "preprod.tipplr.in"
+  },
+  "message": {
+    "order": {
+      "id": "2024-06-14-220594",
+      "state": "Created",
+      "billing": {
+        "address": {
+          "name": "Nithin",
+          "building": "building",
+          "locality": "Dr Ambedkar Road",
+          "city": "Bengaluru",
+          "state": "Karnataka",
+          "country": "IND",
+          "area_code": "560001"
+        },
+        "phone": "8951440205",
+        "name": "Nithin",
+        "email": "nithin@gmail.com",
+        "created_at": "2024-06-14T11:23:03.080Z",
+        "updated_at": "2024-06-14T11:23:03.080Z"
+      },
+      "items": [
+        {
+          "id": "food_item-170383210597342600",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "merchant-167714647372249847"
+        },
+        {
+          "id": "food_item-170383210588937185",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "merchant-167714647372249847",
+          "parent_item_id": "DI1"
+        },
+        {
+          "id": "food_item-170383210588937185:603232",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "merchant-167714647372249847",
+          "tags": [
+            {
+              "code": "type",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "customization"
+                }
+              ]
+            },
+            {
+              "code": "parent",
+              "list": [
+                {
+                  "code": "id",
+                  "value": "76859436"
+                }
+              ]
+            }
+          ],
+          "parent_item_id": "DI1"
+        }
+      ],
+      "provider": {
+        "id": "merchant-167714647372249847",
+        "locations": [
+          {
+            "id": "merchant-167714647372249847"
+          }
+        ]
+      },
+      "fulfillments": [
+        {
+          "@ondc/org/TAT": "PT60M",
+          "id": "merchant-167714647372249847",
+          "tracking": true,
+          "end": {
+            "contact": {
+              "email": "nithin@gmail.com",
+              "phone": "8951440205"
+            },
+            "person": {
+              "name": "Nithin"
+            },
+            "location": {
+              "gps": "12.97943084572564,77.59098932147026",
+              "address": {
+                "name": "Nithin",
+                "building": "building",
+                "locality": "Dr Ambedkar Road",
+                "city": "Bengaluru",
+                "state": "Karnataka",
+                "country": "IND",
+                "area_code": "560001"
+              }
+            }
+          },
+          "type": "Delivery",
+          "start": {
+            "location": {
+              "id": "merchant-167714647372249847",
+              "descriptor": {
+                "name": "Tipplr-swathi d"
+              },
+              "gps": "12.979612,77.590846",
+              "address": {
+                "city": "Bengaluru",
+                "area_code": "560001",
+                "locality": "Vasanth Nagar",
+                "state": "KA"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2024-06-14T11:23:24.387Z",
+                "end": "2024-06-14T12:08:24.387Z"
+              }
+            },
+            "contact": {
+              "phone": "8929221233",
+              "email": "support@tipplr.in"
+            }
+          },
+          "@ondc/org/provider_name": "TIPPLR_DELIVERY",
+          "state": {
+            "descriptor": {
+              "code": "Pending"
+            }
+          }
+        }
+      ],
+      "payment": {
+        "uri": "https://razorpay.com/",
+        "tl_method": "http/get",
+        "params": {
+          "amount": "1330.50",
+          "currency": "INR",
+          "transaction_id": "order_OMcgM99vweLceE"
+        },
+        "status": "PAID",
+        "type": "ON-ORDER",
+        "collected_by": "BAP",
+        "@ondc/org/buyer_app_finder_fee_type": "percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+        "@ondc/org/settlement_basis": "return_window_expiry",
+        "@ondc/org/settlement_window": "P1D",
+        "@ondc/org/withholding_amount": "39.91",
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "seller-app",
+            "settlement_phase": "sale-amount",
+            "settlement_type": "neft",
+            "upi_address": "9900818181@upi",
+            "settlement_bank_account_no": "50200053531451",
+            "settlement_ifsc_code": "HDFC0004051",
+            "beneficiary_name": "FOOD SPACE TECHNOLOGY PRIVATE LIMITED",
+            "bank_name": "HDFC Bank",
+            "branch_name": "CNN"
+          }
+        ]
+      },
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "1330.50"
+        },
+        "breakup": [
+          {
+            "@ondc/org/item_id": "food_item-170383210588937185",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "title": "Chicken pizza",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "2"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "1"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ],
+              "parent_item_id": "DI1"
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210588937185:603232",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "title": "Medium",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "1098"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "549"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "76859436"
+                    }
+                  ]
+                }
+              ],
+              "fulfillment_id": "merchant-167714647372249847",
+              "parent_item_id": "DI1"
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210588937185",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "55.00"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ],
+              "parent_item_id": "DI1"
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210597342600",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "title": "1 Idli 1 Vada",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "110"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "55"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210597342600",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "5.50"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Packing charges",
+            "@ondc/org/title_type": "packing",
+            "price": {
+              "currency": "INR",
+              "value": "10.5"
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Delivery charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "39"
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Convenience Fee",
+            "@ondc/org/title_type": "misc",
+            "price": {
+              "currency": "INR",
+              "value": "10.50"
+            }
+          }
+        ],
+        "ttl": "P1D"
+      },
+      "tags": [
+        {
+          "code": "bpp_terms",
+          "list": [
+            {
+              "code": "tax_number",
+              "value": "29AAECF1747N1Z6"
+            },
+            {
+              "code": "provider_tax_number",
+              "value": "AAECF1747N"
+            },
+            {
+              "code": "np_type",
+              "value": "ISN"
+            }
+          ]
+        },
+        {
+          "code": "bap_terms",
+          "list": [
+            {
+              "code": "tax_number",
+              "value": "GSTIN1234567890"
+            }
+          ]
+        }
+      ],
+      "created_at": "2024-06-14T11:23:24.147Z",
+      "updated_at": "2024-06-14T11:23:26.147Z"
+    }
+  }
+}

--- a/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow5/7. on_status_pending.json
+++ b/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow5/7. on_status_pending.json
@@ -1,0 +1,386 @@
+{
+  "message": {
+    "order": {
+      "id": "2024-06-14-220594",
+      "state": "Accepted",
+      "billing": {
+        "address": {
+          "name": "Nithin",
+          "building": "building",
+          "locality": "Dr Ambedkar Road",
+          "city": "Bengaluru",
+          "state": "Karnataka",
+          "country": "IND",
+          "area_code": "560001"
+        },
+        "phone": "8951440205",
+        "name": "Nithin",
+        "email": "nithin@gmail.com",
+        "created_at": "2024-06-14T11:23:03.080Z",
+        "updated_at": "2024-06-14T11:23:03.080Z"
+      },
+      "items": [
+        {
+          "id": "food_item-170383210597342600",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "merchant-167714647372249847"
+        },
+        {
+          "id": "food_item-170383210588937185",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "merchant-167714647372249847",
+          "parent_item_id": "DI1"
+        },
+        {
+          "id": "food_item-170383210588937185:603232",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "merchant-167714647372249847",
+          "tags": [
+            {
+              "code": "type",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "customization"
+                }
+              ]
+            },
+            {
+              "code": "parent",
+              "list": [
+                {
+                  "code": "id",
+                  "value": "76859436"
+                }
+              ]
+            }
+          ],
+          "parent_item_id": "DI1"
+        }
+      ],
+      "provider": {
+        "id": "merchant-167714647372249847",
+        "locations": [
+          {
+            "id": "merchant-167714647372249847"
+          }
+        ]
+      },
+      "fulfillments": [
+        {
+          "@ondc/org/TAT": "PT45M",
+          "id": "merchant-167714647372249847",
+          "tracking": true,
+          "end": {
+            "contact": {
+              "email": "nithin@gmail.com",
+              "phone": "8951440205"
+            },
+            "person": {
+              "name": "Nithin"
+            },
+            "location": {
+              "gps": "12.97943084572564,77.59098932147026",
+              "address": {
+                "name": "Nithin",
+                "building": "building",
+                "locality": "Dr Ambedkar Road",
+                "city": "Bengaluru",
+                "state": "Karnataka",
+                "country": "IND",
+                "area_code": "560001"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2024-06-14T11:23:53.228Z",
+                "end": "2024-06-14T12:08:53.228Z"
+              }
+            }
+          },
+          "type": "Delivery",
+          "start": {
+            "location": {
+              "id": "merchant-167714647372249847",
+              "descriptor": {
+                "name": "Tipplr-swathi d"
+              },
+              "gps": "12.979612,77.590846",
+              "address": {
+                "city": "Bengaluru",
+                "area_code": "560001",
+                "locality": "Vasanth Nagar",
+                "state": "KA"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2024-06-14T11:23:24.387Z",
+                "end": "2024-06-14T12:08:24.387Z"
+              }
+            },
+            "contact": {
+              "phone": "8929221233",
+              "email": "support@tipplr.in"
+            }
+          },
+          "@ondc/org/provider_name": "TIPPLR_DELIVERY",
+          "state": {
+            "descriptor": {
+              "code": "Pending"
+            }
+          },
+          "tags": [
+            {
+              "code": "routing",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "P2P"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "payment": {
+        "uri": "https://razorpay.com/",
+        "tl_method": "http/get",
+        "params": {
+          "amount": "1330.50",
+          "currency": "INR",
+          "transaction_id": "order_OMcgM99vweLceE"
+        },
+        "status": "PAID",
+        "type": "ON-ORDER",
+        "collected_by": "BAP",
+        "@ondc/org/buyer_app_finder_fee_type": "percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+        "@ondc/org/settlement_basis": "return_window_expiry",
+        "@ondc/org/settlement_window": "P1D",
+        "@ondc/org/withholding_amount": "39.91",
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "seller-app",
+            "settlement_phase": "sale-amount",
+            "settlement_type": "neft",
+            "upi_address": "9900818181@upi",
+            "settlement_bank_account_no": "50200053531451",
+            "settlement_ifsc_code": "HDFC0004051",
+            "beneficiary_name": "FOOD SPACE TECHNOLOGY PRIVATE LIMITED",
+            "bank_name": "HDFC Bank",
+            "branch_name": "CNN"
+          }
+        ]
+      },
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "1330.50"
+        },
+        "breakup": [
+          {
+            "@ondc/org/item_id": "food_item-170383210588937185",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "title": "Chicken pizza",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "2"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "1"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ],
+              "parent_item_id": "DI1"
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210588937185:603232",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "title": "Medium",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "1098"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "549"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "76859436"
+                    }
+                  ]
+                }
+              ],
+              "fulfillment_id": "merchant-167714647372249847",
+              "parent_item_id": "DI1"
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210588937185",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "55.00"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ],
+              "parent_item_id": "DI1"
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210597342600",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "title": "1 Idli 1 Vada",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "110"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "55"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210597342600",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "5.50"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Packing charges",
+            "@ondc/org/title_type": "packing",
+            "price": {
+              "currency": "INR",
+              "value": "10.5"
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Delivery charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "39"
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Convenience Fee",
+            "@ondc/org/title_type": "misc",
+            "price": {
+              "currency": "INR",
+              "value": "10.50"
+            }
+          }
+        ],
+        "ttl": "P1D"
+      },
+      "created_at": "2024-06-14T11:23:24.147Z",
+      "updated_at": "2024-06-14T11:23:53.228Z",
+      "documents": [
+        {
+          "url": "https://tipplr-media.s3.ap-south-1.amazonaws.com/images/Invoice-BNWV79ZYI2CP6WL.pdf",
+          "label": "Invoice"
+        }
+      ]
+    }
+  },
+  "context": {
+    "domain": "ONDC:RET11",
+    "country": "IND",
+    "city": "std:080",
+    "action": "on_status",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_uri": "https://preprod.tipplr.in/ondc/v2",
+    "transaction_id": "a39edcc0-0455-445d-90b4-e5eb80a103c3",
+    "message_id": "4d8b9c3b-b17d-4ba3-a05f-3b091137ec3b",
+    "timestamp": "2024-06-14T11:23:53.228Z",
+    "bpp_id": "preprod.tipplr.in"
+  }
+}

--- a/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow5/8. on_status_packed.json
+++ b/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow5/8. on_status_packed.json
@@ -1,0 +1,386 @@
+{
+  "message": {
+    "order": {
+      "id": "2024-06-14-220594",
+      "state": "In-progress",
+      "billing": {
+        "address": {
+          "name": "Nithin",
+          "building": "building",
+          "locality": "Dr Ambedkar Road",
+          "city": "Bengaluru",
+          "state": "Karnataka",
+          "country": "IND",
+          "area_code": "560001"
+        },
+        "phone": "8951440205",
+        "name": "Nithin",
+        "email": "nithin@gmail.com",
+        "created_at": "2024-06-14T11:23:03.080Z",
+        "updated_at": "2024-06-14T11:23:03.080Z"
+      },
+      "items": [
+        {
+          "id": "food_item-170383210597342600",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "merchant-167714647372249847"
+        },
+        {
+          "id": "food_item-170383210588937185",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "merchant-167714647372249847",
+          "parent_item_id": "DI1"
+        },
+        {
+          "id": "food_item-170383210588937185:603232",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "merchant-167714647372249847",
+          "tags": [
+            {
+              "code": "type",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "customization"
+                }
+              ]
+            },
+            {
+              "code": "parent",
+              "list": [
+                {
+                  "code": "id",
+                  "value": "76859436"
+                }
+              ]
+            }
+          ],
+          "parent_item_id": "DI1"
+        }
+      ],
+      "provider": {
+        "id": "merchant-167714647372249847",
+        "locations": [
+          {
+            "id": "merchant-167714647372249847"
+          }
+        ]
+      },
+      "fulfillments": [
+        {
+          "@ondc/org/TAT": "PT45M",
+          "id": "merchant-167714647372249847",
+          "tracking": true,
+          "end": {
+            "contact": {
+              "email": "nithin@gmail.com",
+              "phone": "8951440205"
+            },
+            "person": {
+              "name": "Nithin"
+            },
+            "location": {
+              "gps": "12.97943084572564,77.59098932147026",
+              "address": {
+                "name": "Nithin",
+                "building": "building",
+                "locality": "Dr Ambedkar Road",
+                "city": "Bengaluru",
+                "state": "Karnataka",
+                "country": "IND",
+                "area_code": "560001"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2024-06-14T11:23:24.387Z",
+                "end": "2024-06-14T12:08:24.387Z"
+              }
+            }
+          },
+          "type": "Delivery",
+          "start": {
+            "location": {
+              "id": "merchant-167714647372249847",
+              "descriptor": {
+                "name": "Tipplr-swathi d"
+              },
+              "gps": "12.979612,77.590846",
+              "address": {
+                "city": "Bengaluru",
+                "area_code": "560001",
+                "locality": "Vasanth Nagar",
+                "state": "KA"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2024-06-14T11:23:24.387Z",
+                "end": "2024-06-14T12:08:24.387Z"
+              }
+            },
+            "contact": {
+              "phone": "8929221233",
+              "email": "support@tipplr.in"
+            }
+          },
+          "@ondc/org/provider_name": "TIPPLR_DELIVERY",
+          "state": {
+            "descriptor": {
+              "code": "Packed"
+            }
+          },
+          "tags": [
+            {
+              "code": "routing",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "P2P"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "payment": {
+        "uri": "https://razorpay.com/",
+        "tl_method": "http/get",
+        "params": {
+          "amount": "1330.50",
+          "currency": "INR",
+          "transaction_id": "order_OMcgM99vweLceE"
+        },
+        "status": "PAID",
+        "type": "ON-ORDER",
+        "collected_by": "BAP",
+        "@ondc/org/buyer_app_finder_fee_type": "percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+        "@ondc/org/settlement_basis": "return_window_expiry",
+        "@ondc/org/settlement_window": "P1D",
+        "@ondc/org/withholding_amount": "39.91",
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "seller-app",
+            "settlement_phase": "sale-amount",
+            "settlement_type": "neft",
+            "upi_address": "9900818181@upi",
+            "settlement_bank_account_no": "50200053531451",
+            "settlement_ifsc_code": "HDFC0004051",
+            "beneficiary_name": "FOOD SPACE TECHNOLOGY PRIVATE LIMITED",
+            "bank_name": "HDFC Bank",
+            "branch_name": "CNN"
+          }
+        ]
+      },
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "1330.50"
+        },
+        "breakup": [
+          {
+            "@ondc/org/item_id": "food_item-170383210588937185",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "title": "Chicken pizza",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "2"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "1"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ],
+              "parent_item_id": "DI1"
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210588937185:603232",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "title": "Medium",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "1098"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "549"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "76859436"
+                    }
+                  ]
+                }
+              ],
+              "fulfillment_id": "merchant-167714647372249847",
+              "parent_item_id": "DI1"
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210588937185",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "55.00"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ],
+              "parent_item_id": "DI1"
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210597342600",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "title": "1 Idli 1 Vada",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "110"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "55"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210597342600",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "5.50"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Packing charges",
+            "@ondc/org/title_type": "packing",
+            "price": {
+              "currency": "INR",
+              "value": "10.5"
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Delivery charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "39"
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Convenience Fee",
+            "@ondc/org/title_type": "misc",
+            "price": {
+              "currency": "INR",
+              "value": "10.50"
+            }
+          }
+        ],
+        "ttl": "P1D"
+      },
+      "created_at": "2024-06-14T11:23:24.147Z",
+      "updated_at": "2024-06-14T11:24:04.910Z",
+      "documents": [
+        {
+          "url": "https://tipplr-media.s3.ap-south-1.amazonaws.com/images/Invoice-BNWV79ZYI2CP6WL.pdf",
+          "label": "Invoice"
+        }
+      ]
+    }
+  },
+  "context": {
+    "domain": "ONDC:RET11",
+    "country": "IND",
+    "city": "std:080",
+    "action": "on_status",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_uri": "https://preprod.tipplr.in/ondc/v2",
+    "transaction_id": "a39edcc0-0455-445d-90b4-e5eb80a103c3",
+    "message_id": "d7923fbe-5f68-4b94-b2f2-88f8a6a9cb5d",
+    "timestamp": "2024-06-14T11:24:04.910Z",
+    "bpp_id": "preprod.tipplr.in"
+  }
+}

--- a/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow5/9. on_status_picked.json
+++ b/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow5/9. on_status_picked.json
@@ -1,0 +1,391 @@
+{
+  "message": {
+    "order": {
+      "id": "2024-06-14-220594",
+      "state": "In-progress",
+      "billing": {
+        "address": {
+          "name": "Nithin",
+          "building": "building",
+          "locality": "Dr Ambedkar Road",
+          "city": "Bengaluru",
+          "state": "Karnataka",
+          "country": "IND",
+          "area_code": "560001"
+        },
+        "phone": "8951440205",
+        "name": "Nithin",
+        "email": "nithin@gmail.com",
+        "created_at": "2024-06-14T11:23:03.080Z",
+        "updated_at": "2024-06-14T11:23:03.080Z"
+      },
+      "items": [
+        {
+          "id": "food_item-170383210597342600",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "merchant-167714647372249847"
+        },
+        {
+          "id": "food_item-170383210588937185",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "merchant-167714647372249847",
+          "parent_item_id": "DI1"
+        },
+        {
+          "id": "food_item-170383210588937185:603232",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "merchant-167714647372249847",
+          "tags": [
+            {
+              "code": "type",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "customization"
+                }
+              ]
+            },
+            {
+              "code": "parent",
+              "list": [
+                {
+                  "code": "id",
+                  "value": "76859436"
+                }
+              ]
+            }
+          ],
+          "parent_item_id": "DI1"
+        }
+      ],
+      "provider": {
+        "id": "merchant-167714647372249847",
+        "locations": [
+          {
+            "id": "merchant-167714647372249847"
+          }
+        ]
+      },
+      "fulfillments": [
+        {
+          "@ondc/org/TAT": "PT45M",
+          "id": "merchant-167714647372249847",
+          "tracking": true,
+          "end": {
+            "contact": {
+              "email": "nithin@gmail.com",
+              "phone": "8951440205"
+            },
+            "person": {
+              "name": "Nithin"
+            },
+            "location": {
+              "gps": "12.97943084572564,77.59098932147026",
+              "address": {
+                "name": "Nithin",
+                "building": "building",
+                "locality": "Dr Ambedkar Road",
+                "city": "Bengaluru",
+                "state": "Karnataka",
+                "country": "IND",
+                "area_code": "560001"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2024-06-14T11:23:24.387Z",
+                "end": "2024-06-14T12:08:24.387Z"
+              }
+            }
+          },
+          "type": "Delivery",
+          "start": {
+            "location": {
+              "id": "merchant-167714647372249847",
+              "descriptor": {
+                "name": "Tipplr-swathi d"
+              },
+              "gps": "12.979612,77.590846",
+              "address": {
+                "city": "Bengaluru",
+                "area_code": "560001",
+                "locality": "Vasanth Nagar",
+                "state": "KA"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2024-06-14T11:23:24.387Z",
+                "end": "2024-06-14T12:08:24.387Z"
+              },
+              "timestamp": "2024-06-14T11:24:09.053Z"
+            },
+            "contact": {
+              "phone": "8929221233",
+              "email": "support@tipplr.in"
+            }
+          },
+          "@ondc/org/provider_name": "TIPPLR_DELIVERY",
+          "state": {
+            "descriptor": {
+              "code": "Order-picked-up"
+            }
+          },
+          "tags": [
+            {
+              "code": "routing",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "P2P"
+                }
+              ]
+            }
+          ],
+          "agent": {
+            "name": "Channappa",
+            "phone": "8310422896"
+          }
+        }
+      ],
+      "payment": {
+        "uri": "https://razorpay.com/",
+        "tl_method": "http/get",
+        "params": {
+          "amount": "1330.50",
+          "currency": "INR",
+          "transaction_id": "order_OMcgM99vweLceE"
+        },
+        "status": "PAID",
+        "type": "ON-ORDER",
+        "collected_by": "BAP",
+        "@ondc/org/buyer_app_finder_fee_type": "percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+        "@ondc/org/settlement_basis": "return_window_expiry",
+        "@ondc/org/settlement_window": "P1D",
+        "@ondc/org/withholding_amount": "39.91",
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "seller-app",
+            "settlement_phase": "sale-amount",
+            "settlement_type": "neft",
+            "upi_address": "9900818181@upi",
+            "settlement_bank_account_no": "50200053531451",
+            "settlement_ifsc_code": "HDFC0004051",
+            "beneficiary_name": "FOOD SPACE TECHNOLOGY PRIVATE LIMITED",
+            "bank_name": "HDFC Bank",
+            "branch_name": "CNN"
+          }
+        ]
+      },
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "1330.50"
+        },
+        "breakup": [
+          {
+            "@ondc/org/item_id": "food_item-170383210588937185",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "title": "Chicken pizza",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "2"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "1"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ],
+              "parent_item_id": "DI1"
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210588937185:603232",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "title": "Medium",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "1098"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "549"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "76859436"
+                    }
+                  ]
+                }
+              ],
+              "fulfillment_id": "merchant-167714647372249847",
+              "parent_item_id": "DI1"
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210588937185",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "55.00"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ],
+              "parent_item_id": "DI1"
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210597342600",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "title": "1 Idli 1 Vada",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "110"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "55"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210597342600",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "5.50"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Packing charges",
+            "@ondc/org/title_type": "packing",
+            "price": {
+              "currency": "INR",
+              "value": "10.5"
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Delivery charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "39"
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Convenience Fee",
+            "@ondc/org/title_type": "misc",
+            "price": {
+              "currency": "INR",
+              "value": "10.50"
+            }
+          }
+        ],
+        "ttl": "P1D"
+      },
+      "created_at": "2024-06-14T11:23:24.147Z",
+      "updated_at": "2024-06-14T11:24:09.053Z",
+      "documents": [
+        {
+          "url": "https://tipplr-media.s3.ap-south-1.amazonaws.com/images/Invoice-BNWV79ZYI2CP6WL.pdf",
+          "label": "Invoice"
+        }
+      ]
+    }
+  },
+  "context": {
+    "domain": "ONDC:RET11",
+    "country": "IND",
+    "city": "std:080",
+    "action": "on_status",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_uri": "https://preprod.tipplr.in/ondc/v2",
+    "transaction_id": "a39edcc0-0455-445d-90b4-e5eb80a103c3",
+    "message_id": "a6495f55-db42-4cb1-9b4d-6e7f3843f124",
+    "timestamp": "2024-06-14T11:24:09.053Z",
+    "bpp_id": "preprod.tipplr.in"
+  }
+}

--- a/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow6/1. select.json
+++ b/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow6/1. select.json
@@ -1,0 +1,93 @@
+{
+  "context": {
+    "domain": "ONDC:RET11",
+    "country": "IND",
+    "city": "std:080",
+    "action": "select",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_uri": "https://preprod.tipplr.in/ondc/v2",
+    "transaction_id": "fd7605ff-aefc-470f-8b26-127b212f9b81",
+    "message_id": "36db5585-263b-41c9-b4b8-0f58e93fea9a",
+    "timestamp": "2024-06-14T11:02:32.032Z",
+    "bpp_id": "preprod.tipplr.in",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "items": [
+        {
+          "id": "food_item-170383210597342600",
+          "quantity": {
+            "count": 2
+          },
+          "location_id": "merchant-167714647372249847"
+        },
+        {
+          "id": "food_item-170383210588937185",
+          "quantity": {
+            "count": 2
+          },
+          "location_id": "merchant-167714647372249847",
+          "parent_item_id": "DI1"
+        },
+        {
+          "id": "food_item-170383210588937185:603230",
+          "quantity": {
+            "count": 2
+          },
+          "location_id": "merchant-167714647372249847",
+          "tags": [
+            {
+              "code": "type",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "customization"
+                }
+              ]
+            },
+            {
+              "code": "parent",
+              "list": [
+                {
+                  "code": "id",
+                  "value": "76859436"
+                }
+              ]
+            }
+          ],
+          "parent_item_id": "DI1"
+        },
+        {
+          "id": "food_item-170383210627835789",
+          "quantity": {
+            "count": 2
+          },
+          "location_id": "merchant-167714647372249847"
+        }
+      ],
+      "provider": {
+        "id": "merchant-167714647372249847",
+        "locations": [
+          {
+            "id": "merchant-167714647372249847"
+          }
+        ]
+      },
+      "fulfillments": [
+        {
+          "end": {
+            "location": {
+              "gps": "12.97943084572564,77.59098932147026",
+              "address": {
+                "area_code": "560001"
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow6/10. on_status_packed.json
+++ b/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow6/10. on_status_packed.json
@@ -1,0 +1,470 @@
+{
+  "message": {
+    "order": {
+      "id": "2024-06-14-884454",
+      "state": "In-progress",
+      "provider": {
+        "id": "merchant-167714647372249847",
+        "locations": [
+          {
+            "id": "merchant-167714647372249847"
+          }
+        ]
+      },
+      "items": [
+        {
+          "id": "food_item-170383210597342600",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "merchant-167714647372249847"
+        },
+        {
+          "id": "food_item-170383210588937185",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "merchant-167714647372249847",
+          "parent_item_id": "DI1"
+        },
+        {
+          "id": "food_item-170383210588937185:603230",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "merchant-167714647372249847",
+          "tags": [
+            {
+              "code": "type",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "customization"
+                }
+              ]
+            },
+            {
+              "code": "parent",
+              "list": [
+                {
+                  "code": "id",
+                  "value": "76859436"
+                }
+              ]
+            }
+          ],
+          "parent_item_id": "DI1"
+        },
+        {
+          "id": "food_item-170383210627835789",
+          "quantity": {
+            "count": 0
+          },
+          "fulfillment_id": "merchant-167714647372249847"
+        },
+        {
+          "id": "food_item-170383210627835789",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "C1"
+        }
+      ],
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "732"
+        },
+        "breakup": [
+          {
+            "@ondc/org/item_id": "food_item-170383210588937185",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "title": "Chicken pizza",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "2"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "1"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ],
+              "parent_item_id": "DI1"
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210588937185:603230",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "title": "Regular",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "518"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "259"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "76859436"
+                    }
+                  ]
+                }
+              ],
+              "fulfillment_id": "merchant-167714647372249847",
+              "parent_item_id": "DI1"
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210588937185",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "26.00"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ],
+              "parent_item_id": "DI1"
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210597342600",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "title": "1 Idli 1 Vada",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "110"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "55"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210597342600",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "5.50"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Packing charges",
+            "@ondc/org/title_type": "packing",
+            "price": {
+              "currency": "INR",
+              "value": "21"
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Delivery charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "39"
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Convenience Fee",
+            "@ondc/org/title_type": "misc",
+            "price": {
+              "currency": "INR",
+              "value": "10.50"
+            }
+          }
+        ],
+        "ttl": "PT1H"
+      },
+      "billing": {
+        "address": {
+          "name": "Nithin",
+          "building": "building",
+          "locality": "Dr Ambedkar Road",
+          "city": "Bengaluru",
+          "state": "Karnataka",
+          "country": "IND",
+          "area_code": "560001"
+        },
+        "phone": "8951440205",
+        "name": "Nithin",
+        "email": "nithin@gmail.com",
+        "created_at": "2024-06-14T11:02:43.429Z",
+        "updated_at": "2024-06-14T11:02:43.429Z"
+      },
+      "payment": {
+        "uri": "https://razorpay.com/",
+        "tl_method": "http/get",
+        "params": {
+          "amount": "879.00",
+          "currency": "INR",
+          "transaction_id": "order_OMcKrZ5NeGGgiO"
+        },
+        "status": "PAID",
+        "type": "ON-ORDER",
+        "collected_by": "BAP",
+        "@ondc/org/buyer_app_finder_fee_type": "percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "seller-app",
+            "settlement_phase": "sale-amount",
+            "settlement_type": "neft",
+            "upi_address": "9900818181@upi",
+            "settlement_bank_account_no": "50200053531451",
+            "settlement_ifsc_code": "HDFC0004051",
+            "beneficiary_name": "FOOD SPACE TECHNOLOGY PRIVATE LIMITED",
+            "bank_name": "HDFC Bank",
+            "branch_name": "CNN"
+          },
+          {
+            "settlement_counterparty": "buyer",
+            "settlement_phase": "refund",
+            "settlement_type": "netbanking",
+            "settlement_amount": "147",
+            "settlement_timestamp": "2024-06-14T11:03:19.408Z"
+          }
+        ]
+      },
+      "fulfillments": [
+        {
+          "@ondc/org/TAT": "PT45M",
+          "id": "merchant-167714647372249847",
+          "tracking": true,
+          "end": {
+            "contact": {
+              "email": "nithin@gmail.com",
+              "phone": "8951440205"
+            },
+            "person": {
+              "name": "Nithin"
+            },
+            "location": {
+              "gps": "12.97943084572564,77.59098932147026",
+              "address": {
+                "name": "Nithin",
+                "building": "building",
+                "locality": "Dr Ambedkar Road",
+                "city": "Bengaluru",
+                "state": "Karnataka",
+                "country": "IND",
+                "area_code": "560001"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2024-06-14T11:03:06.567Z",
+                "end": "2024-06-14T11:48:06.567Z"
+              }
+            }
+          },
+          "type": "Delivery",
+          "start": {
+            "location": {
+              "id": "merchant-167714647372249847",
+              "descriptor": {
+                "name": "Tipplr-swathi d"
+              },
+              "gps": "12.979612,77.590846",
+              "address": {
+                "city": "Bengaluru",
+                "area_code": "560001",
+                "locality": "Vasanth Nagar",
+                "state": "KA"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2024-06-14T11:03:06.567Z",
+                "end": "2024-06-14T11:48:06.567Z"
+              }
+            },
+            "contact": {
+              "phone": "8929221233",
+              "email": "support@tipplr.in"
+            }
+          },
+          "@ondc/org/provider_name": "TIPPLR_DELIVERY",
+          "state": {
+            "descriptor": {
+              "code": "Packed"
+            }
+          },
+          "tags": [
+            {
+              "code": "routing",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "P2P"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "id": "C1",
+          "state": {
+            "descriptor": {
+              "code": "Cancelled"
+            }
+          },
+          "type": "Cancel",
+          "tags": [
+            {
+              "code": "cancel_request",
+              "list": [
+                {
+                  "code": "reason_id",
+                  "value": "002"
+                },
+                {
+                  "code": "initiated_by",
+                  "value": "preprod.tipplr.in"
+                }
+              ]
+            },
+            {
+              "code": "quote_trail",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "item"
+                },
+                {
+                  "code": "id",
+                  "value": "food_item-170383210627835789"
+                },
+                {
+                  "code": "currency",
+                  "value": "INR"
+                },
+                {
+                  "code": "value",
+                  "value": "-140"
+                }
+              ]
+            },
+            {
+              "code": "quote_trail",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "tax"
+                },
+                {
+                  "code": "id",
+                  "value": "food_item-170383210627835789"
+                },
+                {
+                  "code": "currency",
+                  "value": "INR"
+                },
+                {
+                  "code": "value",
+                  "value": "-7.00"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "created_at": "2024-06-14T11:03:06.264Z",
+      "updated_at": "2024-06-14T11:03:51.097Z",
+      "documents": [
+        {
+          "url": "https://tipplr-media.s3.ap-south-1.amazonaws.com/images/Invoice-26SWVY51CSGOW8U.pdf",
+          "label": "Invoice"
+        }
+      ]
+    }
+  },
+  "context": {
+    "domain": "ONDC:RET11",
+    "country": "IND",
+    "city": "std:080",
+    "action": "on_status",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_uri": "https://preprod.tipplr.in/ondc/v2",
+    "transaction_id": "fd7605ff-aefc-470f-8b26-127b212f9b81",
+    "message_id": "ca87aaf5-310e-4ed6-b1ae-6f9faa455c5c",
+    "timestamp": "2024-06-14T11:03:51.097Z",
+    "bpp_id": "preprod.tipplr.in"
+  }
+}

--- a/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow6/11. on_status_picked.json
+++ b/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow6/11. on_status_picked.json
@@ -1,0 +1,475 @@
+{
+  "message": {
+    "order": {
+      "id": "2024-06-14-884454",
+      "state": "In-progress",
+      "provider": {
+        "id": "merchant-167714647372249847",
+        "locations": [
+          {
+            "id": "merchant-167714647372249847"
+          }
+        ]
+      },
+      "items": [
+        {
+          "id": "food_item-170383210597342600",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "merchant-167714647372249847"
+        },
+        {
+          "id": "food_item-170383210588937185",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "merchant-167714647372249847",
+          "parent_item_id": "DI1"
+        },
+        {
+          "id": "food_item-170383210588937185:603230",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "merchant-167714647372249847",
+          "tags": [
+            {
+              "code": "type",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "customization"
+                }
+              ]
+            },
+            {
+              "code": "parent",
+              "list": [
+                {
+                  "code": "id",
+                  "value": "76859436"
+                }
+              ]
+            }
+          ],
+          "parent_item_id": "DI1"
+        },
+        {
+          "id": "food_item-170383210627835789",
+          "quantity": {
+            "count": 0
+          },
+          "fulfillment_id": "merchant-167714647372249847"
+        },
+        {
+          "id": "food_item-170383210627835789",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "C1"
+        }
+      ],
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "732"
+        },
+        "breakup": [
+          {
+            "@ondc/org/item_id": "food_item-170383210588937185",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "title": "Chicken pizza",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "2"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "1"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ],
+              "parent_item_id": "DI1"
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210588937185:603230",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "title": "Regular",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "518"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "259"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "76859436"
+                    }
+                  ]
+                }
+              ],
+              "fulfillment_id": "merchant-167714647372249847",
+              "parent_item_id": "DI1"
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210588937185",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "26.00"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ],
+              "parent_item_id": "DI1"
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210597342600",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "title": "1 Idli 1 Vada",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "110"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "55"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210597342600",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "5.50"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Packing charges",
+            "@ondc/org/title_type": "packing",
+            "price": {
+              "currency": "INR",
+              "value": "21"
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Delivery charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "39"
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Convenience Fee",
+            "@ondc/org/title_type": "misc",
+            "price": {
+              "currency": "INR",
+              "value": "10.50"
+            }
+          }
+        ],
+        "ttl": "PT1H"
+      },
+      "billing": {
+        "address": {
+          "name": "Nithin",
+          "building": "building",
+          "locality": "Dr Ambedkar Road",
+          "city": "Bengaluru",
+          "state": "Karnataka",
+          "country": "IND",
+          "area_code": "560001"
+        },
+        "phone": "8951440205",
+        "name": "Nithin",
+        "email": "nithin@gmail.com",
+        "created_at": "2024-06-14T11:02:43.429Z",
+        "updated_at": "2024-06-14T11:02:43.429Z"
+      },
+      "payment": {
+        "uri": "https://razorpay.com/",
+        "tl_method": "http/get",
+        "params": {
+          "amount": "879.00",
+          "currency": "INR",
+          "transaction_id": "order_OMcKrZ5NeGGgiO"
+        },
+        "status": "PAID",
+        "type": "ON-ORDER",
+        "collected_by": "BAP",
+        "@ondc/org/buyer_app_finder_fee_type": "percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "seller-app",
+            "settlement_phase": "sale-amount",
+            "settlement_type": "neft",
+            "upi_address": "9900818181@upi",
+            "settlement_bank_account_no": "50200053531451",
+            "settlement_ifsc_code": "HDFC0004051",
+            "beneficiary_name": "FOOD SPACE TECHNOLOGY PRIVATE LIMITED",
+            "bank_name": "HDFC Bank",
+            "branch_name": "CNN"
+          },
+          {
+            "settlement_counterparty": "buyer",
+            "settlement_phase": "refund",
+            "settlement_type": "netbanking",
+            "settlement_amount": "147",
+            "settlement_timestamp": "2024-06-14T11:03:19.408Z"
+          }
+        ]
+      },
+      "fulfillments": [
+        {
+          "@ondc/org/TAT": "PT45M",
+          "id": "merchant-167714647372249847",
+          "tracking": true,
+          "end": {
+            "contact": {
+              "email": "nithin@gmail.com",
+              "phone": "8951440205"
+            },
+            "person": {
+              "name": "Nithin"
+            },
+            "location": {
+              "gps": "12.97943084572564,77.59098932147026",
+              "address": {
+                "name": "Nithin",
+                "building": "building",
+                "locality": "Dr Ambedkar Road",
+                "city": "Bengaluru",
+                "state": "Karnataka",
+                "country": "IND",
+                "area_code": "560001"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2024-06-14T11:03:06.567Z",
+                "end": "2024-06-14T11:48:06.567Z"
+              }
+            }
+          },
+          "type": "Delivery",
+          "start": {
+            "location": {
+              "id": "merchant-167714647372249847",
+              "descriptor": {
+                "name": "Tipplr-swathi d"
+              },
+              "gps": "12.979612,77.590846",
+              "address": {
+                "city": "Bengaluru",
+                "area_code": "560001",
+                "locality": "Vasanth Nagar",
+                "state": "KA"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2024-06-14T11:03:06.567Z",
+                "end": "2024-06-14T11:48:06.567Z"
+              },
+              "timestamp": "2024-06-14T11:03:59.082Z"
+            },
+            "contact": {
+              "phone": "8929221233",
+              "email": "support@tipplr.in"
+            }
+          },
+          "@ondc/org/provider_name": "TIPPLR_DELIVERY",
+          "state": {
+            "descriptor": {
+              "code": "Order-picked-up"
+            }
+          },
+          "tags": [
+            {
+              "code": "routing",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "P2P"
+                }
+              ]
+            }
+          ],
+          "agent": {
+            "name": "Channappa",
+            "phone": "8310422896"
+          }
+        },
+        {
+          "id": "C1",
+          "state": {
+            "descriptor": {
+              "code": "Cancelled"
+            }
+          },
+          "type": "Cancel",
+          "tags": [
+            {
+              "code": "cancel_request",
+              "list": [
+                {
+                  "code": "reason_id",
+                  "value": "002"
+                },
+                {
+                  "code": "initiated_by",
+                  "value": "preprod.tipplr.in"
+                }
+              ]
+            },
+            {
+              "code": "quote_trail",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "item"
+                },
+                {
+                  "code": "id",
+                  "value": "food_item-170383210627835789"
+                },
+                {
+                  "code": "currency",
+                  "value": "INR"
+                },
+                {
+                  "code": "value",
+                  "value": "-140"
+                }
+              ]
+            },
+            {
+              "code": "quote_trail",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "tax"
+                },
+                {
+                  "code": "id",
+                  "value": "food_item-170383210627835789"
+                },
+                {
+                  "code": "currency",
+                  "value": "INR"
+                },
+                {
+                  "code": "value",
+                  "value": "-7.00"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "created_at": "2024-06-14T11:03:06.264Z",
+      "updated_at": "2024-06-14T11:03:59.082Z",
+      "documents": [
+        {
+          "url": "https://tipplr-media.s3.ap-south-1.amazonaws.com/images/Invoice-26SWVY51CSGOW8U.pdf",
+          "label": "Invoice"
+        }
+      ]
+    }
+  },
+  "context": {
+    "domain": "ONDC:RET11",
+    "country": "IND",
+    "city": "std:080",
+    "action": "on_status",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_uri": "https://preprod.tipplr.in/ondc/v2",
+    "transaction_id": "fd7605ff-aefc-470f-8b26-127b212f9b81",
+    "message_id": "fde19f68-ba0e-454c-b3c1-be066ccb0018",
+    "timestamp": "2024-06-14T11:03:59.082Z",
+    "bpp_id": "preprod.tipplr.in"
+  }
+}

--- a/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow6/12. on_status_out_for_delivery.json
+++ b/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow6/12. on_status_out_for_delivery.json
@@ -1,0 +1,475 @@
+{
+  "message": {
+    "order": {
+      "id": "2024-06-14-884454",
+      "state": "In-progress",
+      "provider": {
+        "id": "merchant-167714647372249847",
+        "locations": [
+          {
+            "id": "merchant-167714647372249847"
+          }
+        ]
+      },
+      "items": [
+        {
+          "id": "food_item-170383210597342600",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "merchant-167714647372249847"
+        },
+        {
+          "id": "food_item-170383210588937185",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "merchant-167714647372249847",
+          "parent_item_id": "DI1"
+        },
+        {
+          "id": "food_item-170383210588937185:603230",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "merchant-167714647372249847",
+          "tags": [
+            {
+              "code": "type",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "customization"
+                }
+              ]
+            },
+            {
+              "code": "parent",
+              "list": [
+                {
+                  "code": "id",
+                  "value": "76859436"
+                }
+              ]
+            }
+          ],
+          "parent_item_id": "DI1"
+        },
+        {
+          "id": "food_item-170383210627835789",
+          "quantity": {
+            "count": 0
+          },
+          "fulfillment_id": "merchant-167714647372249847"
+        },
+        {
+          "id": "food_item-170383210627835789",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "C1"
+        }
+      ],
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "732"
+        },
+        "breakup": [
+          {
+            "@ondc/org/item_id": "food_item-170383210588937185",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "title": "Chicken pizza",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "2"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "1"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ],
+              "parent_item_id": "DI1"
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210588937185:603230",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "title": "Regular",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "518"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "259"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "76859436"
+                    }
+                  ]
+                }
+              ],
+              "fulfillment_id": "merchant-167714647372249847",
+              "parent_item_id": "DI1"
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210588937185",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "26.00"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ],
+              "parent_item_id": "DI1"
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210597342600",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "title": "1 Idli 1 Vada",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "110"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "55"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210597342600",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "5.50"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Packing charges",
+            "@ondc/org/title_type": "packing",
+            "price": {
+              "currency": "INR",
+              "value": "21"
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Delivery charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "39"
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Convenience Fee",
+            "@ondc/org/title_type": "misc",
+            "price": {
+              "currency": "INR",
+              "value": "10.50"
+            }
+          }
+        ],
+        "ttl": "PT1H"
+      },
+      "billing": {
+        "address": {
+          "name": "Nithin",
+          "building": "building",
+          "locality": "Dr Ambedkar Road",
+          "city": "Bengaluru",
+          "state": "Karnataka",
+          "country": "IND",
+          "area_code": "560001"
+        },
+        "phone": "8951440205",
+        "name": "Nithin",
+        "email": "nithin@gmail.com",
+        "created_at": "2024-06-14T11:02:43.429Z",
+        "updated_at": "2024-06-14T11:02:43.429Z"
+      },
+      "payment": {
+        "uri": "https://razorpay.com/",
+        "tl_method": "http/get",
+        "params": {
+          "amount": "879.00",
+          "currency": "INR",
+          "transaction_id": "order_OMcKrZ5NeGGgiO"
+        },
+        "status": "PAID",
+        "type": "ON-ORDER",
+        "collected_by": "BAP",
+        "@ondc/org/buyer_app_finder_fee_type": "percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "seller-app",
+            "settlement_phase": "sale-amount",
+            "settlement_type": "neft",
+            "upi_address": "9900818181@upi",
+            "settlement_bank_account_no": "50200053531451",
+            "settlement_ifsc_code": "HDFC0004051",
+            "beneficiary_name": "FOOD SPACE TECHNOLOGY PRIVATE LIMITED",
+            "bank_name": "HDFC Bank",
+            "branch_name": "CNN"
+          },
+          {
+            "settlement_counterparty": "buyer",
+            "settlement_phase": "refund",
+            "settlement_type": "netbanking",
+            "settlement_amount": "147",
+            "settlement_timestamp": "2024-06-14T11:03:19.408Z"
+          }
+        ]
+      },
+      "fulfillments": [
+        {
+          "@ondc/org/TAT": "PT45M",
+          "id": "merchant-167714647372249847",
+          "tracking": true,
+          "end": {
+            "contact": {
+              "email": "nithin@gmail.com",
+              "phone": "8951440205"
+            },
+            "person": {
+              "name": "Nithin"
+            },
+            "location": {
+              "gps": "12.97943084572564,77.59098932147026",
+              "address": {
+                "name": "Nithin",
+                "building": "building",
+                "locality": "Dr Ambedkar Road",
+                "city": "Bengaluru",
+                "state": "Karnataka",
+                "country": "IND",
+                "area_code": "560001"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2024-06-14T11:03:06.567Z",
+                "end": "2024-06-14T11:48:06.567Z"
+              }
+            }
+          },
+          "type": "Delivery",
+          "start": {
+            "location": {
+              "id": "merchant-167714647372249847",
+              "descriptor": {
+                "name": "Tipplr-swathi d"
+              },
+              "gps": "12.979612,77.590846",
+              "address": {
+                "city": "Bengaluru",
+                "area_code": "560001",
+                "locality": "Vasanth Nagar",
+                "state": "KA"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2024-06-14T11:03:06.567Z",
+                "end": "2024-06-14T11:48:06.567Z"
+              },
+              "timestamp": "2024-06-14T11:03:59.082Z"
+            },
+            "contact": {
+              "phone": "8929221233",
+              "email": "support@tipplr.in"
+            }
+          },
+          "@ondc/org/provider_name": "TIPPLR_DELIVERY",
+          "state": {
+            "descriptor": {
+              "code": "Out-for-delivery"
+            }
+          },
+          "tags": [
+            {
+              "code": "routing",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "P2P"
+                }
+              ]
+            }
+          ],
+          "agent": {
+            "name": "Channappa",
+            "phone": "8310422896"
+          }
+        },
+        {
+          "id": "C1",
+          "state": {
+            "descriptor": {
+              "code": "Cancelled"
+            }
+          },
+          "type": "Cancel",
+          "tags": [
+            {
+              "code": "cancel_request",
+              "list": [
+                {
+                  "code": "reason_id",
+                  "value": "002"
+                },
+                {
+                  "code": "initiated_by",
+                  "value": "preprod.tipplr.in"
+                }
+              ]
+            },
+            {
+              "code": "quote_trail",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "item"
+                },
+                {
+                  "code": "id",
+                  "value": "food_item-170383210627835789"
+                },
+                {
+                  "code": "currency",
+                  "value": "INR"
+                },
+                {
+                  "code": "value",
+                  "value": "-140"
+                }
+              ]
+            },
+            {
+              "code": "quote_trail",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "tax"
+                },
+                {
+                  "code": "id",
+                  "value": "food_item-170383210627835789"
+                },
+                {
+                  "code": "currency",
+                  "value": "INR"
+                },
+                {
+                  "code": "value",
+                  "value": "-7.00"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "created_at": "2024-06-14T11:03:06.264Z",
+      "updated_at": "2024-06-14T11:03:59.082Z",
+      "documents": [
+        {
+          "url": "https://tipplr-media.s3.ap-south-1.amazonaws.com/images/Invoice-26SWVY51CSGOW8U.pdf",
+          "label": "Invoice"
+        }
+      ]
+    }
+  },
+  "context": {
+    "domain": "ONDC:RET11",
+    "country": "IND",
+    "city": "std:080",
+    "action": "on_status",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_uri": "https://preprod.tipplr.in/ondc/v2",
+    "transaction_id": "fd7605ff-aefc-470f-8b26-127b212f9b81",
+    "message_id": "2efb4898-ee42-4fcb-9349-92df3295e3ad",
+    "timestamp": "2024-06-14T11:03:59.404Z",
+    "bpp_id": "preprod.tipplr.in"
+  }
+}

--- a/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow6/13. on_status_order_deliveried.json
+++ b/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow6/13. on_status_order_deliveried.json
@@ -1,0 +1,472 @@
+{
+  "message": {
+    "order": {
+      "id": "2024-06-14-884454",
+      "state": "Completed",
+      "provider": {
+        "id": "merchant-167714647372249847",
+        "locations": [
+          {
+            "id": "merchant-167714647372249847"
+          }
+        ]
+      },
+      "items": [
+        {
+          "id": "food_item-170383210597342600",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "merchant-167714647372249847"
+        },
+        {
+          "id": "food_item-170383210588937185",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "merchant-167714647372249847",
+          "parent_item_id": "DI1"
+        },
+        {
+          "id": "food_item-170383210588937185:603230",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "merchant-167714647372249847",
+          "tags": [
+            {
+              "code": "type",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "customization"
+                }
+              ]
+            },
+            {
+              "code": "parent",
+              "list": [
+                {
+                  "code": "id",
+                  "value": "76859436"
+                }
+              ]
+            }
+          ],
+          "parent_item_id": "DI1"
+        },
+        {
+          "id": "food_item-170383210627835789",
+          "quantity": {
+            "count": 0
+          },
+          "fulfillment_id": "merchant-167714647372249847"
+        },
+        {
+          "id": "food_item-170383210627835789",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "C1"
+        }
+      ],
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "732"
+        },
+        "breakup": [
+          {
+            "@ondc/org/item_id": "food_item-170383210588937185",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "title": "Chicken pizza",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "2"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "1"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ],
+              "parent_item_id": "DI1"
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210588937185:603230",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "title": "Regular",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "518"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "259"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "76859436"
+                    }
+                  ]
+                }
+              ],
+              "fulfillment_id": "merchant-167714647372249847",
+              "parent_item_id": "DI1"
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210588937185",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "26.00"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ],
+              "parent_item_id": "DI1"
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210597342600",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "title": "1 Idli 1 Vada",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "110"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "55"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210597342600",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "5.50"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Packing charges",
+            "@ondc/org/title_type": "packing",
+            "price": {
+              "currency": "INR",
+              "value": "21"
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Delivery charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "39"
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Convenience Fee",
+            "@ondc/org/title_type": "misc",
+            "price": {
+              "currency": "INR",
+              "value": "10.50"
+            }
+          }
+        ],
+        "ttl": "PT1H"
+      },
+      "billing": {
+        "address": {
+          "name": "Nithin",
+          "building": "building",
+          "locality": "Dr Ambedkar Road",
+          "city": "Bengaluru",
+          "state": "Karnataka",
+          "country": "IND",
+          "area_code": "560001"
+        },
+        "phone": "8951440205",
+        "name": "Nithin",
+        "email": "nithin@gmail.com",
+        "created_at": "2024-06-14T11:02:43.429Z",
+        "updated_at": "2024-06-14T11:02:43.429Z"
+      },
+      "payment": {
+        "uri": "https://razorpay.com/",
+        "tl_method": "http/get",
+        "params": {
+          "amount": "879.00",
+          "currency": "INR",
+          "transaction_id": "order_OMcKrZ5NeGGgiO"
+        },
+        "status": "PAID",
+        "type": "ON-ORDER",
+        "collected_by": "BAP",
+        "@ondc/org/buyer_app_finder_fee_type": "percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "seller-app",
+            "settlement_phase": "sale-amount",
+            "settlement_type": "neft",
+            "upi_address": "9900818181@upi",
+            "settlement_bank_account_no": "50200053531451",
+            "settlement_ifsc_code": "HDFC0004051",
+            "beneficiary_name": "FOOD SPACE TECHNOLOGY PRIVATE LIMITED",
+            "bank_name": "HDFC Bank",
+            "branch_name": "CNN"
+          },
+          {
+            "settlement_counterparty": "buyer",
+            "settlement_phase": "refund",
+            "settlement_type": "netbanking",
+            "settlement_amount": "147",
+            "settlement_timestamp": "2024-06-14T11:03:19.408Z"
+          }
+        ]
+      },
+      "fulfillments": [
+        {
+          "@ondc/org/TAT": "PT45M",
+          "id": "merchant-167714647372249847",
+          "tracking": true,
+          "end": {
+            "contact": {
+              "email": "nithin@gmail.com",
+              "phone": "8951440205"
+            },
+            "person": {
+              "name": "Nithin"
+            },
+            "location": {
+              "gps": "12.97943084572564,77.59098932147026",
+              "address": {
+                "name": "Nithin",
+                "building": "building",
+                "locality": "Dr Ambedkar Road",
+                "city": "Bengaluru",
+                "state": "Karnataka",
+                "country": "IND",
+                "area_code": "560001"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2024-06-14T11:03:06.567Z",
+                "end": "2024-06-14T11:48:06.567Z"
+              },
+              "timestamp": "2024-06-14T11:14:14.746Z"
+            }
+          },
+          "type": "Delivery",
+          "start": {
+            "location": {
+              "id": "merchant-167714647372249847",
+              "descriptor": {
+                "name": "Tipplr-swathi d"
+              },
+              "gps": "12.979612,77.590846",
+              "address": {
+                "city": "Bengaluru",
+                "area_code": "560001",
+                "locality": "Vasanth Nagar",
+                "state": "KA"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2024-06-14T11:03:06.567Z",
+                "end": "2024-06-14T11:48:06.567Z"
+              },
+              "timestamp": "2024-06-14T11:03:59.082Z"
+            },
+            "contact": {
+              "phone": "8929221233",
+              "email": "support@tipplr.in"
+            }
+          },
+          "@ondc/org/provider_name": "TIPPLR_DELIVERY",
+          "state": {
+            "descriptor": {
+              "code": "Order-delivered"
+            }
+          },
+          "tags": [
+            {
+              "code": "routing",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "P2P"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "id": "C1",
+          "state": {
+            "descriptor": {
+              "code": "Cancelled"
+            }
+          },
+          "type": "Cancel",
+          "tags": [
+            {
+              "code": "cancel_request",
+              "list": [
+                {
+                  "code": "reason_id",
+                  "value": "002"
+                },
+                {
+                  "code": "initiated_by",
+                  "value": "preprod.tipplr.in"
+                }
+              ]
+            },
+            {
+              "code": "quote_trail",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "item"
+                },
+                {
+                  "code": "id",
+                  "value": "food_item-170383210627835789"
+                },
+                {
+                  "code": "currency",
+                  "value": "INR"
+                },
+                {
+                  "code": "value",
+                  "value": "-140"
+                }
+              ]
+            },
+            {
+              "code": "quote_trail",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "tax"
+                },
+                {
+                  "code": "id",
+                  "value": "food_item-170383210627835789"
+                },
+                {
+                  "code": "currency",
+                  "value": "INR"
+                },
+                {
+                  "code": "value",
+                  "value": "-7.00"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "created_at": "2024-06-14T11:03:06.264Z",
+      "updated_at": "2024-06-14T11:14:14.746Z",
+      "documents": [
+        {
+          "url": "https://tipplr-media.s3.ap-south-1.amazonaws.com/images/Invoice-26SWVY51CSGOW8U.pdf",
+          "label": "Invoice"
+        }
+      ]
+    }
+  },
+  "context": {
+    "domain": "ONDC:RET11",
+    "country": "IND",
+    "city": "std:080",
+    "action": "on_status",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_uri": "https://preprod.tipplr.in/ondc/v2",
+    "transaction_id": "fd7605ff-aefc-470f-8b26-127b212f9b81",
+    "message_id": "6d2c5ad9-f8f6-4de3-82cf-77737538b726",
+    "timestamp": "2024-06-14T11:14:14.746Z",
+    "bpp_id": "preprod.tipplr.in"
+  }
+}

--- a/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow6/15. update_liquidated.json
+++ b/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow6/15. update_liquidated.json
@@ -1,0 +1,71 @@
+{
+  "context": {
+    "domain": "ONDC:RET11",
+    "country": "IND",
+    "city": "std:080",
+    "action": "update",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_uri": "https://preprod.tipplr.in/ondc/v2",
+    "transaction_id": "fd7605ff-aefc-470f-8b26-127b212f9b81",
+    "message_id": "06a61c13-53ac-416f-af54-704b2cb1919d",
+    "timestamp": "2024-06-14T11:04:37.468Z",
+    "bpp_id": "preprod.tipplr.in",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "update_target": "item",
+    "order": {
+      "id": "2024-06-14-884454",
+      "fulfillments": [
+        {
+          "type": "Return",
+          "tags": [
+            {
+              "code": "return_request",
+              "list": [
+                {
+                  "code": "id",
+                  "value": "666c23c5a4f72bd121f96271"
+                },
+                {
+                  "code": "item_id",
+                  "value": "food_item-170383210597342600"
+                },
+                {
+                  "code": "parent_item_id",
+                  "value": ""
+                },
+                {
+                  "code": "item_quantity",
+                  "value": "2"
+                },
+                {
+                  "code": "reason_id",
+                  "value": "003"
+                },
+                {
+                  "code": "reason_desc",
+                  "value": "detailed description for return"
+                },
+                {
+                  "code": "images",
+                  "value": "https://reference-buyer-app-assets.s3-ap-south-1.amazonaws.com/public-assets/2024-06-14-884454/d59bc1a1-860d-4db2-88f2-2d2f754bc8ed.jpeg"
+                },
+                {
+                  "code": "ttl_approval",
+                  "value": "PT24H"
+                },
+                {
+                  "code": "ttl_reverseqc",
+                  "value": "P3D"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow6/16. on_update_interim_liquidated.json
+++ b/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow6/16. on_update_interim_liquidated.json
@@ -1,0 +1,537 @@
+{
+  "context": {
+    "domain": "ONDC:RET11",
+    "country": "IND",
+    "city": "std:080",
+    "action": "on_update",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_uri": "https://preprod.tipplr.in/ondc/v2",
+    "transaction_id": "fd7605ff-aefc-470f-8b26-127b212f9b81",
+    "message_id": "06a61c13-53ac-416f-af54-704b2cb1919d",
+    "timestamp": "2024-06-14T11:04:37.637Z",
+    "bpp_id": "preprod.tipplr.in",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "update_target": "item",
+    "order": {
+      "id": "2024-06-14-884454",
+      "state": "Completed",
+      "provider": {
+        "id": "merchant-167714647372249847",
+        "locations": [
+          {
+            "id": "merchant-167714647372249847"
+          }
+        ]
+      },
+      "items": [
+        {
+          "id": "food_item-170383210597342600",
+          "quantity": {
+            "count": 0
+          },
+          "fulfillment_id": "merchant-167714647372249847"
+        },
+        {
+          "id": "food_item-170383210588937185",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "merchant-167714647372249847",
+          "parent_item_id": "DI1"
+        },
+        {
+          "id": "food_item-170383210588937185:603230",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "merchant-167714647372249847",
+          "tags": [
+            {
+              "code": "type",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "customization"
+                }
+              ]
+            },
+            {
+              "code": "parent",
+              "list": [
+                {
+                  "code": "id",
+                  "value": "76859436"
+                }
+              ]
+            }
+          ],
+          "parent_item_id": "DI1"
+        },
+        {
+          "id": "food_item-170383210627835789",
+          "quantity": {
+            "count": 0
+          },
+          "fulfillment_id": "merchant-167714647372249847"
+        },
+        {
+          "id": "food_item-170383210627835789",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "C1"
+        },
+        {
+          "id": "food_item-170383210597342600",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "666c23c5a4f72bd121f96271"
+        }
+      ],
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "732"
+        },
+        "breakup": [
+          {
+            "@ondc/org/item_id": "food_item-170383210588937185",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "title": "Chicken pizza",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "2"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "1"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ],
+              "parent_item_id": "DI1"
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210588937185:603230",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "title": "Regular",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "518"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "259"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "76859436"
+                    }
+                  ]
+                }
+              ],
+              "fulfillment_id": "merchant-167714647372249847",
+              "parent_item_id": "DI1"
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210588937185",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "26.00"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ],
+              "parent_item_id": "DI1"
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210597342600",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "title": "1 Idli 1 Vada",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "110"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "55"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210597342600",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "5.50"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Packing charges",
+            "@ondc/org/title_type": "packing",
+            "price": {
+              "currency": "INR",
+              "value": "21"
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Delivery charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "39"
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Convenience Fee",
+            "@ondc/org/title_type": "misc",
+            "price": {
+              "currency": "INR",
+              "value": "10.50"
+            }
+          }
+        ],
+        "ttl": "PT1H"
+      },
+      "billing": {
+        "address": {
+          "name": "Nithin",
+          "building": "building",
+          "locality": "Dr Ambedkar Road",
+          "city": "Bengaluru",
+          "state": "Karnataka",
+          "country": "IND",
+          "area_code": "560001"
+        },
+        "phone": "8951440205",
+        "name": "Nithin",
+        "email": "nithin@gmail.com",
+        "created_at": "2024-06-14T11:02:43.429Z",
+        "updated_at": "2024-06-14T11:02:43.429Z"
+      },
+      "payment": {
+        "uri": "https://razorpay.com/",
+        "tl_method": "http/get",
+        "params": {
+          "amount": "879.00",
+          "currency": "INR",
+          "transaction_id": "order_OMcKrZ5NeGGgiO"
+        },
+        "status": "PAID",
+        "type": "ON-ORDER",
+        "collected_by": "BAP",
+        "@ondc/org/buyer_app_finder_fee_type": "percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "seller-app",
+            "settlement_phase": "sale-amount",
+            "settlement_type": "neft",
+            "upi_address": "9900818181@upi",
+            "settlement_bank_account_no": "50200053531451",
+            "settlement_ifsc_code": "HDFC0004051",
+            "beneficiary_name": "FOOD SPACE TECHNOLOGY PRIVATE LIMITED",
+            "bank_name": "HDFC Bank",
+            "branch_name": "CNN"
+          },
+          {
+            "settlement_counterparty": "buyer",
+            "settlement_phase": "refund",
+            "settlement_type": "netbanking",
+            "settlement_amount": "147",
+            "settlement_timestamp": "2024-06-14T11:03:19.408Z"
+          }
+        ]
+      },
+      "fulfillments": [
+        {
+          "@ondc/org/TAT": "PT45M",
+          "id": "merchant-167714647372249847",
+          "tracking": true,
+          "end": {
+            "contact": {
+              "email": "nithin@gmail.com",
+              "phone": "8951440205"
+            },
+            "person": {
+              "name": "Nithin"
+            },
+            "location": {
+              "gps": "12.97943084572564,77.59098932147026",
+              "address": {
+                "name": "Nithin",
+                "building": "building",
+                "locality": "Dr Ambedkar Road",
+                "city": "Bengaluru",
+                "state": "Karnataka",
+                "country": "IND",
+                "area_code": "560001"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2024-06-14T11:03:06.567Z",
+                "end": "2024-06-14T11:48:06.567Z"
+              },
+              "timestamp": "2024-06-14T11:04:14.746Z"
+            }
+          },
+          "type": "Delivery",
+          "start": {
+            "location": {
+              "id": "merchant-167714647372249847",
+              "descriptor": {
+                "name": "Tipplr-swathi d"
+              },
+              "gps": "12.979612,77.590846",
+              "address": {
+                "city": "Bengaluru",
+                "area_code": "560001",
+                "locality": "Vasanth Nagar",
+                "state": "KA"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2024-06-14T11:03:06.567Z",
+                "end": "2024-06-14T11:48:06.567Z"
+              },
+              "timestamp": "2024-06-14T11:03:59.082Z"
+            },
+            "contact": {
+              "phone": "8929221233",
+              "email": "support@tipplr.in"
+            }
+          },
+          "@ondc/org/provider_name": "TIPPLR_DELIVERY",
+          "state": {
+            "descriptor": {
+              "code": "Order-delivered"
+            }
+          },
+          "tags": [
+            {
+              "code": "routing",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "P2P"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "id": "C1",
+          "state": {
+            "descriptor": {
+              "code": "Cancelled"
+            }
+          },
+          "type": "Cancel",
+          "tags": [
+            {
+              "code": "cancel_request",
+              "list": [
+                {
+                  "code": "reason_id",
+                  "value": "002"
+                },
+                {
+                  "code": "initiated_by",
+                  "value": "preprod.tipplr.in"
+                }
+              ]
+            },
+            {
+              "code": "quote_trail",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "item"
+                },
+                {
+                  "code": "id",
+                  "value": "food_item-170383210627835789"
+                },
+                {
+                  "code": "currency",
+                  "value": "INR"
+                },
+                {
+                  "code": "value",
+                  "value": "-140"
+                }
+              ]
+            },
+            {
+              "code": "quote_trail",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "tax"
+                },
+                {
+                  "code": "id",
+                  "value": "food_item-170383210627835789"
+                },
+                {
+                  "code": "currency",
+                  "value": "INR"
+                },
+                {
+                  "code": "value",
+                  "value": "-7.00"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "Return",
+          "tags": [
+            {
+              "code": "return_request",
+              "list": [
+                {
+                  "code": "id",
+                  "value": "666c23c5a4f72bd121f96271"
+                },
+                {
+                  "code": "item_id",
+                  "value": "food_item-170383210597342600"
+                },
+                {
+                  "code": "parent_item_id",
+                  "value": ""
+                },
+                {
+                  "code": "item_quantity",
+                  "value": "2"
+                },
+                {
+                  "code": "reason_id",
+                  "value": "003"
+                },
+                {
+                  "code": "reason_desc",
+                  "value": "detailed description for return"
+                },
+                {
+                  "code": "images",
+                  "value": "https://reference-buyer-app-assets.s3-ap-south-1.amazonaws.com/public-assets/2024-06-14-884454/d59bc1a1-860d-4db2-88f2-2d2f754bc8ed.jpeg"
+                },
+                {
+                  "code": "ttl_approval",
+                  "value": "PT24H"
+                },
+                {
+                  "code": "ttl_reverseqc",
+                  "value": "P3D"
+                },
+                {
+                  "code": "initiated_by",
+                  "value": "buyer-app-preprod-v2.ondc.org"
+                }
+              ]
+            }
+          ],
+          "id": "666c23c5a4f72bd121f96271",
+          "state": {
+            "descriptor": {
+              "code": "Return_Initiated"
+            }
+          }
+        }
+      ],
+      "created_at": "2024-06-14T11:03:06.264Z",
+      "updated_at": "2024-06-14T11:04:37.561Z",
+      "documents": [
+        {
+          "url": "https://tipplr-media.s3.ap-south-1.amazonaws.com/images/Invoice-26SWVY51CSGOW8U.pdf",
+          "label": "Invoice"
+        }
+      ]
+    }
+  }
+}

--- a/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow6/17. on_update_liquidated.json
+++ b/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow6/17. on_update_liquidated.json
@@ -1,0 +1,528 @@
+{
+  "context": {
+    "domain": "ONDC:RET11",
+    "country": "IND",
+    "city": "std:080",
+    "action": "on_update",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_uri": "https://preprod.tipplr.in/ondc/v2",
+    "transaction_id": "fd7605ff-aefc-470f-8b26-127b212f9b81",
+    "message_id": "21e8a741-c31f-4012-a51c-fa4d522366f9",
+    "timestamp": "2024-06-14T11:04:39.468Z",
+    "bpp_id": "preprod.tipplr.in",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "id": "2024-06-14-884454",
+      "state": "Completed",
+      "provider": {
+        "id": "merchant-167714647372249847",
+        "locations": [
+          {
+            "id": "merchant-167714647372249847"
+          }
+        ]
+      },
+      "items": [
+        {
+          "id": "food_item-170383210597342600",
+          "quantity": {
+            "count": 0
+          },
+          "fulfillment_id": "merchant-167714647372249847"
+        },
+        {
+          "id": "food_item-170383210588937185",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "merchant-167714647372249847",
+          "parent_item_id": "DI1"
+        },
+        {
+          "id": "food_item-170383210588937185:603230",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "merchant-167714647372249847",
+          "tags": [
+            {
+              "code": "type",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "customization"
+                }
+              ]
+            },
+            {
+              "code": "parent",
+              "list": [
+                {
+                  "code": "id",
+                  "value": "76859436"
+                }
+              ]
+            }
+          ],
+          "parent_item_id": "DI1"
+        },
+        {
+          "id": "food_item-170383210627835789",
+          "quantity": {
+            "count": 0
+          },
+          "fulfillment_id": "merchant-167714647372249847"
+        },
+        {
+          "id": "food_item-170383210627835789",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "C1"
+        },
+        {
+          "id": "food_item-170383210597342600",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "666c23c5a4f72bd121f96271"
+        }
+      ],
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "616.5"
+        },
+        "breakup": [
+          {
+            "@ondc/org/item_id": "food_item-170383210588937185",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "title": "Chicken pizza",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "2"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "1"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ],
+              "parent_item_id": "DI1"
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210588937185:603230",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "title": "Regular",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "518"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "259"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "76859436"
+                    }
+                  ]
+                }
+              ],
+              "fulfillment_id": "merchant-167714647372249847",
+              "parent_item_id": "DI1"
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210588937185",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "26.00"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ],
+              "parent_item_id": "DI1"
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Packing charges",
+            "@ondc/org/title_type": "packing",
+            "price": {
+              "currency": "INR",
+              "value": "21"
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Delivery charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "39"
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Convenience Fee",
+            "@ondc/org/title_type": "misc",
+            "price": {
+              "currency": "INR",
+              "value": "10.50"
+            }
+          }
+        ],
+        "ttl": "PT1H"
+      },
+      "billing": {
+        "address": {
+          "name": "Nithin",
+          "building": "building",
+          "locality": "Dr Ambedkar Road",
+          "city": "Bengaluru",
+          "state": "Karnataka",
+          "country": "IND",
+          "area_code": "560001"
+        },
+        "phone": "8951440205",
+        "name": "Nithin",
+        "email": "nithin@gmail.com",
+        "created_at": "2024-06-14T11:02:43.429Z",
+        "updated_at": "2024-06-14T11:02:43.429Z"
+      },
+      "payment": {
+        "uri": "https://razorpay.com/",
+        "tl_method": "http/get",
+        "params": {
+          "amount": "879.00",
+          "currency": "INR",
+          "transaction_id": "order_OMcKrZ5NeGGgiO"
+        },
+        "status": "PAID",
+        "type": "ON-ORDER",
+        "collected_by": "BAP",
+        "@ondc/org/buyer_app_finder_fee_type": "percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "seller-app",
+            "settlement_phase": "sale-amount",
+            "settlement_type": "neft",
+            "upi_address": "9900818181@upi",
+            "settlement_bank_account_no": "50200053531451",
+            "settlement_ifsc_code": "HDFC0004051",
+            "beneficiary_name": "FOOD SPACE TECHNOLOGY PRIVATE LIMITED",
+            "bank_name": "HDFC Bank",
+            "branch_name": "CNN"
+          },
+          {
+            "settlement_counterparty": "buyer",
+            "settlement_phase": "refund",
+            "settlement_type": "netbanking",
+            "settlement_amount": "147",
+            "settlement_timestamp": "2024-06-14T11:03:19.408Z"
+          }
+        ]
+      },
+      "fulfillments": [
+        {
+          "@ondc/org/TAT": "PT45M",
+          "id": "merchant-167714647372249847",
+          "tracking": true,
+          "end": {
+            "contact": {
+              "email": "nithin@gmail.com",
+              "phone": "8951440205"
+            },
+            "person": {
+              "name": "Nithin"
+            },
+            "location": {
+              "gps": "12.97943084572564,77.59098932147026",
+              "address": {
+                "name": "Nithin",
+                "building": "building",
+                "locality": "Dr Ambedkar Road",
+                "city": "Bengaluru",
+                "state": "Karnataka",
+                "country": "IND",
+                "area_code": "560001"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2024-06-14T11:03:06.567Z",
+                "end": "2024-06-14T11:48:06.567Z"
+              },
+              "timestamp": "2024-06-14T11:04:14.746Z"
+            }
+          },
+          "type": "Delivery",
+          "start": {
+            "location": {
+              "id": "merchant-167714647372249847",
+              "descriptor": {
+                "name": "Tipplr-swathi d"
+              },
+              "gps": "12.979612,77.590846",
+              "address": {
+                "city": "Bengaluru",
+                "area_code": "560001",
+                "locality": "Vasanth Nagar",
+                "state": "KA"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2024-06-14T11:03:06.567Z",
+                "end": "2024-06-14T11:48:06.567Z"
+              },
+              "timestamp": "2024-06-14T11:03:59.082Z"
+            },
+            "contact": {
+              "phone": "8929221233",
+              "email": "support@tipplr.in"
+            }
+          },
+          "@ondc/org/provider_name": "TIPPLR_DELIVERY",
+          "state": {
+            "descriptor": {
+              "code": "Order-delivered"
+            }
+          },
+          "tags": [
+            {
+              "code": "routing",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "P2P"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "id": "C1",
+          "state": {
+            "descriptor": {
+              "code": "Cancelled"
+            }
+          },
+          "type": "Cancel",
+          "tags": [
+            {
+              "code": "cancel_request",
+              "list": [
+                {
+                  "code": "reason_id",
+                  "value": "002"
+                },
+                {
+                  "code": "initiated_by",
+                  "value": "preprod.tipplr.in"
+                }
+              ]
+            },
+            {
+              "code": "quote_trail",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "item"
+                },
+                {
+                  "code": "id",
+                  "value": "food_item-170383210627835789"
+                },
+                {
+                  "code": "currency",
+                  "value": "INR"
+                },
+                {
+                  "code": "value",
+                  "value": "-140"
+                }
+              ]
+            },
+            {
+              "code": "quote_trail",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "tax"
+                },
+                {
+                  "code": "id",
+                  "value": "food_item-170383210627835789"
+                },
+                {
+                  "code": "currency",
+                  "value": "INR"
+                },
+                {
+                  "code": "value",
+                  "value": "-7.00"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "Return",
+          "tags": [
+            {
+              "code": "return_request",
+              "list": [
+                {
+                  "code": "id",
+                  "value": "666c23c5a4f72bd121f96271"
+                },
+                {
+                  "code": "item_id",
+                  "value": "food_item-170383210597342600"
+                },
+                {
+                  "code": "parent_item_id",
+                  "value": ""
+                },
+                {
+                  "code": "item_quantity",
+                  "value": "2"
+                },
+                {
+                  "code": "reason_id",
+                  "value": "003"
+                },
+                {
+                  "code": "reason_desc",
+                  "value": "detailed description for return"
+                },
+                {
+                  "code": "images",
+                  "value": "https://reference-buyer-app-assets.s3-ap-south-1.amazonaws.com/public-assets/2024-06-14-884454/d59bc1a1-860d-4db2-88f2-2d2f754bc8ed.jpeg"
+                },
+                {
+                  "code": "ttl_approval",
+                  "value": "PT24H"
+                },
+                {
+                  "code": "ttl_reverseqc",
+                  "value": "P3D"
+                },
+                {
+                  "code": "initiated_by",
+                  "value": "buyer-app-preprod-v2.ondc.org"
+                }
+              ]
+            },
+            {
+              "code": "quote_trail",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "item"
+                },
+                {
+                  "code": "id",
+                  "value": "food_item-170383210597342600"
+                },
+                {
+                  "code": "currency",
+                  "value": "INR"
+                },
+                {
+                  "code": "value",
+                  "value": "-110"
+                }
+              ]
+            },
+            {
+              "code": "quote_trail",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "tax"
+                },
+                {
+                  "code": "id",
+                  "value": "food_item-170383210597342600"
+                },
+                {
+                  "code": "currency",
+                  "value": "INR"
+                },
+                {
+                  "code": "value",
+                  "value": "-5.50"
+                }
+              ]
+            }
+          ],
+          "id": "666c23c5a4f72bd121f96271",
+          "state": {
+            "descriptor": {
+              "code": "Liquidated"
+            }
+          },
+          "@ondc/org/provider_name": "TIPPLR_DELIVERY"
+        }
+      ],
+      "created_at": "2024-06-14T11:03:06.264Z",
+      "updated_at": "2024-06-14T11:04:37.561Z",
+      "documents": [
+        {
+          "url": "https://tipplr-media.s3.ap-south-1.amazonaws.com/images/Invoice-26SWVY51CSGOW8U.pdf",
+          "label": "Invoice"
+        }
+      ]
+    }
+  }
+}

--- a/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow6/18. update_settlement_liquidated.json
+++ b/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow6/18. update_settlement_liquidated.json
@@ -1,0 +1,39 @@
+{
+  "context": {
+    "domain": "ONDC:RET11",
+    "action": "update",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_id": "preprod.tipplr.in",
+    "bpp_uri": "https://preprod.tipplr.in/ondc/v2",
+    "transaction_id": "fd7605ff-aefc-470f-8b26-127b212f9b81",
+    "message_id": "722c139e-ed4f-4601-840b-c1708ee0995f",
+    "city": "std:080",
+    "country": "IND",
+    "timestamp": "2024-06-14T11:05:36.995Z"
+  },
+  "message": {
+    "update_target": "payment",
+    "order": {
+      "id": "2024-06-14-884454",
+      "fulfillments": [
+        {
+          "id": "666c23c5a4f72bd121f96271",
+          "type": "Return"
+        }
+      ],
+      "payment": {
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "buyer",
+            "settlement_phase": "refund",
+            "settlement_type": "netbanking",
+            "settlement_amount": "115.5",
+            "settlement_timestamp": "2024-06-14T11:05:36.995Z"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow6/2. on_select.json
+++ b/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow6/2. on_select.json
@@ -1,0 +1,346 @@
+{
+  "context": {
+    "domain": "ONDC:RET11",
+    "country": "IND",
+    "city": "std:080",
+    "action": "on_select",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_uri": "https://preprod.tipplr.in/ondc/v2",
+    "transaction_id": "fd7605ff-aefc-470f-8b26-127b212f9b81",
+    "message_id": "36db5585-263b-41c9-b4b8-0f58e93fea9a",
+    "timestamp": "2024-06-14T11:02:34.032Z",
+    "bpp_id": "preprod.tipplr.in"
+  },
+  "message": {
+    "order": {
+      "provider": {
+        "id": "merchant-167714647372249847",
+        "locations": [
+          {
+            "id": "merchant-167714647372249847"
+          }
+        ]
+      },
+      "fulfillments": [
+        {
+          "id": "merchant-167714647372249847",
+          "@ondc/org/provider_name": "TIPPLR_DELIVERY",
+          "tracking": true,
+          "@ondc/org/category": "Immediate Delivery",
+          "type": "Delivery",
+          "@ondc/org/TAT": "PT60M",
+          "state": {
+            "descriptor": {
+              "code": "Serviceable"
+            }
+          }
+        }
+      ],
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "879.00"
+        },
+        "breakup": [
+          {
+            "@ondc/org/item_id": "food_item-170383210588937185",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "title": "Chicken pizza",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "2"
+            },
+            "item": {
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "10"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "1"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ],
+              "parent_item_id": "DI1"
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210588937185:603230",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "title": "Regular",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "518"
+            },
+            "item": {
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "10"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "259"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "76859436"
+                    }
+                  ]
+                }
+              ],
+              "fulfillment_id": "merchant-167714647372249847",
+              "parent_item_id": "DI1"
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210588937185",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "26.00"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ],
+              "parent_item_id": "DI1"
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210597342600",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "title": "1 Idli 1 Vada",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "110"
+            },
+            "item": {
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "10"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "55"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210597342600",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "5.50"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210627835789",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "title": "Poori Kurma",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "140"
+            },
+            "item": {
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "10"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "70"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210627835789",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "7.00"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Packing charges",
+            "@ondc/org/title_type": "packing",
+            "price": {
+              "currency": "INR",
+              "value": "21"
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Delivery charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "39"
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Convenience Fee",
+            "@ondc/org/title_type": "misc",
+            "price": {
+              "currency": "INR",
+              "value": "10.50"
+            }
+          }
+        ],
+        "ttl": "P1D"
+      },
+      "items": [
+        {
+          "id": "food_item-170383210588937185",
+          "fulfillment_id": "merchant-167714647372249847",
+          "parent_item_id": "DI1"
+        },
+        {
+          "id": "food_item-170383210588937185:603230",
+          "tags": [
+            {
+              "code": "type",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "customization"
+                }
+              ]
+            },
+            {
+              "code": "parent",
+              "list": [
+                {
+                  "code": "id",
+                  "value": "76859436"
+                }
+              ]
+            }
+          ],
+          "fulfillment_id": "merchant-167714647372249847",
+          "parent_item_id": "DI1"
+        },
+        {
+          "id": "food_item-170383210597342600",
+          "fulfillment_id": "merchant-167714647372249847"
+        },
+        {
+          "id": "food_item-170383210627835789",
+          "fulfillment_id": "merchant-167714647372249847"
+        }
+      ]
+    }
+  }
+}

--- a/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow6/3. init.json
+++ b/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow6/3. init.json
@@ -1,0 +1,125 @@
+{
+  "context": {
+    "domain": "ONDC:RET11",
+    "country": "IND",
+    "city": "std:080",
+    "action": "init",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_uri": "https://preprod.tipplr.in/ondc/v2",
+    "transaction_id": "fd7605ff-aefc-470f-8b26-127b212f9b81",
+    "message_id": "0aff4bf5-4b10-4396-bbb5-148ba1866801",
+    "timestamp": "2024-06-14T11:02:43.429Z",
+    "bpp_id": "preprod.tipplr.in",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "provider": {
+        "id": "merchant-167714647372249847",
+        "locations": [
+          {
+            "id": "merchant-167714647372249847"
+          }
+        ]
+      },
+      "items": [
+        {
+          "id": "food_item-170383210597342600",
+          "quantity": {
+            "count": 2
+          },
+          "location_id": "merchant-167714647372249847",
+          "fulfillment_id": "merchant-167714647372249847"
+        },
+        {
+          "id": "food_item-170383210588937185",
+          "quantity": {
+            "count": 2
+          },
+          "location_id": "merchant-167714647372249847",
+          "parent_item_id": "DI1",
+          "fulfillment_id": "merchant-167714647372249847"
+        },
+        {
+          "id": "food_item-170383210588937185:603230",
+          "quantity": {
+            "count": 2
+          },
+          "location_id": "merchant-167714647372249847",
+          "tags": [
+            {
+              "code": "type",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "customization"
+                }
+              ]
+            },
+            {
+              "code": "parent",
+              "list": [
+                {
+                  "code": "id",
+                  "value": "76859436"
+                }
+              ]
+            }
+          ],
+          "fulfillment_id": "merchant-167714647372249847",
+          "parent_item_id": "DI1"
+        },
+        {
+          "id": "food_item-170383210627835789",
+          "quantity": {
+            "count": 2
+          },
+          "location_id": "merchant-167714647372249847",
+          "fulfillment_id": "merchant-167714647372249847"
+        }
+      ],
+      "billing": {
+        "address": {
+          "building": "building",
+          "city": "Bengaluru",
+          "state": "Karnataka",
+          "country": "IND",
+          "area_code": "560001",
+          "locality": "Dr Ambedkar Road",
+          "name": "Nithin"
+        },
+        "phone": "8951440205",
+        "name": "Nithin",
+        "email": "nithin@gmail.com",
+        "created_at": "2024-06-14T11:02:43.429Z",
+        "updated_at": "2024-06-14T11:02:43.429Z"
+      },
+      "fulfillments": [
+        {
+          "id": "merchant-167714647372249847",
+          "type": "Delivery",
+          "end": {
+            "contact": {
+              "email": "nithin@gmail.com",
+              "phone": "8951440205"
+            },
+            "location": {
+              "gps": "12.97943084572564,77.59098932147026",
+              "address": {
+                "building": "building",
+                "city": "Bengaluru",
+                "state": "Karnataka",
+                "country": "IND",
+                "area_code": "560001",
+                "locality": "Dr Ambedkar Road",
+                "name": "Nithin"
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow6/4. on_init.json
+++ b/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow6/4. on_init.json
@@ -1,0 +1,399 @@
+{
+  "context": {
+    "domain": "ONDC:RET11",
+    "country": "IND",
+    "city": "std:080",
+    "action": "on_init",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_uri": "https://preprod.tipplr.in/ondc/v2",
+    "transaction_id": "fd7605ff-aefc-470f-8b26-127b212f9b81",
+    "message_id": "0aff4bf5-4b10-4396-bbb5-148ba1866801",
+    "timestamp": "2024-06-14T11:02:45.429Z",
+    "bpp_id": "preprod.tipplr.in",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "provider": {
+        "id": "merchant-167714647372249847",
+        "locations": [
+          {
+            "id": "merchant-167714647372249847"
+          }
+        ]
+      },
+      "items": [
+        {
+          "id": "food_item-170383210597342600",
+          "quantity": {
+            "count": 2
+          },
+          "location_id": "merchant-167714647372249847",
+          "fulfillment_id": "merchant-167714647372249847"
+        },
+        {
+          "id": "food_item-170383210588937185",
+          "quantity": {
+            "count": 2
+          },
+          "location_id": "merchant-167714647372249847",
+          "parent_item_id": "DI1",
+          "fulfillment_id": "merchant-167714647372249847"
+        },
+        {
+          "id": "food_item-170383210588937185:603230",
+          "quantity": {
+            "count": 2
+          },
+          "location_id": "merchant-167714647372249847",
+          "tags": [
+            {
+              "code": "type",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "customization"
+                }
+              ]
+            },
+            {
+              "code": "parent",
+              "list": [
+                {
+                  "code": "id",
+                  "value": "76859436"
+                }
+              ]
+            }
+          ],
+          "fulfillment_id": "merchant-167714647372249847",
+          "parent_item_id": "DI1"
+        },
+        {
+          "id": "food_item-170383210627835789",
+          "quantity": {
+            "count": 2
+          },
+          "location_id": "merchant-167714647372249847",
+          "fulfillment_id": "merchant-167714647372249847"
+        }
+      ],
+      "billing": {
+        "address": {
+          "building": "building",
+          "city": "Bengaluru",
+          "state": "Karnataka",
+          "country": "IND",
+          "area_code": "560001",
+          "locality": "Dr Ambedkar Road",
+          "name": "Nithin"
+        },
+        "phone": "8951440205",
+        "name": "Nithin",
+        "email": "nithin@gmail.com",
+        "created_at": "2024-06-14T11:02:43.429Z",
+        "updated_at": "2024-06-14T11:02:43.429Z"
+      },
+      "fulfillments": [
+        {
+          "id": "merchant-167714647372249847",
+          "type": "Delivery",
+          "end": {
+            "contact": {
+              "email": "nithin@gmail.com",
+              "phone": "8951440205"
+            },
+            "location": {
+              "gps": "12.97943084572564,77.59098932147026",
+              "address": {
+                "building": "building",
+                "city": "Bengaluru",
+                "state": "Karnataka",
+                "country": "IND",
+                "area_code": "560001",
+                "locality": "Dr Ambedkar Road",
+                "name": "Nithin"
+              }
+            }
+          },
+          "tracking": true
+        }
+      ],
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "879.00"
+        },
+        "breakup": [
+          {
+            "@ondc/org/item_id": "food_item-170383210588937185",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "title": "Chicken pizza",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "2"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "1"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ],
+              "parent_item_id": "DI1"
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210588937185:603230",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "title": "Regular",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "518"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "259"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "76859436"
+                    }
+                  ]
+                }
+              ],
+              "fulfillment_id": "merchant-167714647372249847",
+              "parent_item_id": "DI1"
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210588937185",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "26.00"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ],
+              "parent_item_id": "DI1"
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210597342600",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "title": "1 Idli 1 Vada",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "110"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "55"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210597342600",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "5.50"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210627835789",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "title": "Poori Kurma",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "140"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "70"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210627835789",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "7.00"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Packing charges",
+            "@ondc/org/title_type": "packing",
+            "price": {
+              "currency": "INR",
+              "value": "21"
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Delivery charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "39"
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Convenience Fee",
+            "@ondc/org/title_type": "misc",
+            "price": {
+              "currency": "INR",
+              "value": "10.50"
+            }
+          }
+        ],
+        "ttl": "P1D"
+      },
+      "payment": {
+        "type": "ON-ORDER",
+        "collected_by": "BAP",
+        "status": "NOT-PAID",
+        "@ondc/org/buyer_app_finder_fee_type": "percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "3",
+        "@ondc/org/settlement_basis": "return_window_expiry",
+        "@ondc/org/settlement_window": "P1D",
+        "@ondc/org/withholding_amount": "26.37",
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "seller-app",
+            "settlement_phase": "sale-amount",
+            "settlement_type": "neft",
+            "upi_address": "9900818181@upi",
+            "settlement_bank_account_no": "50200053531451",
+            "settlement_ifsc_code": "HDFC0004051",
+            "beneficiary_name": "FOOD SPACE TECHNOLOGY PRIVATE LIMITED",
+            "bank_name": "HDFC Bank",
+            "branch_name": "CNN"
+          }
+        ]
+      },
+      "tags": [
+        {
+          "code": "bpp_terms",
+          "list": [
+            {
+              "code": "tax_number",
+              "value": "29AAECF1747N1Z6"
+            },
+            {
+              "code": "provider_tax_number",
+              "value": "AAECF1747N"
+            },
+            {
+              "code": "np_type",
+              "value": "ISN"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow6/5. confirm.json
+++ b/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow6/5. confirm.json
@@ -1,0 +1,419 @@
+{
+  "context": {
+    "domain": "ONDC:RET11",
+    "country": "IND",
+    "city": "std:080",
+    "action": "confirm",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_uri": "https://preprod.tipplr.in/ondc/v2",
+    "transaction_id": "fd7605ff-aefc-470f-8b26-127b212f9b81",
+    "message_id": "b1d45cab-e0e3-48ad-8ca8-35f3b46f1c0c",
+    "timestamp": "2024-06-14T11:03:06.264Z",
+    "bpp_id": "preprod.tipplr.in",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "id": "2024-06-14-884454",
+      "state": "Created",
+      "billing": {
+        "address": {
+          "name": "Nithin",
+          "building": "building",
+          "locality": "Dr Ambedkar Road",
+          "city": "Bengaluru",
+          "state": "Karnataka",
+          "country": "IND",
+          "area_code": "560001"
+        },
+        "phone": "8951440205",
+        "name": "Nithin",
+        "email": "nithin@gmail.com",
+        "created_at": "2024-06-14T11:02:43.429Z",
+        "updated_at": "2024-06-14T11:02:43.429Z"
+      },
+      "items": [
+        {
+          "id": "food_item-170383210597342600",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "merchant-167714647372249847"
+        },
+        {
+          "id": "food_item-170383210588937185",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "merchant-167714647372249847",
+          "parent_item_id": "DI1"
+        },
+        {
+          "id": "food_item-170383210588937185:603230",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "merchant-167714647372249847",
+          "tags": [
+            {
+              "code": "type",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "customization"
+                }
+              ]
+            },
+            {
+              "code": "parent",
+              "list": [
+                {
+                  "code": "id",
+                  "value": "76859436"
+                }
+              ]
+            }
+          ],
+          "parent_item_id": "DI1"
+        },
+        {
+          "id": "food_item-170383210627835789",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "merchant-167714647372249847"
+        }
+      ],
+      "provider": {
+        "id": "merchant-167714647372249847",
+        "locations": [
+          {
+            "id": "merchant-167714647372249847"
+          }
+        ]
+      },
+      "fulfillments": [
+        {
+          "@ondc/org/TAT": "PT60M",
+          "id": "merchant-167714647372249847",
+          "tracking": true,
+          "end": {
+            "contact": {
+              "email": "nithin@gmail.com",
+              "phone": "8951440205"
+            },
+            "person": {
+              "name": "Nithin"
+            },
+            "location": {
+              "gps": "12.97943084572564,77.59098932147026",
+              "address": {
+                "name": "Nithin",
+                "building": "building",
+                "locality": "Dr Ambedkar Road",
+                "city": "Bengaluru",
+                "state": "Karnataka",
+                "country": "IND",
+                "area_code": "560001"
+              }
+            }
+          },
+          "type": "Delivery"
+        }
+      ],
+      "payment": {
+        "uri": "https://razorpay.com/",
+        "tl_method": "http/get",
+        "params": {
+          "amount": "879.00",
+          "currency": "INR",
+          "transaction_id": "order_OMcKrZ5NeGGgiO"
+        },
+        "status": "PAID",
+        "type": "ON-ORDER",
+        "collected_by": "BAP",
+        "@ondc/org/buyer_app_finder_fee_type": "percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+        "@ondc/org/settlement_basis": "return_window_expiry",
+        "@ondc/org/settlement_window": "P1D",
+        "@ondc/org/withholding_amount": "26.37",
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "seller-app",
+            "settlement_phase": "sale-amount",
+            "settlement_type": "neft",
+            "upi_address": "9900818181@upi",
+            "settlement_bank_account_no": "50200053531451",
+            "settlement_ifsc_code": "HDFC0004051",
+            "beneficiary_name": "FOOD SPACE TECHNOLOGY PRIVATE LIMITED",
+            "bank_name": "HDFC Bank",
+            "branch_name": "CNN"
+          }
+        ]
+      },
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "879.00"
+        },
+        "breakup": [
+          {
+            "@ondc/org/item_id": "food_item-170383210588937185",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "title": "Chicken pizza",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "2"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "1"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ],
+              "parent_item_id": "DI1"
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210588937185:603230",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "title": "Regular",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "518"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "259"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "76859436"
+                    }
+                  ]
+                }
+              ],
+              "fulfillment_id": "merchant-167714647372249847",
+              "parent_item_id": "DI1"
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210588937185",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "26.00"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ],
+              "parent_item_id": "DI1"
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210597342600",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "title": "1 Idli 1 Vada",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "110"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "55"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210597342600",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "5.50"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210627835789",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "title": "Poori Kurma",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "140"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "70"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210627835789",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "7.00"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Packing charges",
+            "@ondc/org/title_type": "packing",
+            "price": {
+              "currency": "INR",
+              "value": "21"
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Delivery charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "39"
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Convenience Fee",
+            "@ondc/org/title_type": "misc",
+            "price": {
+              "currency": "INR",
+              "value": "10.50"
+            }
+          }
+        ],
+        "ttl": "P1D"
+      },
+      "tags": [
+        {
+          "code": "bpp_terms",
+          "list": [
+            {
+              "code": "tax_number",
+              "value": "29AAECF1747N1Z6"
+            },
+            {
+              "code": "provider_tax_number",
+              "value": "AAECF1747N"
+            },
+            {
+              "code": "np_type",
+              "value": "ISN"
+            }
+          ]
+        },
+        {
+          "code": "bap_terms",
+          "list": [
+            {
+              "code": "tax_number",
+              "value": "GSTIN1234567890"
+            }
+          ]
+        }
+      ],
+      "created_at": "2024-06-14T11:03:06.264Z",
+      "updated_at": "2024-06-14T11:03:06.264Z"
+    }
+  }
+}

--- a/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow6/6. on_confirm.json
+++ b/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow6/6. on_confirm.json
@@ -1,0 +1,449 @@
+{
+  "context": {
+    "domain": "ONDC:RET11",
+    "country": "IND",
+    "city": "std:080",
+    "action": "on_confirm",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_uri": "https://preprod.tipplr.in/ondc/v2",
+    "transaction_id": "fd7605ff-aefc-470f-8b26-127b212f9b81",
+    "message_id": "b1d45cab-e0e3-48ad-8ca8-35f3b46f1c0c",
+    "timestamp": "2024-06-14T11:03:08.264Z",
+    "bpp_id": "preprod.tipplr.in"
+  },
+  "message": {
+    "order": {
+      "id": "2024-06-14-884454",
+      "state": "Created",
+      "billing": {
+        "address": {
+          "name": "Nithin",
+          "building": "building",
+          "locality": "Dr Ambedkar Road",
+          "city": "Bengaluru",
+          "state": "Karnataka",
+          "country": "IND",
+          "area_code": "560001"
+        },
+        "phone": "8951440205",
+        "name": "Nithin",
+        "email": "nithin@gmail.com",
+        "created_at": "2024-06-14T11:02:43.429Z",
+        "updated_at": "2024-06-14T11:02:43.429Z"
+      },
+      "items": [
+        {
+          "id": "food_item-170383210597342600",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "merchant-167714647372249847"
+        },
+        {
+          "id": "food_item-170383210588937185",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "merchant-167714647372249847",
+          "parent_item_id": "DI1"
+        },
+        {
+          "id": "food_item-170383210588937185:603230",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "merchant-167714647372249847",
+          "tags": [
+            {
+              "code": "type",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "customization"
+                }
+              ]
+            },
+            {
+              "code": "parent",
+              "list": [
+                {
+                  "code": "id",
+                  "value": "76859436"
+                }
+              ]
+            }
+          ],
+          "parent_item_id": "DI1"
+        },
+        {
+          "id": "food_item-170383210627835789",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "merchant-167714647372249847"
+        }
+      ],
+      "provider": {
+        "id": "merchant-167714647372249847",
+        "locations": [
+          {
+            "id": "merchant-167714647372249847"
+          }
+        ]
+      },
+      "fulfillments": [
+        {
+          "@ondc/org/TAT": "PT60M",
+          "id": "merchant-167714647372249847",
+          "tracking": true,
+          "end": {
+            "contact": {
+              "email": "nithin@gmail.com",
+              "phone": "8951440205"
+            },
+            "person": {
+              "name": "Nithin"
+            },
+            "location": {
+              "gps": "12.97943084572564,77.59098932147026",
+              "address": {
+                "name": "Nithin",
+                "building": "building",
+                "locality": "Dr Ambedkar Road",
+                "city": "Bengaluru",
+                "state": "Karnataka",
+                "country": "IND",
+                "area_code": "560001"
+              }
+            }
+          },
+          "type": "Delivery",
+          "start": {
+            "location": {
+              "id": "merchant-167714647372249847",
+              "descriptor": {
+                "name": "Tipplr-swathi d"
+              },
+              "gps": "12.979612,77.590846",
+              "address": {
+                "city": "Bengaluru",
+                "area_code": "560001",
+                "locality": "Vasanth Nagar",
+                "state": "KA"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2024-06-14T11:03:06.567Z",
+                "end": "2024-06-14T11:48:06.567Z"
+              }
+            },
+            "contact": {
+              "phone": "8929221233",
+              "email": "support@tipplr.in"
+            }
+          },
+          "@ondc/org/provider_name": "TIPPLR_DELIVERY",
+          "state": {
+            "descriptor": {
+              "code": "Pending"
+            }
+          }
+        }
+      ],
+      "payment": {
+        "uri": "https://razorpay.com/",
+        "tl_method": "http/get",
+        "params": {
+          "amount": "879.00",
+          "currency": "INR",
+          "transaction_id": "order_OMcKrZ5NeGGgiO"
+        },
+        "status": "PAID",
+        "type": "ON-ORDER",
+        "collected_by": "BAP",
+        "@ondc/org/buyer_app_finder_fee_type": "percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+        "@ondc/org/settlement_basis": "return_window_expiry",
+        "@ondc/org/settlement_window": "P1D",
+        "@ondc/org/withholding_amount": "26.37",
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "seller-app",
+            "settlement_phase": "sale-amount",
+            "settlement_type": "neft",
+            "upi_address": "9900818181@upi",
+            "settlement_bank_account_no": "50200053531451",
+            "settlement_ifsc_code": "HDFC0004051",
+            "beneficiary_name": "FOOD SPACE TECHNOLOGY PRIVATE LIMITED",
+            "bank_name": "HDFC Bank",
+            "branch_name": "CNN"
+          }
+        ]
+      },
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "879.00"
+        },
+        "breakup": [
+          {
+            "@ondc/org/item_id": "food_item-170383210588937185",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "title": "Chicken pizza",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "2"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "1"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ],
+              "parent_item_id": "DI1"
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210588937185:603230",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "title": "Regular",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "518"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "259"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "76859436"
+                    }
+                  ]
+                }
+              ],
+              "fulfillment_id": "merchant-167714647372249847",
+              "parent_item_id": "DI1"
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210588937185",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "26.00"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ],
+              "parent_item_id": "DI1"
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210597342600",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "title": "1 Idli 1 Vada",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "110"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "55"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210597342600",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "5.50"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210627835789",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "title": "Poori Kurma",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "140"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "70"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210627835789",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "7.00"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Packing charges",
+            "@ondc/org/title_type": "packing",
+            "price": {
+              "currency": "INR",
+              "value": "21"
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Delivery charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "39"
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Convenience Fee",
+            "@ondc/org/title_type": "misc",
+            "price": {
+              "currency": "INR",
+              "value": "10.50"
+            }
+          }
+        ],
+        "ttl": "P1D"
+      },
+      "tags": [
+        {
+          "code": "bpp_terms",
+          "list": [
+            {
+              "code": "tax_number",
+              "value": "29AAECF1747N1Z6"
+            },
+            {
+              "code": "provider_tax_number",
+              "value": "AAECF1747N"
+            },
+            {
+              "code": "np_type",
+              "value": "ISN"
+            }
+          ]
+        },
+        {
+          "code": "bap_terms",
+          "list": [
+            {
+              "code": "tax_number",
+              "value": "GSTIN1234567890"
+            }
+          ]
+        }
+      ],
+      "created_at": "2024-06-14T11:03:06.264Z",
+      "updated_at": "2024-06-14T11:03:08.264Z"
+    }
+  }
+}

--- a/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow6/7. on_update_part_cancel.json
+++ b/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow6/7. on_update_part_cancel.json
@@ -1,0 +1,446 @@
+{
+  "message": {
+    "order": {
+      "id": "2024-06-14-884454",
+      "state": "Created",
+      "provider": {
+        "id": "merchant-167714647372249847",
+        "locations": [
+          {
+            "id": "merchant-167714647372249847"
+          }
+        ]
+      },
+      "items": [
+        {
+          "id": "food_item-170383210597342600",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "merchant-167714647372249847"
+        },
+        {
+          "id": "food_item-170383210588937185",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "merchant-167714647372249847",
+          "parent_item_id": "DI1"
+        },
+        {
+          "id": "food_item-170383210588937185:603230",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "merchant-167714647372249847",
+          "tags": [
+            {
+              "code": "type",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "customization"
+                }
+              ]
+            },
+            {
+              "code": "parent",
+              "list": [
+                {
+                  "code": "id",
+                  "value": "76859436"
+                }
+              ]
+            }
+          ],
+          "parent_item_id": "DI1"
+        },
+        {
+          "id": "food_item-170383210627835789",
+          "quantity": {
+            "count": 0
+          },
+          "fulfillment_id": "merchant-167714647372249847"
+        },
+        {
+          "id": "food_item-170383210627835789",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "C1"
+        }
+      ],
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "732"
+        },
+        "breakup": [
+          {
+            "@ondc/org/item_id": "food_item-170383210588937185",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "title": "Chicken pizza",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "2"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "1"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ],
+              "parent_item_id": "DI1"
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210588937185:603230",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "title": "Regular",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "518"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "259"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "76859436"
+                    }
+                  ]
+                }
+              ],
+              "fulfillment_id": "merchant-167714647372249847",
+              "parent_item_id": "DI1"
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210588937185",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "26.00"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ],
+              "parent_item_id": "DI1"
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210597342600",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "title": "1 Idli 1 Vada",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "110"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "55"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210597342600",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "5.50"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Packing charges",
+            "@ondc/org/title_type": "packing",
+            "price": {
+              "currency": "INR",
+              "value": "21"
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Delivery charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "39"
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Convenience Fee",
+            "@ondc/org/title_type": "misc",
+            "price": {
+              "currency": "INR",
+              "value": "10.50"
+            }
+          }
+        ],
+        "ttl": "PT1H"
+      },
+      "billing": {
+        "address": {
+          "name": "Nithin",
+          "building": "building",
+          "locality": "Dr Ambedkar Road",
+          "city": "Bengaluru",
+          "state": "Karnataka",
+          "country": "IND",
+          "area_code": "560001"
+        },
+        "phone": "8951440205",
+        "name": "Nithin",
+        "email": "nithin@gmail.com",
+        "created_at": "2024-06-14T11:02:43.429Z",
+        "updated_at": "2024-06-14T11:02:43.429Z"
+      },
+      "payment": {
+        "uri": "https://razorpay.com/",
+        "tl_method": "http/get",
+        "params": {
+          "amount": "879.00",
+          "currency": "INR",
+          "transaction_id": "order_OMcKrZ5NeGGgiO"
+        },
+        "status": "PAID",
+        "type": "ON-ORDER",
+        "collected_by": "BAP",
+        "@ondc/org/buyer_app_finder_fee_type": "percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "seller-app",
+            "settlement_phase": "sale-amount",
+            "settlement_type": "neft",
+            "upi_address": "9900818181@upi",
+            "settlement_bank_account_no": "50200053531451",
+            "settlement_ifsc_code": "HDFC0004051",
+            "beneficiary_name": "FOOD SPACE TECHNOLOGY PRIVATE LIMITED",
+            "bank_name": "HDFC Bank",
+            "branch_name": "CNN"
+          }
+        ]
+      },
+      "fulfillments": [
+        {
+          "@ondc/org/TAT": "PT60M",
+          "id": "merchant-167714647372249847",
+          "tracking": true,
+          "end": {
+            "contact": {
+              "email": "nithin@gmail.com",
+              "phone": "8951440205"
+            },
+            "person": {
+              "name": "Nithin"
+            },
+            "location": {
+              "gps": "12.97943084572564,77.59098932147026",
+              "address": {
+                "name": "Nithin",
+                "building": "building",
+                "locality": "Dr Ambedkar Road",
+                "city": "Bengaluru",
+                "state": "Karnataka",
+                "country": "IND",
+                "area_code": "560001"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2024-06-14T11:03:06.567Z",
+                "end": "2024-06-14T11:48:06.567Z"
+              }
+            }
+          },
+          "type": "Delivery",
+          "start": {
+            "location": {
+              "id": "merchant-167714647372249847",
+              "descriptor": {
+                "name": "Tipplr-swathi d"
+              },
+              "gps": "12.979612,77.590846",
+              "address": {
+                "city": "Bengaluru",
+                "area_code": "560001",
+                "locality": "Vasanth Nagar",
+                "state": "KA"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2024-06-14T11:03:06.567Z",
+                "end": "2024-06-14T11:48:06.567Z"
+              }
+            },
+            "contact": {
+              "phone": "8929221233",
+              "email": "support@tipplr.in"
+            }
+          },
+          "@ondc/org/provider_name": "TIPPLR_DELIVERY",
+          "state": {
+            "descriptor": {
+              "code": "Pending"
+            }
+          }
+        },
+        {
+          "id": "C1",
+          "state": {
+            "descriptor": {
+              "code": "Cancelled"
+            }
+          },
+          "type": "Cancel",
+          "tags": [
+            {
+              "code": "cancel_request",
+              "list": [
+                {
+                  "code": "reason_id",
+                  "value": "002"
+                },
+                {
+                  "code": "initiated_by",
+                  "value": "preprod.tipplr.in"
+                }
+              ]
+            },
+            {
+              "code": "quote_trail",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "item"
+                },
+                {
+                  "code": "id",
+                  "value": "food_item-170383210627835789"
+                },
+                {
+                  "code": "currency",
+                  "value": "INR"
+                },
+                {
+                  "code": "value",
+                  "value": "-140"
+                }
+              ]
+            },
+            {
+              "code": "quote_trail",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "tax"
+                },
+                {
+                  "code": "id",
+                  "value": "food_item-170383210627835789"
+                },
+                {
+                  "code": "currency",
+                  "value": "INR"
+                },
+                {
+                  "code": "value",
+                  "value": "-7.00"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "created_at": "2024-06-14T11:03:06.264Z",
+      "updated_at": "2024-06-14T11:03:19.039Z"
+    }
+  },
+  "context": {
+    "domain": "ONDC:RET11",
+    "country": "IND",
+    "city": "std:080",
+    "action": "on_update",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_uri": "https://preprod.tipplr.in/ondc/v2",
+    "transaction_id": "fd7605ff-aefc-470f-8b26-127b212f9b81",
+    "message_id": "e1880cd9-dc60-486d-8a22-9ad8a7d2d948",
+    "timestamp": "2024-06-14T11:03:19.039Z",
+    "bpp_id": "preprod.tipplr.in"
+  }
+}

--- a/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow6/8. update_settlement_part_cancel.json
+++ b/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow6/8. update_settlement_part_cancel.json
@@ -1,0 +1,39 @@
+{
+  "context": {
+    "domain": "ONDC:RET11",
+    "action": "update",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_id": "preprod.tipplr.in",
+    "bpp_uri": "https://preprod.tipplr.in/ondc/v2",
+    "transaction_id": "fd7605ff-aefc-470f-8b26-127b212f9b81",
+    "message_id": "85b09190-4d47-4814-b679-1bfeb1669b79",
+    "city": "std:080",
+    "country": "IND",
+    "timestamp": "2024-06-14T11:03:19.408Z"
+  },
+  "message": {
+    "update_target": "payment",
+    "order": {
+      "id": "2024-06-14-884454",
+      "fulfillments": [
+        {
+          "id": "C1",
+          "type": "Cancel"
+        }
+      ],
+      "payment": {
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "buyer",
+            "settlement_phase": "refund",
+            "settlement_type": "netbanking",
+            "settlement_amount": "147",
+            "settlement_timestamp": "2024-06-14T11:03:19.408Z"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow6/9. on_status_pending.json
+++ b/Tipplr/seller-app-v1.2-logs(F&B-RET11)-14-Jun/Flow6/9. on_status_pending.json
@@ -1,0 +1,470 @@
+{
+  "message": {
+    "order": {
+      "id": "2024-06-14-884454",
+      "state": "Accepted",
+      "provider": {
+        "id": "merchant-167714647372249847",
+        "locations": [
+          {
+            "id": "merchant-167714647372249847"
+          }
+        ]
+      },
+      "items": [
+        {
+          "id": "food_item-170383210597342600",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "merchant-167714647372249847"
+        },
+        {
+          "id": "food_item-170383210588937185",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "merchant-167714647372249847",
+          "parent_item_id": "DI1"
+        },
+        {
+          "id": "food_item-170383210588937185:603230",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "merchant-167714647372249847",
+          "tags": [
+            {
+              "code": "type",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "customization"
+                }
+              ]
+            },
+            {
+              "code": "parent",
+              "list": [
+                {
+                  "code": "id",
+                  "value": "76859436"
+                }
+              ]
+            }
+          ],
+          "parent_item_id": "DI1"
+        },
+        {
+          "id": "food_item-170383210627835789",
+          "quantity": {
+            "count": 0
+          },
+          "fulfillment_id": "merchant-167714647372249847"
+        },
+        {
+          "id": "food_item-170383210627835789",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "C1"
+        }
+      ],
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "732"
+        },
+        "breakup": [
+          {
+            "@ondc/org/item_id": "food_item-170383210588937185",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "title": "Chicken pizza",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "2"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "1"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ],
+              "parent_item_id": "DI1"
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210588937185:603230",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "title": "Regular",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "518"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "259"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "customization"
+                    }
+                  ]
+                },
+                {
+                  "code": "parent",
+                  "list": [
+                    {
+                      "code": "id",
+                      "value": "76859436"
+                    }
+                  ]
+                }
+              ],
+              "fulfillment_id": "merchant-167714647372249847",
+              "parent_item_id": "DI1"
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210588937185",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "26.00"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ],
+              "parent_item_id": "DI1"
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210597342600",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "title": "1 Idli 1 Vada",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "110"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "55"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "food_item-170383210597342600",
+            "title": "Tax",
+            "@ondc/org/title_type": "tax",
+            "price": {
+              "currency": "INR",
+              "value": "5.50"
+            },
+            "item": {
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "item"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Packing charges",
+            "@ondc/org/title_type": "packing",
+            "price": {
+              "currency": "INR",
+              "value": "21"
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Delivery charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "39"
+            }
+          },
+          {
+            "@ondc/org/item_id": "merchant-167714647372249847",
+            "title": "Convenience Fee",
+            "@ondc/org/title_type": "misc",
+            "price": {
+              "currency": "INR",
+              "value": "10.50"
+            }
+          }
+        ],
+        "ttl": "PT1H"
+      },
+      "billing": {
+        "address": {
+          "name": "Nithin",
+          "building": "building",
+          "locality": "Dr Ambedkar Road",
+          "city": "Bengaluru",
+          "state": "Karnataka",
+          "country": "IND",
+          "area_code": "560001"
+        },
+        "phone": "8951440205",
+        "name": "Nithin",
+        "email": "nithin@gmail.com",
+        "created_at": "2024-06-14T11:02:43.429Z",
+        "updated_at": "2024-06-14T11:02:43.429Z"
+      },
+      "payment": {
+        "uri": "https://razorpay.com/",
+        "tl_method": "http/get",
+        "params": {
+          "amount": "879.00",
+          "currency": "INR",
+          "transaction_id": "order_OMcKrZ5NeGGgiO"
+        },
+        "status": "PAID",
+        "type": "ON-ORDER",
+        "collected_by": "BAP",
+        "@ondc/org/buyer_app_finder_fee_type": "percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "seller-app",
+            "settlement_phase": "sale-amount",
+            "settlement_type": "neft",
+            "upi_address": "9900818181@upi",
+            "settlement_bank_account_no": "50200053531451",
+            "settlement_ifsc_code": "HDFC0004051",
+            "beneficiary_name": "FOOD SPACE TECHNOLOGY PRIVATE LIMITED",
+            "bank_name": "HDFC Bank",
+            "branch_name": "CNN"
+          },
+          {
+            "settlement_counterparty": "buyer",
+            "settlement_phase": "refund",
+            "settlement_type": "netbanking",
+            "settlement_amount": "147",
+            "settlement_timestamp": "2024-06-14T11:03:19.408Z"
+          }
+        ]
+      },
+      "fulfillments": [
+        {
+          "@ondc/org/TAT": "PT45M",
+          "id": "merchant-167714647372249847",
+          "tracking": true,
+          "end": {
+            "contact": {
+              "email": "nithin@gmail.com",
+              "phone": "8951440205"
+            },
+            "person": {
+              "name": "Nithin"
+            },
+            "location": {
+              "gps": "12.97943084572564,77.59098932147026",
+              "address": {
+                "name": "Nithin",
+                "building": "building",
+                "locality": "Dr Ambedkar Road",
+                "city": "Bengaluru",
+                "state": "Karnataka",
+                "country": "IND",
+                "area_code": "560001"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2024-06-14T11:03:06.567Z",
+                "end": "2024-06-14T11:48:06.567Z"
+              }
+            }
+          },
+          "type": "Delivery",
+          "start": {
+            "location": {
+              "id": "merchant-167714647372249847",
+              "descriptor": {
+                "name": "Tipplr-swathi d"
+              },
+              "gps": "12.979612,77.590846",
+              "address": {
+                "city": "Bengaluru",
+                "area_code": "560001",
+                "locality": "Vasanth Nagar",
+                "state": "KA"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2024-06-14T11:03:06.567Z",
+                "end": "2024-06-14T11:48:06.567Z"
+              }
+            },
+            "contact": {
+              "phone": "8929221233",
+              "email": "support@tipplr.in"
+            }
+          },
+          "@ondc/org/provider_name": "TIPPLR_DELIVERY",
+          "state": {
+            "descriptor": {
+              "code": "Pending"
+            }
+          },
+          "tags": [
+            {
+              "code": "routing",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "P2P"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "id": "C1",
+          "state": {
+            "descriptor": {
+              "code": "Cancelled"
+            }
+          },
+          "type": "Cancel",
+          "tags": [
+            {
+              "code": "cancel_request",
+              "list": [
+                {
+                  "code": "reason_id",
+                  "value": "002"
+                },
+                {
+                  "code": "initiated_by",
+                  "value": "preprod.tipplr.in"
+                }
+              ]
+            },
+            {
+              "code": "quote_trail",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "item"
+                },
+                {
+                  "code": "id",
+                  "value": "food_item-170383210627835789"
+                },
+                {
+                  "code": "currency",
+                  "value": "INR"
+                },
+                {
+                  "code": "value",
+                  "value": "-140"
+                }
+              ]
+            },
+            {
+              "code": "quote_trail",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "tax"
+                },
+                {
+                  "code": "id",
+                  "value": "food_item-170383210627835789"
+                },
+                {
+                  "code": "currency",
+                  "value": "INR"
+                },
+                {
+                  "code": "value",
+                  "value": "-7.00"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "created_at": "2024-06-14T11:03:06.264Z",
+      "updated_at": "2024-06-14T11:03:30.592Z",
+      "documents": [
+        {
+          "url": "https://tipplr-media.s3.ap-south-1.amazonaws.com/images/Invoice-26SWVY51CSGOW8U.pdf",
+          "label": "Invoice"
+        }
+      ]
+    }
+  },
+  "context": {
+    "domain": "ONDC:RET11",
+    "country": "IND",
+    "city": "std:080",
+    "action": "on_status",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_uri": "https://preprod.tipplr.in/ondc/v2",
+    "transaction_id": "fd7605ff-aefc-470f-8b26-127b212f9b81",
+    "message_id": "a5a12a10-ee04-493d-a232-a7512c0c9796",
+    "timestamp": "2024-06-14T11:03:30.593Z",
+    "bpp_id": "preprod.tipplr.in"
+  }
+}


### PR DESCRIPTION
Hi sandeep,

We have worked on the points mentioned in the new compliance.
We have made changes accordingly.

In Compliance they had mentioned: 
If the timing construct for order and delivery are the same, you can use the enum 'All' instead.

Our response:  We dont support Pickup option, If we give “All” it will take pickup also, so We intentionally added Delivery and Order.


Please accept our pr.

Thank you.
