### PR TITLE
2024 06 20 maaserp latest logs

### DIFF
--- a/MaasERP_Solutions/Retail/RET10/2024-06-20/Flow 2/confirm.json
+++ b/MaasERP_Solutions/Retail/RET10/2024-06-20/Flow 2/confirm.json
@@ -1,0 +1,202 @@
+{
+    "context": {
+        "domain": "ONDC:RET10",
+        "country": "IND",
+        "city": "std:040",
+        "action": "confirm",
+        "core_version": "1.2.0",
+        "bap_id": "buyer-app-preprod-v2.ondc.org",
+        "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+        "bpp_uri": "https://seller.dhihyperlocal.com/api/v1",
+        "transaction_id": "5fd141fa-6289-46ee-b4e4-b2d7ffcee443",
+        "message_id": "df4e84ea-280a-43e9-b106-affb4187fed8",
+        "timestamp": "2024-06-20T05:11:46.942Z",
+        "bpp_id": "seller.dhihyperlocal.com",
+        "ttl": "PT30S"
+    },
+    "message": {
+        "order": {
+            "id": "2024-06-20-984678",
+            "state": "Created",
+            "billing": {
+                "address": {
+                    "name": "pardeep singh",
+                    "building": "cyber tower",
+                    "locality": "Police Colony Road",
+                    "city": "Hyderabad",
+                    "state": "Telangana",
+                    "country": "IND",
+                    "area_code": "500084"
+                },
+                "phone": "8360441031",
+                "name": "pardeep singh",
+                "email": "pardeepsingh.it@maaserp.com",
+                "created_at": "2024-06-20T05:11:19.001Z",
+                "updated_at": "2024-06-20T05:11:19.001Z"
+            },
+            "items": [
+                {
+                    "id": "I51422",
+                    "quantity": {
+                        "count": 1
+                    },
+                    "fulfillment_id": "F3659"
+                },
+                {
+                    "id": "I51423",
+                    "quantity": {
+                        "count": 1
+                    },
+                    "fulfillment_id": "F3659"
+                }
+            ],
+            "provider": {
+                "id": "P1104",
+                "locations": [
+                    {
+                        "id": "L1104"
+                    }
+                ]
+            },
+            "fulfillments": [
+                {
+                    "@ondc/org/TAT": "P0DT6M",
+                    "id": "F3659",
+                    "tracking": true,
+                    "end": {
+                        "contact": {
+                            "email": "pardeepsingh.it@maaserp.com",
+                            "phone": "8360441031"
+                        },
+                        "person": {
+                            "name": "pardeep singh"
+                        },
+                        "location": {
+                            "gps": "17.464141,78.366162",
+                            "address": {
+                                "name": "pardeep singh",
+                                "building": "cyber tower",
+                                "locality": "Police Colony Road",
+                                "city": "Hyderabad",
+                                "state": "Telangana",
+                                "country": "IND",
+                                "area_code": "500084"
+                            }
+                        }
+                    },
+                    "type": "Delivery"
+                }
+            ],
+            "payment": {
+                "uri": "https://razorpay.com/",
+                "tl_method": "http/get",
+                "params": {
+                    "amount": "133.00",
+                    "currency": "INR",
+                    "transaction_id": "order_OOtYSc02w7Zmoy"
+                },
+                "status": "PAID",
+                "type": "ON-ORDER",
+                "collected_by": "BAP",
+                "@ondc/org/buyer_app_finder_fee_type": "percent",
+                "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+                "@ondc/org/settlement_details": [
+                    {
+                        "settlement_counterparty": "seller-app",
+                        "settlement_phase": "sale-amount",
+                        "settlement_type": "neft",
+                        "beneficiary_name": "MAAS ERP SOLUTIONS PRIVATE LIMITED",
+                        "settlement_bank_account_no": "59112345678901",
+                        "settlement_ifsc_code": "HDFC0000001",
+                        "bank_name": "HDFC",
+                        "branch_name": "Hyderabad"
+                    }
+                ]
+            },
+            "quote": {
+                "price": {
+                    "currency": "INR",
+                    "value": "133.00"
+                },
+                "breakup": [
+                    {
+                        "@ondc/org/item_id": "I51422",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
+                        },
+                        "@ondc/org/title_type": "item",
+                        "item": {
+                            "price": {
+                                "currency": "INR",
+                                "value": "44.00"
+                            }
+                        },
+                        "title": "rin ala fabric whitener 200 milli_litre",
+                        "price": {
+                            "currency": "INR",
+                            "value": "44.00"
+                        }
+                    },
+                    {
+                        "@ondc/org/item_id": "I51423",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
+                        },
+                        "@ondc/org/title_type": "item",
+                        "item": {
+                            "price": {
+                                "currency": "INR",
+                                "value": "89.00"
+                            }
+                        },
+                        "title": "rin ala fabric whitener 500 milli_litre",
+                        "price": {
+                            "currency": "INR",
+                            "value": "89.00"
+                        }
+                    },
+                    {
+                        "@ondc/org/item_id": "F3659",
+                        "title": "Delivery charges",
+                        "@ondc/org/title_type": "delivery",
+                        "price": {
+                            "currency": "INR",
+                            "value": "0"
+                        }
+                    }
+                ],
+                "ttl": "P1D"
+            },
+            "tags": [
+                {
+                    "code": "bpp_terms",
+                    "list": [
+                        {
+                            "code": "provider_tax_number",
+                            "value": "DMNPR5885P"
+                        },
+                        {
+                            "code": "tax_number",
+                            "value": "36AAPCM0450Q1ZX"
+                        },
+                        {
+                            "code": "np_type",
+                            "value": "MSN"
+                        }
+                    ]
+                },
+                {
+                    "code": "bap_terms",
+                    "list": [
+                        {
+                            "code": "tax_number",
+                            "value": "GSTIN1234567890"
+                        }
+                    ]
+                }
+            ],
+            "created_at": "2024-06-20T05:11:46.942Z",
+            "updated_at": "2024-06-20T05:11:46.942Z"
+        }
+    }
+}

--- a/MaasERP_Solutions/Retail/RET10/2024-06-20/Flow 2/init.json
+++ b/MaasERP_Solutions/Retail/RET10/2024-06-20/Flow 2/init.json
@@ -1,0 +1,87 @@
+{
+    "context": {
+        "domain": "ONDC:RET10",
+        "country": "IND",
+        "city": "std:040",
+        "action": "init",
+        "core_version": "1.2.0",
+        "bap_id": "buyer-app-preprod-v2.ondc.org",
+        "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+        "bpp_uri": "https://seller.dhihyperlocal.com/api/v1",
+        "transaction_id": "5fd141fa-6289-46ee-b4e4-b2d7ffcee443",
+        "message_id": "e35bf361-d552-48cd-8ec2-4fbf8ce69a9b",
+        "timestamp": "2024-06-20T05:11:19.001Z",
+        "bpp_id": "seller.dhihyperlocal.com",
+        "ttl": "PT30S"
+    },
+    "message": {
+        "order": {
+            "provider": {
+                "id": "P1104",
+                "locations": [
+                    {
+                        "id": "L1104"
+                    }
+                ]
+            },
+            "items": [
+                {
+                    "id": "I51422",
+                    "quantity": {
+                        "count": 1
+                    },
+                    "location_id": "L1104",
+                    "fulfillment_id": "F3659"
+                },
+                {
+                    "id": "I51423",
+                    "quantity": {
+                        "count": 1
+                    },
+                    "location_id": "L1104",
+                    "fulfillment_id": "F3659"
+                }
+            ],
+            "billing": {
+                "address": {
+                    "building": "cyber tower",
+                    "city": "Hyderabad",
+                    "state": "Telangana",
+                    "country": "IND",
+                    "area_code": "500084",
+                    "locality": "Police Colony Road",
+                    "name": "pardeep singh"
+                },
+                "phone": "8360441031",
+                "name": "pardeep singh",
+                "email": "pardeepsingh.it@maaserp.com",
+                "created_at": "2024-06-20T05:11:19.001Z",
+                "updated_at": "2024-06-20T05:11:19.001Z"
+            },
+            "fulfillments": [
+                {
+                    "id": "F3659",
+                    "type": "Delivery",
+                    "end": {
+                        "contact": {
+                            "email": "pardeepsingh.it@maaserp.com",
+                            "phone": "8360441031"
+                        },
+                        "location": {
+                            "gps": "17.464141,78.366162",
+                            "address": {
+                                "building": "cyber tower",
+                                "city": "Hyderabad",
+                                "state": "Telangana",
+                                "country": "IND",
+                                "area_code": "500084",
+                                "locality": "Police Colony Road",
+                                "name": "pardeep singh"
+                            }
+                        }
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/MaasERP_Solutions/Retail/RET10/2024-06-20/Flow 2/on_confirm.json
+++ b/MaasERP_Solutions/Retail/RET10/2024-06-20/Flow 2/on_confirm.json
@@ -1,0 +1,258 @@
+{
+    "context": {
+        "domain": "ONDC:RET10",
+        "country": "IND",
+        "city": "std:040",
+        "action": "on_confirm",
+        "core_version": "1.2.0",
+        "bap_id": "buyer-app-preprod-v2.ondc.org",
+        "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+        "bpp_uri": "https://seller.dhihyperlocal.com/api/v1",
+        "transaction_id": "5fd141fa-6289-46ee-b4e4-b2d7ffcee443",
+        "message_id": "df4e84ea-280a-43e9-b106-affb4187fed8",
+        "timestamp": "2024-06-20T05:11:48.000Z",
+        "bpp_id": "seller.dhihyperlocal.com",
+        "ttl": "PT30S"
+    },
+    "message": {
+        "order": {
+            "id": "2024-06-20-984678",
+            "state": "Created",
+            "provider": {
+                "id": "P1104",
+                "locations": [
+                    {
+                        "id": "L1104"
+                    }
+                ]
+            },
+            "items": [
+                {
+                    "id": "I51422",
+                    "fulfillment_id": "F3659",
+                    "quantity": {
+                        "count": 1
+                    }
+                },
+                {
+                    "id": "I51423",
+                    "fulfillment_id": "F3659",
+                    "quantity": {
+                        "count": 1
+                    }
+                }
+            ],
+            "billing": {
+                "name": "pardeep singh",
+                "address": {
+                    "name": "pardeep singh",
+                    "building": "cyber tower",
+                    "locality": "Police Colony Road",
+                    "city": "Hyderabad",
+                    "state": "Telangana",
+                    "country": "IND",
+                    "area_code": "500084"
+                },
+                "email": "pardeepsingh.it@maaserp.com",
+                "phone": "8360441031",
+                "created_at": "2024-06-20T05:11:19.001Z",
+                "updated_at": "2024-06-20T05:11:19.001Z"
+            },
+            "fulfillments": [
+                {
+                    "id": "F3659",
+                    "@ondc/org/provider_name": "sangameshwara super market",
+                    "type": "Delivery",
+                    "tracking": true,
+                    "@ondc/org/TAT": "P0DT6M",
+                    "state": {
+                        "descriptor": {
+                            "code": "Pending"
+                        }
+                    },
+                    "start": {
+                        "location": {
+                            "descriptor": {
+                                "name": "sangameshwara super market"
+                            },
+                            "id": "L1104",
+                            "gps": "17.462485,78.365312",
+                            "address": {
+                                "locality": "Lalitha Nilayam, Hanuman Nagar, Prashanth Nagar Colony, Kondapur, Telangana, India",
+                                "city": "Kondapur",
+                                "area_code": "500084",
+                                "state": "Telangana"
+                            }
+                        },
+                        "contact": {
+                            "phone": "8555051431",
+                            "email": "vamshikailasa0207@gmail.com"
+                        },
+                        "time": {
+                            "range": {
+                                "start": "2024-06-20T05:16:55.071Z",
+                                "end": "2024-06-20T05:21:55.071Z"
+                            }
+                        }
+                    },
+                    "end": {
+                        "location": {
+                            "gps": "17.464141,78.366162",
+                            "address": {
+                                "name": "pardeep singh",
+                                "building": "cyber tower",
+                                "locality": "Police Colony Road",
+                                "city": "Hyderabad",
+                                "state": "Telangana",
+                                "country": "IND",
+                                "area_code": "500084"
+                            }
+                        },
+                        "time": {
+                            "range": {
+                                "start": "2024-06-20T05:22:55.071Z",
+                                "end": "2024-06-20T05:27:55.071Z"
+                            }
+                        },
+                        "contact": {
+                            "phone": "8360441031",
+                            "email": "pardeepsingh.it@maaserp.com"
+                        },
+                        "person": {
+                            "name": "pardeep singh"
+                        }
+                    },
+                    "tags": [
+                        {
+                            "code": "tracking",
+                            "list": [
+                                {
+                                    "code": "gps_enabled",
+                                    "value": "no"
+                                },
+                                {
+                                    "code": "url_enabled",
+                                    "value": "yes"
+                                },
+                                {
+                                    "code": "url",
+                                    "value": "https://bbc.maaserp.com/ondc/tracking/13558"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "quote": {
+                "price": {
+                    "currency": "INR",
+                    "value": "133.00"
+                },
+                "breakup": [
+                    {
+                        "@ondc/org/item_id": "I51422",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
+                        },
+                        "title": "rin ala fabric whitener 200 milli_litre",
+                        "@ondc/org/title_type": "item",
+                        "price": {
+                            "currency": "INR",
+                            "value": "44.00"
+                        },
+                        "item": {
+                            "price": {
+                                "currency": "INR",
+                                "value": "44.00"
+                            }
+                        }
+                    },
+                    {
+                        "@ondc/org/item_id": "I51423",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
+                        },
+                        "title": "rin ala fabric whitener 500 milli_litre",
+                        "@ondc/org/title_type": "item",
+                        "price": {
+                            "currency": "INR",
+                            "value": "89.00"
+                        },
+                        "item": {
+                            "price": {
+                                "currency": "INR",
+                                "value": "89.00"
+                            }
+                        }
+                    },
+                    {
+                        "@ondc/org/item_id": "F3659",
+                        "title": "Delivery charges",
+                        "@ondc/org/title_type": "delivery",
+                        "price": {
+                            "currency": "INR",
+                            "value": "0"
+                        }
+                    }
+                ],
+                "ttl": "P1D"
+            },
+            "payment": {
+                "uri": "https://razorpay.com/",
+                "tl_method": "http/get",
+                "params": {
+                    "amount": "133.00",
+                    "currency": "INR",
+                    "transaction_id": "order_OOtYSc02w7Zmoy"
+                },
+                "status": "PAID",
+                "type": "ON-ORDER",
+                "collected_by": "BAP",
+                "@ondc/org/buyer_app_finder_fee_type": "percent",
+                "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+                "@ondc/org/settlement_details": [
+                    {
+                        "settlement_counterparty": "seller-app",
+                        "settlement_phase": "sale-amount",
+                        "settlement_type": "neft",
+                        "beneficiary_name": "MAAS ERP SOLUTIONS PRIVATE LIMITED",
+                        "settlement_bank_account_no": "59112345678901",
+                        "settlement_ifsc_code": "HDFC0000001",
+                        "bank_name": "HDFC",
+                        "branch_name": "Hyderabad"
+                    }
+                ]
+            },
+            "created_at": "2024-06-20T05:11:46.942Z",
+            "updated_at": "2024-06-20T05:11:48.000Z",
+            "tags": [
+                {
+                    "code": "bpp_terms",
+                    "list": [
+                        {
+                            "code": "provider_tax_number",
+                            "value": "DMNPR5885P"
+                        },
+                        {
+                            "code": "tax_number",
+                            "value": "36AAPCM0450Q1ZX"
+                        },
+                        {
+                            "code": "np_type",
+                            "value": "MSN"
+                        }
+                    ]
+                },
+                {
+                    "code": "bap_terms",
+                    "list": [
+                        {
+                            "code": "tax_number",
+                            "value": "GSTIN1234567890"
+                        }
+                    ]
+                }
+            ]
+        }
+    }
+}

--- a/MaasERP_Solutions/Retail/RET10/2024-06-20/Flow 2/on_init.json
+++ b/MaasERP_Solutions/Retail/RET10/2024-06-20/Flow 2/on_init.json
@@ -1,0 +1,176 @@
+{
+    "context": {
+        "domain": "ONDC:RET10",
+        "country": "IND",
+        "city": "std:040",
+        "action": "on_init",
+        "core_version": "1.2.0",
+        "bap_id": "buyer-app-preprod-v2.ondc.org",
+        "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+        "bpp_uri": "https://seller.dhihyperlocal.com/api/v1",
+        "transaction_id": "5fd141fa-6289-46ee-b4e4-b2d7ffcee443",
+        "message_id": "e35bf361-d552-48cd-8ec2-4fbf8ce69a9b",
+        "timestamp": "2024-06-20T05:11:21.358Z",
+        "bpp_id": "seller.dhihyperlocal.com",
+        "ttl": "PT30S"
+    },
+    "message": {
+        "order": {
+            "provider": {
+                "id": "P1104",
+                "locations": [
+                    {
+                        "id": "L1104"
+                    }
+                ]
+            },
+            "items": [
+                {
+                    "id": "I51422",
+                    "quantity": {
+                        "count": 1
+                    },
+                    "fulfillment_id": "F3659"
+                },
+                {
+                    "id": "I51423",
+                    "quantity": {
+                        "count": 1
+                    },
+                    "fulfillment_id": "F3659"
+                }
+            ],
+            "billing": {
+                "name": "pardeep singh",
+                "address": {
+                    "name": "pardeep singh",
+                    "building": "cyber tower",
+                    "locality": "Police Colony Road",
+                    "city": "Hyderabad",
+                    "state": "Telangana",
+                    "country": "IND",
+                    "area_code": "500084"
+                },
+                "email": "pardeepsingh.it@maaserp.com",
+                "phone": "8360441031",
+                "created_at": "2024-06-20T05:11:19.001Z",
+                "updated_at": "2024-06-20T05:11:19.001Z"
+            },
+            "fulfillments": [
+                {
+                    "id": "F3659",
+                    "type": "Delivery",
+                    "tracking": true,
+                    "end": {
+                        "location": {
+                            "gps": "17.464141,78.366162",
+                            "address": {
+                                "name": "pardeep singh",
+                                "building": "cyber tower",
+                                "locality": "Police Colony Road",
+                                "city": "Hyderabad",
+                                "state": "Telangana",
+                                "country": "IND",
+                                "area_code": "500084"
+                            }
+                        },
+                        "contact": {
+                            "phone": "8360441031",
+                            "email": "pardeepsingh.it@maaserp.com"
+                        }
+                    },
+                    "@ondc/org/TAT": "P0DT6M"
+                }
+            ],
+            "quote": {
+                "price": {
+                    "currency": "INR",
+                    "value": "133.00"
+                },
+                "breakup": [
+                    {
+                        "@ondc/org/item_id": "I51422",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
+                        },
+                        "@ondc/org/title_type": "item",
+                        "item": {
+                            "price": {
+                                "currency": "INR",
+                                "value": "44.00"
+                            }
+                        },
+                        "title": "rin ala fabric whitener 200 milli_litre",
+                        "price": {
+                            "currency": "INR",
+                            "value": "44.00"
+                        }
+                    },
+                    {
+                        "@ondc/org/item_id": "I51423",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
+                        },
+                        "@ondc/org/title_type": "item",
+                        "item": {
+                            "price": {
+                                "currency": "INR",
+                                "value": "89.00"
+                            }
+                        },
+                        "title": "rin ala fabric whitener 500 milli_litre",
+                        "price": {
+                            "currency": "INR",
+                            "value": "89.00"
+                        }
+                    },
+                    {
+                        "@ondc/org/item_id": "F3659",
+                        "title": "Delivery charges",
+                        "@ondc/org/title_type": "delivery",
+                        "price": {
+                            "currency": "INR",
+                            "value": "0"
+                        }
+                    }
+                ],
+                "ttl": "P1D"
+            },
+            "payment": {
+                "@ondc/org/buyer_app_finder_fee_type": "percent",
+                "@ondc/org/buyer_app_finder_fee_amount": "3",
+                "@ondc/org/settlement_details": [
+                    {
+                        "settlement_counterparty": "seller-app",
+                        "settlement_phase": "sale-amount",
+                        "settlement_type": "neft",
+                        "beneficiary_name": "MAAS ERP SOLUTIONS PRIVATE LIMITED",
+                        "settlement_bank_account_no": "59112345678901",
+                        "settlement_ifsc_code": "HDFC0000001",
+                        "bank_name": "HDFC",
+                        "branch_name": "Hyderabad"
+                    }
+                ]
+            },
+            "tags": [
+                {
+                    "code": "bpp_terms",
+                    "list": [
+                        {
+                            "code": "provider_tax_number",
+                            "value": "DMNPR5885P"
+                        },
+                        {
+                            "code": "tax_number",
+                            "value": "36AAPCM0450Q1ZX"
+                        },
+                        {
+                            "code": "np_type",
+                            "value": "MSN"
+                        }
+                    ]
+                }
+            ]
+        }
+    }
+}

--- a/MaasERP_Solutions/Retail/RET10/2024-06-20/Flow 2/on_select.json
+++ b/MaasERP_Solutions/Retail/RET10/2024-06-20/Flow 2/on_select.json
@@ -1,0 +1,137 @@
+{
+    "context": {
+        "domain": "ONDC:RET10",
+        "country": "IND",
+        "city": "std:040",
+        "action": "on_select",
+        "core_version": "1.2.0",
+        "bap_id": "buyer-app-preprod-v2.ondc.org",
+        "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+        "bpp_uri": "https://seller.dhihyperlocal.com/api/v1",
+        "transaction_id": "5fd141fa-6289-46ee-b4e4-b2d7ffcee443",
+        "message_id": "1ebdd588-0173-4330-b86d-cca13d807e98",
+        "timestamp": "2024-06-20T05:11:03.468Z",
+        "bpp_id": "seller.dhihyperlocal.com",
+        "ttl": "PT30S"
+    },
+    "message": {
+        "order": {
+            "provider": {
+                "id": "P1104",
+                "locations": [
+                    {
+                        "id": "L1104"
+                    }
+                ]
+            },
+            "items": [
+                {
+                    "fulfillment_id": "F3659",
+                    "id": "I51422"
+                },
+                {
+                    "fulfillment_id": "F3659",
+                    "id": "I51423"
+                }
+            ],
+            "fulfillments": [
+                {
+                    "id": "F3659",
+                    "@ondc/org/provider_name": "sangameshwara super market",
+                    "tracking": true,
+                    "type": "Delivery",
+                    "@ondc/org/category": "Immediate Delivery",
+                    "@ondc/org/TAT": "P0DT6M",
+                    "state": {
+                        "descriptor": {
+                            "code": "Serviceable"
+                        }
+                    }
+                },
+                {
+                    "id": "F3660",
+                    "type": "Self-Pickup",
+                    "@ondc/org/provider_name": "",
+                    "tracking": false,
+                    "@ondc/org/category": "Takeaway",
+                    "@ondc/org/TAT": "PT5M",
+                    "state": {
+                        "descriptor": {
+                            "code": "Serviceable"
+                        }
+                    }
+                }
+            ],
+            "quote": {
+                "price": {
+                    "currency": "INR",
+                    "value": "133.00"
+                },
+                "breakup": [
+                    {
+                        "@ondc/org/item_id": "I51422",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
+                        },
+                        "title": "rin ala fabric whitener 200 milli_litre",
+                        "@ondc/org/title_type": "item",
+                        "price": {
+                            "currency": "INR",
+                            "value": "44.00"
+                        },
+                        "item": {
+                            "quantity": {
+                                "available": {
+                                    "count": "99"
+                                },
+                                "maximum": {
+                                    "count": "5"
+                                }
+                            },
+                            "price": {
+                                "currency": "INR",
+                                "value": "44.00"
+                            }
+                        }
+                    },
+                    {
+                        "@ondc/org/item_id": "I51423",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
+                        },
+                        "title": "rin ala fabric whitener 500 milli_litre",
+                        "@ondc/org/title_type": "item",
+                        "price": {
+                            "currency": "INR",
+                            "value": "89.00"
+                        },
+                        "item": {
+                            "quantity": {
+                                "available": {
+                                    "count": "99"
+                                },
+                                "maximum": {
+                                    "count": "5"
+                                }
+                            },
+                            "price": {
+                                "currency": "INR",
+                                "value": "89.00"
+                            }
+                        }
+                    },
+                    {
+                        "@ondc/org/item_id": "F3659",
+                        "title": "Delivery charges",
+                        "@ondc/org/title_type": "delivery",
+                        "price": {
+                            "currency": "INR",
+                            "value": "0"
+                        }
+                    }
+                ],
+                "ttl": "P1D"
+            }
+        }
+    }
+}

--- a/MaasERP_Solutions/Retail/RET10/2024-06-20/Flow 2/on_status_agent-assigned.json
+++ b/MaasERP_Solutions/Retail/RET10/2024-06-20/Flow 2/on_status_agent-assigned.json
@@ -1,0 +1,239 @@
+{
+    "context": {
+        "domain": "ONDC:RET10",
+        "country": "IND",
+        "city": "std:040",
+        "action": "on_status",
+        "core_version": "1.2.0",
+        "bap_id": "buyer-app-preprod-v2.ondc.org",
+        "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+        "bpp_uri": "https://seller.dhihyperlocal.com/api/v1",
+        "transaction_id": "5fd141fa-6289-46ee-b4e4-b2d7ffcee443",
+        "message_id": "e7ca297f-2901-4dd1-bd9f-ec2134d10f4a",
+        "timestamp": "2024-06-20T05:17:05.000Z",
+        "bpp_id": "seller.dhihyperlocal.com",
+        "ttl": "PT30S"
+    },
+    "message": {
+        "order": {
+            "id": "2024-06-20-984678",
+            "state": "In-progress",
+            "provider": {
+                "id": "P1104",
+                "locations": [
+                    {
+                        "id": "L1104"
+                    }
+                ]
+            },
+            "items": [
+                {
+                    "id": "I51422",
+                    "fulfillment_id": "F3659",
+                    "quantity": {
+                        "count": 1
+                    }
+                },
+                {
+                    "id": "I51423",
+                    "fulfillment_id": "F3659",
+                    "quantity": {
+                        "count": 1
+                    }
+                }
+            ],
+            "billing": {
+                "name": "pardeep singh",
+                "address": {
+                    "name": "pardeep singh",
+                    "building": "cyber tower",
+                    "locality": "Police Colony Road",
+                    "city": "Hyderabad",
+                    "state": "Telangana",
+                    "country": "IND",
+                    "area_code": "500084"
+                },
+                "email": "pardeepsingh.it@maaserp.com",
+                "phone": "8360441031",
+                "created_at": "2024-06-20T05:11:19.001Z",
+                "updated_at": "2024-06-20T05:11:19.001Z"
+            },
+            "fulfillments": [
+                {
+                    "id": "F3659",
+                    "@ondc/org/provider_name": "sangameshwara super market",
+                    "type": "Delivery",
+                    "tracking": true,
+                    "@ondc/org/TAT": "P0DT6M",
+                    "state": {
+                        "descriptor": {
+                            "code": "Agent-assigned"
+                        }
+                    },
+                    "start": {
+                        "location": {
+                            "descriptor": {
+                                "name": "sangameshwara super market"
+                            },
+                            "id": "L1104",
+                            "gps": "17.462485,78.365312",
+                            "address": {
+                                "locality": "Lalitha Nilayam, Hanuman Nagar, Prashanth Nagar Colony, Kondapur, Telangana, India",
+                                "city": "Kondapur",
+                                "area_code": "500084",
+                                "state": "Telangana"
+                            }
+                        },
+                        "contact": {
+                            "phone": "8555051431",
+                            "email": "vamshikailasa0207@gmail.com"
+                        },
+                        "time": {
+                            "range": {
+                                "start": "2024-06-20T05:16:55.071Z",
+                                "end": "2024-06-20T05:21:55.071Z"
+                            }
+                        }
+                    },
+                    "tags": [
+                        {
+                            "code": "routing",
+                            "list": [
+                                {
+                                    "code": "type",
+                                    "value": "P2P"
+                                }
+                            ]
+                        },
+                        {
+                            "code": "tracking",
+                            "list": [
+                                {
+                                    "code": "gps_enabled",
+                                    "value": "no"
+                                },
+                                {
+                                    "code": "url_enabled",
+                                    "value": "yes"
+                                },
+                                {
+                                    "code": "url",
+                                    "value": "https://bbc.maaserp.com/ondc/tracking/13558"
+                                }
+                            ]
+                        }
+                    ],
+                    "end": {
+                        "location": {
+                            "gps": "17.464141,78.366162",
+                            "address": {
+                                "name": "pardeep singh",
+                                "building": "cyber tower",
+                                "locality": "Police Colony Road",
+                                "city": "Hyderabad",
+                                "state": "Telangana",
+                                "country": "IND",
+                                "area_code": "500084"
+                            }
+                        },
+                        "time": {
+                            "range": {
+                                "start": "2024-06-20T05:22:55.071Z",
+                                "end": "2024-06-20T05:27:55.071Z"
+                            }
+                        },
+                        "contact": {
+                            "phone": "8360441031",
+                            "email": "pardeepsingh.it@maaserp.com"
+                        },
+                        "person": {
+                            "name": "pardeep singh"
+                        }
+                    }
+                }
+            ],
+            "quote": {
+                "price": {
+                    "currency": "INR",
+                    "value": "133.00"
+                },
+                "breakup": [
+                    {
+                        "@ondc/org/item_id": "I51422",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
+                        },
+                        "title": "rin ala fabric whitener 200 milli_litre",
+                        "@ondc/org/title_type": "item",
+                        "price": {
+                            "currency": "INR",
+                            "value": "44.00"
+                        },
+                        "item": {
+                            "price": {
+                                "currency": "INR",
+                                "value": "44.00"
+                            }
+                        }
+                    },
+                    {
+                        "@ondc/org/item_id": "I51423",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
+                        },
+                        "title": "rin ala fabric whitener 500 milli_litre",
+                        "@ondc/org/title_type": "item",
+                        "price": {
+                            "currency": "INR",
+                            "value": "89.00"
+                        },
+                        "item": {
+                            "price": {
+                                "currency": "INR",
+                                "value": "89.00"
+                            }
+                        }
+                    },
+                    {
+                        "@ondc/org/item_id": "F3659",
+                        "title": "Delivery charges",
+                        "@ondc/org/title_type": "delivery",
+                        "price": {
+                            "currency": "INR",
+                            "value": "0"
+                        }
+                    }
+                ],
+                "ttl": "P1D"
+            },
+            "payment": {
+                "uri": "https://razorpay.com/",
+                "tl_method": "http/get",
+                "params": {
+                    "amount": "133.00",
+                    "currency": "INR",
+                    "transaction_id": "order_OOtYSc02w7Zmoy"
+                },
+                "status": "PAID",
+                "type": "ON-ORDER",
+                "collected_by": "BAP",
+                "@ondc/org/buyer_app_finder_fee_type": "percent",
+                "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+                "@ondc/org/settlement_details": [
+                    {
+                        "settlement_counterparty": "seller-app",
+                        "settlement_phase": "sale-amount",
+                        "settlement_type": "neft",
+                        "beneficiary_name": "MAAS ERP SOLUTIONS PRIVATE LIMITED",
+                        "settlement_bank_account_no": "59112345678901",
+                        "settlement_ifsc_code": "HDFC0000001",
+                        "bank_name": "HDFC",
+                        "branch_name": "Hyderabad"
+                    }
+                ]
+            },
+            "created_at": "2024-06-20T05:11:46.942Z",
+            "updated_at": "2024-06-20T05:17:05.000Z"
+        }
+    }
+}

--- a/MaasERP_Solutions/Retail/RET10/2024-06-20/Flow 2/on_status_order-delivered.json
+++ b/MaasERP_Solutions/Retail/RET10/2024-06-20/Flow 2/on_status_order-delivered.json
@@ -1,0 +1,247 @@
+{
+    "context": {
+        "domain": "ONDC:RET10",
+        "country": "IND",
+        "city": "std:040",
+        "action": "on_status",
+        "core_version": "1.2.0",
+        "bap_id": "buyer-app-preprod-v2.ondc.org",
+        "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+        "bpp_uri": "https://seller.dhihyperlocal.com/api/v1",
+        "transaction_id": "5fd141fa-6289-46ee-b4e4-b2d7ffcee443",
+        "message_id": "50db8876-2140-40c3-9282-092ec369aaf5",
+        "timestamp": "2024-06-20T05:22:35.000Z",
+        "bpp_id": "seller.dhihyperlocal.com",
+        "ttl": "PT30S"
+    },
+    "message": {
+        "order": {
+            "id": "2024-06-20-984678",
+            "state": "Completed",
+            "provider": {
+                "id": "P1104",
+                "locations": [
+                    {
+                        "id": "L1104"
+                    }
+                ]
+            },
+            "items": [
+                {
+                    "id": "I51422",
+                    "fulfillment_id": "F3659",
+                    "quantity": {
+                        "count": 1
+                    }
+                },
+                {
+                    "id": "I51423",
+                    "fulfillment_id": "F3659",
+                    "quantity": {
+                        "count": 1
+                    }
+                }
+            ],
+            "billing": {
+                "name": "pardeep singh",
+                "address": {
+                    "name": "pardeep singh",
+                    "building": "cyber tower",
+                    "locality": "Police Colony Road",
+                    "city": "Hyderabad",
+                    "state": "Telangana",
+                    "country": "IND",
+                    "area_code": "500084"
+                },
+                "email": "pardeepsingh.it@maaserp.com",
+                "phone": "8360441031",
+                "created_at": "2024-06-20T05:11:19.001Z",
+                "updated_at": "2024-06-20T05:11:19.001Z"
+            },
+            "fulfillments": [
+                {
+                    "id": "F3659",
+                    "@ondc/org/provider_name": "sangameshwara super market",
+                    "type": "Delivery",
+                    "tracking": true,
+                    "@ondc/org/TAT": "P0DT6M",
+                    "state": {
+                        "descriptor": {
+                            "code": "Order-delivered"
+                        }
+                    },
+                    "start": {
+                        "location": {
+                            "descriptor": {
+                                "name": "sangameshwara super market"
+                            },
+                            "id": "L1104",
+                            "gps": "17.462485,78.365312",
+                            "address": {
+                                "locality": "Lalitha Nilayam, Hanuman Nagar, Prashanth Nagar Colony, Kondapur, Telangana, India",
+                                "city": "Kondapur",
+                                "area_code": "500084",
+                                "state": "Telangana"
+                            }
+                        },
+                        "contact": {
+                            "phone": "8555051431",
+                            "email": "vamshikailasa0207@gmail.com"
+                        },
+                        "time": {
+                            "range": {
+                                "start": "2024-06-20T05:16:55.071Z",
+                                "end": "2024-06-20T05:21:55.071Z"
+                            },
+                            "timestamp": "2024-06-20T05:17:26.000Z"
+                        }
+                    },
+                    "tags": [
+                        {
+                            "code": "routing",
+                            "list": [
+                                {
+                                    "code": "type",
+                                    "value": "P2P"
+                                }
+                            ]
+                        },
+                        {
+                            "code": "tracking",
+                            "list": [
+                                {
+                                    "code": "gps_enabled",
+                                    "value": "no"
+                                },
+                                {
+                                    "code": "url_enabled",
+                                    "value": "yes"
+                                },
+                                {
+                                    "code": "url",
+                                    "value": "https://bbc.maaserp.com/ondc/tracking/13558"
+                                }
+                            ]
+                        }
+                    ],
+                    "end": {
+                        "location": {
+                            "gps": "17.464141,78.366162",
+                            "address": {
+                                "name": "pardeep singh",
+                                "building": "cyber tower",
+                                "locality": "Police Colony Road",
+                                "city": "Hyderabad",
+                                "state": "Telangana",
+                                "country": "IND",
+                                "area_code": "500084"
+                            }
+                        },
+                        "time": {
+                            "range": {
+                                "start": "2024-06-20T05:22:55.071Z",
+                                "end": "2024-06-20T05:27:55.071Z"
+                            },
+                            "timestamp": "2024-06-20T05:21:44.000Z"
+                        },
+                        "contact": {
+                            "phone": "8360441031",
+                            "email": "pardeepsingh.it@maaserp.com"
+                        },
+                        "person": {
+                            "name": "pardeep singh"
+                        }
+                    }
+                }
+            ],
+            "quote": {
+                "price": {
+                    "currency": "INR",
+                    "value": "133.00"
+                },
+                "breakup": [
+                    {
+                        "@ondc/org/item_id": "I51422",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
+                        },
+                        "title": "rin ala fabric whitener 200 milli_litre",
+                        "@ondc/org/title_type": "item",
+                        "price": {
+                            "currency": "INR",
+                            "value": "44.00"
+                        },
+                        "item": {
+                            "price": {
+                                "currency": "INR",
+                                "value": "44.00"
+                            }
+                        }
+                    },
+                    {
+                        "@ondc/org/item_id": "I51423",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
+                        },
+                        "title": "rin ala fabric whitener 500 milli_litre",
+                        "@ondc/org/title_type": "item",
+                        "price": {
+                            "currency": "INR",
+                            "value": "89.00"
+                        },
+                        "item": {
+                            "price": {
+                                "currency": "INR",
+                                "value": "89.00"
+                            }
+                        }
+                    },
+                    {
+                        "@ondc/org/item_id": "F3659",
+                        "title": "Delivery charges",
+                        "@ondc/org/title_type": "delivery",
+                        "price": {
+                            "currency": "INR",
+                            "value": "0"
+                        }
+                    }
+                ],
+                "ttl": "P1D"
+            },
+            "payment": {
+                "uri": "https://razorpay.com/",
+                "tl_method": "http/get",
+                "params": {
+                    "amount": "133.00",
+                    "currency": "INR",
+                    "transaction_id": "order_OOtYSc02w7Zmoy"
+                },
+                "status": "PAID",
+                "type": "ON-ORDER",
+                "collected_by": "BAP",
+                "@ondc/org/buyer_app_finder_fee_type": "percent",
+                "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+                "@ondc/org/settlement_details": [
+                    {
+                        "settlement_counterparty": "seller-app",
+                        "settlement_phase": "sale-amount",
+                        "settlement_type": "neft",
+                        "beneficiary_name": "MAAS ERP SOLUTIONS PRIVATE LIMITED",
+                        "settlement_bank_account_no": "59112345678901",
+                        "settlement_ifsc_code": "HDFC0000001",
+                        "bank_name": "HDFC",
+                        "branch_name": "Hyderabad"
+                    }
+                ]
+            },
+            "created_at": "2024-06-20T05:11:46.942Z",
+            "updated_at": "2024-06-20T05:22:35.000Z",
+            "documents": [
+                {
+                    "url": "https://newnfresume.s3-us-west-2.amazonaws.com/Orderinvoices/INV_1718860454_1932370078_34224_13558.pdf",
+                    "label": "Invoice"
+                }
+            ]
+        }
+    }
+}

--- a/MaasERP_Solutions/Retail/RET10/2024-06-20/Flow 2/on_status_order-picked-up.json
+++ b/MaasERP_Solutions/Retail/RET10/2024-06-20/Flow 2/on_status_order-picked-up.json
@@ -1,0 +1,246 @@
+{
+    "context": {
+        "domain": "ONDC:RET10",
+        "country": "IND",
+        "city": "std:040",
+        "action": "on_status",
+        "core_version": "1.2.0",
+        "bap_id": "buyer-app-preprod-v2.ondc.org",
+        "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+        "bpp_uri": "https://seller.dhihyperlocal.com/api/v1",
+        "transaction_id": "5fd141fa-6289-46ee-b4e4-b2d7ffcee443",
+        "message_id": "9e12149b-1544-4358-b07b-c5ecfacafda4",
+        "timestamp": "2024-06-20T05:17:26.000Z",
+        "bpp_id": "seller.dhihyperlocal.com",
+        "ttl": "PT30S"
+    },
+    "message": {
+        "order": {
+            "id": "2024-06-20-984678",
+            "state": "In-progress",
+            "provider": {
+                "id": "P1104",
+                "locations": [
+                    {
+                        "id": "L1104"
+                    }
+                ]
+            },
+            "items": [
+                {
+                    "id": "I51422",
+                    "fulfillment_id": "F3659",
+                    "quantity": {
+                        "count": 1
+                    }
+                },
+                {
+                    "id": "I51423",
+                    "fulfillment_id": "F3659",
+                    "quantity": {
+                        "count": 1
+                    }
+                }
+            ],
+            "billing": {
+                "name": "pardeep singh",
+                "address": {
+                    "name": "pardeep singh",
+                    "building": "cyber tower",
+                    "locality": "Police Colony Road",
+                    "city": "Hyderabad",
+                    "state": "Telangana",
+                    "country": "IND",
+                    "area_code": "500084"
+                },
+                "email": "pardeepsingh.it@maaserp.com",
+                "phone": "8360441031",
+                "created_at": "2024-06-20T05:11:19.001Z",
+                "updated_at": "2024-06-20T05:11:19.001Z"
+            },
+            "fulfillments": [
+                {
+                    "id": "F3659",
+                    "@ondc/org/provider_name": "sangameshwara super market",
+                    "type": "Delivery",
+                    "tracking": true,
+                    "@ondc/org/TAT": "P0DT6M",
+                    "state": {
+                        "descriptor": {
+                            "code": "Order-picked-up"
+                        }
+                    },
+                    "start": {
+                        "location": {
+                            "descriptor": {
+                                "name": "sangameshwara super market"
+                            },
+                            "id": "L1104",
+                            "gps": "17.462485,78.365312",
+                            "address": {
+                                "locality": "Lalitha Nilayam, Hanuman Nagar, Prashanth Nagar Colony, Kondapur, Telangana, India",
+                                "city": "Kondapur",
+                                "area_code": "500084",
+                                "state": "Telangana"
+                            }
+                        },
+                        "contact": {
+                            "phone": "8555051431",
+                            "email": "vamshikailasa0207@gmail.com"
+                        },
+                        "time": {
+                            "range": {
+                                "start": "2024-06-20T05:16:55.071Z",
+                                "end": "2024-06-20T05:21:55.071Z"
+                            },
+                            "timestamp": "2024-06-20T05:17:26.000Z"
+                        }
+                    },
+                    "tags": [
+                        {
+                            "code": "routing",
+                            "list": [
+                                {
+                                    "code": "type",
+                                    "value": "P2P"
+                                }
+                            ]
+                        },
+                        {
+                            "code": "tracking",
+                            "list": [
+                                {
+                                    "code": "gps_enabled",
+                                    "value": "no"
+                                },
+                                {
+                                    "code": "url_enabled",
+                                    "value": "yes"
+                                },
+                                {
+                                    "code": "url",
+                                    "value": "https://bbc.maaserp.com/ondc/tracking/13558"
+                                }
+                            ]
+                        }
+                    ],
+                    "end": {
+                        "location": {
+                            "gps": "17.464141,78.366162",
+                            "address": {
+                                "name": "pardeep singh",
+                                "building": "cyber tower",
+                                "locality": "Police Colony Road",
+                                "city": "Hyderabad",
+                                "state": "Telangana",
+                                "country": "IND",
+                                "area_code": "500084"
+                            }
+                        },
+                        "time": {
+                            "range": {
+                                "start": "2024-06-20T05:22:55.071Z",
+                                "end": "2024-06-20T05:27:55.071Z"
+                            }
+                        },
+                        "contact": {
+                            "phone": "8360441031",
+                            "email": "pardeepsingh.it@maaserp.com"
+                        },
+                        "person": {
+                            "name": "pardeep singh"
+                        }
+                    }
+                }
+            ],
+            "quote": {
+                "price": {
+                    "currency": "INR",
+                    "value": "133.00"
+                },
+                "breakup": [
+                    {
+                        "@ondc/org/item_id": "I51422",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
+                        },
+                        "title": "rin ala fabric whitener 200 milli_litre",
+                        "@ondc/org/title_type": "item",
+                        "price": {
+                            "currency": "INR",
+                            "value": "44.00"
+                        },
+                        "item": {
+                            "price": {
+                                "currency": "INR",
+                                "value": "44.00"
+                            }
+                        }
+                    },
+                    {
+                        "@ondc/org/item_id": "I51423",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
+                        },
+                        "title": "rin ala fabric whitener 500 milli_litre",
+                        "@ondc/org/title_type": "item",
+                        "price": {
+                            "currency": "INR",
+                            "value": "89.00"
+                        },
+                        "item": {
+                            "price": {
+                                "currency": "INR",
+                                "value": "89.00"
+                            }
+                        }
+                    },
+                    {
+                        "@ondc/org/item_id": "F3659",
+                        "title": "Delivery charges",
+                        "@ondc/org/title_type": "delivery",
+                        "price": {
+                            "currency": "INR",
+                            "value": "0"
+                        }
+                    }
+                ],
+                "ttl": "P1D"
+            },
+            "payment": {
+                "uri": "https://razorpay.com/",
+                "tl_method": "http/get",
+                "params": {
+                    "amount": "133.00",
+                    "currency": "INR",
+                    "transaction_id": "order_OOtYSc02w7Zmoy"
+                },
+                "status": "PAID",
+                "type": "ON-ORDER",
+                "collected_by": "BAP",
+                "@ondc/org/buyer_app_finder_fee_type": "percent",
+                "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+                "@ondc/org/settlement_details": [
+                    {
+                        "settlement_counterparty": "seller-app",
+                        "settlement_phase": "sale-amount",
+                        "settlement_type": "neft",
+                        "beneficiary_name": "MAAS ERP SOLUTIONS PRIVATE LIMITED",
+                        "settlement_bank_account_no": "59112345678901",
+                        "settlement_ifsc_code": "HDFC0000001",
+                        "bank_name": "HDFC",
+                        "branch_name": "Hyderabad"
+                    }
+                ]
+            },
+            "created_at": "2024-06-20T05:11:46.942Z",
+            "updated_at": "2024-06-20T05:17:26.000Z",
+            "documents": [
+                {
+                    "url": "https://newnfresume.s3-us-west-2.amazonaws.com/Orderinvoices/INV_1718860454_1932370078_34224_13558.pdf",
+                    "label": "Invoice"
+                }
+            ]
+        }
+    }
+}

--- a/MaasERP_Solutions/Retail/RET10/2024-06-20/Flow 2/on_status_out-for-delivery.json
+++ b/MaasERP_Solutions/Retail/RET10/2024-06-20/Flow 2/on_status_out-for-delivery.json
@@ -1,0 +1,246 @@
+{
+    "context": {
+        "domain": "ONDC:RET10",
+        "country": "IND",
+        "city": "std:040",
+        "action": "on_status",
+        "core_version": "1.2.0",
+        "bap_id": "buyer-app-preprod-v2.ondc.org",
+        "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+        "bpp_uri": "https://seller.dhihyperlocal.com/api/v1",
+        "transaction_id": "5fd141fa-6289-46ee-b4e4-b2d7ffcee443",
+        "message_id": "4e122607-7f49-4a4a-9eee-3bbd54d4590d",
+        "timestamp": "2024-06-20T05:17:45.000Z",
+        "bpp_id": "seller.dhihyperlocal.com",
+        "ttl": "PT30S"
+    },
+    "message": {
+        "order": {
+            "id": "2024-06-20-984678",
+            "state": "In-progress",
+            "provider": {
+                "id": "P1104",
+                "locations": [
+                    {
+                        "id": "L1104"
+                    }
+                ]
+            },
+            "items": [
+                {
+                    "id": "I51422",
+                    "fulfillment_id": "F3659",
+                    "quantity": {
+                        "count": 1
+                    }
+                },
+                {
+                    "id": "I51423",
+                    "fulfillment_id": "F3659",
+                    "quantity": {
+                        "count": 1
+                    }
+                }
+            ],
+            "billing": {
+                "name": "pardeep singh",
+                "address": {
+                    "name": "pardeep singh",
+                    "building": "cyber tower",
+                    "locality": "Police Colony Road",
+                    "city": "Hyderabad",
+                    "state": "Telangana",
+                    "country": "IND",
+                    "area_code": "500084"
+                },
+                "email": "pardeepsingh.it@maaserp.com",
+                "phone": "8360441031",
+                "created_at": "2024-06-20T05:11:19.001Z",
+                "updated_at": "2024-06-20T05:11:19.001Z"
+            },
+            "fulfillments": [
+                {
+                    "id": "F3659",
+                    "@ondc/org/provider_name": "sangameshwara super market",
+                    "type": "Delivery",
+                    "tracking": true,
+                    "@ondc/org/TAT": "P0DT6M",
+                    "state": {
+                        "descriptor": {
+                            "code": "Out-for-delivery"
+                        }
+                    },
+                    "start": {
+                        "location": {
+                            "descriptor": {
+                                "name": "sangameshwara super market"
+                            },
+                            "id": "L1104",
+                            "gps": "17.462485,78.365312",
+                            "address": {
+                                "locality": "Lalitha Nilayam, Hanuman Nagar, Prashanth Nagar Colony, Kondapur, Telangana, India",
+                                "city": "Kondapur",
+                                "area_code": "500084",
+                                "state": "Telangana"
+                            }
+                        },
+                        "contact": {
+                            "phone": "8555051431",
+                            "email": "vamshikailasa0207@gmail.com"
+                        },
+                        "time": {
+                            "range": {
+                                "start": "2024-06-20T05:16:55.071Z",
+                                "end": "2024-06-20T05:21:55.071Z"
+                            },
+                            "timestamp": "2024-06-20T05:17:26.000Z"
+                        }
+                    },
+                    "tags": [
+                        {
+                            "code": "routing",
+                            "list": [
+                                {
+                                    "code": "type",
+                                    "value": "P2P"
+                                }
+                            ]
+                        },
+                        {
+                            "code": "tracking",
+                            "list": [
+                                {
+                                    "code": "gps_enabled",
+                                    "value": "no"
+                                },
+                                {
+                                    "code": "url_enabled",
+                                    "value": "yes"
+                                },
+                                {
+                                    "code": "url",
+                                    "value": "https://bbc.maaserp.com/ondc/tracking/13558"
+                                }
+                            ]
+                        }
+                    ],
+                    "end": {
+                        "location": {
+                            "gps": "17.464141,78.366162",
+                            "address": {
+                                "name": "pardeep singh",
+                                "building": "cyber tower",
+                                "locality": "Police Colony Road",
+                                "city": "Hyderabad",
+                                "state": "Telangana",
+                                "country": "IND",
+                                "area_code": "500084"
+                            }
+                        },
+                        "time": {
+                            "range": {
+                                "start": "2024-06-20T05:22:55.071Z",
+                                "end": "2024-06-20T05:27:55.071Z"
+                            }
+                        },
+                        "contact": {
+                            "phone": "8360441031",
+                            "email": "pardeepsingh.it@maaserp.com"
+                        },
+                        "person": {
+                            "name": "pardeep singh"
+                        }
+                    }
+                }
+            ],
+            "quote": {
+                "price": {
+                    "currency": "INR",
+                    "value": "133.00"
+                },
+                "breakup": [
+                    {
+                        "@ondc/org/item_id": "I51422",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
+                        },
+                        "title": "rin ala fabric whitener 200 milli_litre",
+                        "@ondc/org/title_type": "item",
+                        "price": {
+                            "currency": "INR",
+                            "value": "44.00"
+                        },
+                        "item": {
+                            "price": {
+                                "currency": "INR",
+                                "value": "44.00"
+                            }
+                        }
+                    },
+                    {
+                        "@ondc/org/item_id": "I51423",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
+                        },
+                        "title": "rin ala fabric whitener 500 milli_litre",
+                        "@ondc/org/title_type": "item",
+                        "price": {
+                            "currency": "INR",
+                            "value": "89.00"
+                        },
+                        "item": {
+                            "price": {
+                                "currency": "INR",
+                                "value": "89.00"
+                            }
+                        }
+                    },
+                    {
+                        "@ondc/org/item_id": "F3659",
+                        "title": "Delivery charges",
+                        "@ondc/org/title_type": "delivery",
+                        "price": {
+                            "currency": "INR",
+                            "value": "0"
+                        }
+                    }
+                ],
+                "ttl": "P1D"
+            },
+            "payment": {
+                "uri": "https://razorpay.com/",
+                "tl_method": "http/get",
+                "params": {
+                    "amount": "133.00",
+                    "currency": "INR",
+                    "transaction_id": "order_OOtYSc02w7Zmoy"
+                },
+                "status": "PAID",
+                "type": "ON-ORDER",
+                "collected_by": "BAP",
+                "@ondc/org/buyer_app_finder_fee_type": "percent",
+                "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+                "@ondc/org/settlement_details": [
+                    {
+                        "settlement_counterparty": "seller-app",
+                        "settlement_phase": "sale-amount",
+                        "settlement_type": "neft",
+                        "beneficiary_name": "MAAS ERP SOLUTIONS PRIVATE LIMITED",
+                        "settlement_bank_account_no": "59112345678901",
+                        "settlement_ifsc_code": "HDFC0000001",
+                        "bank_name": "HDFC",
+                        "branch_name": "Hyderabad"
+                    }
+                ]
+            },
+            "created_at": "2024-06-20T05:11:46.942Z",
+            "updated_at": "2024-06-20T05:17:45.000Z",
+            "documents": [
+                {
+                    "url": "https://newnfresume.s3-us-west-2.amazonaws.com/Orderinvoices/INV_1718860454_1932370078_34224_13558.pdf",
+                    "label": "Invoice"
+                }
+            ]
+        }
+    }
+}

--- a/MaasERP_Solutions/Retail/RET10/2024-06-20/Flow 2/on_status_packed.json
+++ b/MaasERP_Solutions/Retail/RET10/2024-06-20/Flow 2/on_status_packed.json
@@ -1,0 +1,230 @@
+{
+    "context": {
+        "domain": "ONDC:RET10",
+        "country": "IND",
+        "city": "std:040",
+        "action": "on_status",
+        "core_version": "1.2.0",
+        "bap_id": "buyer-app-preprod-v2.ondc.org",
+        "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+        "bpp_uri": "https://seller.dhihyperlocal.com/api/v1",
+        "transaction_id": "5fd141fa-6289-46ee-b4e4-b2d7ffcee443",
+        "message_id": "eef93958-0cfc-4c1c-9547-c3dcbca47de4",
+        "timestamp": "2024-06-20T05:15:14.000Z",
+        "bpp_id": "seller.dhihyperlocal.com",
+        "ttl": "PT30S"
+    },
+    "message": {
+        "order": {
+            "id": "2024-06-20-984678",
+            "state": "In-progress",
+            "provider": {
+                "id": "P1104",
+                "locations": [
+                    {
+                        "id": "L1104"
+                    }
+                ]
+            },
+            "items": [
+                {
+                    "id": "I51422",
+                    "fulfillment_id": "F3659",
+                    "quantity": {
+                        "count": 1
+                    }
+                },
+                {
+                    "id": "I51423",
+                    "fulfillment_id": "F3659",
+                    "quantity": {
+                        "count": 1
+                    }
+                }
+            ],
+            "billing": {
+                "name": "pardeep singh",
+                "address": {
+                    "name": "pardeep singh",
+                    "building": "cyber tower",
+                    "locality": "Police Colony Road",
+                    "city": "Hyderabad",
+                    "state": "Telangana",
+                    "country": "IND",
+                    "area_code": "500084"
+                },
+                "email": "pardeepsingh.it@maaserp.com",
+                "phone": "8360441031",
+                "created_at": "2024-06-20T05:11:19.001Z",
+                "updated_at": "2024-06-20T05:11:19.001Z"
+            },
+            "fulfillments": [
+                {
+                    "id": "F3659",
+                    "@ondc/org/provider_name": "sangameshwara super market",
+                    "type": "Delivery",
+                    "tracking": true,
+                    "@ondc/org/TAT": "P0DT6M",
+                    "state": {
+                        "descriptor": {
+                            "code": "Packed"
+                        }
+                    },
+                    "start": {
+                        "location": {
+                            "descriptor": {
+                                "name": "sangameshwara super market"
+                            },
+                            "id": "L1104",
+                            "gps": "17.462485,78.365312",
+                            "address": {
+                                "locality": "Lalitha Nilayam, Hanuman Nagar, Prashanth Nagar Colony, Kondapur, Telangana, India",
+                                "city": "Kondapur",
+                                "area_code": "500084",
+                                "state": "Telangana"
+                            }
+                        },
+                        "contact": {
+                            "phone": "8555051431",
+                            "email": "vamshikailasa0207@gmail.com"
+                        },
+                        "time": {
+                            "range": {
+                                "start": "2024-06-20T05:16:55.071Z",
+                                "end": "2024-06-20T05:21:55.071Z"
+                            }
+                        }
+                    },
+                    "end": {
+                        "location": {
+                            "gps": "17.464141,78.366162",
+                            "address": {
+                                "name": "pardeep singh",
+                                "building": "cyber tower",
+                                "locality": "Police Colony Road",
+                                "city": "Hyderabad",
+                                "state": "Telangana",
+                                "country": "IND",
+                                "area_code": "500084"
+                            }
+                        },
+                        "time": {
+                            "range": {
+                                "start": "2024-06-20T05:22:55.071Z",
+                                "end": "2024-06-20T05:27:55.071Z"
+                            }
+                        },
+                        "contact": {
+                            "phone": "8360441031",
+                            "email": "pardeepsingh.it@maaserp.com"
+                        },
+                        "person": {
+                            "name": "pardeep singh"
+                        }
+                    },
+                    "tags": [
+                        {
+                            "code": "tracking",
+                            "list": [
+                                {
+                                    "code": "gps_enabled",
+                                    "value": "no"
+                                },
+                                {
+                                    "code": "url_enabled",
+                                    "value": "yes"
+                                },
+                                {
+                                    "code": "url",
+                                    "value": "https://bbc.maaserp.com/ondc/tracking/13558"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "quote": {
+                "price": {
+                    "currency": "INR",
+                    "value": "133.00"
+                },
+                "breakup": [
+                    {
+                        "@ondc/org/item_id": "I51422",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
+                        },
+                        "title": "rin ala fabric whitener 200 milli_litre",
+                        "@ondc/org/title_type": "item",
+                        "price": {
+                            "currency": "INR",
+                            "value": "44.00"
+                        },
+                        "item": {
+                            "price": {
+                                "currency": "INR",
+                                "value": "44.00"
+                            }
+                        }
+                    },
+                    {
+                        "@ondc/org/item_id": "I51423",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
+                        },
+                        "title": "rin ala fabric whitener 500 milli_litre",
+                        "@ondc/org/title_type": "item",
+                        "price": {
+                            "currency": "INR",
+                            "value": "89.00"
+                        },
+                        "item": {
+                            "price": {
+                                "currency": "INR",
+                                "value": "89.00"
+                            }
+                        }
+                    },
+                    {
+                        "@ondc/org/item_id": "F3659",
+                        "title": "Delivery charges",
+                        "@ondc/org/title_type": "delivery",
+                        "price": {
+                            "currency": "INR",
+                            "value": "0"
+                        }
+                    }
+                ],
+                "ttl": "P1D"
+            },
+            "payment": {
+                "uri": "https://razorpay.com/",
+                "tl_method": "http/get",
+                "params": {
+                    "amount": "133.00",
+                    "currency": "INR",
+                    "transaction_id": "order_OOtYSc02w7Zmoy"
+                },
+                "status": "PAID",
+                "type": "ON-ORDER",
+                "collected_by": "BAP",
+                "@ondc/org/buyer_app_finder_fee_type": "percent",
+                "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+                "@ondc/org/settlement_details": [
+                    {
+                        "settlement_counterparty": "seller-app",
+                        "settlement_phase": "sale-amount",
+                        "settlement_type": "neft",
+                        "beneficiary_name": "MAAS ERP SOLUTIONS PRIVATE LIMITED",
+                        "settlement_bank_account_no": "59112345678901",
+                        "settlement_ifsc_code": "HDFC0000001",
+                        "bank_name": "HDFC",
+                        "branch_name": "Hyderabad"
+                    }
+                ]
+            },
+            "created_at": "2024-06-20T05:11:46.942Z",
+            "updated_at": "2024-06-20T05:15:14.000Z"
+        }
+    }
+}

--- a/MaasERP_Solutions/Retail/RET10/2024-06-20/Flow 2/on_status_pending.json
+++ b/MaasERP_Solutions/Retail/RET10/2024-06-20/Flow 2/on_status_pending.json
@@ -1,0 +1,230 @@
+{
+    "context": {
+        "domain": "ONDC:RET10",
+        "country": "IND",
+        "city": "std:040",
+        "action": "on_status",
+        "core_version": "1.2.0",
+        "bap_id": "buyer-app-preprod-v2.ondc.org",
+        "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+        "bpp_uri": "https://seller.dhihyperlocal.com/api/v1",
+        "transaction_id": "5fd141fa-6289-46ee-b4e4-b2d7ffcee443",
+        "message_id": "80fb7108-92e8-49c5-b610-847590018158",
+        "timestamp": "2024-06-20T05:14:25.000Z",
+        "bpp_id": "seller.dhihyperlocal.com",
+        "ttl": "PT30S"
+    },
+    "message": {
+        "order": {
+            "id": "2024-06-20-984678",
+            "state": "Accepted",
+            "provider": {
+                "id": "P1104",
+                "locations": [
+                    {
+                        "id": "L1104"
+                    }
+                ]
+            },
+            "items": [
+                {
+                    "id": "I51422",
+                    "fulfillment_id": "F3659",
+                    "quantity": {
+                        "count": 1
+                    }
+                },
+                {
+                    "id": "I51423",
+                    "fulfillment_id": "F3659",
+                    "quantity": {
+                        "count": 1
+                    }
+                }
+            ],
+            "billing": {
+                "name": "pardeep singh",
+                "address": {
+                    "name": "pardeep singh",
+                    "building": "cyber tower",
+                    "locality": "Police Colony Road",
+                    "city": "Hyderabad",
+                    "state": "Telangana",
+                    "country": "IND",
+                    "area_code": "500084"
+                },
+                "email": "pardeepsingh.it@maaserp.com",
+                "phone": "8360441031",
+                "created_at": "2024-06-20T05:11:19.001Z",
+                "updated_at": "2024-06-20T05:11:19.001Z"
+            },
+            "fulfillments": [
+                {
+                    "id": "F3659",
+                    "@ondc/org/provider_name": "sangameshwara super market",
+                    "type": "Delivery",
+                    "tracking": true,
+                    "@ondc/org/TAT": "P0DT6M",
+                    "state": {
+                        "descriptor": {
+                            "code": "Pending"
+                        }
+                    },
+                    "start": {
+                        "location": {
+                            "descriptor": {
+                                "name": "sangameshwara super market"
+                            },
+                            "id": "L1104",
+                            "gps": "17.462485,78.365312",
+                            "address": {
+                                "locality": "Lalitha Nilayam, Hanuman Nagar, Prashanth Nagar Colony, Kondapur, Telangana, India",
+                                "city": "Kondapur",
+                                "area_code": "500084",
+                                "state": "Telangana"
+                            }
+                        },
+                        "contact": {
+                            "phone": "8555051431",
+                            "email": "vamshikailasa0207@gmail.com"
+                        },
+                        "time": {
+                            "range": {
+                                "start": "2024-06-20T05:16:55.071Z",
+                                "end": "2024-06-20T05:21:55.071Z"
+                            }
+                        }
+                    },
+                    "end": {
+                        "location": {
+                            "gps": "17.464141,78.366162",
+                            "address": {
+                                "name": "pardeep singh",
+                                "building": "cyber tower",
+                                "locality": "Police Colony Road",
+                                "city": "Hyderabad",
+                                "state": "Telangana",
+                                "country": "IND",
+                                "area_code": "500084"
+                            }
+                        },
+                        "time": {
+                            "range": {
+                                "start": "2024-06-20T05:22:55.071Z",
+                                "end": "2024-06-20T05:27:55.071Z"
+                            }
+                        },
+                        "contact": {
+                            "phone": "8360441031",
+                            "email": "pardeepsingh.it@maaserp.com"
+                        },
+                        "person": {
+                            "name": "pardeep singh"
+                        }
+                    },
+                    "tags": [
+                        {
+                            "code": "tracking",
+                            "list": [
+                                {
+                                    "code": "gps_enabled",
+                                    "value": "no"
+                                },
+                                {
+                                    "code": "url_enabled",
+                                    "value": "yes"
+                                },
+                                {
+                                    "code": "url",
+                                    "value": "https://bbc.maaserp.com/ondc/tracking/13558"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "quote": {
+                "price": {
+                    "currency": "INR",
+                    "value": "133.00"
+                },
+                "breakup": [
+                    {
+                        "@ondc/org/item_id": "I51422",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
+                        },
+                        "title": "rin ala fabric whitener 200 milli_litre",
+                        "@ondc/org/title_type": "item",
+                        "price": {
+                            "currency": "INR",
+                            "value": "44.00"
+                        },
+                        "item": {
+                            "price": {
+                                "currency": "INR",
+                                "value": "44.00"
+                            }
+                        }
+                    },
+                    {
+                        "@ondc/org/item_id": "I51423",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
+                        },
+                        "title": "rin ala fabric whitener 500 milli_litre",
+                        "@ondc/org/title_type": "item",
+                        "price": {
+                            "currency": "INR",
+                            "value": "89.00"
+                        },
+                        "item": {
+                            "price": {
+                                "currency": "INR",
+                                "value": "89.00"
+                            }
+                        }
+                    },
+                    {
+                        "@ondc/org/item_id": "F3659",
+                        "title": "Delivery charges",
+                        "@ondc/org/title_type": "delivery",
+                        "price": {
+                            "currency": "INR",
+                            "value": "0"
+                        }
+                    }
+                ],
+                "ttl": "P1D"
+            },
+            "payment": {
+                "uri": "https://razorpay.com/",
+                "tl_method": "http/get",
+                "params": {
+                    "amount": "133.00",
+                    "currency": "INR",
+                    "transaction_id": "order_OOtYSc02w7Zmoy"
+                },
+                "status": "PAID",
+                "type": "ON-ORDER",
+                "collected_by": "BAP",
+                "@ondc/org/buyer_app_finder_fee_type": "percent",
+                "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+                "@ondc/org/settlement_details": [
+                    {
+                        "settlement_counterparty": "seller-app",
+                        "settlement_phase": "sale-amount",
+                        "settlement_type": "neft",
+                        "beneficiary_name": "MAAS ERP SOLUTIONS PRIVATE LIMITED",
+                        "settlement_bank_account_no": "59112345678901",
+                        "settlement_ifsc_code": "HDFC0000001",
+                        "bank_name": "HDFC",
+                        "branch_name": "Hyderabad"
+                    }
+                ]
+            },
+            "created_at": "2024-06-20T05:11:46.942Z",
+            "updated_at": "2024-06-20T05:14:25.000Z"
+        }
+    }
+}

--- a/MaasERP_Solutions/Retail/RET10/2024-06-20/Flow 2/select.json
+++ b/MaasERP_Solutions/Retail/RET10/2024-06-20/Flow 2/select.json
@@ -1,0 +1,57 @@
+{
+    "context": {
+        "domain": "ONDC:RET10",
+        "country": "IND",
+        "city": "std:040",
+        "action": "select",
+        "core_version": "1.2.0",
+        "bap_id": "buyer-app-preprod-v2.ondc.org",
+        "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+        "bpp_uri": "https://seller.dhihyperlocal.com/api/v1",
+        "transaction_id": "5fd141fa-6289-46ee-b4e4-b2d7ffcee443",
+        "message_id": "1ebdd588-0173-4330-b86d-cca13d807e98",
+        "timestamp": "2024-06-20T05:11:00.867Z",
+        "bpp_id": "seller.dhihyperlocal.com",
+        "ttl": "PT30S"
+    },
+    "message": {
+        "order": {
+            "items": [
+                {
+                    "id": "I51422",
+                    "quantity": {
+                        "count": 1
+                    },
+                    "location_id": "L1104"
+                },
+                {
+                    "id": "I51423",
+                    "quantity": {
+                        "count": 1
+                    },
+                    "location_id": "L1104"
+                }
+            ],
+            "provider": {
+                "id": "P1104",
+                "locations": [
+                    {
+                        "id": "L1104"
+                    }
+                ]
+            },
+            "fulfillments": [
+                {
+                    "end": {
+                        "location": {
+                            "gps": "17.464141,78.366162",
+                            "address": {
+                                "area_code": "500084"
+                            }
+                        }
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/MaasERP_Solutions/Retail/RET10/2024-06-20/Flow 4/cancel.json
+++ b/MaasERP_Solutions/Retail/RET10/2024-06-20/Flow 4/cancel.json
@@ -1,0 +1,21 @@
+{
+    "context": {
+        "domain": "ONDC:RET10",
+        "country": "IND",
+        "city": "std:040",
+        "action": "cancel",
+        "core_version": "1.2.0",
+        "bap_id": "buyer-app-preprod-v2.ondc.org",
+        "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+        "bpp_uri": "https://seller.dhihyperlocal.com/api/v1",
+        "transaction_id": "d0dcc8a4-66e8-4a8b-9301-320f74f1131f",
+        "message_id": "cfb86749-e97a-46b9-9735-c8d5d01b16e7",
+        "timestamp": "2024-06-20T05:13:34.124Z",
+        "bpp_id": "seller.dhihyperlocal.com",
+        "ttl": "PT30S"
+    },
+    "message": {
+        "order_id": "2024-06-20-147701",
+        "cancellation_reason_id": "003"
+    }
+}

--- a/MaasERP_Solutions/Retail/RET10/2024-06-20/Flow 4/confirm.json
+++ b/MaasERP_Solutions/Retail/RET10/2024-06-20/Flow 4/confirm.json
@@ -1,0 +1,202 @@
+{
+    "context": {
+        "domain": "ONDC:RET10",
+        "country": "IND",
+        "city": "std:040",
+        "action": "confirm",
+        "core_version": "1.2.0",
+        "bap_id": "buyer-app-preprod-v2.ondc.org",
+        "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+        "bpp_uri": "https://seller.dhihyperlocal.com/api/v1",
+        "transaction_id": "d0dcc8a4-66e8-4a8b-9301-320f74f1131f",
+        "message_id": "582697d6-5c5a-45f3-affa-f2d0114c0146",
+        "timestamp": "2024-06-20T05:11:58.243Z",
+        "bpp_id": "seller.dhihyperlocal.com",
+        "ttl": "PT30S"
+    },
+    "message": {
+        "order": {
+            "id": "2024-06-20-147701",
+            "state": "Created",
+            "billing": {
+                "address": {
+                    "name": "Ritu",
+                    "building": "cyber city",
+                    "locality": "Hitech City Road",
+                    "city": "Hyderabad",
+                    "state": "Telangana",
+                    "country": "IND",
+                    "area_code": "500081"
+                },
+                "phone": "9807260002",
+                "name": "Ritu",
+                "email": "rituthakur@maaserp.com",
+                "created_at": "2024-06-20T05:11:17.572Z",
+                "updated_at": "2024-06-20T05:11:17.572Z"
+            },
+            "items": [
+                {
+                    "id": "I51423",
+                    "quantity": {
+                        "count": 2
+                    },
+                    "fulfillment_id": "F3657"
+                },
+                {
+                    "id": "I51422",
+                    "quantity": {
+                        "count": 2
+                    },
+                    "fulfillment_id": "F3657"
+                }
+            ],
+            "provider": {
+                "id": "P1104",
+                "locations": [
+                    {
+                        "id": "L1104"
+                    }
+                ]
+            },
+            "fulfillments": [
+                {
+                    "@ondc/org/TAT": "P0DT13M",
+                    "id": "F3657",
+                    "tracking": true,
+                    "end": {
+                        "contact": {
+                            "email": "rituthakur@maaserp.com",
+                            "phone": "9807260002"
+                        },
+                        "person": {
+                            "name": "Ritu"
+                        },
+                        "location": {
+                            "gps": "17.450356,78.381059",
+                            "address": {
+                                "name": "Ritu",
+                                "building": "cyber city",
+                                "locality": "Hitech City Road",
+                                "city": "Hyderabad",
+                                "state": "Telangana",
+                                "country": "IND",
+                                "area_code": "500081"
+                            }
+                        }
+                    },
+                    "type": "Delivery"
+                }
+            ],
+            "payment": {
+                "uri": "https://razorpay.com/",
+                "tl_method": "http/get",
+                "params": {
+                    "amount": "266.00",
+                    "currency": "INR",
+                    "transaction_id": "order_OOtYR8OUxsrZDM"
+                },
+                "status": "PAID",
+                "type": "ON-ORDER",
+                "collected_by": "BAP",
+                "@ondc/org/buyer_app_finder_fee_type": "percent",
+                "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+                "@ondc/org/settlement_details": [
+                    {
+                        "settlement_counterparty": "seller-app",
+                        "settlement_phase": "sale-amount",
+                        "settlement_type": "neft",
+                        "beneficiary_name": "MAAS ERP SOLUTIONS PRIVATE LIMITED",
+                        "settlement_bank_account_no": "59112345678901",
+                        "settlement_ifsc_code": "HDFC0000001",
+                        "bank_name": "HDFC",
+                        "branch_name": "Hyderabad"
+                    }
+                ]
+            },
+            "quote": {
+                "price": {
+                    "currency": "INR",
+                    "value": "266.00"
+                },
+                "breakup": [
+                    {
+                        "@ondc/org/item_id": "I51423",
+                        "@ondc/org/item_quantity": {
+                            "count": 2
+                        },
+                        "@ondc/org/title_type": "item",
+                        "item": {
+                            "price": {
+                                "currency": "INR",
+                                "value": "89.00"
+                            }
+                        },
+                        "title": "rin ala fabric whitener 500 milli_litre",
+                        "price": {
+                            "currency": "INR",
+                            "value": "178.00"
+                        }
+                    },
+                    {
+                        "@ondc/org/item_id": "I51422",
+                        "@ondc/org/item_quantity": {
+                            "count": 2
+                        },
+                        "@ondc/org/title_type": "item",
+                        "item": {
+                            "price": {
+                                "currency": "INR",
+                                "value": "44.00"
+                            }
+                        },
+                        "title": "rin ala fabric whitener 200 milli_litre",
+                        "price": {
+                            "currency": "INR",
+                            "value": "88.00"
+                        }
+                    },
+                    {
+                        "@ondc/org/item_id": "F3657",
+                        "title": "Delivery charges",
+                        "@ondc/org/title_type": "delivery",
+                        "price": {
+                            "currency": "INR",
+                            "value": "0"
+                        }
+                    }
+                ],
+                "ttl": "P1D"
+            },
+            "tags": [
+                {
+                    "code": "bpp_terms",
+                    "list": [
+                        {
+                            "code": "provider_tax_number",
+                            "value": "DMNPR5885P"
+                        },
+                        {
+                            "code": "tax_number",
+                            "value": "36AAPCM0450Q1ZX"
+                        },
+                        {
+                            "code": "np_type",
+                            "value": "MSN"
+                        }
+                    ]
+                },
+                {
+                    "code": "bap_terms",
+                    "list": [
+                        {
+                            "code": "tax_number",
+                            "value": "GSTIN1234567890"
+                        }
+                    ]
+                }
+            ],
+            "created_at": "2024-06-20T05:11:58.243Z",
+            "updated_at": "2024-06-20T05:11:58.243Z"
+        }
+    }
+}

--- a/MaasERP_Solutions/Retail/RET10/2024-06-20/Flow 4/init.json
+++ b/MaasERP_Solutions/Retail/RET10/2024-06-20/Flow 4/init.json
@@ -1,0 +1,87 @@
+{
+    "context": {
+        "domain": "ONDC:RET10",
+        "country": "IND",
+        "city": "std:040",
+        "action": "init",
+        "core_version": "1.2.0",
+        "bap_id": "buyer-app-preprod-v2.ondc.org",
+        "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+        "bpp_uri": "https://seller.dhihyperlocal.com/api/v1",
+        "transaction_id": "d0dcc8a4-66e8-4a8b-9301-320f74f1131f",
+        "message_id": "10c3b41b-52a1-4929-b3b6-beefee2cea72",
+        "timestamp": "2024-06-20T05:11:17.572Z",
+        "bpp_id": "seller.dhihyperlocal.com",
+        "ttl": "PT30S"
+    },
+    "message": {
+        "order": {
+            "provider": {
+                "id": "P1104",
+                "locations": [
+                    {
+                        "id": "L1104"
+                    }
+                ]
+            },
+            "items": [
+                {
+                    "id": "I51423",
+                    "quantity": {
+                        "count": 2
+                    },
+                    "location_id": "L1104",
+                    "fulfillment_id": "F3657"
+                },
+                {
+                    "id": "I51422",
+                    "quantity": {
+                        "count": 2
+                    },
+                    "location_id": "L1104",
+                    "fulfillment_id": "F3657"
+                }
+            ],
+            "billing": {
+                "address": {
+                    "building": "cyber city",
+                    "city": "Hyderabad",
+                    "state": "Telangana",
+                    "country": "IND",
+                    "area_code": "500081",
+                    "locality": "Hitech City Road",
+                    "name": "Ritu"
+                },
+                "phone": "9807260002",
+                "name": "Ritu",
+                "email": "rituthakur@maaserp.com",
+                "created_at": "2024-06-20T05:11:17.572Z",
+                "updated_at": "2024-06-20T05:11:17.572Z"
+            },
+            "fulfillments": [
+                {
+                    "id": "F3657",
+                    "type": "Delivery",
+                    "end": {
+                        "contact": {
+                            "email": "rituthakur@maaserp.com",
+                            "phone": "9807260002"
+                        },
+                        "location": {
+                            "gps": "17.450356,78.381059",
+                            "address": {
+                                "building": "cyber city",
+                                "city": "Hyderabad",
+                                "state": "Telangana",
+                                "country": "IND",
+                                "area_code": "500081",
+                                "locality": "Hitech City Road",
+                                "name": "Ritu"
+                            }
+                        }
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/MaasERP_Solutions/Retail/RET10/2024-06-20/Flow 4/on_cancel.json
+++ b/MaasERP_Solutions/Retail/RET10/2024-06-20/Flow 4/on_cancel.json
@@ -1,0 +1,312 @@
+{
+    "context": {
+        "domain": "ONDC:RET10",
+        "country": "IND",
+        "city": "std:040",
+        "action": "on_cancel",
+        "core_version": "1.2.0",
+        "bap_id": "buyer-app-preprod-v2.ondc.org",
+        "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+        "bpp_uri": "https://seller.dhihyperlocal.com/api/v1",
+        "transaction_id": "d0dcc8a4-66e8-4a8b-9301-320f74f1131f",
+        "message_id": "cfb86749-e97a-46b9-9735-c8d5d01b16e7",
+        "timestamp": "2024-06-20T05:13:36.000Z",
+        "bpp_id": "seller.dhihyperlocal.com",
+        "ttl": "PT30S"
+    },
+    "message": {
+        "order": {
+            "id": "2024-06-20-147701",
+            "state": "Cancelled",
+            "cancellation": {
+                "cancelled_by": "buyer-app-preprod-v2.ondc.org",
+                "reason": {
+                    "id": "003"
+                }
+            },
+            "provider": {
+                "id": "P1104",
+                "locations": [
+                    {
+                        "id": "L1104"
+                    }
+                ]
+            },
+            "items": [
+                {
+                    "id": "I51423",
+                    "fulfillment_id": "F3657",
+                    "quantity": {
+                        "count": 0
+                    }
+                },
+                {
+                    "id": "I51422",
+                    "fulfillment_id": "F3657",
+                    "quantity": {
+                        "count": 0
+                    }
+                },
+                {
+                    "id": "I51423",
+                    "fulfillment_id": "C3657",
+                    "quantity": {
+                        "count": 2
+                    }
+                },
+                {
+                    "id": "I51422",
+                    "fulfillment_id": "C3657",
+                    "quantity": {
+                        "count": 2
+                    }
+                }
+            ],
+            "billing": {
+                "name": "Ritu",
+                "address": {
+                    "name": "Ritu",
+                    "building": "cyber city",
+                    "locality": "Hitech City Road",
+                    "city": "Hyderabad",
+                    "state": "Telangana",
+                    "country": "IND",
+                    "area_code": "500081"
+                },
+                "email": "rituthakur@maaserp.com",
+                "phone": "9807260002",
+                "created_at": "2024-06-20T05:11:17.572Z",
+                "updated_at": "2024-06-20T05:11:17.572Z"
+            },
+            "fulfillments": [
+                {
+                    "id": "F3657",
+                    "@ondc/org/provider_name": "sangameshwara super market",
+                    "type": "Delivery",
+                    "tracking": true,
+                    "@ondc/org/TAT": "P0DT13M",
+                    "state": {
+                        "descriptor": {
+                            "code": "Cancelled"
+                        }
+                    },
+                    "start": {
+                        "location": {
+                            "descriptor": {
+                                "name": "sangameshwara super market"
+                            },
+                            "id": "L1104",
+                            "gps": "17.462485,78.365312",
+                            "address": {
+                                "locality": "Lalitha Nilayam, Hanuman Nagar, Prashanth Nagar Colony, Kondapur, Telangana, India",
+                                "city": "Kondapur",
+                                "area_code": "500084",
+                                "state": "Telangana"
+                            }
+                        },
+                        "contact": {
+                            "phone": "8555051431",
+                            "email": "vamshikailasa0207@gmail.com"
+                        },
+                        "time": {
+                            "range": {
+                                "start": "2024-06-20T05:17:06.780Z",
+                                "end": "2024-06-20T05:22:06.780Z"
+                            }
+                        }
+                    },
+                    "end": {
+                        "location": {
+                            "gps": "17.450356,78.381059",
+                            "address": {
+                                "name": "Ritu",
+                                "building": "cyber city",
+                                "locality": "Hitech City Road",
+                                "city": "Hyderabad",
+                                "state": "Telangana",
+                                "country": "IND",
+                                "area_code": "500081"
+                            }
+                        },
+                        "time": {
+                            "range": {
+                                "start": "2024-06-20T05:30:06.780Z",
+                                "end": "2024-06-20T05:35:06.780Z"
+                            }
+                        },
+                        "contact": {
+                            "phone": "9807260002",
+                            "email": "rituthakur@maaserp.com"
+                        },
+                        "person": {
+                            "name": "Ritu"
+                        }
+                    },
+                    "tags": [
+                        {
+                            "code": "cancel_request",
+                            "list": [
+                                {
+                                    "code": "reason_id",
+                                    "value": "003"
+                                },
+                                {
+                                    "code": "initiated_by",
+                                    "value": "buyer-app-preprod-v2.ondc.org"
+                                }
+                            ]
+                        },
+                        {
+                            "code": "precancel_state",
+                            "list": [
+                                {
+                                    "code": "fulfillment_state",
+                                    "value": "Pending"
+                                },
+                                {
+                                    "code": "updated_at",
+                                    "value": "2024-06-20T05:11:59.000Z"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "id": "C3657",
+                    "type": "Cancel",
+                    "state": {
+                        "descriptor": {
+                            "code": "Cancelled"
+                        }
+                    },
+                    "tags": [
+                        {
+                            "code": "quote_trail",
+                            "list": [
+                                {
+                                    "code": "type",
+                                    "value": "item"
+                                },
+                                {
+                                    "code": "id",
+                                    "value": "I51423"
+                                },
+                                {
+                                    "code": "currency",
+                                    "value": "INR"
+                                },
+                                {
+                                    "code": "value",
+                                    "value": "-178"
+                                }
+                            ]
+                        },
+                        {
+                            "code": "quote_trail",
+                            "list": [
+                                {
+                                    "code": "type",
+                                    "value": "item"
+                                },
+                                {
+                                    "code": "id",
+                                    "value": "I51422"
+                                },
+                                {
+                                    "code": "currency",
+                                    "value": "INR"
+                                },
+                                {
+                                    "code": "value",
+                                    "value": "-88"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "quote": {
+                "price": {
+                    "currency": "INR",
+                    "value": "0"
+                },
+                "breakup": [
+                    {
+                        "@ondc/org/item_id": "I51423",
+                        "@ondc/org/item_quantity": {
+                            "count": 0
+                        },
+                        "title": "rin ala fabric whitener 500 milli_litre",
+                        "@ondc/org/title_type": "item",
+                        "price": {
+                            "currency": "INR",
+                            "value": "0"
+                        },
+                        "item": {
+                            "price": {
+                                "currency": "INR",
+                                "value": "89.00"
+                            }
+                        }
+                    },
+                    {
+                        "@ondc/org/item_id": "I51422",
+                        "@ondc/org/item_quantity": {
+                            "count": 0
+                        },
+                        "title": "rin ala fabric whitener 200 milli_litre",
+                        "@ondc/org/title_type": "item",
+                        "price": {
+                            "currency": "INR",
+                            "value": "0"
+                        },
+                        "item": {
+                            "price": {
+                                "currency": "INR",
+                                "value": "44.00"
+                            }
+                        }
+                    },
+                    {
+                        "@ondc/org/item_id": "F3657",
+                        "title": "Delivery charges",
+                        "@ondc/org/title_type": "delivery",
+                        "price": {
+                            "currency": "INR",
+                            "value": "0"
+                        }
+                    }
+                ],
+                "ttl": "P1D"
+            },
+            "payment": {
+                "uri": "https://razorpay.com/",
+                "tl_method": "http/get",
+                "params": {
+                    "amount": "266.00",
+                    "currency": "INR",
+                    "transaction_id": "order_OOtYR8OUxsrZDM"
+                },
+                "status": "PAID",
+                "type": "ON-ORDER",
+                "collected_by": "BAP",
+                "@ondc/org/buyer_app_finder_fee_type": "percent",
+                "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+                "@ondc/org/settlement_details": [
+                    {
+                        "settlement_counterparty": "seller-app",
+                        "settlement_phase": "sale-amount",
+                        "settlement_type": "neft",
+                        "beneficiary_name": "MAAS ERP SOLUTIONS PRIVATE LIMITED",
+                        "settlement_bank_account_no": "59112345678901",
+                        "settlement_ifsc_code": "HDFC0000001",
+                        "bank_name": "HDFC",
+                        "branch_name": "Hyderabad"
+                    }
+                ]
+            },
+            "created_at": "2024-06-20T05:11:58.243Z",
+            "updated_at": "2024-06-20T05:13:36.000Z"
+        }
+    }
+}

--- a/MaasERP_Solutions/Retail/RET10/2024-06-20/Flow 4/on_confirm.json
+++ b/MaasERP_Solutions/Retail/RET10/2024-06-20/Flow 4/on_confirm.json
@@ -1,0 +1,258 @@
+{
+    "context": {
+        "domain": "ONDC:RET10",
+        "country": "IND",
+        "city": "std:040",
+        "action": "on_confirm",
+        "core_version": "1.2.0",
+        "bap_id": "buyer-app-preprod-v2.ondc.org",
+        "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+        "bpp_uri": "https://seller.dhihyperlocal.com/api/v1",
+        "transaction_id": "d0dcc8a4-66e8-4a8b-9301-320f74f1131f",
+        "message_id": "582697d6-5c5a-45f3-affa-f2d0114c0146",
+        "timestamp": "2024-06-20T05:11:59.000Z",
+        "bpp_id": "seller.dhihyperlocal.com",
+        "ttl": "PT30S"
+    },
+    "message": {
+        "order": {
+            "id": "2024-06-20-147701",
+            "state": "Created",
+            "provider": {
+                "id": "P1104",
+                "locations": [
+                    {
+                        "id": "L1104"
+                    }
+                ]
+            },
+            "items": [
+                {
+                    "id": "I51423",
+                    "fulfillment_id": "F3657",
+                    "quantity": {
+                        "count": 2
+                    }
+                },
+                {
+                    "id": "I51422",
+                    "fulfillment_id": "F3657",
+                    "quantity": {
+                        "count": 2
+                    }
+                }
+            ],
+            "billing": {
+                "name": "Ritu",
+                "address": {
+                    "name": "Ritu",
+                    "building": "cyber city",
+                    "locality": "Hitech City Road",
+                    "city": "Hyderabad",
+                    "state": "Telangana",
+                    "country": "IND",
+                    "area_code": "500081"
+                },
+                "email": "rituthakur@maaserp.com",
+                "phone": "9807260002",
+                "created_at": "2024-06-20T05:11:17.572Z",
+                "updated_at": "2024-06-20T05:11:17.572Z"
+            },
+            "fulfillments": [
+                {
+                    "id": "F3657",
+                    "@ondc/org/provider_name": "sangameshwara super market",
+                    "type": "Delivery",
+                    "tracking": true,
+                    "@ondc/org/TAT": "P0DT13M",
+                    "state": {
+                        "descriptor": {
+                            "code": "Pending"
+                        }
+                    },
+                    "start": {
+                        "location": {
+                            "descriptor": {
+                                "name": "sangameshwara super market"
+                            },
+                            "id": "L1104",
+                            "gps": "17.462485,78.365312",
+                            "address": {
+                                "locality": "Lalitha Nilayam, Hanuman Nagar, Prashanth Nagar Colony, Kondapur, Telangana, India",
+                                "city": "Kondapur",
+                                "area_code": "500084",
+                                "state": "Telangana"
+                            }
+                        },
+                        "contact": {
+                            "phone": "8555051431",
+                            "email": "vamshikailasa0207@gmail.com"
+                        },
+                        "time": {
+                            "range": {
+                                "start": "2024-06-20T05:17:06.780Z",
+                                "end": "2024-06-20T05:22:06.780Z"
+                            }
+                        }
+                    },
+                    "end": {
+                        "location": {
+                            "gps": "17.450356,78.381059",
+                            "address": {
+                                "name": "Ritu",
+                                "building": "cyber city",
+                                "locality": "Hitech City Road",
+                                "city": "Hyderabad",
+                                "state": "Telangana",
+                                "country": "IND",
+                                "area_code": "500081"
+                            }
+                        },
+                        "time": {
+                            "range": {
+                                "start": "2024-06-20T05:30:06.780Z",
+                                "end": "2024-06-20T05:35:06.780Z"
+                            }
+                        },
+                        "contact": {
+                            "phone": "9807260002",
+                            "email": "rituthakur@maaserp.com"
+                        },
+                        "person": {
+                            "name": "Ritu"
+                        }
+                    },
+                    "tags": [
+                        {
+                            "code": "tracking",
+                            "list": [
+                                {
+                                    "code": "gps_enabled",
+                                    "value": "no"
+                                },
+                                {
+                                    "code": "url_enabled",
+                                    "value": "yes"
+                                },
+                                {
+                                    "code": "url",
+                                    "value": "https://bbc.maaserp.com/ondc/tracking/13557"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "quote": {
+                "price": {
+                    "currency": "INR",
+                    "value": "266.00"
+                },
+                "breakup": [
+                    {
+                        "@ondc/org/item_id": "I51423",
+                        "@ondc/org/item_quantity": {
+                            "count": 2
+                        },
+                        "title": "rin ala fabric whitener 500 milli_litre",
+                        "@ondc/org/title_type": "item",
+                        "price": {
+                            "currency": "INR",
+                            "value": "178.00"
+                        },
+                        "item": {
+                            "price": {
+                                "currency": "INR",
+                                "value": "89.00"
+                            }
+                        }
+                    },
+                    {
+                        "@ondc/org/item_id": "I51422",
+                        "@ondc/org/item_quantity": {
+                            "count": 2
+                        },
+                        "title": "rin ala fabric whitener 200 milli_litre",
+                        "@ondc/org/title_type": "item",
+                        "price": {
+                            "currency": "INR",
+                            "value": "88.00"
+                        },
+                        "item": {
+                            "price": {
+                                "currency": "INR",
+                                "value": "44.00"
+                            }
+                        }
+                    },
+                    {
+                        "@ondc/org/item_id": "F3657",
+                        "title": "Delivery charges",
+                        "@ondc/org/title_type": "delivery",
+                        "price": {
+                            "currency": "INR",
+                            "value": "0"
+                        }
+                    }
+                ],
+                "ttl": "P1D"
+            },
+            "payment": {
+                "uri": "https://razorpay.com/",
+                "tl_method": "http/get",
+                "params": {
+                    "amount": "266.00",
+                    "currency": "INR",
+                    "transaction_id": "order_OOtYR8OUxsrZDM"
+                },
+                "status": "PAID",
+                "type": "ON-ORDER",
+                "collected_by": "BAP",
+                "@ondc/org/buyer_app_finder_fee_type": "percent",
+                "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+                "@ondc/org/settlement_details": [
+                    {
+                        "settlement_counterparty": "seller-app",
+                        "settlement_phase": "sale-amount",
+                        "settlement_type": "neft",
+                        "beneficiary_name": "MAAS ERP SOLUTIONS PRIVATE LIMITED",
+                        "settlement_bank_account_no": "59112345678901",
+                        "settlement_ifsc_code": "HDFC0000001",
+                        "bank_name": "HDFC",
+                        "branch_name": "Hyderabad"
+                    }
+                ]
+            },
+            "created_at": "2024-06-20T05:11:58.243Z",
+            "updated_at": "2024-06-20T05:11:59.000Z",
+            "tags": [
+                {
+                    "code": "bpp_terms",
+                    "list": [
+                        {
+                            "code": "provider_tax_number",
+                            "value": "DMNPR5885P"
+                        },
+                        {
+                            "code": "tax_number",
+                            "value": "36AAPCM0450Q1ZX"
+                        },
+                        {
+                            "code": "np_type",
+                            "value": "MSN"
+                        }
+                    ]
+                },
+                {
+                    "code": "bap_terms",
+                    "list": [
+                        {
+                            "code": "tax_number",
+                            "value": "GSTIN1234567890"
+                        }
+                    ]
+                }
+            ]
+        }
+    }
+}

--- a/MaasERP_Solutions/Retail/RET10/2024-06-20/Flow 4/on_init.json
+++ b/MaasERP_Solutions/Retail/RET10/2024-06-20/Flow 4/on_init.json
@@ -1,0 +1,176 @@
+{
+    "context": {
+        "domain": "ONDC:RET10",
+        "country": "IND",
+        "city": "std:040",
+        "action": "on_init",
+        "core_version": "1.2.0",
+        "bap_id": "buyer-app-preprod-v2.ondc.org",
+        "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+        "bpp_uri": "https://seller.dhihyperlocal.com/api/v1",
+        "transaction_id": "d0dcc8a4-66e8-4a8b-9301-320f74f1131f",
+        "message_id": "10c3b41b-52a1-4929-b3b6-beefee2cea72",
+        "timestamp": "2024-06-20T05:11:20.241Z",
+        "bpp_id": "seller.dhihyperlocal.com",
+        "ttl": "PT30S"
+    },
+    "message": {
+        "order": {
+            "provider": {
+                "id": "P1104",
+                "locations": [
+                    {
+                        "id": "L1104"
+                    }
+                ]
+            },
+            "items": [
+                {
+                    "id": "I51423",
+                    "quantity": {
+                        "count": 2
+                    },
+                    "fulfillment_id": "F3657"
+                },
+                {
+                    "id": "I51422",
+                    "quantity": {
+                        "count": 2
+                    },
+                    "fulfillment_id": "F3657"
+                }
+            ],
+            "billing": {
+                "name": "Ritu",
+                "address": {
+                    "name": "Ritu",
+                    "building": "cyber city",
+                    "locality": "Hitech City Road",
+                    "city": "Hyderabad",
+                    "state": "Telangana",
+                    "country": "IND",
+                    "area_code": "500081"
+                },
+                "email": "rituthakur@maaserp.com",
+                "phone": "9807260002",
+                "created_at": "2024-06-20T05:11:17.572Z",
+                "updated_at": "2024-06-20T05:11:17.572Z"
+            },
+            "fulfillments": [
+                {
+                    "id": "F3657",
+                    "type": "Delivery",
+                    "tracking": true,
+                    "end": {
+                        "location": {
+                            "gps": "17.450356,78.381059",
+                            "address": {
+                                "name": "Ritu",
+                                "building": "cyber city",
+                                "locality": "Hitech City Road",
+                                "city": "Hyderabad",
+                                "state": "Telangana",
+                                "country": "IND",
+                                "area_code": "500081"
+                            }
+                        },
+                        "contact": {
+                            "phone": "9807260002",
+                            "email": "rituthakur@maaserp.com"
+                        }
+                    },
+                    "@ondc/org/TAT": "P0DT13M"
+                }
+            ],
+            "quote": {
+                "price": {
+                    "currency": "INR",
+                    "value": "266.00"
+                },
+                "breakup": [
+                    {
+                        "@ondc/org/item_id": "I51423",
+                        "@ondc/org/item_quantity": {
+                            "count": 2
+                        },
+                        "@ondc/org/title_type": "item",
+                        "item": {
+                            "price": {
+                                "currency": "INR",
+                                "value": "89.00"
+                            }
+                        },
+                        "title": "rin ala fabric whitener 500 milli_litre",
+                        "price": {
+                            "currency": "INR",
+                            "value": "178.00"
+                        }
+                    },
+                    {
+                        "@ondc/org/item_id": "I51422",
+                        "@ondc/org/item_quantity": {
+                            "count": 2
+                        },
+                        "@ondc/org/title_type": "item",
+                        "item": {
+                            "price": {
+                                "currency": "INR",
+                                "value": "44.00"
+                            }
+                        },
+                        "title": "rin ala fabric whitener 200 milli_litre",
+                        "price": {
+                            "currency": "INR",
+                            "value": "88.00"
+                        }
+                    },
+                    {
+                        "@ondc/org/item_id": "F3657",
+                        "title": "Delivery charges",
+                        "@ondc/org/title_type": "delivery",
+                        "price": {
+                            "currency": "INR",
+                            "value": "0"
+                        }
+                    }
+                ],
+                "ttl": "P1D"
+            },
+            "payment": {
+                "@ondc/org/buyer_app_finder_fee_type": "percent",
+                "@ondc/org/buyer_app_finder_fee_amount": "3",
+                "@ondc/org/settlement_details": [
+                    {
+                        "settlement_counterparty": "seller-app",
+                        "settlement_phase": "sale-amount",
+                        "settlement_type": "neft",
+                        "beneficiary_name": "MAAS ERP SOLUTIONS PRIVATE LIMITED",
+                        "settlement_bank_account_no": "59112345678901",
+                        "settlement_ifsc_code": "HDFC0000001",
+                        "bank_name": "HDFC",
+                        "branch_name": "Hyderabad"
+                    }
+                ]
+            },
+            "tags": [
+                {
+                    "code": "bpp_terms",
+                    "list": [
+                        {
+                            "code": "provider_tax_number",
+                            "value": "DMNPR5885P"
+                        },
+                        {
+                            "code": "tax_number",
+                            "value": "36AAPCM0450Q1ZX"
+                        },
+                        {
+                            "code": "np_type",
+                            "value": "MSN"
+                        }
+                    ]
+                }
+            ]
+        }
+    }
+}

--- a/MaasERP_Solutions/Retail/RET10/2024-06-20/Flow 4/on_select.json
+++ b/MaasERP_Solutions/Retail/RET10/2024-06-20/Flow 4/on_select.json
@@ -1,0 +1,137 @@
+{
+    "context": {
+        "domain": "ONDC:RET10",
+        "country": "IND",
+        "city": "std:040",
+        "action": "on_select",
+        "core_version": "1.2.0",
+        "bap_id": "buyer-app-preprod-v2.ondc.org",
+        "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+        "bpp_uri": "https://seller.dhihyperlocal.com/api/v1",
+        "transaction_id": "d0dcc8a4-66e8-4a8b-9301-320f74f1131f",
+        "message_id": "b010a9af-011e-4678-9bed-e44d91a1af34",
+        "timestamp": "2024-06-20T05:10:52.097Z",
+        "bpp_id": "seller.dhihyperlocal.com",
+        "ttl": "PT30S"
+    },
+    "message": {
+        "order": {
+            "provider": {
+                "id": "P1104",
+                "locations": [
+                    {
+                        "id": "L1104"
+                    }
+                ]
+            },
+            "items": [
+                {
+                    "fulfillment_id": "F3657",
+                    "id": "I51423"
+                },
+                {
+                    "fulfillment_id": "F3657",
+                    "id": "I51422"
+                }
+            ],
+            "fulfillments": [
+                {
+                    "id": "F3657",
+                    "@ondc/org/provider_name": "sangameshwara super market",
+                    "tracking": true,
+                    "type": "Delivery",
+                    "@ondc/org/category": "Immediate Delivery",
+                    "@ondc/org/TAT": "P0DT13M",
+                    "state": {
+                        "descriptor": {
+                            "code": "Serviceable"
+                        }
+                    }
+                },
+                {
+                    "id": "F3658",
+                    "type": "Self-Pickup",
+                    "@ondc/org/provider_name": "",
+                    "tracking": false,
+                    "@ondc/org/category": "Takeaway",
+                    "@ondc/org/TAT": "PT5M",
+                    "state": {
+                        "descriptor": {
+                            "code": "Serviceable"
+                        }
+                    }
+                }
+            ],
+            "quote": {
+                "price": {
+                    "currency": "INR",
+                    "value": "266.00"
+                },
+                "breakup": [
+                    {
+                        "@ondc/org/item_id": "I51423",
+                        "@ondc/org/item_quantity": {
+                            "count": 2
+                        },
+                        "title": "rin ala fabric whitener 500 milli_litre",
+                        "@ondc/org/title_type": "item",
+                        "price": {
+                            "currency": "INR",
+                            "value": "178.00"
+                        },
+                        "item": {
+                            "quantity": {
+                                "available": {
+                                    "count": "99"
+                                },
+                                "maximum": {
+                                    "count": "5"
+                                }
+                            },
+                            "price": {
+                                "currency": "INR",
+                                "value": "89.00"
+                            }
+                        }
+                    },
+                    {
+                        "@ondc/org/item_id": "I51422",
+                        "@ondc/org/item_quantity": {
+                            "count": 2
+                        },
+                        "title": "rin ala fabric whitener 200 milli_litre",
+                        "@ondc/org/title_type": "item",
+                        "price": {
+                            "currency": "INR",
+                            "value": "88.00"
+                        },
+                        "item": {
+                            "quantity": {
+                                "available": {
+                                    "count": "99"
+                                },
+                                "maximum": {
+                                    "count": "5"
+                                }
+                            },
+                            "price": {
+                                "currency": "INR",
+                                "value": "44.00"
+                            }
+                        }
+                    },
+                    {
+                        "@ondc/org/item_id": "F3657",
+                        "title": "Delivery charges",
+                        "@ondc/org/title_type": "delivery",
+                        "price": {
+                            "currency": "INR",
+                            "value": "0"
+                        }
+                    }
+                ],
+                "ttl": "P1D"
+            }
+        }
+    }
+}

--- a/MaasERP_Solutions/Retail/RET10/2024-06-20/Flow 4/select.json
+++ b/MaasERP_Solutions/Retail/RET10/2024-06-20/Flow 4/select.json
@@ -1,0 +1,57 @@
+{
+    "context": {
+        "domain": "ONDC:RET10",
+        "country": "IND",
+        "city": "std:040",
+        "action": "select",
+        "core_version": "1.2.0",
+        "bap_id": "buyer-app-preprod-v2.ondc.org",
+        "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+        "bpp_uri": "https://seller.dhihyperlocal.com/api/v1",
+        "transaction_id": "d0dcc8a4-66e8-4a8b-9301-320f74f1131f",
+        "message_id": "b010a9af-011e-4678-9bed-e44d91a1af34",
+        "timestamp": "2024-06-20T05:10:48.136Z",
+        "bpp_id": "seller.dhihyperlocal.com",
+        "ttl": "PT30S"
+    },
+    "message": {
+        "order": {
+            "items": [
+                {
+                    "id": "I51423",
+                    "quantity": {
+                        "count": 2
+                    },
+                    "location_id": "L1104"
+                },
+                {
+                    "id": "I51422",
+                    "quantity": {
+                        "count": 2
+                    },
+                    "location_id": "L1104"
+                }
+            ],
+            "provider": {
+                "id": "P1104",
+                "locations": [
+                    {
+                        "id": "L1104"
+                    }
+                ]
+            },
+            "fulfillments": [
+                {
+                    "end": {
+                        "location": {
+                            "gps": "17.450356,78.381059",
+                            "address": {
+                                "area_code": "500081"
+                            }
+                        }
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/MaasERP_Solutions/Retail/RET10/2024-06-20/Flow 5/confirm.json
+++ b/MaasERP_Solutions/Retail/RET10/2024-06-20/Flow 5/confirm.json
@@ -1,0 +1,202 @@
+{
+    "context": {
+        "domain": "ONDC:RET10",
+        "country": "IND",
+        "city": "std:040",
+        "action": "confirm",
+        "core_version": "1.2.0",
+        "bap_id": "buyer-app-preprod-v2.ondc.org",
+        "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+        "bpp_uri": "https://seller.dhihyperlocal.com/api/v1",
+        "transaction_id": "843bb3ba-f79e-4623-a45d-cd72b43f6b38",
+        "message_id": "6cc525b4-2241-4d25-b0a0-f357f725c82b",
+        "timestamp": "2024-06-20T04:39:26.860Z",
+        "bpp_id": "seller.dhihyperlocal.com",
+        "ttl": "PT30S"
+    },
+    "message": {
+        "order": {
+            "id": "2024-06-20-487661",
+            "state": "Created",
+            "billing": {
+                "address": {
+                    "name": "pardeep singh",
+                    "building": "cyber tower",
+                    "locality": "Police Colony Road",
+                    "city": "Hyderabad",
+                    "state": "Telangana",
+                    "country": "IND",
+                    "area_code": "500084"
+                },
+                "phone": "8360441031",
+                "name": "pardeep singh",
+                "email": "pardeepsingh.it@maaserp.com",
+                "created_at": "2024-06-20T04:38:56.382Z",
+                "updated_at": "2024-06-20T04:38:56.382Z"
+            },
+            "items": [
+                {
+                    "id": "I51422",
+                    "quantity": {
+                        "count": 2
+                    },
+                    "fulfillment_id": "F3653"
+                },
+                {
+                    "id": "I51423",
+                    "quantity": {
+                        "count": 2
+                    },
+                    "fulfillment_id": "F3653"
+                }
+            ],
+            "provider": {
+                "id": "P1104",
+                "locations": [
+                    {
+                        "id": "L1104"
+                    }
+                ]
+            },
+            "fulfillments": [
+                {
+                    "@ondc/org/TAT": "P0DT6M",
+                    "id": "F3653",
+                    "tracking": true,
+                    "end": {
+                        "contact": {
+                            "email": "pardeepsingh.it@maaserp.com",
+                            "phone": "8360441031"
+                        },
+                        "person": {
+                            "name": "pardeep singh"
+                        },
+                        "location": {
+                            "gps": "17.464141,78.366162",
+                            "address": {
+                                "name": "pardeep singh",
+                                "building": "cyber tower",
+                                "locality": "Police Colony Road",
+                                "city": "Hyderabad",
+                                "state": "Telangana",
+                                "country": "IND",
+                                "area_code": "500084"
+                            }
+                        }
+                    },
+                    "type": "Delivery"
+                }
+            ],
+            "payment": {
+                "uri": "https://razorpay.com/",
+                "tl_method": "http/get",
+                "params": {
+                    "amount": "266.00",
+                    "currency": "INR",
+                    "transaction_id": "order_OOt0H3IrcpnggQ"
+                },
+                "status": "PAID",
+                "type": "ON-ORDER",
+                "collected_by": "BAP",
+                "@ondc/org/buyer_app_finder_fee_type": "percent",
+                "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+                "@ondc/org/settlement_details": [
+                    {
+                        "settlement_counterparty": "seller-app",
+                        "settlement_phase": "sale-amount",
+                        "settlement_type": "neft",
+                        "beneficiary_name": "MAAS ERP SOLUTIONS PRIVATE LIMITED",
+                        "settlement_bank_account_no": "59112345678901",
+                        "settlement_ifsc_code": "HDFC0000001",
+                        "bank_name": "HDFC",
+                        "branch_name": "Hyderabad"
+                    }
+                ]
+            },
+            "quote": {
+                "price": {
+                    "currency": "INR",
+                    "value": "266.00"
+                },
+                "breakup": [
+                    {
+                        "@ondc/org/item_id": "I51422",
+                        "@ondc/org/item_quantity": {
+                            "count": 2
+                        },
+                        "@ondc/org/title_type": "item",
+                        "item": {
+                            "price": {
+                                "currency": "INR",
+                                "value": "44.00"
+                            }
+                        },
+                        "title": "rin ala fabric whitener 200 milli_litre",
+                        "price": {
+                            "currency": "INR",
+                            "value": "88.00"
+                        }
+                    },
+                    {
+                        "@ondc/org/item_id": "I51423",
+                        "@ondc/org/item_quantity": {
+                            "count": 2
+                        },
+                        "@ondc/org/title_type": "item",
+                        "item": {
+                            "price": {
+                                "currency": "INR",
+                                "value": "89.00"
+                            }
+                        },
+                        "title": "rin ala fabric whitener 500 milli_litre",
+                        "price": {
+                            "currency": "INR",
+                            "value": "178.00"
+                        }
+                    },
+                    {
+                        "@ondc/org/item_id": "F3653",
+                        "title": "Delivery charges",
+                        "@ondc/org/title_type": "delivery",
+                        "price": {
+                            "currency": "INR",
+                            "value": "0"
+                        }
+                    }
+                ],
+                "ttl": "P1D"
+            },
+            "tags": [
+                {
+                    "code": "bpp_terms",
+                    "list": [
+                        {
+                            "code": "provider_tax_number",
+                            "value": "DMNPR5885P"
+                        },
+                        {
+                            "code": "tax_number",
+                            "value": "36AAPCM0450Q1ZX"
+                        },
+                        {
+                            "code": "np_type",
+                            "value": "MSN"
+                        }
+                    ]
+                },
+                {
+                    "code": "bap_terms",
+                    "list": [
+                        {
+                            "code": "tax_number",
+                            "value": "GSTIN1234567890"
+                        }
+                    ]
+                }
+            ],
+            "created_at": "2024-06-20T04:39:26.860Z",
+            "updated_at": "2024-06-20T04:39:26.860Z"
+        }
+    }
+}

--- a/MaasERP_Solutions/Retail/RET10/2024-06-20/Flow 5/init.json
+++ b/MaasERP_Solutions/Retail/RET10/2024-06-20/Flow 5/init.json
@@ -1,0 +1,87 @@
+{
+    "context": {
+        "domain": "ONDC:RET10",
+        "country": "IND",
+        "city": "std:040",
+        "action": "init",
+        "core_version": "1.2.0",
+        "bap_id": "buyer-app-preprod-v2.ondc.org",
+        "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+        "bpp_uri": "https://seller.dhihyperlocal.com/api/v1",
+        "transaction_id": "843bb3ba-f79e-4623-a45d-cd72b43f6b38",
+        "message_id": "2ee5f00c-497c-4c7a-b2da-93e1dba9329f",
+        "timestamp": "2024-06-20T04:38:56.382Z",
+        "bpp_id": "seller.dhihyperlocal.com",
+        "ttl": "PT30S"
+    },
+    "message": {
+        "order": {
+            "provider": {
+                "id": "P1104",
+                "locations": [
+                    {
+                        "id": "L1104"
+                    }
+                ]
+            },
+            "items": [
+                {
+                    "id": "I51422",
+                    "quantity": {
+                        "count": 2
+                    },
+                    "location_id": "L1104",
+                    "fulfillment_id": "F3653"
+                },
+                {
+                    "id": "I51423",
+                    "quantity": {
+                        "count": 2
+                    },
+                    "location_id": "L1104",
+                    "fulfillment_id": "F3653"
+                }
+            ],
+            "billing": {
+                "address": {
+                    "building": "cyber tower",
+                    "city": "Hyderabad",
+                    "state": "Telangana",
+                    "country": "IND",
+                    "area_code": "500084",
+                    "locality": "Police Colony Road",
+                    "name": "pardeep singh"
+                },
+                "phone": "8360441031",
+                "name": "pardeep singh",
+                "email": "pardeepsingh.it@maaserp.com",
+                "created_at": "2024-06-20T04:38:56.382Z",
+                "updated_at": "2024-06-20T04:38:56.382Z"
+            },
+            "fulfillments": [
+                {
+                    "id": "F3653",
+                    "type": "Delivery",
+                    "end": {
+                        "contact": {
+                            "email": "pardeepsingh.it@maaserp.com",
+                            "phone": "8360441031"
+                        },
+                        "location": {
+                            "gps": "17.464141,78.366162",
+                            "address": {
+                                "building": "cyber tower",
+                                "city": "Hyderabad",
+                                "state": "Telangana",
+                                "country": "IND",
+                                "area_code": "500084",
+                                "locality": "Police Colony Road",
+                                "name": "pardeep singh"
+                            }
+                        }
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/MaasERP_Solutions/Retail/RET10/2024-06-20/Flow 5/on_cancel.json
+++ b/MaasERP_Solutions/Retail/RET10/2024-06-20/Flow 5/on_cancel.json
@@ -1,0 +1,356 @@
+{
+    "context": {
+        "domain": "ONDC:RET10",
+        "country": "IND",
+        "city": "std:040",
+        "action": "on_cancel",
+        "core_version": "1.2.0",
+        "bap_id": "buyer-app-preprod-v2.ondc.org",
+        "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+        "bpp_uri": "https://seller.dhihyperlocal.com/api/v1",
+        "transaction_id": "843bb3ba-f79e-4623-a45d-cd72b43f6b38",
+        "message_id": "2297c446-63e3-4e1c-ada9-c19c4945262c",
+        "timestamp": "2024-06-20T04:46:13.000Z",
+        "bpp_id": "seller.dhihyperlocal.com",
+        "ttl": "PT30S"
+    },
+    "message": {
+        "order": {
+            "id": "2024-06-20-487661",
+            "state": "Cancelled",
+            "provider": {
+                "id": "P1104",
+                "locations": [
+                    {
+                        "id": "L1104"
+                    }
+                ]
+            },
+            "items": [
+                {
+                    "id": "I51422",
+                    "fulfillment_id": "F3653",
+                    "quantity": {
+                        "count": 0
+                    }
+                },
+                {
+                    "id": "I51423",
+                    "fulfillment_id": "F3653",
+                    "quantity": {
+                        "count": 0
+                    }
+                },
+                {
+                    "id": "I51422",
+                    "fulfillment_id": "C3653",
+                    "quantity": {
+                        "count": 2
+                    }
+                },
+                {
+                    "id": "I51423",
+                    "fulfillment_id": "C3653",
+                    "quantity": {
+                        "count": 2
+                    }
+                }
+            ],
+            "billing": {
+                "name": "pardeep singh",
+                "address": {
+                    "name": "pardeep singh",
+                    "building": "cyber tower",
+                    "locality": "Police Colony Road",
+                    "city": "Hyderabad",
+                    "state": "Telangana",
+                    "country": "IND",
+                    "area_code": "500084"
+                },
+                "email": "pardeepsingh.it@maaserp.com",
+                "phone": "8360441031",
+                "created_at": "2024-06-20T04:38:56.382Z",
+                "updated_at": "2024-06-20T04:38:56.382Z"
+            },
+            "fulfillments": [
+                {
+                    "id": "F3653",
+                    "@ondc/org/provider_name": "sangameshwara super market",
+                    "type": "Delivery",
+                    "tracking": true,
+                    "@ondc/org/TAT": "P0DT6M",
+                    "state": {
+                        "descriptor": {
+                            "code": "Cancelled"
+                        }
+                    },
+                    "start": {
+                        "location": {
+                            "descriptor": {
+                                "name": "sangameshwara super market"
+                            },
+                            "id": "L1104",
+                            "gps": "17.462485,78.365312",
+                            "address": {
+                                "locality": "Lalitha Nilayam, Hanuman Nagar, Prashanth Nagar Colony, Kondapur, Telangana, India",
+                                "city": "Kondapur",
+                                "area_code": "500084",
+                                "state": "Telangana"
+                            }
+                        },
+                        "contact": {
+                            "phone": "7555945623",
+                            "email": "maasteststore@mailinator.com"
+                        },
+                        "time": {
+                            "range": {
+                                "start": "2024-06-20T04:44:37.572Z",
+                                "end": "2024-06-20T04:49:37.572Z"
+                            },
+                            "timestamp": "2024-06-20T04:45:32.000Z"
+                        }
+                    },
+                    "end": {
+                        "location": {
+                            "gps": "17.464141,78.366162",
+                            "address": {
+                                "name": "pardeep singh",
+                                "building": "cyber tower",
+                                "locality": "Police Colony Road",
+                                "city": "Hyderabad",
+                                "state": "Telangana",
+                                "country": "IND",
+                                "area_code": "500084"
+                            }
+                        },
+                        "time": {
+                            "range": {
+                                "start": "2024-06-20T04:50:37.572Z",
+                                "end": "2024-06-20T04:55:37.572Z"
+                            }
+                        },
+                        "contact": {
+                            "phone": "8360441031",
+                            "email": "pardeepsingh.it@maaserp.com"
+                        },
+                        "person": {
+                            "name": "pardeep singh"
+                        }
+                    },
+                    "tags": [
+                        {
+                            "code": "cancel_request",
+                            "list": [
+                                {
+                                    "code": "reason_id",
+                                    "value": "011"
+                                },
+                                {
+                                    "code": "initiated_by",
+                                    "value": "seller.dhihyperlocal.com"
+                                },
+                                {
+                                    "code": "rto_id",
+                                    "value": "C3653"
+                                },
+                                {
+                                    "code": "retry_count",
+                                    "value": "3"
+                                }
+                            ]
+                        },
+                        {
+                            "code": "precancel_state",
+                            "list": [
+                                {
+                                    "code": "fulfillment_state",
+                                    "value": "Out-for-delivery"
+                                },
+                                {
+                                    "code": "updated_at",
+                                    "value": "2024-06-20T04:45:47.000Z"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "id": "C3653",
+                    "type": "RTO",
+                    "state": {
+                        "descriptor": {
+                            "code": "RTO-Initiated"
+                        }
+                    },
+                    "start": {
+                        "time": {
+                            "timestamp": "2024-06-20T04:46:13.000Z"
+                        },
+                        "location": {
+                            "gps": "17.464141,78.366162",
+                            "address": {
+                                "name": "pardeep singh",
+                                "building": "cyber tower",
+                                "locality": "Police Colony Road",
+                                "city": "Hyderabad",
+                                "state": "Telangana",
+                                "country": "IND",
+                                "area_code": "500084"
+                            }
+                        }
+                    },
+                    "end": {
+                        "location": {
+                            "descriptor": {
+                                "name": "sangameshwara super market"
+                            },
+                            "id": "L1104",
+                            "gps": "17.462485,78.365312",
+                            "address": {
+                                "locality": "Lalitha Nilayam, Hanuman Nagar, Prashanth Nagar Colony, Kondapur, Telangana, India",
+                                "city": "Kondapur",
+                                "area_code": "500084",
+                                "state": "Telangana"
+                            }
+                        }
+                    },
+                    "tags": [
+                        {
+                            "code": "quote_trail",
+                            "list": [
+                                {
+                                    "code": "type",
+                                    "value": "item"
+                                },
+                                {
+                                    "code": "id",
+                                    "value": "I51422"
+                                },
+                                {
+                                    "code": "currency",
+                                    "value": "INR"
+                                },
+                                {
+                                    "code": "value",
+                                    "value": "-88"
+                                }
+                            ]
+                        },
+                        {
+                            "code": "quote_trail",
+                            "list": [
+                                {
+                                    "code": "type",
+                                    "value": "item"
+                                },
+                                {
+                                    "code": "id",
+                                    "value": "I51423"
+                                },
+                                {
+                                    "code": "currency",
+                                    "value": "INR"
+                                },
+                                {
+                                    "code": "value",
+                                    "value": "-178"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "quote": {
+                "price": {
+                    "currency": "INR",
+                    "value": "0"
+                },
+                "breakup": [
+                    {
+                        "@ondc/org/item_id": "I51422",
+                        "@ondc/org/item_quantity": {
+                            "count": 0
+                        },
+                        "title": "rin ala fabric whitener 200 milli_litre",
+                        "@ondc/org/title_type": "item",
+                        "price": {
+                            "currency": "INR",
+                            "value": "0"
+                        },
+                        "item": {
+                            "price": {
+                                "currency": "INR",
+                                "value": "44.00"
+                            }
+                        }
+                    },
+                    {
+                        "@ondc/org/item_id": "I51423",
+                        "@ondc/org/item_quantity": {
+                            "count": 0
+                        },
+                        "title": "rin ala fabric whitener 500 milli_litre",
+                        "@ondc/org/title_type": "item",
+                        "price": {
+                            "currency": "INR",
+                            "value": "0"
+                        },
+                        "item": {
+                            "price": {
+                                "currency": "INR",
+                                "value": "89.00"
+                            }
+                        }
+                    },
+                    {
+                        "@ondc/org/item_id": "F3653",
+                        "title": "Delivery charges",
+                        "@ondc/org/title_type": "delivery",
+                        "price": {
+                            "currency": "INR",
+                            "value": "0"
+                        }
+                    },
+                    {
+                        "@ondc/org/item_id": "C3653",
+                        "title": "Delivery charges",
+                        "@ondc/org/title_type": "delivery",
+                        "price": {
+                            "currency": "INR",
+                            "value": "0"
+                        }
+                    }
+                ],
+                "ttl": "P1D"
+            },
+            "payment": {
+                "uri": "https://razorpay.com/",
+                "tl_method": "http/get",
+                "params": {
+                    "amount": "266.00",
+                    "currency": "INR",
+                    "transaction_id": "order_OOt0H3IrcpnggQ"
+                },
+                "status": "PAID",
+                "type": "ON-ORDER",
+                "collected_by": "BAP",
+                "@ondc/org/buyer_app_finder_fee_type": "percent",
+                "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+                "@ondc/org/settlement_details": [
+                    {
+                        "settlement_counterparty": "seller-app",
+                        "settlement_phase": "sale-amount",
+                        "settlement_type": "neft",
+                        "beneficiary_name": "MAAS ERP SOLUTIONS PRIVATE LIMITED",
+                        "settlement_bank_account_no": "59112345678901",
+                        "settlement_ifsc_code": "HDFC0000001",
+                        "bank_name": "HDFC",
+                        "branch_name": "Hyderabad"
+                    }
+                ]
+            },
+            "created_at": "2024-06-20T04:39:26.860Z",
+            "updated_at": "2024-06-20T04:46:13.000Z"
+        }
+    }
+}

--- a/MaasERP_Solutions/Retail/RET10/2024-06-20/Flow 5/on_confirm.json
+++ b/MaasERP_Solutions/Retail/RET10/2024-06-20/Flow 5/on_confirm.json
@@ -1,0 +1,258 @@
+{
+    "context": {
+        "domain": "ONDC:RET10",
+        "country": "IND",
+        "city": "std:040",
+        "action": "on_confirm",
+        "core_version": "1.2.0",
+        "bap_id": "buyer-app-preprod-v2.ondc.org",
+        "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+        "bpp_uri": "https://seller.dhihyperlocal.com/api/v1",
+        "transaction_id": "843bb3ba-f79e-4623-a45d-cd72b43f6b38",
+        "message_id": "6cc525b4-2241-4d25-b0a0-f357f725c82b",
+        "timestamp": "2024-06-20T04:39:30.000Z",
+        "bpp_id": "seller.dhihyperlocal.com",
+        "ttl": "PT30S"
+    },
+    "message": {
+        "order": {
+            "id": "2024-06-20-487661",
+            "state": "Created",
+            "provider": {
+                "id": "P1104",
+                "locations": [
+                    {
+                        "id": "L1104"
+                    }
+                ]
+            },
+            "items": [
+                {
+                    "id": "I51422",
+                    "fulfillment_id": "F3653",
+                    "quantity": {
+                        "count": 2
+                    }
+                },
+                {
+                    "id": "I51423",
+                    "fulfillment_id": "F3653",
+                    "quantity": {
+                        "count": 2
+                    }
+                }
+            ],
+            "billing": {
+                "name": "pardeep singh",
+                "address": {
+                    "name": "pardeep singh",
+                    "building": "cyber tower",
+                    "locality": "Police Colony Road",
+                    "city": "Hyderabad",
+                    "state": "Telangana",
+                    "country": "IND",
+                    "area_code": "500084"
+                },
+                "email": "pardeepsingh.it@maaserp.com",
+                "phone": "8360441031",
+                "created_at": "2024-06-20T04:38:56.382Z",
+                "updated_at": "2024-06-20T04:38:56.382Z"
+            },
+            "fulfillments": [
+                {
+                    "id": "F3653",
+                    "@ondc/org/provider_name": "sangameshwara super market",
+                    "type": "Delivery",
+                    "tracking": true,
+                    "@ondc/org/TAT": "P0DT6M",
+                    "state": {
+                        "descriptor": {
+                            "code": "Pending"
+                        }
+                    },
+                    "start": {
+                        "location": {
+                            "descriptor": {
+                                "name": "sangameshwara super market"
+                            },
+                            "id": "L1104",
+                            "gps": "17.462485,78.365312",
+                            "address": {
+                                "locality": "Lalitha Nilayam, Hanuman Nagar, Prashanth Nagar Colony, Kondapur, Telangana, India",
+                                "city": "Kondapur",
+                                "area_code": "500084",
+                                "state": "Telangana"
+                            }
+                        },
+                        "contact": {
+                            "phone": "8555051431",
+                            "email": "vamshikailasa0207@gmail.com"
+                        },
+                        "time": {
+                            "range": {
+                                "start": "2024-06-20T04:44:37.572Z",
+                                "end": "2024-06-20T04:49:37.572Z"
+                            }
+                        }
+                    },
+                    "end": {
+                        "location": {
+                            "gps": "17.464141,78.366162",
+                            "address": {
+                                "name": "pardeep singh",
+                                "building": "cyber tower",
+                                "locality": "Police Colony Road",
+                                "city": "Hyderabad",
+                                "state": "Telangana",
+                                "country": "IND",
+                                "area_code": "500084"
+                            }
+                        },
+                        "time": {
+                            "range": {
+                                "start": "2024-06-20T04:50:37.572Z",
+                                "end": "2024-06-20T04:55:37.572Z"
+                            }
+                        },
+                        "contact": {
+                            "phone": "8360441031",
+                            "email": "pardeepsingh.it@maaserp.com"
+                        },
+                        "person": {
+                            "name": "pardeep singh"
+                        }
+                    },
+                    "tags": [
+                        {
+                            "code": "tracking",
+                            "list": [
+                                {
+                                    "code": "gps_enabled",
+                                    "value": "no"
+                                },
+                                {
+                                    "code": "url_enabled",
+                                    "value": "yes"
+                                },
+                                {
+                                    "code": "url",
+                                    "value": "https://bbc.maaserp.com/ondc/tracking/13556"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "quote": {
+                "price": {
+                    "currency": "INR",
+                    "value": "266.00"
+                },
+                "breakup": [
+                    {
+                        "@ondc/org/item_id": "I51422",
+                        "@ondc/org/item_quantity": {
+                            "count": 2
+                        },
+                        "title": "rin ala fabric whitener 200 milli_litre",
+                        "@ondc/org/title_type": "item",
+                        "price": {
+                            "currency": "INR",
+                            "value": "88.00"
+                        },
+                        "item": {
+                            "price": {
+                                "currency": "INR",
+                                "value": "44.00"
+                            }
+                        }
+                    },
+                    {
+                        "@ondc/org/item_id": "I51423",
+                        "@ondc/org/item_quantity": {
+                            "count": 2
+                        },
+                        "title": "rin ala fabric whitener 500 milli_litre",
+                        "@ondc/org/title_type": "item",
+                        "price": {
+                            "currency": "INR",
+                            "value": "178.00"
+                        },
+                        "item": {
+                            "price": {
+                                "currency": "INR",
+                                "value": "89.00"
+                            }
+                        }
+                    },
+                    {
+                        "@ondc/org/item_id": "F3653",
+                        "title": "Delivery charges",
+                        "@ondc/org/title_type": "delivery",
+                        "price": {
+                            "currency": "INR",
+                            "value": "0"
+                        }
+                    }
+                ],
+                "ttl": "P1D"
+            },
+            "payment": {
+                "uri": "https://razorpay.com/",
+                "tl_method": "http/get",
+                "params": {
+                    "amount": "266.00",
+                    "currency": "INR",
+                    "transaction_id": "order_OOt0H3IrcpnggQ"
+                },
+                "status": "PAID",
+                "type": "ON-ORDER",
+                "collected_by": "BAP",
+                "@ondc/org/buyer_app_finder_fee_type": "percent",
+                "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+                "@ondc/org/settlement_details": [
+                    {
+                        "settlement_counterparty": "seller-app",
+                        "settlement_phase": "sale-amount",
+                        "settlement_type": "neft",
+                        "beneficiary_name": "MAAS ERP SOLUTIONS PRIVATE LIMITED",
+                        "settlement_bank_account_no": "59112345678901",
+                        "settlement_ifsc_code": "HDFC0000001",
+                        "bank_name": "HDFC",
+                        "branch_name": "Hyderabad"
+                    }
+                ]
+            },
+            "created_at": "2024-06-20T04:39:26.860Z",
+            "updated_at": "2024-06-20T04:39:30.000Z",
+            "tags": [
+                {
+                    "code": "bpp_terms",
+                    "list": [
+                        {
+                            "code": "provider_tax_number",
+                            "value": "DMNPR5885P"
+                        },
+                        {
+                            "code": "tax_number",
+                            "value": "36AAPCM0450Q1ZX"
+                        },
+                        {
+                            "code": "np_type",
+                            "value": "MSN"
+                        }
+                    ]
+                },
+                {
+                    "code": "bap_terms",
+                    "list": [
+                        {
+                            "code": "tax_number",
+                            "value": "GSTIN1234567890"
+                        }
+                    ]
+                }
+            ]
+        }
+    }
+}

--- a/MaasERP_Solutions/Retail/RET10/2024-06-20/Flow 5/on_init.json
+++ b/MaasERP_Solutions/Retail/RET10/2024-06-20/Flow 5/on_init.json
@@ -1,0 +1,176 @@
+{
+    "context": {
+        "domain": "ONDC:RET10",
+        "country": "IND",
+        "city": "std:040",
+        "action": "on_init",
+        "core_version": "1.2.0",
+        "bap_id": "buyer-app-preprod-v2.ondc.org",
+        "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+        "bpp_uri": "https://seller.dhihyperlocal.com/api/v1",
+        "transaction_id": "843bb3ba-f79e-4623-a45d-cd72b43f6b38",
+        "message_id": "2ee5f00c-497c-4c7a-b2da-93e1dba9329f",
+        "timestamp": "2024-06-20T04:38:59.775Z",
+        "bpp_id": "seller.dhihyperlocal.com",
+        "ttl": "PT30S"
+    },
+    "message": {
+        "order": {
+            "provider": {
+                "id": "P1104",
+                "locations": [
+                    {
+                        "id": "L1104"
+                    }
+                ]
+            },
+            "items": [
+                {
+                    "id": "I51422",
+                    "quantity": {
+                        "count": 2
+                    },
+                    "fulfillment_id": "F3653"
+                },
+                {
+                    "id": "I51423",
+                    "quantity": {
+                        "count": 2
+                    },
+                    "fulfillment_id": "F3653"
+                }
+            ],
+            "billing": {
+                "name": "pardeep singh",
+                "address": {
+                    "name": "pardeep singh",
+                    "building": "cyber tower",
+                    "locality": "Police Colony Road",
+                    "city": "Hyderabad",
+                    "state": "Telangana",
+                    "country": "IND",
+                    "area_code": "500084"
+                },
+                "email": "pardeepsingh.it@maaserp.com",
+                "phone": "8360441031",
+                "created_at": "2024-06-20T04:38:56.382Z",
+                "updated_at": "2024-06-20T04:38:56.382Z"
+            },
+            "fulfillments": [
+                {
+                    "id": "F3653",
+                    "type": "Delivery",
+                    "tracking": true,
+                    "end": {
+                        "location": {
+                            "gps": "17.464141,78.366162",
+                            "address": {
+                                "name": "pardeep singh",
+                                "building": "cyber tower",
+                                "locality": "Police Colony Road",
+                                "city": "Hyderabad",
+                                "state": "Telangana",
+                                "country": "IND",
+                                "area_code": "500084"
+                            }
+                        },
+                        "contact": {
+                            "phone": "8360441031",
+                            "email": "pardeepsingh.it@maaserp.com"
+                        }
+                    },
+                    "@ondc/org/TAT": "P0DT6M"
+                }
+            ],
+            "quote": {
+                "price": {
+                    "currency": "INR",
+                    "value": "266.00"
+                },
+                "breakup": [
+                    {
+                        "@ondc/org/item_id": "I51422",
+                        "@ondc/org/item_quantity": {
+                            "count": 2
+                        },
+                        "@ondc/org/title_type": "item",
+                        "item": {
+                            "price": {
+                                "currency": "INR",
+                                "value": "44.00"
+                            }
+                        },
+                        "title": "rin ala fabric whitener 200 milli_litre",
+                        "price": {
+                            "currency": "INR",
+                            "value": "88.00"
+                        }
+                    },
+                    {
+                        "@ondc/org/item_id": "I51423",
+                        "@ondc/org/item_quantity": {
+                            "count": 2
+                        },
+                        "@ondc/org/title_type": "item",
+                        "item": {
+                            "price": {
+                                "currency": "INR",
+                                "value": "89.00"
+                            }
+                        },
+                        "title": "rin ala fabric whitener 500 milli_litre",
+                        "price": {
+                            "currency": "INR",
+                            "value": "178.00"
+                        }
+                    },
+                    {
+                        "@ondc/org/item_id": "F3653",
+                        "title": "Delivery charges",
+                        "@ondc/org/title_type": "delivery",
+                        "price": {
+                            "currency": "INR",
+                            "value": "0"
+                        }
+                    }
+                ],
+                "ttl": "P1D"
+            },
+            "payment": {
+                "@ondc/org/buyer_app_finder_fee_type": "percent",
+                "@ondc/org/buyer_app_finder_fee_amount": "3",
+                "@ondc/org/settlement_details": [
+                    {
+                        "settlement_counterparty": "seller-app",
+                        "settlement_phase": "sale-amount",
+                        "settlement_type": "neft",
+                        "beneficiary_name": "MAAS ERP SOLUTIONS PRIVATE LIMITED",
+                        "settlement_bank_account_no": "59112345678901",
+                        "settlement_ifsc_code": "HDFC0000001",
+                        "bank_name": "HDFC",
+                        "branch_name": "Hyderabad"
+                    }
+                ]
+            },
+            "tags": [
+                {
+                    "code": "bpp_terms",
+                    "list": [
+                        {
+                            "code": "provider_tax_number",
+                            "value": "DMNPR5885P"
+                        },
+                        {
+                            "code": "tax_number",
+                            "value": "36AAPCM0450Q1ZX"
+                        },
+                        {
+                            "code": "np_type",
+                            "value": "MSN"
+                        }
+                    ]
+                }
+            ]
+        }
+    }
+}

--- a/MaasERP_Solutions/Retail/RET10/2024-06-20/Flow 5/on_select.json
+++ b/MaasERP_Solutions/Retail/RET10/2024-06-20/Flow 5/on_select.json
@@ -1,0 +1,137 @@
+{
+    "context": {
+        "domain": "ONDC:RET10",
+        "country": "IND",
+        "city": "std:040",
+        "action": "on_select",
+        "core_version": "1.2.0",
+        "bap_id": "buyer-app-preprod-v2.ondc.org",
+        "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+        "bpp_uri": "https://seller.dhihyperlocal.com/api/v1",
+        "transaction_id": "843bb3ba-f79e-4623-a45d-cd72b43f6b38",
+        "message_id": "9d5a3c73-7ac3-4b4c-8b3d-8d203186950f",
+        "timestamp": "2024-06-20T04:38:46.548Z",
+        "bpp_id": "seller.dhihyperlocal.com",
+        "ttl": "PT30S"
+    },
+    "message": {
+        "order": {
+            "provider": {
+                "id": "P1104",
+                "locations": [
+                    {
+                        "id": "L1104"
+                    }
+                ]
+            },
+            "items": [
+                {
+                    "fulfillment_id": "F3653",
+                    "id": "I51422"
+                },
+                {
+                    "fulfillment_id": "F3653",
+                    "id": "I51423"
+                }
+            ],
+            "fulfillments": [
+                {
+                    "id": "F3653",
+                    "@ondc/org/provider_name": "sangameshwara super market",
+                    "tracking": true,
+                    "type": "Delivery",
+                    "@ondc/org/category": "Immediate Delivery",
+                    "@ondc/org/TAT": "P0DT6M",
+                    "state": {
+                        "descriptor": {
+                            "code": "Serviceable"
+                        }
+                    }
+                },
+                {
+                    "id": "F3654",
+                    "type": "Self-Pickup",
+                    "@ondc/org/provider_name": "",
+                    "tracking": false,
+                    "@ondc/org/category": "Takeaway",
+                    "@ondc/org/TAT": "PT5M",
+                    "state": {
+                        "descriptor": {
+                            "code": "Serviceable"
+                        }
+                    }
+                }
+            ],
+            "quote": {
+                "price": {
+                    "currency": "INR",
+                    "value": "266.00"
+                },
+                "breakup": [
+                    {
+                        "@ondc/org/item_id": "I51422",
+                        "@ondc/org/item_quantity": {
+                            "count": 2
+                        },
+                        "title": "rin ala fabric whitener 200 milli_litre",
+                        "@ondc/org/title_type": "item",
+                        "price": {
+                            "currency": "INR",
+                            "value": "88.00"
+                        },
+                        "item": {
+                            "quantity": {
+                                "available": {
+                                    "count": "99"
+                                },
+                                "maximum": {
+                                    "count": "5"
+                                }
+                            },
+                            "price": {
+                                "currency": "INR",
+                                "value": "44.00"
+                            }
+                        }
+                    },
+                    {
+                        "@ondc/org/item_id": "I51423",
+                        "@ondc/org/item_quantity": {
+                            "count": 2
+                        },
+                        "title": "rin ala fabric whitener 500 milli_litre",
+                        "@ondc/org/title_type": "item",
+                        "price": {
+                            "currency": "INR",
+                            "value": "178.00"
+                        },
+                        "item": {
+                            "quantity": {
+                                "available": {
+                                    "count": "99"
+                                },
+                                "maximum": {
+                                    "count": "5"
+                                }
+                            },
+                            "price": {
+                                "currency": "INR",
+                                "value": "89.00"
+                            }
+                        }
+                    },
+                    {
+                        "@ondc/org/item_id": "F3653",
+                        "title": "Delivery charges",
+                        "@ondc/org/title_type": "delivery",
+                        "price": {
+                            "currency": "INR",
+                            "value": "0"
+                        }
+                    }
+                ],
+                "ttl": "P1D"
+            }
+        }
+    }
+}

--- a/MaasERP_Solutions/Retail/RET10/2024-06-20/Flow 5/on_status_agent-assigned.json
+++ b/MaasERP_Solutions/Retail/RET10/2024-06-20/Flow 5/on_status_agent-assigned.json
@@ -1,0 +1,239 @@
+{
+    "context": {
+        "domain": "ONDC:RET10",
+        "country": "IND",
+        "city": "std:040",
+        "action": "on_status",
+        "core_version": "1.2.0",
+        "bap_id": "buyer-app-preprod-v2.ondc.org",
+        "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+        "bpp_uri": "https://seller.dhihyperlocal.com/api/v1",
+        "transaction_id": "843bb3ba-f79e-4623-a45d-cd72b43f6b38",
+        "message_id": "a545bed8-b70a-4344-8b2e-7a87642dfa21",
+        "timestamp": "2024-06-20T04:45:12.000Z",
+        "bpp_id": "seller.dhihyperlocal.com",
+        "ttl": "PT30S"
+    },
+    "message": {
+        "order": {
+            "id": "2024-06-20-487661",
+            "state": "In-progress",
+            "provider": {
+                "id": "P1104",
+                "locations": [
+                    {
+                        "id": "L1104"
+                    }
+                ]
+            },
+            "items": [
+                {
+                    "id": "I51422",
+                    "fulfillment_id": "F3653",
+                    "quantity": {
+                        "count": 2
+                    }
+                },
+                {
+                    "id": "I51423",
+                    "fulfillment_id": "F3653",
+                    "quantity": {
+                        "count": 2
+                    }
+                }
+            ],
+            "billing": {
+                "name": "pardeep singh",
+                "address": {
+                    "name": "pardeep singh",
+                    "building": "cyber tower",
+                    "locality": "Police Colony Road",
+                    "city": "Hyderabad",
+                    "state": "Telangana",
+                    "country": "IND",
+                    "area_code": "500084"
+                },
+                "email": "pardeepsingh.it@maaserp.com",
+                "phone": "8360441031",
+                "created_at": "2024-06-20T04:38:56.382Z",
+                "updated_at": "2024-06-20T04:38:56.382Z"
+            },
+            "fulfillments": [
+                {
+                    "id": "F3653",
+                    "@ondc/org/provider_name": "sangameshwara super market",
+                    "type": "Delivery",
+                    "tracking": true,
+                    "@ondc/org/TAT": "P0DT6M",
+                    "state": {
+                        "descriptor": {
+                            "code": "Agent-assigned"
+                        }
+                    },
+                    "start": {
+                        "location": {
+                            "descriptor": {
+                                "name": "sangameshwara super market"
+                            },
+                            "id": "L1104",
+                            "gps": "17.462485,78.365312",
+                            "address": {
+                                "locality": "Lalitha Nilayam, Hanuman Nagar, Prashanth Nagar Colony, Kondapur, Telangana, India",
+                                "city": "Kondapur",
+                                "area_code": "500084",
+                                "state": "Telangana"
+                            }
+                        },
+                        "contact": {
+                            "phone": "8555051431",
+                            "email": "vamshikailasa0207@gmail.com"
+                        },
+                        "time": {
+                            "range": {
+                                "start": "2024-06-20T04:44:37.572Z",
+                                "end": "2024-06-20T04:49:37.572Z"
+                            }
+                        }
+                    },
+                    "tags": [
+                        {
+                            "code": "routing",
+                            "list": [
+                                {
+                                    "code": "type",
+                                    "value": "P2P"
+                                }
+                            ]
+                        },
+                        {
+                            "code": "tracking",
+                            "list": [
+                                {
+                                    "code": "gps_enabled",
+                                    "value": "no"
+                                },
+                                {
+                                    "code": "url_enabled",
+                                    "value": "yes"
+                                },
+                                {
+                                    "code": "url",
+                                    "value": "https://bbc.maaserp.com/ondc/tracking/13556"
+                                }
+                            ]
+                        }
+                    ],
+                    "end": {
+                        "location": {
+                            "gps": "17.464141,78.366162",
+                            "address": {
+                                "name": "pardeep singh",
+                                "building": "cyber tower",
+                                "locality": "Police Colony Road",
+                                "city": "Hyderabad",
+                                "state": "Telangana",
+                                "country": "IND",
+                                "area_code": "500084"
+                            }
+                        },
+                        "time": {
+                            "range": {
+                                "start": "2024-06-20T04:50:37.572Z",
+                                "end": "2024-06-20T04:55:37.572Z"
+                            }
+                        },
+                        "contact": {
+                            "phone": "8360441031",
+                            "email": "pardeepsingh.it@maaserp.com"
+                        },
+                        "person": {
+                            "name": "pardeep singh"
+                        }
+                    }
+                }
+            ],
+            "quote": {
+                "price": {
+                    "currency": "INR",
+                    "value": "266.00"
+                },
+                "breakup": [
+                    {
+                        "@ondc/org/item_id": "I51422",
+                        "@ondc/org/item_quantity": {
+                            "count": 2
+                        },
+                        "title": "rin ala fabric whitener 200 milli_litre",
+                        "@ondc/org/title_type": "item",
+                        "price": {
+                            "currency": "INR",
+                            "value": "88.00"
+                        },
+                        "item": {
+                            "price": {
+                                "currency": "INR",
+                                "value": "44.00"
+                            }
+                        }
+                    },
+                    {
+                        "@ondc/org/item_id": "I51423",
+                        "@ondc/org/item_quantity": {
+                            "count": 2
+                        },
+                        "title": "rin ala fabric whitener 500 milli_litre",
+                        "@ondc/org/title_type": "item",
+                        "price": {
+                            "currency": "INR",
+                            "value": "178.00"
+                        },
+                        "item": {
+                            "price": {
+                                "currency": "INR",
+                                "value": "89.00"
+                            }
+                        }
+                    },
+                    {
+                        "@ondc/org/item_id": "F3653",
+                        "title": "Delivery charges",
+                        "@ondc/org/title_type": "delivery",
+                        "price": {
+                            "currency": "INR",
+                            "value": "0"
+                        }
+                    }
+                ],
+                "ttl": "P1D"
+            },
+            "payment": {
+                "uri": "https://razorpay.com/",
+                "tl_method": "http/get",
+                "params": {
+                    "amount": "266.00",
+                    "currency": "INR",
+                    "transaction_id": "order_OOt0H3IrcpnggQ"
+                },
+                "status": "PAID",
+                "type": "ON-ORDER",
+                "collected_by": "BAP",
+                "@ondc/org/buyer_app_finder_fee_type": "percent",
+                "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+                "@ondc/org/settlement_details": [
+                    {
+                        "settlement_counterparty": "seller-app",
+                        "settlement_phase": "sale-amount",
+                        "settlement_type": "neft",
+                        "beneficiary_name": "MAAS ERP SOLUTIONS PRIVATE LIMITED",
+                        "settlement_bank_account_no": "59112345678901",
+                        "settlement_ifsc_code": "HDFC0000001",
+                        "bank_name": "HDFC",
+                        "branch_name": "Hyderabad"
+                    }
+                ]
+            },
+            "created_at": "2024-06-20T04:39:26.860Z",
+            "updated_at": "2024-06-20T04:45:12.000Z"
+        }
+    }
+}

--- a/MaasERP_Solutions/Retail/RET10/2024-06-20/Flow 5/on_status_order-picked-up.json
+++ b/MaasERP_Solutions/Retail/RET10/2024-06-20/Flow 5/on_status_order-picked-up.json
@@ -1,0 +1,246 @@
+{
+    "context": {
+        "domain": "ONDC:RET10",
+        "country": "IND",
+        "city": "std:040",
+        "action": "on_status",
+        "core_version": "1.2.0",
+        "bap_id": "buyer-app-preprod-v2.ondc.org",
+        "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+        "bpp_uri": "https://seller.dhihyperlocal.com/api/v1",
+        "transaction_id": "843bb3ba-f79e-4623-a45d-cd72b43f6b38",
+        "message_id": "b942b425-3769-40dd-a079-c2e562b52164",
+        "timestamp": "2024-06-20T04:45:32.000Z",
+        "bpp_id": "seller.dhihyperlocal.com",
+        "ttl": "PT30S"
+    },
+    "message": {
+        "order": {
+            "id": "2024-06-20-487661",
+            "state": "In-progress",
+            "provider": {
+                "id": "P1104",
+                "locations": [
+                    {
+                        "id": "L1104"
+                    }
+                ]
+            },
+            "items": [
+                {
+                    "id": "I51422",
+                    "fulfillment_id": "F3653",
+                    "quantity": {
+                        "count": 2
+                    }
+                },
+                {
+                    "id": "I51423",
+                    "fulfillment_id": "F3653",
+                    "quantity": {
+                        "count": 2
+                    }
+                }
+            ],
+            "billing": {
+                "name": "pardeep singh",
+                "address": {
+                    "name": "pardeep singh",
+                    "building": "cyber tower",
+                    "locality": "Police Colony Road",
+                    "city": "Hyderabad",
+                    "state": "Telangana",
+                    "country": "IND",
+                    "area_code": "500084"
+                },
+                "email": "pardeepsingh.it@maaserp.com",
+                "phone": "8360441031",
+                "created_at": "2024-06-20T04:38:56.382Z",
+                "updated_at": "2024-06-20T04:38:56.382Z"
+            },
+            "fulfillments": [
+                {
+                    "id": "F3653",
+                    "@ondc/org/provider_name": "sangameshwara super market",
+                    "type": "Delivery",
+                    "tracking": true,
+                    "@ondc/org/TAT": "P0DT6M",
+                    "state": {
+                        "descriptor": {
+                            "code": "Order-picked-up"
+                        }
+                    },
+                    "start": {
+                        "location": {
+                            "descriptor": {
+                                "name": "sangameshwara super market"
+                            },
+                            "id": "L1104",
+                            "gps": "17.462485,78.365312",
+                            "address": {
+                                "locality": "Lalitha Nilayam, Hanuman Nagar, Prashanth Nagar Colony, Kondapur, Telangana, India",
+                                "city": "Kondapur",
+                                "area_code": "500084",
+                                "state": "Telangana"
+                            }
+                        },
+                        "contact": {
+                            "phone": "8555051431",
+                            "email": "vamshikailasa0207@gmail.com"
+                        },
+                        "time": {
+                            "range": {
+                                "start": "2024-06-20T04:44:37.572Z",
+                                "end": "2024-06-20T04:49:37.572Z"
+                            },
+                            "timestamp": "2024-06-20T04:45:32.000Z"
+                        }
+                    },
+                    "tags": [
+                        {
+                            "code": "routing",
+                            "list": [
+                                {
+                                    "code": "type",
+                                    "value": "P2P"
+                                }
+                            ]
+                        },
+                        {
+                            "code": "tracking",
+                            "list": [
+                                {
+                                    "code": "gps_enabled",
+                                    "value": "no"
+                                },
+                                {
+                                    "code": "url_enabled",
+                                    "value": "yes"
+                                },
+                                {
+                                    "code": "url",
+                                    "value": "https://bbc.maaserp.com/ondc/tracking/13556"
+                                }
+                            ]
+                        }
+                    ],
+                    "end": {
+                        "location": {
+                            "gps": "17.464141,78.366162",
+                            "address": {
+                                "name": "pardeep singh",
+                                "building": "cyber tower",
+                                "locality": "Police Colony Road",
+                                "city": "Hyderabad",
+                                "state": "Telangana",
+                                "country": "IND",
+                                "area_code": "500084"
+                            }
+                        },
+                        "time": {
+                            "range": {
+                                "start": "2024-06-20T04:50:37.572Z",
+                                "end": "2024-06-20T04:55:37.572Z"
+                            }
+                        },
+                        "contact": {
+                            "phone": "8360441031",
+                            "email": "pardeepsingh.it@maaserp.com"
+                        },
+                        "person": {
+                            "name": "pardeep singh"
+                        }
+                    }
+                }
+            ],
+            "quote": {
+                "price": {
+                    "currency": "INR",
+                    "value": "266.00"
+                },
+                "breakup": [
+                    {
+                        "@ondc/org/item_id": "I51422",
+                        "@ondc/org/item_quantity": {
+                            "count": 2
+                        },
+                        "title": "rin ala fabric whitener 200 milli_litre",
+                        "@ondc/org/title_type": "item",
+                        "price": {
+                            "currency": "INR",
+                            "value": "88.00"
+                        },
+                        "item": {
+                            "price": {
+                                "currency": "INR",
+                                "value": "44.00"
+                            }
+                        }
+                    },
+                    {
+                        "@ondc/org/item_id": "I51423",
+                        "@ondc/org/item_quantity": {
+                            "count": 2
+                        },
+                        "title": "rin ala fabric whitener 500 milli_litre",
+                        "@ondc/org/title_type": "item",
+                        "price": {
+                            "currency": "INR",
+                            "value": "178.00"
+                        },
+                        "item": {
+                            "price": {
+                                "currency": "INR",
+                                "value": "89.00"
+                            }
+                        }
+                    },
+                    {
+                        "@ondc/org/item_id": "F3653",
+                        "title": "Delivery charges",
+                        "@ondc/org/title_type": "delivery",
+                        "price": {
+                            "currency": "INR",
+                            "value": "0"
+                        }
+                    }
+                ],
+                "ttl": "P1D"
+            },
+            "payment": {
+                "uri": "https://razorpay.com/",
+                "tl_method": "http/get",
+                "params": {
+                    "amount": "266.00",
+                    "currency": "INR",
+                    "transaction_id": "order_OOt0H3IrcpnggQ"
+                },
+                "status": "PAID",
+                "type": "ON-ORDER",
+                "collected_by": "BAP",
+                "@ondc/org/buyer_app_finder_fee_type": "percent",
+                "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+                "@ondc/org/settlement_details": [
+                    {
+                        "settlement_counterparty": "seller-app",
+                        "settlement_phase": "sale-amount",
+                        "settlement_type": "neft",
+                        "beneficiary_name": "MAAS ERP SOLUTIONS PRIVATE LIMITED",
+                        "settlement_bank_account_no": "59112345678901",
+                        "settlement_ifsc_code": "HDFC0000001",
+                        "bank_name": "HDFC",
+                        "branch_name": "Hyderabad"
+                    }
+                ]
+            },
+            "created_at": "2024-06-20T04:39:26.860Z",
+            "updated_at": "2024-06-20T04:45:32.000Z",
+            "documents": [
+                {
+                    "url": "https://newnfresume.s3-us-west-2.amazonaws.com/Orderinvoices/INV_1718858447_1536042115_34224_13556.pdf",
+                    "label": "Invoice"
+                }
+            ]
+        }
+    }
+}

--- a/MaasERP_Solutions/Retail/RET10/2024-06-20/Flow 5/on_status_out-for-delivery.json
+++ b/MaasERP_Solutions/Retail/RET10/2024-06-20/Flow 5/on_status_out-for-delivery.json
@@ -1,0 +1,246 @@
+{
+    "context": {
+        "domain": "ONDC:RET10",
+        "country": "IND",
+        "city": "std:040",
+        "action": "on_status",
+        "core_version": "1.2.0",
+        "bap_id": "buyer-app-preprod-v2.ondc.org",
+        "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+        "bpp_uri": "https://seller.dhihyperlocal.com/api/v1",
+        "transaction_id": "843bb3ba-f79e-4623-a45d-cd72b43f6b38",
+        "message_id": "600a4620-472c-46e9-b9c1-c1ee77632872",
+        "timestamp": "2024-06-20T04:45:47.000Z",
+        "bpp_id": "seller.dhihyperlocal.com",
+        "ttl": "PT30S"
+    },
+    "message": {
+        "order": {
+            "id": "2024-06-20-487661",
+            "state": "In-progress",
+            "provider": {
+                "id": "P1104",
+                "locations": [
+                    {
+                        "id": "L1104"
+                    }
+                ]
+            },
+            "items": [
+                {
+                    "id": "I51422",
+                    "fulfillment_id": "F3653",
+                    "quantity": {
+                        "count": 2
+                    }
+                },
+                {
+                    "id": "I51423",
+                    "fulfillment_id": "F3653",
+                    "quantity": {
+                        "count": 2
+                    }
+                }
+            ],
+            "billing": {
+                "name": "pardeep singh",
+                "address": {
+                    "name": "pardeep singh",
+                    "building": "cyber tower",
+                    "locality": "Police Colony Road",
+                    "city": "Hyderabad",
+                    "state": "Telangana",
+                    "country": "IND",
+                    "area_code": "500084"
+                },
+                "email": "pardeepsingh.it@maaserp.com",
+                "phone": "8360441031",
+                "created_at": "2024-06-20T04:38:56.382Z",
+                "updated_at": "2024-06-20T04:38:56.382Z"
+            },
+            "fulfillments": [
+                {
+                    "id": "F3653",
+                    "@ondc/org/provider_name": "sangameshwara super market",
+                    "type": "Delivery",
+                    "tracking": true,
+                    "@ondc/org/TAT": "P0DT6M",
+                    "state": {
+                        "descriptor": {
+                            "code": "Out-for-delivery"
+                        }
+                    },
+                    "start": {
+                        "location": {
+                            "descriptor": {
+                                "name": "sangameshwara super market"
+                            },
+                            "id": "L1104",
+                            "gps": "17.462485,78.365312",
+                            "address": {
+                                "locality": "Lalitha Nilayam, Hanuman Nagar, Prashanth Nagar Colony, Kondapur, Telangana, India",
+                                "city": "Kondapur",
+                                "area_code": "500084",
+                                "state": "Telangana"
+                            }
+                        },
+                        "contact": {
+                            "phone": "8555051431",
+                            "email": "vamshikailasa0207@gmail.com"
+                        },
+                        "time": {
+                            "range": {
+                                "start": "2024-06-20T04:44:37.572Z",
+                                "end": "2024-06-20T04:49:37.572Z"
+                            },
+                            "timestamp": "2024-06-20T04:45:32.000Z"
+                        }
+                    },
+                    "tags": [
+                        {
+                            "code": "routing",
+                            "list": [
+                                {
+                                    "code": "type",
+                                    "value": "P2P"
+                                }
+                            ]
+                        },
+                        {
+                            "code": "tracking",
+                            "list": [
+                                {
+                                    "code": "gps_enabled",
+                                    "value": "no"
+                                },
+                                {
+                                    "code": "url_enabled",
+                                    "value": "yes"
+                                },
+                                {
+                                    "code": "url",
+                                    "value": "https://bbc.maaserp.com/ondc/tracking/13556"
+                                }
+                            ]
+                        }
+                    ],
+                    "end": {
+                        "location": {
+                            "gps": "17.464141,78.366162",
+                            "address": {
+                                "name": "pardeep singh",
+                                "building": "cyber tower",
+                                "locality": "Police Colony Road",
+                                "city": "Hyderabad",
+                                "state": "Telangana",
+                                "country": "IND",
+                                "area_code": "500084"
+                            }
+                        },
+                        "time": {
+                            "range": {
+                                "start": "2024-06-20T04:50:37.572Z",
+                                "end": "2024-06-20T04:55:37.572Z"
+                            }
+                        },
+                        "contact": {
+                            "phone": "8360441031",
+                            "email": "pardeepsingh.it@maaserp.com"
+                        },
+                        "person": {
+                            "name": "pardeep singh"
+                        }
+                    }
+                }
+            ],
+            "quote": {
+                "price": {
+                    "currency": "INR",
+                    "value": "266.00"
+                },
+                "breakup": [
+                    {
+                        "@ondc/org/item_id": "I51422",
+                        "@ondc/org/item_quantity": {
+                            "count": 2
+                        },
+                        "title": "rin ala fabric whitener 200 milli_litre",
+                        "@ondc/org/title_type": "item",
+                        "price": {
+                            "currency": "INR",
+                            "value": "88.00"
+                        },
+                        "item": {
+                            "price": {
+                                "currency": "INR",
+                                "value": "44.00"
+                            }
+                        }
+                    },
+                    {
+                        "@ondc/org/item_id": "I51423",
+                        "@ondc/org/item_quantity": {
+                            "count": 2
+                        },
+                        "title": "rin ala fabric whitener 500 milli_litre",
+                        "@ondc/org/title_type": "item",
+                        "price": {
+                            "currency": "INR",
+                            "value": "178.00"
+                        },
+                        "item": {
+                            "price": {
+                                "currency": "INR",
+                                "value": "89.00"
+                            }
+                        }
+                    },
+                    {
+                        "@ondc/org/item_id": "F3653",
+                        "title": "Delivery charges",
+                        "@ondc/org/title_type": "delivery",
+                        "price": {
+                            "currency": "INR",
+                            "value": "0"
+                        }
+                    }
+                ],
+                "ttl": "P1D"
+            },
+            "payment": {
+                "uri": "https://razorpay.com/",
+                "tl_method": "http/get",
+                "params": {
+                    "amount": "266.00",
+                    "currency": "INR",
+                    "transaction_id": "order_OOt0H3IrcpnggQ"
+                },
+                "status": "PAID",
+                "type": "ON-ORDER",
+                "collected_by": "BAP",
+                "@ondc/org/buyer_app_finder_fee_type": "percent",
+                "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+                "@ondc/org/settlement_details": [
+                    {
+                        "settlement_counterparty": "seller-app",
+                        "settlement_phase": "sale-amount",
+                        "settlement_type": "neft",
+                        "beneficiary_name": "MAAS ERP SOLUTIONS PRIVATE LIMITED",
+                        "settlement_bank_account_no": "59112345678901",
+                        "settlement_ifsc_code": "HDFC0000001",
+                        "bank_name": "HDFC",
+                        "branch_name": "Hyderabad"
+                    }
+                ]
+            },
+            "created_at": "2024-06-20T04:39:26.860Z",
+            "updated_at": "2024-06-20T04:45:47.000Z",
+            "documents": [
+                {
+                    "url": "https://newnfresume.s3-us-west-2.amazonaws.com/Orderinvoices/INV_1718858447_1536042115_34224_13556.pdf",
+                    "label": "Invoice"
+                }
+            ]
+        }
+    }
+}

--- a/MaasERP_Solutions/Retail/RET10/2024-06-20/Flow 5/on_status_packed.json
+++ b/MaasERP_Solutions/Retail/RET10/2024-06-20/Flow 5/on_status_packed.json
@@ -1,0 +1,230 @@
+{
+    "context": {
+        "domain": "ONDC:RET10",
+        "country": "IND",
+        "city": "std:040",
+        "action": "on_status",
+        "core_version": "1.2.0",
+        "bap_id": "buyer-app-preprod-v2.ondc.org",
+        "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+        "bpp_uri": "https://seller.dhihyperlocal.com/api/v1",
+        "transaction_id": "843bb3ba-f79e-4623-a45d-cd72b43f6b38",
+        "message_id": "35fbda46-c63a-4338-a930-d36f72fa76d8",
+        "timestamp": "2024-06-20T04:41:52.000Z",
+        "bpp_id": "seller.dhihyperlocal.com",
+        "ttl": "PT30S"
+    },
+    "message": {
+        "order": {
+            "id": "2024-06-20-487661",
+            "state": "In-progress",
+            "provider": {
+                "id": "P1104",
+                "locations": [
+                    {
+                        "id": "L1104"
+                    }
+                ]
+            },
+            "items": [
+                {
+                    "id": "I51422",
+                    "fulfillment_id": "F3653",
+                    "quantity": {
+                        "count": 2
+                    }
+                },
+                {
+                    "id": "I51423",
+                    "fulfillment_id": "F3653",
+                    "quantity": {
+                        "count": 2
+                    }
+                }
+            ],
+            "billing": {
+                "name": "pardeep singh",
+                "address": {
+                    "name": "pardeep singh",
+                    "building": "cyber tower",
+                    "locality": "Police Colony Road",
+                    "city": "Hyderabad",
+                    "state": "Telangana",
+                    "country": "IND",
+                    "area_code": "500084"
+                },
+                "email": "pardeepsingh.it@maaserp.com",
+                "phone": "8360441031",
+                "created_at": "2024-06-20T04:38:56.382Z",
+                "updated_at": "2024-06-20T04:38:56.382Z"
+            },
+            "fulfillments": [
+                {
+                    "id": "F3653",
+                    "@ondc/org/provider_name": "sangameshwara super market",
+                    "type": "Delivery",
+                    "tracking": true,
+                    "@ondc/org/TAT": "P0DT6M",
+                    "state": {
+                        "descriptor": {
+                            "code": "Packed"
+                        }
+                    },
+                    "start": {
+                        "location": {
+                            "descriptor": {
+                                "name": "sangameshwara super market"
+                            },
+                            "id": "L1104",
+                            "gps": "17.462485,78.365312",
+                            "address": {
+                                "locality": "Lalitha Nilayam, Hanuman Nagar, Prashanth Nagar Colony, Kondapur, Telangana, India",
+                                "city": "Kondapur",
+                                "area_code": "500084",
+                                "state": "Telangana"
+                            }
+                        },
+                        "contact": {
+                            "phone": "8555051431",
+                            "email": "vamshikailasa0207@gmail.com"
+                        },
+                        "time": {
+                            "range": {
+                                "start": "2024-06-20T04:44:37.572Z",
+                                "end": "2024-06-20T04:49:37.572Z"
+                            }
+                        }
+                    },
+                    "end": {
+                        "location": {
+                            "gps": "17.464141,78.366162",
+                            "address": {
+                                "name": "pardeep singh",
+                                "building": "cyber tower",
+                                "locality": "Police Colony Road",
+                                "city": "Hyderabad",
+                                "state": "Telangana",
+                                "country": "IND",
+                                "area_code": "500084"
+                            }
+                        },
+                        "time": {
+                            "range": {
+                                "start": "2024-06-20T04:50:37.572Z",
+                                "end": "2024-06-20T04:55:37.572Z"
+                            }
+                        },
+                        "contact": {
+                            "phone": "8360441031",
+                            "email": "pardeepsingh.it@maaserp.com"
+                        },
+                        "person": {
+                            "name": "pardeep singh"
+                        }
+                    },
+                    "tags": [
+                        {
+                            "code": "tracking",
+                            "list": [
+                                {
+                                    "code": "gps_enabled",
+                                    "value": "no"
+                                },
+                                {
+                                    "code": "url_enabled",
+                                    "value": "yes"
+                                },
+                                {
+                                    "code": "url",
+                                    "value": "https://bbc.maaserp.com/ondc/tracking/13556"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "quote": {
+                "price": {
+                    "currency": "INR",
+                    "value": "266.00"
+                },
+                "breakup": [
+                    {
+                        "@ondc/org/item_id": "I51422",
+                        "@ondc/org/item_quantity": {
+                            "count": 2
+                        },
+                        "title": "rin ala fabric whitener 200 milli_litre",
+                        "@ondc/org/title_type": "item",
+                        "price": {
+                            "currency": "INR",
+                            "value": "88.00"
+                        },
+                        "item": {
+                            "price": {
+                                "currency": "INR",
+                                "value": "44.00"
+                            }
+                        }
+                    },
+                    {
+                        "@ondc/org/item_id": "I51423",
+                        "@ondc/org/item_quantity": {
+                            "count": 2
+                        },
+                        "title": "rin ala fabric whitener 500 milli_litre",
+                        "@ondc/org/title_type": "item",
+                        "price": {
+                            "currency": "INR",
+                            "value": "178.00"
+                        },
+                        "item": {
+                            "price": {
+                                "currency": "INR",
+                                "value": "89.00"
+                            }
+                        }
+                    },
+                    {
+                        "@ondc/org/item_id": "F3653",
+                        "title": "Delivery charges",
+                        "@ondc/org/title_type": "delivery",
+                        "price": {
+                            "currency": "INR",
+                            "value": "0"
+                        }
+                    }
+                ],
+                "ttl": "P1D"
+            },
+            "payment": {
+                "uri": "https://razorpay.com/",
+                "tl_method": "http/get",
+                "params": {
+                    "amount": "266.00",
+                    "currency": "INR",
+                    "transaction_id": "order_OOt0H3IrcpnggQ"
+                },
+                "status": "PAID",
+                "type": "ON-ORDER",
+                "collected_by": "BAP",
+                "@ondc/org/buyer_app_finder_fee_type": "percent",
+                "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+                "@ondc/org/settlement_details": [
+                    {
+                        "settlement_counterparty": "seller-app",
+                        "settlement_phase": "sale-amount",
+                        "settlement_type": "neft",
+                        "beneficiary_name": "MAAS ERP SOLUTIONS PRIVATE LIMITED",
+                        "settlement_bank_account_no": "59112345678901",
+                        "settlement_ifsc_code": "HDFC0000001",
+                        "bank_name": "HDFC",
+                        "branch_name": "Hyderabad"
+                    }
+                ]
+            },
+            "created_at": "2024-06-20T04:39:26.860Z",
+            "updated_at": "2024-06-20T04:41:52.000Z"
+        }
+    }
+}

--- a/MaasERP_Solutions/Retail/RET10/2024-06-20/Flow 5/on_status_pending.json
+++ b/MaasERP_Solutions/Retail/RET10/2024-06-20/Flow 5/on_status_pending.json
@@ -1,0 +1,230 @@
+{
+    "context": {
+        "domain": "ONDC:RET10",
+        "country": "IND",
+        "city": "std:040",
+        "action": "on_status",
+        "core_version": "1.2.0",
+        "bap_id": "buyer-app-preprod-v2.ondc.org",
+        "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+        "bpp_uri": "https://seller.dhihyperlocal.com/api/v1",
+        "transaction_id": "843bb3ba-f79e-4623-a45d-cd72b43f6b38",
+        "message_id": "4488baf2-1ce7-4fa7-af92-be9c2f14d7c0",
+        "timestamp": "2024-06-20T04:40:54.000Z",
+        "bpp_id": "seller.dhihyperlocal.com",
+        "ttl": "PT30S"
+    },
+    "message": {
+        "order": {
+            "id": "2024-06-20-487661",
+            "state": "Accepted",
+            "provider": {
+                "id": "P1104",
+                "locations": [
+                    {
+                        "id": "L1104"
+                    }
+                ]
+            },
+            "items": [
+                {
+                    "id": "I51422",
+                    "fulfillment_id": "F3653",
+                    "quantity": {
+                        "count": 2
+                    }
+                },
+                {
+                    "id": "I51423",
+                    "fulfillment_id": "F3653",
+                    "quantity": {
+                        "count": 2
+                    }
+                }
+            ],
+            "billing": {
+                "name": "pardeep singh",
+                "address": {
+                    "name": "pardeep singh",
+                    "building": "cyber tower",
+                    "locality": "Police Colony Road",
+                    "city": "Hyderabad",
+                    "state": "Telangana",
+                    "country": "IND",
+                    "area_code": "500084"
+                },
+                "email": "pardeepsingh.it@maaserp.com",
+                "phone": "8360441031",
+                "created_at": "2024-06-20T04:38:56.382Z",
+                "updated_at": "2024-06-20T04:38:56.382Z"
+            },
+            "fulfillments": [
+                {
+                    "id": "F3653",
+                    "@ondc/org/provider_name": "sangameshwara super market",
+                    "type": "Delivery",
+                    "tracking": true,
+                    "@ondc/org/TAT": "P0DT6M",
+                    "state": {
+                        "descriptor": {
+                            "code": "Pending"
+                        }
+                    },
+                    "start": {
+                        "location": {
+                            "descriptor": {
+                                "name": "sangameshwara super market"
+                            },
+                            "id": "L1104",
+                            "gps": "17.462485,78.365312",
+                            "address": {
+                                "locality": "Lalitha Nilayam, Hanuman Nagar, Prashanth Nagar Colony, Kondapur, Telangana, India",
+                                "city": "Kondapur",
+                                "area_code": "500084",
+                                "state": "Telangana"
+                            }
+                        },
+                        "contact": {
+                            "phone": "8555051431",
+                            "email": "vamshikailasa0207@gmail.com"
+                        },
+                        "time": {
+                            "range": {
+                                "start": "2024-06-20T04:44:37.572Z",
+                                "end": "2024-06-20T04:49:37.572Z"
+                            }
+                        }
+                    },
+                    "end": {
+                        "location": {
+                            "gps": "17.464141,78.366162",
+                            "address": {
+                                "name": "pardeep singh",
+                                "building": "cyber tower",
+                                "locality": "Police Colony Road",
+                                "city": "Hyderabad",
+                                "state": "Telangana",
+                                "country": "IND",
+                                "area_code": "500084"
+                            }
+                        },
+                        "time": {
+                            "range": {
+                                "start": "2024-06-20T04:50:37.572Z",
+                                "end": "2024-06-20T04:55:37.572Z"
+                            }
+                        },
+                        "contact": {
+                            "phone": "8360441031",
+                            "email": "pardeepsingh.it@maaserp.com"
+                        },
+                        "person": {
+                            "name": "pardeep singh"
+                        }
+                    },
+                    "tags": [
+                        {
+                            "code": "tracking",
+                            "list": [
+                                {
+                                    "code": "gps_enabled",
+                                    "value": "no"
+                                },
+                                {
+                                    "code": "url_enabled",
+                                    "value": "yes"
+                                },
+                                {
+                                    "code": "url",
+                                    "value": "https://bbc.maaserp.com/ondc/tracking/13556"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "quote": {
+                "price": {
+                    "currency": "INR",
+                    "value": "266.00"
+                },
+                "breakup": [
+                    {
+                        "@ondc/org/item_id": "I51422",
+                        "@ondc/org/item_quantity": {
+                            "count": 2
+                        },
+                        "title": "rin ala fabric whitener 200 milli_litre",
+                        "@ondc/org/title_type": "item",
+                        "price": {
+                            "currency": "INR",
+                            "value": "88.00"
+                        },
+                        "item": {
+                            "price": {
+                                "currency": "INR",
+                                "value": "44.00"
+                            }
+                        }
+                    },
+                    {
+                        "@ondc/org/item_id": "I51423",
+                        "@ondc/org/item_quantity": {
+                            "count": 2
+                        },
+                        "title": "rin ala fabric whitener 500 milli_litre",
+                        "@ondc/org/title_type": "item",
+                        "price": {
+                            "currency": "INR",
+                            "value": "178.00"
+                        },
+                        "item": {
+                            "price": {
+                                "currency": "INR",
+                                "value": "89.00"
+                            }
+                        }
+                    },
+                    {
+                        "@ondc/org/item_id": "F3653",
+                        "title": "Delivery charges",
+                        "@ondc/org/title_type": "delivery",
+                        "price": {
+                            "currency": "INR",
+                            "value": "0"
+                        }
+                    }
+                ],
+                "ttl": "P1D"
+            },
+            "payment": {
+                "uri": "https://razorpay.com/",
+                "tl_method": "http/get",
+                "params": {
+                    "amount": "266.00",
+                    "currency": "INR",
+                    "transaction_id": "order_OOt0H3IrcpnggQ"
+                },
+                "status": "PAID",
+                "type": "ON-ORDER",
+                "collected_by": "BAP",
+                "@ondc/org/buyer_app_finder_fee_type": "percent",
+                "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+                "@ondc/org/settlement_details": [
+                    {
+                        "settlement_counterparty": "seller-app",
+                        "settlement_phase": "sale-amount",
+                        "settlement_type": "neft",
+                        "beneficiary_name": "MAAS ERP SOLUTIONS PRIVATE LIMITED",
+                        "settlement_bank_account_no": "59112345678901",
+                        "settlement_ifsc_code": "HDFC0000001",
+                        "bank_name": "HDFC",
+                        "branch_name": "Hyderabad"
+                    }
+                ]
+            },
+            "created_at": "2024-06-20T04:39:26.860Z",
+            "updated_at": "2024-06-20T04:40:54.000Z"
+        }
+    }
+}

--- a/MaasERP_Solutions/Retail/RET10/2024-06-20/Flow 5/on_status_rto-delivered.json
+++ b/MaasERP_Solutions/Retail/RET10/2024-06-20/Flow 5/on_status_rto-delivered.json
@@ -1,0 +1,365 @@
+{
+    "context": {
+        "domain": "ONDC:RET10",
+        "country": "IND",
+        "city": "std:040",
+        "action": "on_status",
+        "core_version": "1.2.0",
+        "bap_id": "buyer-app-preprod-v2.ondc.org",
+        "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+        "bpp_uri": "https://seller.dhihyperlocal.com/api/v1",
+        "transaction_id": "843bb3ba-f79e-4623-a45d-cd72b43f6b38",
+        "message_id": "a822e40e-da9e-4bc3-9db4-7cdc77d2a582",
+        "timestamp": "2024-06-20T04:46:48.489Z",
+        "bpp_id": "seller.dhihyperlocal.com",
+        "ttl": "PT30S"
+    },
+    "message": {
+        "order": {
+            "id": "2024-06-20-487661",
+            "state": "Cancelled",
+            "provider": {
+                "id": "P1104",
+                "locations": [
+                    {
+                        "id": "L1104"
+                    }
+                ]
+            },
+            "items": [
+                {
+                    "id": "I51422",
+                    "fulfillment_id": "F3653",
+                    "quantity": {
+                        "count": 0
+                    }
+                },
+                {
+                    "id": "I51423",
+                    "fulfillment_id": "F3653",
+                    "quantity": {
+                        "count": 0
+                    }
+                },
+                {
+                    "id": "I51422",
+                    "fulfillment_id": "C3653",
+                    "quantity": {
+                        "count": 2
+                    }
+                },
+                {
+                    "id": "I51423",
+                    "fulfillment_id": "C3653",
+                    "quantity": {
+                        "count": 2
+                    }
+                }
+            ],
+            "billing": {
+                "name": "pardeep singh",
+                "address": {
+                    "name": "pardeep singh",
+                    "building": "cyber tower",
+                    "locality": "Police Colony Road",
+                    "city": "Hyderabad",
+                    "state": "Telangana",
+                    "country": "IND",
+                    "area_code": "500084"
+                },
+                "email": "pardeepsingh.it@maaserp.com",
+                "phone": "8360441031",
+                "created_at": "2024-06-20T04:38:56.382Z",
+                "updated_at": "2024-06-20T04:38:56.382Z"
+            },
+            "fulfillments": [
+                {
+                    "id": "F3653",
+                    "@ondc/org/provider_name": "sangameshwara super market",
+                    "type": "Delivery",
+                    "tracking": true,
+                    "@ondc/org/TAT": "P0DT6M",
+                    "state": {
+                        "descriptor": {
+                            "code": "Cancelled"
+                        }
+                    },
+                    "start": {
+                        "location": {
+                            "descriptor": {
+                                "name": "sangameshwara super market"
+                            },
+                            "id": "L1104",
+                            "gps": "17.462485,78.365312",
+                            "address": {
+                                "locality": "Lalitha Nilayam, Hanuman Nagar, Prashanth Nagar Colony, Kondapur, Telangana, India",
+                                "city": "Kondapur",
+                                "area_code": "500084",
+                                "state": "Telangana"
+                            }
+                        },
+                        "contact": {
+                            "phone": "7555945623",
+                            "email": "maasteststore@mailinator.com"
+                        },
+                        "time": {
+                            "range": {
+                                "start": "2024-06-20T04:44:37.572Z",
+                                "end": "2024-06-20T04:49:37.572Z"
+                            },
+                            "timestamp": "2024-06-20T04:45:32.000Z"
+                        }
+                    },
+                    "end": {
+                        "location": {
+                            "gps": "17.464141,78.366162",
+                            "address": {
+                                "name": "pardeep singh",
+                                "building": "cyber tower",
+                                "locality": "Police Colony Road",
+                                "city": "Hyderabad",
+                                "state": "Telangana",
+                                "country": "IND",
+                                "area_code": "500084"
+                            }
+                        },
+                        "time": {
+                            "range": {
+                                "start": "2024-06-20T04:50:37.572Z",
+                                "end": "2024-06-20T04:55:37.572Z"
+                            }
+                        },
+                        "contact": {
+                            "phone": "8360441031",
+                            "email": "pardeepsingh.it@maaserp.com"
+                        },
+                        "person": {
+                            "name": "pardeep singh"
+                        }
+                    },
+                    "tags": [
+                        {
+                            "code": "cancel_request",
+                            "list": [
+                                {
+                                    "code": "reason_id",
+                                    "value": "011"
+                                },
+                                {
+                                    "code": "initiated_by",
+                                    "value": "seller.dhihyperlocal.com"
+                                },
+                                {
+                                    "code": "rto_id",
+                                    "value": "C3653"
+                                },
+                                {
+                                    "code": "retry_count",
+                                    "value": "3"
+                                }
+                            ]
+                        },
+                        {
+                            "code": "precancel_state",
+                            "list": [
+                                {
+                                    "code": "fulfillment_state",
+                                    "value": "Out-for-delivery"
+                                },
+                                {
+                                    "code": "updated_at",
+                                    "value": "2024-06-20T04:45:47.000Z"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "id": "C3653",
+                    "type": "RTO",
+                    "state": {
+                        "descriptor": {
+                            "code": "RTO-Delivered"
+                        }
+                    },
+                    "start": {
+                        "time": {
+                            "timestamp": "2024-06-20T04:46:13.000Z"
+                        },
+                        "location": {
+                            "gps": "17.464141,78.366162",
+                            "address": {
+                                "name": "pardeep singh",
+                                "building": "cyber tower",
+                                "locality": "Police Colony Road",
+                                "city": "Hyderabad",
+                                "state": "Telangana",
+                                "country": "IND",
+                                "area_code": "500084"
+                            }
+                        }
+                    },
+                    "end": {
+                        "time": {
+                            "timestamp": "2024-06-20T04:46:48.489Z"
+                        },
+                        "location": {
+                            "descriptor": {
+                                "name": "sangameshwara super market"
+                            },
+                            "id": "L1104",
+                            "gps": "17.462485,78.365312",
+                            "address": {
+                                "locality": "Lalitha Nilayam, Hanuman Nagar, Prashanth Nagar Colony, Kondapur, Telangana, India",
+                                "city": "Kondapur",
+                                "area_code": "500084",
+                                "state": "Telangana"
+                            }
+                        }
+                    },
+                    "tags": [
+                        {
+                            "code": "quote_trail",
+                            "list": [
+                                {
+                                    "code": "type",
+                                    "value": "item"
+                                },
+                                {
+                                    "code": "id",
+                                    "value": "I51422"
+                                },
+                                {
+                                    "code": "currency",
+                                    "value": "INR"
+                                },
+                                {
+                                    "code": "value",
+                                    "value": "-88"
+                                }
+                            ]
+                        },
+                        {
+                            "code": "quote_trail",
+                            "list": [
+                                {
+                                    "code": "type",
+                                    "value": "item"
+                                },
+                                {
+                                    "code": "id",
+                                    "value": "I51423"
+                                },
+                                {
+                                    "code": "currency",
+                                    "value": "INR"
+                                },
+                                {
+                                    "code": "value",
+                                    "value": "-178"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "quote": {
+                "price": {
+                    "currency": "INR",
+                    "value": "0"
+                },
+                "breakup": [
+                    {
+                        "@ondc/org/item_id": "I51422",
+                        "@ondc/org/item_quantity": {
+                            "count": 0
+                        },
+                        "title": "rin ala fabric whitener 200 milli_litre",
+                        "@ondc/org/title_type": "item",
+                        "price": {
+                            "currency": "INR",
+                            "value": "0"
+                        },
+                        "item": {
+                            "price": {
+                                "currency": "INR",
+                                "value": "44.00"
+                            }
+                        }
+                    },
+                    {
+                        "@ondc/org/item_id": "I51423",
+                        "@ondc/org/item_quantity": {
+                            "count": 0
+                        },
+                        "title": "rin ala fabric whitener 500 milli_litre",
+                        "@ondc/org/title_type": "item",
+                        "price": {
+                            "currency": "INR",
+                            "value": "0"
+                        },
+                        "item": {
+                            "price": {
+                                "currency": "INR",
+                                "value": "89.00"
+                            }
+                        }
+                    },
+                    {
+                        "@ondc/org/item_id": "F3653",
+                        "title": "Delivery charges",
+                        "@ondc/org/title_type": "delivery",
+                        "price": {
+                            "currency": "INR",
+                            "value": "0"
+                        }
+                    },
+                    {
+                        "@ondc/org/item_id": "C3653",
+                        "title": "Delivery charges",
+                        "@ondc/org/title_type": "delivery",
+                        "price": {
+                            "currency": "INR",
+                            "value": "0"
+                        }
+                    }
+                ],
+                "ttl": "P1D"
+            },
+            "payment": {
+                "uri": "https://razorpay.com/",
+                "tl_method": "http/get",
+                "params": {
+                    "amount": "266.00",
+                    "currency": "INR",
+                    "transaction_id": "order_OOt0H3IrcpnggQ"
+                },
+                "status": "PAID",
+                "type": "ON-ORDER",
+                "collected_by": "BAP",
+                "@ondc/org/buyer_app_finder_fee_type": "percent",
+                "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+                "@ondc/org/settlement_details": [
+                    {
+                        "settlement_counterparty": "seller-app",
+                        "settlement_phase": "sale-amount",
+                        "settlement_type": "neft",
+                        "beneficiary_name": "MAAS ERP SOLUTIONS PRIVATE LIMITED",
+                        "settlement_bank_account_no": "59112345678901",
+                        "settlement_ifsc_code": "HDFC0000001",
+                        "bank_name": "HDFC",
+                        "branch_name": "Hyderabad"
+                    }
+                ]
+            },
+            "created_at": "2024-06-20T04:39:26.860Z",
+            "updated_at": "2024-06-20T04:46:48.489Z",
+            "documents": [
+                {
+                    "url": "https://newnfresume.s3-us-west-2.amazonaws.com/Orderinvoices/INV_1718858447_1536042115_34224_13556.pdf",
+                    "label": "Invoice"
+                }
+            ]
+        }
+    }
+}

--- a/MaasERP_Solutions/Retail/RET10/2024-06-20/Flow 5/select.json
+++ b/MaasERP_Solutions/Retail/RET10/2024-06-20/Flow 5/select.json
@@ -1,0 +1,57 @@
+{
+    "context": {
+        "domain": "ONDC:RET10",
+        "country": "IND",
+        "city": "std:040",
+        "action": "select",
+        "core_version": "1.2.0",
+        "bap_id": "buyer-app-preprod-v2.ondc.org",
+        "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+        "bpp_uri": "https://seller.dhihyperlocal.com/api/v1",
+        "transaction_id": "843bb3ba-f79e-4623-a45d-cd72b43f6b38",
+        "message_id": "9d5a3c73-7ac3-4b4c-8b3d-8d203186950f",
+        "timestamp": "2024-06-20T04:38:43.385Z",
+        "bpp_id": "seller.dhihyperlocal.com",
+        "ttl": "PT30S"
+    },
+    "message": {
+        "order": {
+            "items": [
+                {
+                    "id": "I51422",
+                    "quantity": {
+                        "count": 2
+                    },
+                    "location_id": "L1104"
+                },
+                {
+                    "id": "I51423",
+                    "quantity": {
+                        "count": 2
+                    },
+                    "location_id": "L1104"
+                }
+            ],
+            "provider": {
+                "id": "P1104",
+                "locations": [
+                    {
+                        "id": "L1104"
+                    }
+                ]
+            },
+            "fulfillments": [
+                {
+                    "end": {
+                        "location": {
+                            "gps": "17.464141,78.366162",
+                            "address": {
+                                "area_code": "500084"
+                            }
+                        }
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/MaasERP_Solutions/Retail/RET10/2024-06-20/Flow1/on_search_full_catalog_refresh.json
+++ b/MaasERP_Solutions/Retail/RET10/2024-06-20/Flow1/on_search_full_catalog_refresh.json
@@ -1,0 +1,754 @@
+{
+    "context": {
+        "domain": "ONDC:RET10",
+        "action": "on_search",
+        "country": "IND",
+        "city": "std:040",
+        "core_version": "1.2.0",
+        "bap_id": "buyer-app-preprod-v2.ondc.org",
+        "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+        "transaction_id": "80311a37-ca6e-408a-942e-065d8403e2ae",
+        "message_id": "32a2ff5e-2202-4e5c-bff9-f8d894b90d48",
+        "timestamp": "2024-06-20T00:00:04.774Z",
+        "ttl": "PT30S",
+        "bpp_id": "seller.dhihyperlocal.com",
+        "bpp_uri": "https://seller.dhihyperlocal.com/api/v1"
+    },
+    "message": {
+        "catalog": {
+            "bpp/descriptor": {
+                "name": "MaaS",
+                "symbol": "https://seller.dhihyperlocal.com/api/v1/assets/img/mScan_logo.png",
+                "short_desc": "We strive to provide valuable solutions for our customers, no matter their individual needs",
+                "long_desc": "Our customers are our top priority - We strive to provide valuable solutions for our customers, no matter their individual needs. Our goal is to gain an in-depth understanding of all their challenges and issues, so we can empower them with the answers that really make a difference.",
+                "images": [
+                    "https://seller.dhihyperlocal.com/api/v1/assets/img/mScan_logo.png"
+                ],
+                "tags": [
+                    {
+                        "code": "bpp_terms",
+                        "list": [
+                            {
+                                "code": "np_type",
+                                "value": "MSN"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "bpp/fulfillments": [
+                {
+                    "id": "F1",
+                    "type": "Delivery"
+                },
+                {
+                    "id": "F2",
+                    "type": "Self-Pickup"
+                }
+            ],
+            "bpp/providers": [
+                {
+                    "id": "P1104",
+                    "time": {
+                        "label": "enable",
+                        "timestamp": "2024-06-20T00:00:04.774Z"
+                    },
+                    "descriptor": {
+                        "name": "sangameshwara super market",
+                        "symbol": "https://newnfresume.s3-us-west-2.amazonaws.com/AdminAttachment/Avatar/Admin_sangameshwara_super_market_1715777638.png",
+                        "short_desc": "At sangameshwara super market, we bring you a delightful shopping experience tailored to meet all your Fast-Moving Consumer Goods (FMCG) needs. Nestled in the heart of the city, our store is a one-stop destination for quality groceries, household essentials, personal care products, and much more.",
+                        "long_desc": "At sangameshwara super market, we pride ourselves on offering an unparalleled shopping experience tailored to meet the diverse needs of our discerning customers. Located in the bustling heart of the city, our expansive store is a treasure trove of high-quality Fast-Moving Consumer Goods that cater to every aspect of your daily life.",
+                        "images": [
+                            "https://newnfresume.s3-us-west-2.amazonaws.com/AdminAttachment/Avatar/Admin_sangameshwara_super_market_1715777638.png"
+                        ]
+                    },
+                    "ttl": "P1D",
+                    "locations": [
+                        {
+                            "id": "L1104",
+                            "gps": "17.462485,78.365312",
+                            "address": {
+                                "locality": "Lalitha Nilayam",
+                                "street": "Hanuman Nagar",
+                                "city": "Kondapur",
+                                "area_code": "500084",
+                                "state": "Telangana"
+                            },
+                            "circle": {
+                                "gps": "17.462485,78.365312",
+                                "radius": {
+                                    "unit": "km",
+                                    "value": "10"
+                                }
+                            },
+                            "time": {
+                                "label": "enable",
+                                "days": "1,2,3,4,5",
+                                "schedule": {
+                                    "holidays": []
+                                },
+                                "timestamp": "2024-04-29T11:54:46.000Z",
+                                "range": {
+                                    "start": "0900",
+                                    "end": "1800"
+                                }
+                            }
+                        }
+                    ],
+                    "items": [
+                        {
+                            "id": "I51417",
+                            "time": {
+                                "label": "enable",
+                                "timestamp": "2024-05-15T13:10:25.000Z"
+                            },
+                            "descriptor": {
+                                "name": "niine naturally soft sanitary napkin ultra thin 6 piece",
+                                "code": "1:8908010780610",
+                                "symbol": "https://newnfresume.s3-us-west-2.amazonaws.com/Mass/BBC/Skills/product__1715920278_1984921213.png",
+                                "short_desc": "6PIECE",
+                                "long_desc": "Niine Naturally Soft Sanitary Napkin Ultra Thin 6 PIECE",
+                                "images": [
+                                    "https://newnfresume.s3-us-west-2.amazonaws.com/Mass/BBC/Skills/product__1715920278_1984921213.png",
+                                    "https://newnfresume.s3-us-west-2.amazonaws.com/Mass/BBC/Skills/product__1715920254_771526060.png",
+                                    "https://newnfresume.s3-us-west-2.amazonaws.com/Mass/BBC/Skills/product__1715920235_1746594033.png",
+                                    "https://newnfresume.s3-us-west-2.amazonaws.com/Mass/BBC/Skills/product__1715846189_967493672.png"
+                                ]
+                            },
+                            "quantity": {
+                                "available": {
+                                    "count": "99"
+                                },
+                                "maximum": {
+                                    "count": "5"
+                                },
+                                "unitized": {
+                                    "measure": {
+                                        "unit": "unit",
+                                        "value": "1"
+                                    }
+                                }
+                            },
+                            "price": {
+                                "currency": "INR",
+                                "value": "75.00",
+                                "maximum_value": "75.00"
+                            },
+                            "category_id": "Cleaning & Household",
+                            "fulfillment_id": "F1",
+                            "location_id": "L1104",
+                            "recommended": true,
+                            "related": false,
+                            "@ondc/org/returnable": true,
+                            "@ondc/org/cancellable": true,
+                            "@ondc/org/seller_pickup_return": false,
+                            "@ondc/org/time_to_ship": "PT5M",
+                            "@ondc/org/available_on_cod": false,
+                            "@ondc/org/contact_details_consumer_care": "sangameshwara super market,vamshikailasa0207@gmail.com,8555051431",
+                            "tags": [
+                                {
+                                    "code": "origin",
+                                    "list": [
+                                        {
+                                            "code": "country",
+                                            "value": "IND"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "veg_nonveg",
+                                    "list": [
+                                        {
+                                            "code": "veg",
+                                            "value": "yes"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "@ondc/org/return_window": "P1D",
+                            "@ondc/org/statutory_reqs_packaged_commodities": {
+                                "manufacturer_or_packer_name": "ITC",
+                                "manufacturer_or_packer_address": "ITC Quality Care Cell,P.O Box No.592,Bangalore-560005",
+                                "common_or_generic_name_of_commodity": "niine naturally soft sanitary napkin ultra thin 6 piece",
+                                "month_year_of_manufacture_packing_import": "06/2024"
+                            }
+                        },
+                        {
+                            "id": "I51420",
+                            "time": {
+                                "label": "enable",
+                                "timestamp": "2024-05-15T13:10:41.000Z"
+                            },
+                            "descriptor": {
+                                "name": "surf excel matic top load liquid detergent 1 litre",
+                                "code": "1:8901030962295",
+                                "symbol": "https://newnfresume.s3-us-west-2.amazonaws.com/Mass/BBC/Skills/product__1715919907_335403736.png",
+                                "short_desc": "1LITRE",
+                                "long_desc": "Surf Excel Matic Top Load Liquid Detergent 1 LITRE",
+                                "images": [
+                                    "https://newnfresume.s3-us-west-2.amazonaws.com/Mass/BBC/Skills/product__1715919907_335403736.png",
+                                    "https://newnfresume.s3-us-west-2.amazonaws.com/Mass/BBC/Skills/product__1715919889_1593739396.png",
+                                    "https://newnfresume.s3-us-west-2.amazonaws.com/Mass/BBC/Skills/product__1715919868_1091108494.png",
+                                    "https://newnfresume.s3-us-west-2.amazonaws.com/Mass/BBC/Skills/product__1715845356_1992195343.png"
+                                ]
+                            },
+                            "quantity": {
+                                "available": {
+                                    "count": "99"
+                                },
+                                "maximum": {
+                                    "count": "5"
+                                },
+                                "unitized": {
+                                    "measure": {
+                                        "unit": "unit",
+                                        "value": "1"
+                                    }
+                                }
+                            },
+                            "price": {
+                                "currency": "INR",
+                                "value": "190.00",
+                                "maximum_value": "190.00"
+                            },
+                            "category_id": "Cleaning & Household",
+                            "fulfillment_id": "F1",
+                            "location_id": "L1104",
+                            "recommended": true,
+                            "related": false,
+                            "@ondc/org/returnable": true,
+                            "@ondc/org/cancellable": true,
+                            "@ondc/org/seller_pickup_return": true,
+                            "@ondc/org/time_to_ship": "PT5M",
+                            "@ondc/org/available_on_cod": false,
+                            "@ondc/org/contact_details_consumer_care": "sangameshwara super market,vamshikailasa0207@gmail.com,8555051431",
+                            "tags": [
+                                {
+                                    "code": "origin",
+                                    "list": [
+                                        {
+                                            "code": "country",
+                                            "value": "IND"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "veg_nonveg",
+                                    "list": [
+                                        {
+                                            "code": "veg",
+                                            "value": "yes"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "@ondc/org/return_window": "P2D",
+                            "@ondc/org/statutory_reqs_packaged_commodities": {
+                                "manufacturer_or_packer_name": "ITC",
+                                "manufacturer_or_packer_address": "ITC Quality Care Cell,P.O Box No.592,Bangalore-560005",
+                                "common_or_generic_name_of_commodity": "surf excel matic top load liquid detergent 1 litre",
+                                "month_year_of_manufacture_packing_import": "06/2024"
+                            }
+                        },
+                        {
+                            "id": "I51421",
+                            "time": {
+                                "label": "enable",
+                                "timestamp": "2024-05-15T13:10:46.000Z"
+                            },
+                            "descriptor": {
+                                "name": "surf excel matic front load liquid detergent 1 litre",
+                                "code": "1:8901030962318",
+                                "symbol": "https://newnfresume.s3-us-west-2.amazonaws.com/Mass/BBC/Skills/product__1715919743_1551896590.png",
+                                "short_desc": "1LITRE",
+                                "long_desc": "Surf Excel Matic Front Load Liquid Detergent 1 LITRE",
+                                "images": [
+                                    "https://newnfresume.s3-us-west-2.amazonaws.com/Mass/BBC/Skills/product__1715919743_1551896590.png",
+                                    "https://newnfresume.s3-us-west-2.amazonaws.com/Mass/BBC/Skills/product__1715919718_550952278.png",
+                                    "https://newnfresume.s3-us-west-2.amazonaws.com/Mass/BBC/Skills/product__1715919693_1572777297.png",
+                                    "https://newnfresume.s3-us-west-2.amazonaws.com/Mass/BBC/Skills/product__1715919660_1296226867.png",
+                                    "https://newnfresume.s3-us-west-2.amazonaws.com/Mass/BBC/Skills/product__1715840969_29294678.jpg"
+                                ]
+                            },
+                            "quantity": {
+                                "available": {
+                                    "count": "99"
+                                },
+                                "maximum": {
+                                    "count": "5"
+                                },
+                                "unitized": {
+                                    "measure": {
+                                        "unit": "unit",
+                                        "value": "1"
+                                    }
+                                }
+                            },
+                            "price": {
+                                "currency": "INR",
+                                "value": "220.00",
+                                "maximum_value": "220.00"
+                            },
+                            "category_id": "Cleaning & Household",
+                            "fulfillment_id": "F1",
+                            "location_id": "L1104",
+                            "recommended": true,
+                            "related": false,
+                            "@ondc/org/returnable": false,
+                            "@ondc/org/cancellable": false,
+                            "@ondc/org/seller_pickup_return": true,
+                            "@ondc/org/time_to_ship": "PT5M",
+                            "@ondc/org/available_on_cod": false,
+                            "@ondc/org/contact_details_consumer_care": "sangameshwara super market,vamshikailasa0207@gmail.com,8555051431",
+                            "tags": [
+                                {
+                                    "code": "origin",
+                                    "list": [
+                                        {
+                                            "code": "country",
+                                            "value": "IND"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "veg_nonveg",
+                                    "list": [
+                                        {
+                                            "code": "veg",
+                                            "value": "yes"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "@ondc/org/return_window": "P3D",
+                            "@ondc/org/statutory_reqs_packaged_commodities": {
+                                "manufacturer_or_packer_name": "ITC",
+                                "manufacturer_or_packer_address": "ITC Quality Care Cell,P.O Box No.592,Bangalore-560005",
+                                "common_or_generic_name_of_commodity": "surf excel matic front load liquid detergent 1 litre",
+                                "month_year_of_manufacture_packing_import": "06/2024"
+                            }
+                        },
+                        {
+                            "id": "I51422",
+                            "time": {
+                                "label": "enable",
+                                "timestamp": "2024-05-15T13:10:56.000Z"
+                            },
+                            "descriptor": {
+                                "name": "rin ala fabric whitener 200 milli litre",
+                                "code": "1:8901030761188",
+                                "symbol": "https://newnfresume.s3-us-west-2.amazonaws.com/Mass/BBC/Skills/product__1715919305_1793421847.png",
+                                "short_desc": "200MILLI_LITRE",
+                                "long_desc": "Rin Ala Fabric Whitener 200 MILLI_LITRE",
+                                "images": [
+                                    "https://newnfresume.s3-us-west-2.amazonaws.com/Mass/BBC/Skills/product__1715919305_1793421847.png",
+                                    "https://newnfresume.s3-us-west-2.amazonaws.com/Mass/BBC/Skills/product__1715845224_1819661858.png"
+                                ]
+                            },
+                            "quantity": {
+                                "available": {
+                                    "count": "99"
+                                },
+                                "maximum": {
+                                    "count": "5"
+                                },
+                                "unitized": {
+                                    "measure": {
+                                        "unit": "unit",
+                                        "value": "1"
+                                    }
+                                }
+                            },
+                            "price": {
+                                "currency": "INR",
+                                "value": "44.00",
+                                "maximum_value": "44.00"
+                            },
+                            "category_id": "Cleaning & Household",
+                            "fulfillment_id": "F1",
+                            "location_id": "L1104",
+                            "recommended": true,
+                            "related": false,
+                            "@ondc/org/returnable": true,
+                            "@ondc/org/cancellable": true,
+                            "@ondc/org/seller_pickup_return": false,
+                            "@ondc/org/time_to_ship": "PT5M",
+                            "@ondc/org/available_on_cod": false,
+                            "@ondc/org/contact_details_consumer_care": "sangameshwara super market,vamshikailasa0207@gmail.com,8555051431",
+                            "tags": [
+                                {
+                                    "code": "origin",
+                                    "list": [
+                                        {
+                                            "code": "country",
+                                            "value": "IND"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "veg_nonveg",
+                                    "list": [
+                                        {
+                                            "code": "veg",
+                                            "value": "yes"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "@ondc/org/return_window": "P4D",
+                            "@ondc/org/statutory_reqs_packaged_commodities": {
+                                "manufacturer_or_packer_name": "ITC",
+                                "manufacturer_or_packer_address": "ITC Quality Care Cell,P.O Box No.592,Bangalore-560005",
+                                "common_or_generic_name_of_commodity": "rin ala fabric whitener 200 milli_litre",
+                                "month_year_of_manufacture_packing_import": "06/2024"
+                            }
+                        },
+                        {
+                            "id": "I51423",
+                            "time": {
+                                "label": "enable",
+                                "timestamp": "2024-05-15T13:11:02.000Z"
+                            },
+                            "descriptor": {
+                                "name": "rin ala fabric whitener 500 milli litre",
+                                "code": "1:8901030761195",
+                                "symbol": "https://newnfresume.s3-us-west-2.amazonaws.com/Mass/BBC/Skills/product__1715919169_637735055.png",
+                                "short_desc": "500MILLI_LITRE",
+                                "long_desc": "Rin Ala Fabric Whitener 500 MILLI_LITRE",
+                                "images": [
+                                    "https://newnfresume.s3-us-west-2.amazonaws.com/Mass/BBC/Skills/product__1715919169_637735055.png",
+                                    "https://newnfresume.s3-us-west-2.amazonaws.com/Mass/BBC/Skills/product__1715919151_1023807697.png",
+                                    "https://newnfresume.s3-us-west-2.amazonaws.com/Mass/BBC/Skills/product__1715919129_1369535813.png",
+                                    "https://newnfresume.s3-us-west-2.amazonaws.com/Mass/BBC/Skills/product__1715919099_1386902735.png",
+                                    "https://newnfresume.s3-us-west-2.amazonaws.com/Mass/BBC/Skills/product__1715842190_1373905711.jpg"
+                                ]
+                            },
+                            "quantity": {
+                                "available": {
+                                    "count": "99"
+                                },
+                                "maximum": {
+                                    "count": "5"
+                                },
+                                "unitized": {
+                                    "measure": {
+                                        "unit": "unit",
+                                        "value": "1"
+                                    }
+                                }
+                            },
+                            "price": {
+                                "currency": "INR",
+                                "value": "89.00",
+                                "maximum_value": "89.00"
+                            },
+                            "category_id": "Cleaning & Household",
+                            "fulfillment_id": "F1",
+                            "location_id": "L1104",
+                            "recommended": true,
+                            "related": false,
+                            "@ondc/org/returnable": true,
+                            "@ondc/org/cancellable": true,
+                            "@ondc/org/seller_pickup_return": true,
+                            "@ondc/org/time_to_ship": "PT5M",
+                            "@ondc/org/available_on_cod": false,
+                            "@ondc/org/contact_details_consumer_care": "sangameshwara super market,vamshikailasa0207@gmail.com,8555051431",
+                            "tags": [
+                                {
+                                    "code": "origin",
+                                    "list": [
+                                        {
+                                            "code": "country",
+                                            "value": "IND"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "veg_nonveg",
+                                    "list": [
+                                        {
+                                            "code": "veg",
+                                            "value": "yes"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "@ondc/org/return_window": "P3D",
+                            "@ondc/org/statutory_reqs_packaged_commodities": {
+                                "manufacturer_or_packer_name": "ITC",
+                                "manufacturer_or_packer_address": "ITC Quality Care Cell,P.O Box No.592,Bangalore-560005",
+                                "common_or_generic_name_of_commodity": "rin ala fabric whitener 500 milli_litre",
+                                "month_year_of_manufacture_packing_import": "06/2024"
+                            }
+                        },
+                        {
+                            "id": "I51655",
+                            "time": {
+                                "label": "enable",
+                                "timestamp": "2024-06-19T13:49:28.000Z"
+                            },
+                            "descriptor": {
+                                "name": "harpic bathroom cleaner liquid",
+                                "code": "1:8901396153368",
+                                "symbol": "https://newnfresume.s3-us-west-2.amazonaws.com/Mass/BBC/Skills/Retailer_Product_image_19_06_2024_1718804963_1668967697.png",
+                                "short_desc": "Disinfectant Bathroom Cleaner. Kills 99.9 of germs",
+                                "long_desc": "Harpic bathroom cleaner gives you unbeatable cleaning on greasy soil and particulate matter and Harpic freshness for the whole bathroom. Its thick liquid formula with powerful cleaning agents removes tough stains and kills 99.9 percent of germs. It also gives your bathroom a pleasant fresh fragrance. Used for regular cleaning of bathroom floor and tiles. Use 1.5 capfuls in half bucket of water. For tough stains and sink. Use undiluted to clean for best results. Then scrub gently and rinse. For disinfection of bathroom floor, tiles and sink. Use undiluted for best results or dilute using 1.5 capfuls in half bucket of water. Apply on surface, leave for 5 minutes then scrub gently and rinse. Suitable for most bathroom surfaces. Do not use on aluminium, brass and copper. Always spot check on a small, hidden area before using. Always use Harpic bathroom cleaner separately. Do not mix with other products.",
+                                "images": [
+                                    "https://newnfresume.s3-us-west-2.amazonaws.com/Mass/BBC/Skills/Retailer_Product_image_19_06_2024_1718804963_1668967697.png"
+                                ]
+                            },
+                            "quantity": {
+                                "available": {
+                                    "count": "99"
+                                },
+                                "maximum": {
+                                    "count": "5"
+                                },
+                                "unitized": {
+                                    "measure": {
+                                        "unit": "millilitre",
+                                        "value": "500"
+                                    }
+                                }
+                            },
+                            "price": {
+                                "currency": "INR",
+                                "value": "60.00",
+                                "maximum_value": "70.00"
+                            },
+                            "category_id": "Cleaning & Household",
+                            "fulfillment_id": "F1",
+                            "location_id": "L1104",
+                            "recommended": true,
+                            "related": false,
+                            "@ondc/org/returnable": false,
+                            "@ondc/org/cancellable": false,
+                            "@ondc/org/seller_pickup_return": false,
+                            "@ondc/org/time_to_ship": "PT0H5M0S",
+                            "@ondc/org/available_on_cod": true,
+                            "@ondc/org/contact_details_consumer_care": "sangameshwara super market,vamshikailasa0207@gmail.com,8555051431",
+                            "tags": [
+                                {
+                                    "code": "origin",
+                                    "list": [
+                                        {
+                                            "code": "country",
+                                            "value": "IND"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "veg_nonveg",
+                                    "list": [
+                                        {
+                                            "code": "veg",
+                                            "value": "yes"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "parent_item_id": "V20",
+                            "@ondc/org/return_window": "P1D",
+                            "@ondc/org/statutory_reqs_packaged_commodities": {
+                                "manufacturer_or_packer_name": "ITC",
+                                "manufacturer_or_packer_address": "ITC Quality Care Cell,P.O Box No.592,Bangalore-560005",
+                                "common_or_generic_name_of_commodity": "500ml_harpic bathroom cleaner liquid",
+                                "month_year_of_manufacture_packing_import": "06/2024"
+                            }
+                        },
+                        {
+                            "id": "I51656",
+                            "time": {
+                                "label": "enable",
+                                "timestamp": "2024-06-19T13:49:29.000Z"
+                            },
+                            "descriptor": {
+                                "name": "harpic bathroom cleaner liquid",
+                                "code": "1:8901396173915",
+                                "symbol": "https://newnfresume.s3-us-west-2.amazonaws.com/Mass/BBC/Skills/Retailer_Product_image_19_06_2024_1718804965_882595749.png",
+                                "short_desc": "Disinfectant Bathroom Cleaner. Kills 99.9 of germs",
+                                "long_desc": "Harpic bathroom cleaner gives you unbeatable cleaning on greasy soil and particulate matter and Harpic freshness for the whole bathroom. Its thick liquid formula with powerful cleaning agents removes tough stains and kills 99.9 percent of germs. It also gives your bathroom a pleasant fresh fragrance. Used for regular cleaning of bathroom floor and tiles. Use 1.5 capfuls in half bucket of water. For tough stains and sink. Use undiluted to clean for best results. Then scrub gently and rinse. For disinfection of bathroom floor, tiles and sink. Use undiluted for best results or dilute using 1.5 capfuls in half bucket of water. Apply on surface, leave for 5 minutes then scrub gently and rinse. Suitable for most bathroom surfaces. Do not use on aluminium, brass and copper. Always spot check on a small, hidden area before using. Always use Harpic bathroom cleaner separately. Do not mix with other products.",
+                                "images": [
+                                    "https://newnfresume.s3-us-west-2.amazonaws.com/Mass/BBC/Skills/Retailer_Product_image_19_06_2024_1718804965_882595749.png"
+                                ]
+                            },
+                            "quantity": {
+                                "available": {
+                                    "count": "99"
+                                },
+                                "maximum": {
+                                    "count": "5"
+                                },
+                                "unitized": {
+                                    "measure": {
+                                        "unit": "millilitre",
+                                        "value": "1000"
+                                    }
+                                }
+                            },
+                            "price": {
+                                "currency": "INR",
+                                "value": "120.00",
+                                "maximum_value": "130.00"
+                            },
+                            "category_id": "Cleaning & Household",
+                            "fulfillment_id": "F1",
+                            "location_id": "L1104",
+                            "recommended": true,
+                            "related": false,
+                            "@ondc/org/returnable": false,
+                            "@ondc/org/cancellable": false,
+                            "@ondc/org/seller_pickup_return": false,
+                            "@ondc/org/time_to_ship": "PT0H5M0S",
+                            "@ondc/org/available_on_cod": true,
+                            "@ondc/org/contact_details_consumer_care": "sangameshwara super market,vamshikailasa0207@gmail.com,8555051431",
+                            "tags": [
+                                {
+                                    "code": "origin",
+                                    "list": [
+                                        {
+                                            "code": "country",
+                                            "value": "IND"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "veg_nonveg",
+                                    "list": [
+                                        {
+                                            "code": "veg",
+                                            "value": "yes"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "parent_item_id": "V20",
+                            "@ondc/org/return_window": "P1D",
+                            "@ondc/org/statutory_reqs_packaged_commodities": {
+                                "manufacturer_or_packer_name": "ITC",
+                                "manufacturer_or_packer_address": "ITC Quality Care Cell,P.O Box No.592,Bangalore-560005",
+                                "common_or_generic_name_of_commodity": "1000ml_harpic bathroom cleaner liquid",
+                                "month_year_of_manufacture_packing_import": "06/2024"
+                            }
+                        }
+                    ],
+                    "tags": [
+                        {
+                            "code": "order_value",
+                            "list": [
+                                {
+                                    "code": "min_value",
+                                    "value": "0"
+                                }
+                            ]
+                        },
+                        {
+                            "code": "serviceability",
+                            "list": [
+                                {
+                                    "code": "location",
+                                    "value": "L1104"
+                                },
+                                {
+                                    "code": "category",
+                                    "value": "Cleaning & Household"
+                                },
+                                {
+                                    "code": "type",
+                                    "value": "10"
+                                },
+                                {
+                                    "code": "val",
+                                    "value": "10"
+                                },
+                                {
+                                    "code": "unit",
+                                    "value": "km"
+                                }
+                            ]
+                        },
+                        {
+                            "code": "timing",
+                            "list": [
+                                {
+                                    "code": "type",
+                                    "value": "All"
+                                },
+                                {
+                                    "code": "location",
+                                    "value": "L1104"
+                                },
+                                {
+                                    "code": "day_from",
+                                    "value": "1"
+                                },
+                                {
+                                    "code": "day_to",
+                                    "value": "5"
+                                },
+                                {
+                                    "code": "time_from",
+                                    "value": "0900"
+                                },
+                                {
+                                    "code": "time_to",
+                                    "value": "1800"
+                                }
+                            ]
+                        }
+                    ],
+                    "fulfillments": [
+                        {
+                            "contact": {
+                                "email": "vamshikailasa0207@gmail.com",
+                                "phone": "8555051431"
+                            },
+                            "id": "F1",
+                            "type": "Delivery"
+                        },
+                        {
+                            "contact": {
+                                "email": "vamshikailasa0207@gmail.com",
+                                "phone": "8555051431"
+                            },
+                            "id": "F2",
+                            "type": "Self-Pickup"
+                        }
+                    ],
+                    "categories": [
+                        {
+                            "id": "V20",
+                            "descriptor": {
+                                "name": "Volume"
+                            },
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "variant_group"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "attr",
+                                    "list": [
+                                        {
+                                            "code": "name",
+                                            "value": "item.quantity.unitized.measure"
+                                        },
+                                        {
+                                            "code": "seq",
+                                            "value": "1"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }
+    }
+}

--- a/MaasERP_Solutions/Retail/RET10/2024-06-20/Flow1/on_search_inc_refresh.json
+++ b/MaasERP_Solutions/Retail/RET10/2024-06-20/Flow1/on_search_inc_refresh.json
@@ -1,0 +1,106 @@
+{
+    "context": {
+        "domain": "ONDC:RET10",
+        "action": "on_search",
+        "country": "IND",
+        "city": "*",
+        "core_version": "1.2.0",
+        "bap_id": "buyer-app-preprod-v2.ondc.org",
+        "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+        "transaction_id": "aeee1e45-6870-470e-a0dc-8a9e5f9cde36",
+        "message_id": "fa24868e-b58e-451f-a930-a2bf82288039",
+        "timestamp": "2024-06-20T05:23:47.000Z",
+        "ttl": "PT30S",
+        "bpp_id": "seller.dhihyperlocal.com",
+        "bpp_uri": "https://seller.dhihyperlocal.com/api/v1"
+    },
+    "message": {
+        "catalog": {
+            "bpp/providers": [
+                {
+                    "id": "P1104",
+                    "items": [
+                        {
+                            "id": "I51421",
+                            "time": {
+                                "label": "enable",
+                                "timestamp": "2024-06-20T05:23:36.000Z"
+                            },
+                            "descriptor": {
+                                "name": "surf excel matic front load liquid detergent 1 litre",
+                                "code": "1:8901030962318",
+                                "symbol": "https://newnfresume.s3-us-west-2.amazonaws.com/Mass/BBC/Skills/product__1715919743_1551896590.png",
+                                "short_desc": "1LITRE",
+                                "long_desc": "Surf Excel Matic Front Load Liquid Detergent 1 LITRE",
+                                "images": [
+                                    "https://newnfresume.s3-us-west-2.amazonaws.com/Mass/BBC/Skills/product__1715919743_1551896590.png",
+                                    "https://newnfresume.s3-us-west-2.amazonaws.com/Mass/BBC/Skills/product__1715919718_550952278.png",
+                                    "https://newnfresume.s3-us-west-2.amazonaws.com/Mass/BBC/Skills/product__1715919693_1572777297.png",
+                                    "https://newnfresume.s3-us-west-2.amazonaws.com/Mass/BBC/Skills/product__1715919660_1296226867.png",
+                                    "https://newnfresume.s3-us-west-2.amazonaws.com/Mass/BBC/Skills/product__1715840969_29294678.jpg"
+                                ]
+                            },
+                            "quantity": {
+                                "available": {
+                                    "count": "99"
+                                },
+                                "maximum": {
+                                    "count": "5"
+                                },
+                                "unitized": {
+                                    "measure": {
+                                        "unit": "unit",
+                                        "value": "1"
+                                    }
+                                }
+                            },
+                            "price": {
+                                "currency": "INR",
+                                "value": "220.00",
+                                "maximum_value": "220.00"
+                            },
+                            "category_id": "Cleaning & Household",
+                            "fulfillment_id": "F1",
+                            "location_id": "L1104",
+                            "related": false,
+                            "recommended": true,
+                            "@ondc/org/returnable": true,
+                            "@ondc/org/cancellable": true,
+                            "@ondc/org/seller_pickup_return": true,
+                            "@ondc/org/time_to_ship": "PT5M",
+                            "@ondc/org/available_on_cod": false,
+                            "@ondc/org/contact_details_consumer_care": "sangameshwara super market,vamshikailasa0207@gmail.com,8555051431",
+                            "tags": [
+                                {
+                                    "code": "origin",
+                                    "list": [
+                                        {
+                                            "code": "country",
+                                            "value": "IND"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "veg_nonveg",
+                                    "list": [
+                                        {
+                                            "code": "veg",
+                                            "value": "yes"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "@ondc/org/return_window": "P3D",
+                            "@ondc/org/statutory_reqs_packaged_commodities": {
+                                "manufacturer_or_packer_name": "ITC",
+                                "manufacturer_or_packer_address": "ITC Quality Care Cell,P.O Box No.592,Bangalore-560005",
+                                "common_or_generic_name_of_commodity": "surf excel matic front load liquid detergent 1 litre",
+                                "month_year_of_manufacture_packing_import": "06/2024"
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    }
+}

--- a/MaasERP_Solutions/Retail/RET10/2024-06-20/Flow1/search_full_catalog_refresh.json
+++ b/MaasERP_Solutions/Retail/RET10/2024-06-20/Flow1/search_full_catalog_refresh.json
@@ -1,0 +1,26 @@
+{
+    "context": {
+        "domain": "ONDC:RET10",
+        "action": "search",
+        "country": "IND",
+        "city": "std:040",
+        "core_version": "1.2.0",
+        "bap_id": "buyer-app-preprod-v2.ondc.org",
+        "bap_uri": "https:\/\/buyer-app-preprod-v2.ondc.org\/protocol\/v1",
+        "transaction_id": "80311a37-ca6e-408a-942e-065d8403e2ae",
+        "message_id": "32a2ff5e-2202-4e5c-bff9-f8d894b90d48",
+        "timestamp": "2024-06-20T00:00:01.054Z",
+        "ttl": "PT30S"
+    },
+    "message": {
+        "intent": {
+            "fulfillment": {
+                "type": "Delivery"
+            },
+            "payment": {
+                "@ondc\/org\/buyer_app_finder_fee_type": "percent",
+                "@ondc\/org\/buyer_app_finder_fee_amount": "3"
+            }
+        }
+    }
+}

--- a/MaasERP_Solutions/Retail/RET10/2024-06-20/Flow1/search_inc_refresh.json
+++ b/MaasERP_Solutions/Retail/RET10/2024-06-20/Flow1/search_inc_refresh.json
@@ -1,0 +1,34 @@
+{
+    "context": {
+        "domain": "ONDC:RET10",
+        "action": "search",
+        "country": "IND",
+        "city": "*",
+        "core_version": "1.2.0",
+        "bap_id": "buyer-app-preprod-v2.ondc.org",
+        "bap_uri": "https:\/\/buyer-app-preprod-v2.ondc.org\/protocol\/v1",
+        "transaction_id": "aeee1e45-6870-470e-a0dc-8a9e5f9cde36",
+        "message_id": "c85978f1-cfc2-46f9-876b-5f57fe9636d7",
+        "timestamp": "2024-06-19T21:30:16.583Z",
+        "ttl": "PT30S"
+    },
+    "message": {
+        "intent": {
+            "payment": {
+                "@ondc\/org\/buyer_app_finder_fee_type": "percent",
+                "@ondc\/org\/buyer_app_finder_fee_amount": "3"
+            },
+            "tags": [
+                {
+                    "code": "catalog_inc",
+                    "list": [
+                        {
+                            "code": "mode",
+                            "value": "start"
+                        }
+                    ]
+                }
+            ]
+        }
+    }
+}


### PR DESCRIPTION
I had a call with the ONDC team regarding the aforementioned issues and also communicated with them via email. They informed me that the following are false errors, as per my expectations:

Incorrect Mapping of item/quantity/unitized/measure with item/name and item/description

Example: The product "surf excel matic front load liquid detergent 1 litre" has a quantity of 1.
Their reply: "I have checked the payload. You can address this invalid error on the issue board. item/quantity/unitized/measure is not correctly mapped with item/name and item/description."
Mismatch of /fulfillments[1]/@ondc/org/TAT (O2D) in /on_select with @ondc/org/time_to_ship (O2S) in /on_search

I have sent two fulfillment methods: delivery and self-pickup. In this case, the time_to_ship should be equal to O2S since it is a self-pickup. For self-pickup, only O2S needs to be sent, not O2D.
Addition of C3419, C3432 in quote/breakup

Their reply: "For flow 4, new fulfillment charges should not be included; you can apply them in flow 5."
Consequently, I have removed the delivery charges in Flow 4, as they were from the buyer's side, but retained the delivery charges in Flow 5.