### PR TITLE
2024 06 25 maaserp

### DIFF
--- a/MaasERP_Solutions/Retail/RET10/2024-06-25/Flow 1/on_search_full_catalog_refresh.json
+++ b/MaasERP_Solutions/Retail/RET10/2024-06-25/Flow 1/on_search_full_catalog_refresh.json
@@ -1,0 +1,677 @@
+{
+    "context": {
+        "domain": "ONDC:RET10",
+        "action": "on_search",
+        "country": "IND",
+        "city": "std:040",
+        "core_version": "1.2.0",
+        "bap_id": "buyer-app-preprod-v2.ondc.org",
+        "bap_uri": "https:\/\/buyer-app-preprod-v2.ondc.org\/protocol\/v1",
+        "transaction_id": "6907b38a-12cc-4026-9d63-d51cd8980431",
+        "message_id": "47e61959-bb8d-4f3b-b6fc-ff056a4d1ec6",
+        "timestamp": "2024-06-25T06:00:04.123Z",
+        "ttl": "PT30S",
+        "bpp_id": "seller.dhihyperlocal.com",
+        "bpp_uri": "https:\/\/seller.dhihyperlocal.com\/api\/v1"
+    },
+    "message": {
+        "catalog": {
+            "bpp\/descriptor": {
+                "name": "MaaS",
+                "symbol": "https:\/\/seller.dhihyperlocal.com\/api\/v1\/assets\/img\/mScan_logo.png",
+                "short_desc": "We strive to provide valuable solutions for our customers, no matter their individual needs",
+                "long_desc": "Our customers are our top priority - We strive to provide valuable solutions for our customers, no matter their individual needs. Our goal is to gain an in-depth understanding of all their challenges and issues, so we can empower them with the answers that really make a difference.",
+                "images": [
+                    "https:\/\/seller.dhihyperlocal.com\/api\/v1\/assets\/img\/mScan_logo.png"
+                ],
+                "tags": [
+                    {
+                        "code": "bpp_terms",
+                        "list": [
+                            {
+                                "code": "np_type",
+                                "value": "MSN"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "bpp\/fulfillments": [
+                {
+                    "id": "F1",
+                    "type": "Delivery"
+                },
+                {
+                    "id": "F2",
+                    "type": "Self-Pickup"
+                }
+            ],
+            "bpp\/providers": [
+                {
+                    "id": "P1104",
+                    "time": {
+                        "label": "enable",
+                        "timestamp": "2024-06-25T06:00:04.123Z"
+                    },
+                    "descriptor": {
+                        "name": "sangameshwara super market",
+                        "symbol": "https:\/\/newnfresume.s3-us-west-2.amazonaws.com\/AdminAttachment\/Avatar\/Admin_sangameshwara_super_market_1715777638.png",
+                        "short_desc": "At sangameshwara super market, we bring you a delightful shopping experience tailored to meet all your Fast-Moving Consumer Goods (FMCG) needs. Nestled in the heart of the city, our store is a one-stop destination for quality groceries, household essentials, personal care products, and much more.",
+                        "long_desc": "At sangameshwara super market, we pride ourselves on offering an unparalleled shopping experience tailored to meet the diverse needs of our discerning customers. Located in the bustling heart of the city, our expansive store is a treasure trove of high-quality Fast-Moving Consumer Goods that cater to every aspect of your daily life.",
+                        "images": [
+                            "https:\/\/newnfresume.s3-us-west-2.amazonaws.com\/AdminAttachment\/Avatar\/Admin_sangameshwara_super_market_1715777638.png"
+                        ]
+                    },
+                    "ttl": "P1D",
+                    "locations": [
+                        {
+                            "id": "L1104",
+                            "gps": "17.462485,78.365312",
+                            "address": {
+                                "locality": "Lalitha Nilayam",
+                                "street": "Hanuman Nagar",
+                                "city": "Kondapur",
+                                "area_code": "500084",
+                                "state": "Telangana"
+                            },
+                            "circle": {
+                                "gps": "17.462485,78.365312",
+                                "radius": {
+                                    "unit": "km",
+                                    "value": "10"
+                                }
+                            },
+                            "time": {
+                                "label": "enable",
+                                "days": "1,2,3,4,5",
+                                "schedule": {
+                                    "holidays": []
+                                },
+                                "timestamp": "2024-04-29T11:54:46.000Z",
+                                "range": {
+                                    "start": "0900",
+                                    "end": "1800"
+                                }
+                            }
+                        }
+                    ],
+                    "items": [
+                        {
+                            "id": "I51420",
+                            "time": {
+                                "label": "enable",
+                                "timestamp": "2024-05-15T13:10:41.000Z"
+                            },
+                            "descriptor": {
+                                "name": "surf excel matic top load liquid detergent 1 litre",
+                                "code": "1:8901030962295",
+                                "symbol": "https:\/\/newnfresume.s3-us-west-2.amazonaws.com\/Mass\/BBC\/Skills\/product__1715919907_335403736.png",
+                                "short_desc": "1LITRE",
+                                "long_desc": "Surf Excel Matic Top Load Liquid Detergent 1 LITRE",
+                                "images": [
+                                    "https:\/\/newnfresume.s3-us-west-2.amazonaws.com\/Mass\/BBC\/Skills\/product__1715919907_335403736.png",
+                                    "https:\/\/newnfresume.s3-us-west-2.amazonaws.com\/Mass\/BBC\/Skills\/product__1715919889_1593739396.png",
+                                    "https:\/\/newnfresume.s3-us-west-2.amazonaws.com\/Mass\/BBC\/Skills\/product__1715919868_1091108494.png",
+                                    "https:\/\/newnfresume.s3-us-west-2.amazonaws.com\/Mass\/BBC\/Skills\/product__1715845356_1992195343.png"
+                                ]
+                            },
+                            "quantity": {
+                                "available": {
+                                    "count": "99"
+                                },
+                                "maximum": {
+                                    "count": "5"
+                                },
+                                "unitized": {
+                                    "measure": {
+                                        "unit": "litre",
+                                        "value": "1"
+                                    }
+                                }
+                            },
+                            "price": {
+                                "currency": "INR",
+                                "value": "190.00",
+                                "maximum_value": "190.00"
+                            },
+                            "category_id": "Cleaning & Household",
+                            "fulfillment_id": "F1",
+                            "location_id": "L1104",
+                            "recommended": true,
+                            "related": false,
+                            "@ondc\/org\/returnable": true,
+                            "@ondc\/org\/cancellable": true,
+                            "@ondc\/org\/seller_pickup_return": true,
+                            "@ondc\/org\/time_to_ship": "PT0H10M0S",
+                            "@ondc\/org\/available_on_cod": false,
+                            "@ondc\/org\/contact_details_consumer_care": "sangameshwara super market,vamshikailasa0207@gmail.com,8555051431",
+                            "tags": [
+                                {
+                                    "code": "origin",
+                                    "list": [
+                                        {
+                                            "code": "country",
+                                            "value": "IND"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "veg_nonveg",
+                                    "list": [
+                                        {
+                                            "code": "veg",
+                                            "value": "yes"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "@ondc\/org\/return_window": "P2D",
+                            "@ondc\/org\/statutory_reqs_packaged_commodities": {
+                                "manufacturer_or_packer_name": "ITC",
+                                "manufacturer_or_packer_address": "ITC Quality Care Cell,P.O Box No.592,Bangalore-560005",
+                                "common_or_generic_name_of_commodity": "surf excel matic top load liquid detergent 1 litre",
+                                "month_year_of_manufacture_packing_import": "06\/2024"
+                            }
+                        },
+                        {
+                            "id": "I51421",
+                            "time": {
+                                "label": "enable",
+                                "timestamp": "2024-05-15T13:10:46.000Z"
+                            },
+                            "descriptor": {
+                                "name": "surf excel matic front load liquid detergent 1 litre",
+                                "code": "1:8901030962318",
+                                "symbol": "https:\/\/newnfresume.s3-us-west-2.amazonaws.com\/Mass\/BBC\/Skills\/product__1715919743_1551896590.png",
+                                "short_desc": "1LITRE",
+                                "long_desc": "Surf Excel Matic Front Load Liquid Detergent 1 LITRE",
+                                "images": [
+                                    "https:\/\/newnfresume.s3-us-west-2.amazonaws.com\/Mass\/BBC\/Skills\/product__1715919743_1551896590.png",
+                                    "https:\/\/newnfresume.s3-us-west-2.amazonaws.com\/Mass\/BBC\/Skills\/product__1715919718_550952278.png",
+                                    "https:\/\/newnfresume.s3-us-west-2.amazonaws.com\/Mass\/BBC\/Skills\/product__1715919693_1572777297.png",
+                                    "https:\/\/newnfresume.s3-us-west-2.amazonaws.com\/Mass\/BBC\/Skills\/product__1715919660_1296226867.png",
+                                    "https:\/\/newnfresume.s3-us-west-2.amazonaws.com\/Mass\/BBC\/Skills\/product__1715840969_29294678.jpg"
+                                ]
+                            },
+                            "quantity": {
+                                "available": {
+                                    "count": "99"
+                                },
+                                "maximum": {
+                                    "count": "5"
+                                },
+                                "unitized": {
+                                    "measure": {
+                                        "unit": "litre",
+                                        "value": "1"
+                                    }
+                                }
+                            },
+                            "price": {
+                                "currency": "INR",
+                                "value": "220.00",
+                                "maximum_value": "220.00"
+                            },
+                            "category_id": "Cleaning & Household",
+                            "fulfillment_id": "F1",
+                            "location_id": "L1104",
+                            "recommended": true,
+                            "related": false,
+                            "@ondc\/org\/returnable": false,
+                            "@ondc\/org\/cancellable": false,
+                            "@ondc\/org\/seller_pickup_return": true,
+                            "@ondc\/org\/time_to_ship": "PT0H10M0S",
+                            "@ondc\/org\/available_on_cod": false,
+                            "@ondc\/org\/contact_details_consumer_care": "sangameshwara super market,vamshikailasa0207@gmail.com,8555051431",
+                            "tags": [
+                                {
+                                    "code": "origin",
+                                    "list": [
+                                        {
+                                            "code": "country",
+                                            "value": "IND"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "veg_nonveg",
+                                    "list": [
+                                        {
+                                            "code": "veg",
+                                            "value": "yes"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "@ondc\/org\/return_window": "P1D",
+                            "@ondc\/org\/statutory_reqs_packaged_commodities": {
+                                "manufacturer_or_packer_name": "ITC",
+                                "manufacturer_or_packer_address": "ITC Quality Care Cell,P.O Box No.592,Bangalore-560005",
+                                "common_or_generic_name_of_commodity": "surf excel matic front load liquid detergent 1 litre",
+                                "month_year_of_manufacture_packing_import": "06\/2024"
+                            }
+                        },
+                        {
+                            "id": "I51422",
+                            "time": {
+                                "label": "enable",
+                                "timestamp": "2024-05-15T13:10:56.000Z"
+                            },
+                            "descriptor": {
+                                "name": "rin ala fabric whitener 200 milli litre",
+                                "code": "1:8901030761188",
+                                "symbol": "https:\/\/newnfresume.s3-us-west-2.amazonaws.com\/Mass\/BBC\/Skills\/product__1715919305_1793421847.png",
+                                "short_desc": "200MILLI_LITRE",
+                                "long_desc": "Rin Ala Fabric Whitener 200 MILLI_LITRE",
+                                "images": [
+                                    "https:\/\/newnfresume.s3-us-west-2.amazonaws.com\/Mass\/BBC\/Skills\/product__1715919305_1793421847.png",
+                                    "https:\/\/newnfresume.s3-us-west-2.amazonaws.com\/Mass\/BBC\/Skills\/product__1715845224_1819661858.png"
+                                ]
+                            },
+                            "quantity": {
+                                "available": {
+                                    "count": "99"
+                                },
+                                "maximum": {
+                                    "count": "5"
+                                },
+                                "unitized": {
+                                    "measure": {
+                                        "unit": "millilitre",
+                                        "value": "200"
+                                    }
+                                }
+                            },
+                            "price": {
+                                "currency": "INR",
+                                "value": "44.00",
+                                "maximum_value": "44.00"
+                            },
+                            "category_id": "Cleaning & Household",
+                            "fulfillment_id": "F1",
+                            "location_id": "L1104",
+                            "recommended": true,
+                            "related": false,
+                            "@ondc\/org\/returnable": true,
+                            "@ondc\/org\/cancellable": true,
+                            "@ondc\/org\/seller_pickup_return": false,
+                            "@ondc\/org\/time_to_ship": "PT0H10M0S",
+                            "@ondc\/org\/available_on_cod": false,
+                            "@ondc\/org\/contact_details_consumer_care": "sangameshwara super market,vamshikailasa0207@gmail.com,8555051431",
+                            "tags": [
+                                {
+                                    "code": "origin",
+                                    "list": [
+                                        {
+                                            "code": "country",
+                                            "value": "IND"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "veg_nonveg",
+                                    "list": [
+                                        {
+                                            "code": "veg",
+                                            "value": "yes"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "@ondc\/org\/return_window": "P4D",
+                            "@ondc\/org\/statutory_reqs_packaged_commodities": {
+                                "manufacturer_or_packer_name": "ITC",
+                                "manufacturer_or_packer_address": "ITC Quality Care Cell,P.O Box No.592,Bangalore-560005",
+                                "common_or_generic_name_of_commodity": "rin ala fabric whitener 200 milli_litre",
+                                "month_year_of_manufacture_packing_import": "06\/2024"
+                            }
+                        },
+                        {
+                            "id": "I51423",
+                            "time": {
+                                "label": "enable",
+                                "timestamp": "2024-05-15T13:11:02.000Z"
+                            },
+                            "descriptor": {
+                                "name": "rin ala fabric whitener 500 milli litre",
+                                "code": "1:8901030761195",
+                                "symbol": "https:\/\/newnfresume.s3-us-west-2.amazonaws.com\/Mass\/BBC\/Skills\/product__1715919169_637735055.png",
+                                "short_desc": "500MILLI_LITRE",
+                                "long_desc": "Rin Ala Fabric Whitener 500 MILLI_LITRE",
+                                "images": [
+                                    "https:\/\/newnfresume.s3-us-west-2.amazonaws.com\/Mass\/BBC\/Skills\/product__1715919169_637735055.png",
+                                    "https:\/\/newnfresume.s3-us-west-2.amazonaws.com\/Mass\/BBC\/Skills\/product__1715919151_1023807697.png",
+                                    "https:\/\/newnfresume.s3-us-west-2.amazonaws.com\/Mass\/BBC\/Skills\/product__1715919129_1369535813.png",
+                                    "https:\/\/newnfresume.s3-us-west-2.amazonaws.com\/Mass\/BBC\/Skills\/product__1715919099_1386902735.png",
+                                    "https:\/\/newnfresume.s3-us-west-2.amazonaws.com\/Mass\/BBC\/Skills\/product__1715842190_1373905711.jpg"
+                                ]
+                            },
+                            "quantity": {
+                                "available": {
+                                    "count": "99"
+                                },
+                                "maximum": {
+                                    "count": "5"
+                                },
+                                "unitized": {
+                                    "measure": {
+                                        "unit": "millilitre",
+                                        "value": "500"
+                                    }
+                                }
+                            },
+                            "price": {
+                                "currency": "INR",
+                                "value": "89.00",
+                                "maximum_value": "89.00"
+                            },
+                            "category_id": "Cleaning & Household",
+                            "fulfillment_id": "F1",
+                            "location_id": "L1104",
+                            "recommended": true,
+                            "related": false,
+                            "@ondc\/org\/returnable": true,
+                            "@ondc\/org\/cancellable": true,
+                            "@ondc\/org\/seller_pickup_return": true,
+                            "@ondc\/org\/time_to_ship": "PT0H10M0S",
+                            "@ondc\/org\/available_on_cod": false,
+                            "@ondc\/org\/contact_details_consumer_care": "sangameshwara super market,vamshikailasa0207@gmail.com,8555051431",
+                            "tags": [
+                                {
+                                    "code": "origin",
+                                    "list": [
+                                        {
+                                            "code": "country",
+                                            "value": "IND"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "veg_nonveg",
+                                    "list": [
+                                        {
+                                            "code": "veg",
+                                            "value": "yes"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "@ondc\/org\/return_window": "P1D",
+                            "@ondc\/org\/statutory_reqs_packaged_commodities": {
+                                "manufacturer_or_packer_name": "ITC",
+                                "manufacturer_or_packer_address": "ITC Quality Care Cell,P.O Box No.592,Bangalore-560005",
+                                "common_or_generic_name_of_commodity": "rin ala fabric whitener 500 milli_litre",
+                                "month_year_of_manufacture_packing_import": "06\/2024"
+                            }
+                        },
+                        {
+                            "id": "I51655",
+                            "time": {
+                                "label": "enable",
+                                "timestamp": "2024-06-19T13:49:28.000Z"
+                            },
+                            "descriptor": {
+                                "name": "harpic bathroom cleaner liquid",
+                                "code": "1:8901396153368",
+                                "symbol": "https:\/\/newnfresume.s3-us-west-2.amazonaws.com\/Mass\/BBC\/Skills\/Retailer_Product_image_19_06_2024_1718804963_1668967697.png",
+                                "short_desc": "Disinfectant Bathroom Cleaner. Kills 99.9 of germs",
+                                "long_desc": "Harpic bathroom cleaner gives you unbeatable cleaning on greasy soil and particulate matter and Harpic freshness for the whole bathroom. Its thick liquid formula with powerful cleaning agents removes tough stains and kills 99.9 percent of germs. It also gives your bathroom a pleasant fresh fragrance. Used for regular cleaning of bathroom floor and tiles. Use 1.5 capfuls in half bucket of water. For tough stains and sink. Use undiluted to clean for best results. Then scrub gently and rinse. For disinfection of bathroom floor, tiles and sink. Use undiluted for best results or dilute using 1.5 capfuls in half bucket of water. Apply on surface, leave for 5 minutes then scrub gently and rinse. Suitable for most bathroom surfaces. Do not use on aluminium, brass and copper. Always spot check on a small, hidden area before using. Always use Harpic bathroom cleaner separately. Do not mix with other products.",
+                                "images": [
+                                    "https:\/\/newnfresume.s3-us-west-2.amazonaws.com\/Mass\/BBC\/Skills\/Retailer_Product_image_19_06_2024_1718804963_1668967697.png"
+                                ]
+                            },
+                            "quantity": {
+                                "available": {
+                                    "count": "99"
+                                },
+                                "maximum": {
+                                    "count": "5"
+                                },
+                                "unitized": {
+                                    "measure": {
+                                        "unit": "millilitre",
+                                        "value": "500"
+                                    }
+                                }
+                            },
+                            "price": {
+                                "currency": "INR",
+                                "value": "60.00",
+                                "maximum_value": "70.00"
+                            },
+                            "category_id": "Cleaning & Household",
+                            "fulfillment_id": "F1",
+                            "location_id": "L1104",
+                            "recommended": true,
+                            "related": false,
+                            "@ondc\/org\/returnable": false,
+                            "@ondc\/org\/cancellable": false,
+                            "@ondc\/org\/seller_pickup_return": false,
+                            "@ondc\/org\/time_to_ship": "PT0H5M0S",
+                            "@ondc\/org\/available_on_cod": true,
+                            "@ondc\/org\/contact_details_consumer_care": "sangameshwara super market,vamshikailasa0207@gmail.com,8555051431",
+                            "tags": [
+                                {
+                                    "code": "origin",
+                                    "list": [
+                                        {
+                                            "code": "country",
+                                            "value": "IND"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "veg_nonveg",
+                                    "list": [
+                                        {
+                                            "code": "veg",
+                                            "value": "yes"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "parent_item_id": "V20",
+                            "@ondc\/org\/return_window": "P1D",
+                            "@ondc\/org\/statutory_reqs_packaged_commodities": {
+                                "manufacturer_or_packer_name": "ITC",
+                                "manufacturer_or_packer_address": "ITC Quality Care Cell,P.O Box No.592,Bangalore-560005",
+                                "common_or_generic_name_of_commodity": "500ml_harpic bathroom cleaner liquid",
+                                "month_year_of_manufacture_packing_import": "06\/2024"
+                            }
+                        },
+                        {
+                            "id": "I51656",
+                            "time": {
+                                "label": "enable",
+                                "timestamp": "2024-06-19T13:49:29.000Z"
+                            },
+                            "descriptor": {
+                                "name": "harpic bathroom cleaner liquid",
+                                "code": "1:8901396173915",
+                                "symbol": "https:\/\/newnfresume.s3-us-west-2.amazonaws.com\/Mass\/BBC\/Skills\/Retailer_Product_image_19_06_2024_1718804965_882595749.png",
+                                "short_desc": "Disinfectant Bathroom Cleaner. Kills 99.9 of germs",
+                                "long_desc": "Harpic bathroom cleaner gives you unbeatable cleaning on greasy soil and particulate matter and Harpic freshness for the whole bathroom. Its thick liquid formula with powerful cleaning agents removes tough stains and kills 99.9 percent of germs. It also gives your bathroom a pleasant fresh fragrance. Used for regular cleaning of bathroom floor and tiles. Use 1.5 capfuls in half bucket of water. For tough stains and sink. Use undiluted to clean for best results. Then scrub gently and rinse. For disinfection of bathroom floor, tiles and sink. Use undiluted for best results or dilute using 1.5 capfuls in half bucket of water. Apply on surface, leave for 5 minutes then scrub gently and rinse. Suitable for most bathroom surfaces. Do not use on aluminium, brass and copper. Always spot check on a small, hidden area before using. Always use Harpic bathroom cleaner separately. Do not mix with other products.",
+                                "images": [
+                                    "https:\/\/newnfresume.s3-us-west-2.amazonaws.com\/Mass\/BBC\/Skills\/Retailer_Product_image_19_06_2024_1718804965_882595749.png"
+                                ]
+                            },
+                            "quantity": {
+                                "available": {
+                                    "count": "99"
+                                },
+                                "maximum": {
+                                    "count": "5"
+                                },
+                                "unitized": {
+                                    "measure": {
+                                        "unit": "millilitre",
+                                        "value": "1000"
+                                    }
+                                }
+                            },
+                            "price": {
+                                "currency": "INR",
+                                "value": "120.00",
+                                "maximum_value": "130.00"
+                            },
+                            "category_id": "Cleaning & Household",
+                            "fulfillment_id": "F1",
+                            "location_id": "L1104",
+                            "recommended": true,
+                            "related": false,
+                            "@ondc\/org\/returnable": false,
+                            "@ondc\/org\/cancellable": false,
+                            "@ondc\/org\/seller_pickup_return": false,
+                            "@ondc\/org\/time_to_ship": "PT0H5M0S",
+                            "@ondc\/org\/available_on_cod": true,
+                            "@ondc\/org\/contact_details_consumer_care": "sangameshwara super market,vamshikailasa0207@gmail.com,8555051431",
+                            "tags": [
+                                {
+                                    "code": "origin",
+                                    "list": [
+                                        {
+                                            "code": "country",
+                                            "value": "IND"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "veg_nonveg",
+                                    "list": [
+                                        {
+                                            "code": "veg",
+                                            "value": "yes"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "parent_item_id": "V20",
+                            "@ondc\/org\/return_window": "P1D",
+                            "@ondc\/org\/statutory_reqs_packaged_commodities": {
+                                "manufacturer_or_packer_name": "ITC",
+                                "manufacturer_or_packer_address": "ITC Quality Care Cell,P.O Box No.592,Bangalore-560005",
+                                "common_or_generic_name_of_commodity": "1000ml_harpic bathroom cleaner liquid",
+                                "month_year_of_manufacture_packing_import": "06\/2024"
+                            }
+                        }
+                    ],
+                    "tags": [
+                        {
+                            "code": "order_value",
+                            "list": [
+                                {
+                                    "code": "min_value",
+                                    "value": "0"
+                                }
+                            ]
+                        },
+                        {
+                            "code": "serviceability",
+                            "list": [
+                                {
+                                    "code": "location",
+                                    "value": "L1104"
+                                },
+                                {
+                                    "code": "category",
+                                    "value": "Cleaning & Household"
+                                },
+                                {
+                                    "code": "type",
+                                    "value": "10"
+                                },
+                                {
+                                    "code": "val",
+                                    "value": "10"
+                                },
+                                {
+                                    "code": "unit",
+                                    "value": "km"
+                                }
+                            ]
+                        },
+                        {
+                            "code": "timing",
+                            "list": [
+                                {
+                                    "code": "type",
+                                    "value": "All"
+                                },
+                                {
+                                    "code": "location",
+                                    "value": "L1104"
+                                },
+                                {
+                                    "code": "day_from",
+                                    "value": "1"
+                                },
+                                {
+                                    "code": "day_to",
+                                    "value": "5"
+                                },
+                                {
+                                    "code": "time_from",
+                                    "value": "0900"
+                                },
+                                {
+                                    "code": "time_to",
+                                    "value": "1800"
+                                }
+                            ]
+                        }
+                    ],
+                    "fulfillments": [
+                        {
+                            "contact": {
+                                "email": "vamshikailasa0207@gmail.com",
+                                "phone": "8555051431"
+                            },
+                            "id": "F1",
+                            "type": "Delivery"
+                        },
+                        {
+                            "contact": {
+                                "email": "vamshikailasa0207@gmail.com",
+                                "phone": "8555051431"
+                            },
+                            "id": "F2",
+                            "type": "Self-Pickup"
+                        }
+                    ],
+                    "categories": [
+                        {
+                            "id": "V20",
+                            "descriptor": {
+                                "name": "Volume"
+                            },
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "variant_group"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "attr",
+                                    "list": [
+                                        {
+                                            "code": "name",
+                                            "value": "item.quantity.unitized.measure"
+                                        },
+                                        {
+                                            "code": "seq",
+                                            "value": "1"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }
+    }
+}

--- a/MaasERP_Solutions/Retail/RET10/2024-06-25/Flow 1/on_search_inc_refresh.json
+++ b/MaasERP_Solutions/Retail/RET10/2024-06-25/Flow 1/on_search_inc_refresh.json
@@ -1,0 +1,106 @@
+{
+    "context": {
+        "domain": "ONDC:RET10",
+        "action": "on_search",
+        "country": "IND",
+        "city": "*",
+        "core_version": "1.2.0",
+        "bap_id": "buyer-app-preprod-v2.ondc.org",
+        "bap_uri": "https:\/\/buyer-app-preprod-v2.ondc.org\/protocol\/v1",
+        "transaction_id": "a6a02641-0247-4b84-9948-393f920ab889",
+        "message_id": "f5522e21-0123-4f8f-8ec3-96fc55de8d47",
+        "timestamp": "2024-06-25T09:46:53.000Z",
+        "ttl": "PT30S",
+        "bpp_id": "seller.dhihyperlocal.com",
+        "bpp_uri": "https:\/\/seller.dhihyperlocal.com\/api\/v1"
+    },
+    "message": {
+        "catalog": {
+            "bpp\/providers": [
+                {
+                    "id": "P1104",
+                    "items": [
+                        {
+                            "id": "I51421",
+                            "time": {
+                                "label": "enable",
+                                "timestamp": "2024-06-25T09:46:46.000Z"
+                            },
+                            "descriptor": {
+                                "name": "surf excel matic front load liquid detergent 1 litre",
+                                "code": "1:8901030962318",
+                                "symbol": "https:\/\/newnfresume.s3-us-west-2.amazonaws.com\/Mass\/BBC\/Skills\/product__1715919743_1551896590.png",
+                                "short_desc": "1LITRE",
+                                "long_desc": "Surf Excel Matic Front Load Liquid Detergent 1 LITRE",
+                                "images": [
+                                    "https:\/\/newnfresume.s3-us-west-2.amazonaws.com\/Mass\/BBC\/Skills\/product__1715919743_1551896590.png",
+                                    "https:\/\/newnfresume.s3-us-west-2.amazonaws.com\/Mass\/BBC\/Skills\/product__1715919718_550952278.png",
+                                    "https:\/\/newnfresume.s3-us-west-2.amazonaws.com\/Mass\/BBC\/Skills\/product__1715919693_1572777297.png",
+                                    "https:\/\/newnfresume.s3-us-west-2.amazonaws.com\/Mass\/BBC\/Skills\/product__1715919660_1296226867.png",
+                                    "https:\/\/newnfresume.s3-us-west-2.amazonaws.com\/Mass\/BBC\/Skills\/product__1715840969_29294678.jpg"
+                                ]
+                            },
+                            "quantity": {
+                                "available": {
+                                    "count": "99"
+                                },
+                                "maximum": {
+                                    "count": "5"
+                                },
+                                "unitized": {
+                                    "measure": {
+                                        "unit": "litre",
+                                        "value": "1"
+                                    }
+                                }
+                            },
+                            "price": {
+                                "currency": "INR",
+                                "value": "220.00",
+                                "maximum_value": "220.00"
+                            },
+                            "category_id": "Cleaning & Household",
+                            "fulfillment_id": "F1",
+                            "location_id": "L1104",
+                            "related": false,
+                            "recommended": true,
+                            "@ondc\/org\/returnable": false,
+                            "@ondc\/org\/cancellable": true,
+                            "@ondc\/org\/seller_pickup_return": true,
+                            "@ondc\/org\/time_to_ship": "PT0H10M0S",
+                            "@ondc\/org\/available_on_cod": false,
+                            "@ondc\/org\/contact_details_consumer_care": "sangameshwara super market,vamshikailasa0207@gmail.com,8555051431",
+                            "tags": [
+                                {
+                                    "code": "origin",
+                                    "list": [
+                                        {
+                                            "code": "country",
+                                            "value": "IND"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "veg_nonveg",
+                                    "list": [
+                                        {
+                                            "code": "veg",
+                                            "value": "yes"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "@ondc\/org\/return_window": "P1D",
+                            "@ondc\/org\/statutory_reqs_packaged_commodities": {
+                                "manufacturer_or_packer_name": "ITC",
+                                "manufacturer_or_packer_address": "ITC Quality Care Cell,P.O Box No.592,Bangalore-560005",
+                                "common_or_generic_name_of_commodity": "surf excel matic front load liquid detergent 1 litre",
+                                "month_year_of_manufacture_packing_import": "06\/2024"
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    }
+}

--- a/MaasERP_Solutions/Retail/RET10/2024-06-25/Flow 1/search_full_catalog_refresh.json
+++ b/MaasERP_Solutions/Retail/RET10/2024-06-25/Flow 1/search_full_catalog_refresh.json
@@ -1,0 +1,26 @@
+{
+    "context": {
+        "domain": "ONDC:RET10",
+        "action": "search",
+        "country": "IND",
+        "city": "std:040",
+        "core_version": "1.2.0",
+        "bap_id": "buyer-app-preprod-v2.ondc.org",
+        "bap_uri": "https:\/\/buyer-app-preprod-v2.ondc.org\/protocol\/v1",
+        "transaction_id": "6907b38a-12cc-4026-9d63-d51cd8980431",
+        "message_id": "47e61959-bb8d-4f3b-b6fc-ff056a4d1ec6",
+        "timestamp": "2024-06-25T06:00:01.033Z",
+        "ttl": "PT30S"
+    },
+    "message": {
+        "intent": {
+            "fulfillment": {
+                "type": "Delivery"
+            },
+            "payment": {
+                "@ondc\/org\/buyer_app_finder_fee_type": "percent",
+                "@ondc\/org\/buyer_app_finder_fee_amount": "3"
+            }
+        }
+    }
+}

--- a/MaasERP_Solutions/Retail/RET10/2024-06-25/Flow 1/search_inc_refresh.json
+++ b/MaasERP_Solutions/Retail/RET10/2024-06-25/Flow 1/search_inc_refresh.json
@@ -1,0 +1,34 @@
+{
+    "context": {
+        "domain": "ONDC:RET10",
+        "action": "search",
+        "country": "IND",
+        "city": "*",
+        "core_version": "1.2.0",
+        "bap_id": "buyer-app-preprod-v2.ondc.org",
+        "bap_uri": "https:\/\/buyer-app-preprod-v2.ondc.org\/protocol\/v1",
+        "transaction_id": "a6a02641-0247-4b84-9948-393f920ab889",
+        "message_id": "d9eca857-013b-436e-8a4c-cb4f65c26ec6",
+        "timestamp": "2024-06-24T21:30:15.035Z",
+        "ttl": "PT30S"
+    },
+    "message": {
+        "intent": {
+            "payment": {
+                "@ondc\/org\/buyer_app_finder_fee_type": "percent",
+                "@ondc\/org\/buyer_app_finder_fee_amount": "3"
+            },
+            "tags": [
+                {
+                    "code": "catalog_inc",
+                    "list": [
+                        {
+                            "code": "mode",
+                            "value": "start"
+                        }
+                    ]
+                }
+            ]
+        }
+    }
+}

--- a/MaasERP_Solutions/Retail/RET10/2024-06-25/Flow 2/confirm.json
+++ b/MaasERP_Solutions/Retail/RET10/2024-06-25/Flow 2/confirm.json
@@ -1,0 +1,202 @@
+{
+    "context": {
+        "domain": "ONDC:RET10",
+        "country": "IND",
+        "city": "std:040",
+        "action": "confirm",
+        "core_version": "1.2.0",
+        "bap_id": "buyer-app-preprod-v2.ondc.org",
+        "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+        "bpp_uri": "https://seller.dhihyperlocal.com/api/v1",
+        "transaction_id": "5fc6780b-10bb-4583-9424-37a764dd3019",
+        "message_id": "8d7ce2d7-e3cd-4c9a-9053-5f06839065e2",
+        "timestamp": "2024-06-25T10:45:00.665Z",
+        "bpp_id": "seller.dhihyperlocal.com",
+        "ttl": "PT30S"
+    },
+    "message": {
+        "order": {
+            "id": "2024-06-25-512778",
+            "state": "Created",
+            "billing": {
+                "address": {
+                    "name": "Gagandeep Singh",
+                    "building": "MaasERP",
+                    "locality": "Street Number 14",
+                    "city": "Hyderabad",
+                    "state": "Telangana",
+                    "country": "IND",
+                    "area_code": "500081"
+                },
+                "phone": "9872520660",
+                "name": "Gagandeep Singh",
+                "email": "gagandeep.singh@mailinator.com",
+                "created_at": "2024-06-25T10:44:27.747Z",
+                "updated_at": "2024-06-25T10:44:27.747Z"
+            },
+            "items": [
+                {
+                    "id": "I51422",
+                    "quantity": {
+                        "count": 2
+                    },
+                    "fulfillment_id": "F3943"
+                },
+                {
+                    "id": "I51423",
+                    "quantity": {
+                        "count": 2
+                    },
+                    "fulfillment_id": "F3943"
+                }
+            ],
+            "provider": {
+                "id": "P1104",
+                "locations": [
+                    {
+                        "id": "L1104"
+                    }
+                ]
+            },
+            "fulfillments": [
+                {
+                    "@ondc/org/TAT": "P0DT19M",
+                    "id": "F3943",
+                    "tracking": true,
+                    "end": {
+                        "contact": {
+                            "email": "gagandeep.singh@mailinator.com",
+                            "phone": "9872520660"
+                        },
+                        "person": {
+                            "name": "Gagandeep Singh"
+                        },
+                        "location": {
+                            "gps": "17.448144,78.367474",
+                            "address": {
+                                "name": "Gagandeep Singh",
+                                "building": "MaasERP",
+                                "locality": "Street Number 14",
+                                "city": "Hyderabad",
+                                "state": "Telangana",
+                                "country": "IND",
+                                "area_code": "500081"
+                            }
+                        }
+                    },
+                    "type": "Delivery"
+                }
+            ],
+            "payment": {
+                "uri": "https://razorpay.com/",
+                "tl_method": "http/get",
+                "params": {
+                    "amount": "266.00",
+                    "currency": "INR",
+                    "transaction_id": "order_OQxtynUFAqAY4r"
+                },
+                "status": "PAID",
+                "type": "ON-ORDER",
+                "collected_by": "BAP",
+                "@ondc/org/buyer_app_finder_fee_type": "percent",
+                "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+                "@ondc/org/settlement_details": [
+                    {
+                        "settlement_counterparty": "seller-app",
+                        "settlement_phase": "sale-amount",
+                        "settlement_type": "neft",
+                        "beneficiary_name": "MAAS ERP SOLUTIONS PRIVATE LIMITED",
+                        "settlement_bank_account_no": "59112345678901",
+                        "settlement_ifsc_code": "HDFC0000001",
+                        "bank_name": "HDFC",
+                        "branch_name": "Hyderabad"
+                    }
+                ]
+            },
+            "quote": {
+                "price": {
+                    "currency": "INR",
+                    "value": "266.00"
+                },
+                "breakup": [
+                    {
+                        "@ondc/org/item_id": "I51422",
+                        "@ondc/org/item_quantity": {
+                            "count": 2
+                        },
+                        "@ondc/org/title_type": "item",
+                        "item": {
+                            "price": {
+                                "currency": "INR",
+                                "value": "44.00"
+                            }
+                        },
+                        "title": "rin ala fabric whitener 200 milli_litre",
+                        "price": {
+                            "currency": "INR",
+                            "value": "88.00"
+                        }
+                    },
+                    {
+                        "@ondc/org/item_id": "I51423",
+                        "@ondc/org/item_quantity": {
+                            "count": 2
+                        },
+                        "@ondc/org/title_type": "item",
+                        "item": {
+                            "price": {
+                                "currency": "INR",
+                                "value": "89.00"
+                            }
+                        },
+                        "title": "rin ala fabric whitener 500 milli_litre",
+                        "price": {
+                            "currency": "INR",
+                            "value": "178.00"
+                        }
+                    },
+                    {
+                        "@ondc/org/item_id": "F3943",
+                        "title": "Delivery charges",
+                        "@ondc/org/title_type": "delivery",
+                        "price": {
+                            "currency": "INR",
+                            "value": "0"
+                        }
+                    }
+                ],
+                "ttl": "P1D"
+            },
+            "tags": [
+                {
+                    "code": "bpp_terms",
+                    "list": [
+                        {
+                            "code": "provider_tax_number",
+                            "value": "DMNPR5885P"
+                        },
+                        {
+                            "code": "tax_number",
+                            "value": "36AAPCM0450Q1ZX"
+                        },
+                        {
+                            "code": "np_type",
+                            "value": "MSN"
+                        }
+                    ]
+                },
+                {
+                    "code": "bap_terms",
+                    "list": [
+                        {
+                            "code": "tax_number",
+                            "value": "GSTIN1234567890"
+                        }
+                    ]
+                }
+            ],
+            "created_at": "2024-06-25T10:45:00.665Z",
+            "updated_at": "2024-06-25T10:45:00.665Z"
+        }
+    }
+}

--- a/MaasERP_Solutions/Retail/RET10/2024-06-25/Flow 2/init.json
+++ b/MaasERP_Solutions/Retail/RET10/2024-06-25/Flow 2/init.json
@@ -1,0 +1,87 @@
+{
+    "context": {
+        "domain": "ONDC:RET10",
+        "country": "IND",
+        "city": "std:040",
+        "action": "init",
+        "core_version": "1.2.0",
+        "bap_id": "buyer-app-preprod-v2.ondc.org",
+        "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+        "bpp_uri": "https://seller.dhihyperlocal.com/api/v1",
+        "transaction_id": "5fc6780b-10bb-4583-9424-37a764dd3019",
+        "message_id": "e6c56a5b-fade-4a39-8cf1-953285827b86",
+        "timestamp": "2024-06-25T10:44:27.747Z",
+        "bpp_id": "seller.dhihyperlocal.com",
+        "ttl": "PT30S"
+    },
+    "message": {
+        "order": {
+            "provider": {
+                "id": "P1104",
+                "locations": [
+                    {
+                        "id": "L1104"
+                    }
+                ]
+            },
+            "items": [
+                {
+                    "id": "I51422",
+                    "quantity": {
+                        "count": 2
+                    },
+                    "location_id": "L1104",
+                    "fulfillment_id": "F3943"
+                },
+                {
+                    "id": "I51423",
+                    "quantity": {
+                        "count": 2
+                    },
+                    "location_id": "L1104",
+                    "fulfillment_id": "F3943"
+                }
+            ],
+            "billing": {
+                "address": {
+                    "building": "MaasERP",
+                    "city": "Hyderabad",
+                    "state": "Telangana",
+                    "country": "IND",
+                    "area_code": "500081",
+                    "locality": "Street Number 14",
+                    "name": "Gagandeep Singh"
+                },
+                "phone": "9872520660",
+                "name": "Gagandeep Singh",
+                "email": "gagandeep.singh@mailinator.com",
+                "created_at": "2024-06-25T10:44:27.747Z",
+                "updated_at": "2024-06-25T10:44:27.747Z"
+            },
+            "fulfillments": [
+                {
+                    "id": "F3943",
+                    "type": "Delivery",
+                    "end": {
+                        "contact": {
+                            "email": "gagandeep.singh@mailinator.com",
+                            "phone": "9872520660"
+                        },
+                        "location": {
+                            "gps": "17.448144,78.367474",
+                            "address": {
+                                "building": "MaasERP",
+                                "city": "Hyderabad",
+                                "state": "Telangana",
+                                "country": "IND",
+                                "area_code": "500081",
+                                "locality": "Street Number 14",
+                                "name": "Gagandeep Singh"
+                            }
+                        }
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/MaasERP_Solutions/Retail/RET10/2024-06-25/Flow 2/on_confirm.json
+++ b/MaasERP_Solutions/Retail/RET10/2024-06-25/Flow 2/on_confirm.json
@@ -1,0 +1,258 @@
+{
+    "context": {
+        "domain": "ONDC:RET10",
+        "country": "IND",
+        "city": "std:040",
+        "action": "on_confirm",
+        "core_version": "1.2.0",
+        "bap_id": "buyer-app-preprod-v2.ondc.org",
+        "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+        "bpp_uri": "https://seller.dhihyperlocal.com/api/v1",
+        "transaction_id": "5fc6780b-10bb-4583-9424-37a764dd3019",
+        "message_id": "8d7ce2d7-e3cd-4c9a-9053-5f06839065e2",
+        "timestamp": "2024-06-25T10:45:03.000Z",
+        "bpp_id": "seller.dhihyperlocal.com",
+        "ttl": "PT30S"
+    },
+    "message": {
+        "order": {
+            "id": "2024-06-25-512778",
+            "state": "Created",
+            "provider": {
+                "id": "P1104",
+                "locations": [
+                    {
+                        "id": "L1104"
+                    }
+                ]
+            },
+            "items": [
+                {
+                    "id": "I51422",
+                    "fulfillment_id": "F3943",
+                    "quantity": {
+                        "count": 2
+                    }
+                },
+                {
+                    "id": "I51423",
+                    "fulfillment_id": "F3943",
+                    "quantity": {
+                        "count": 2
+                    }
+                }
+            ],
+            "billing": {
+                "name": "Gagandeep Singh",
+                "address": {
+                    "name": "Gagandeep Singh",
+                    "building": "MaasERP",
+                    "locality": "Street Number 14",
+                    "city": "Hyderabad",
+                    "state": "Telangana",
+                    "country": "IND",
+                    "area_code": "500081"
+                },
+                "email": "gagandeep.singh@mailinator.com",
+                "phone": "9872520660",
+                "created_at": "2024-06-25T10:44:27.747Z",
+                "updated_at": "2024-06-25T10:44:27.747Z"
+            },
+            "fulfillments": [
+                {
+                    "id": "F3943",
+                    "@ondc/org/provider_name": "sangameshwara super market",
+                    "type": "Delivery",
+                    "tracking": true,
+                    "@ondc/org/TAT": "P0DT19M",
+                    "state": {
+                        "descriptor": {
+                            "code": "Pending"
+                        }
+                    },
+                    "start": {
+                        "location": {
+                            "descriptor": {
+                                "name": "sangameshwara super market"
+                            },
+                            "id": "L1104",
+                            "gps": "17.462485,78.365312",
+                            "address": {
+                                "locality": "Lalitha Nilayam, Hanuman Nagar, Prashanth Nagar Colony, Kondapur, Telangana, India",
+                                "city": "Kondapur",
+                                "area_code": "500084",
+                                "state": "Telangana"
+                            }
+                        },
+                        "contact": {
+                            "phone": "8555051431",
+                            "email": "vamshikailasa0207@gmail.com"
+                        },
+                        "time": {
+                            "range": {
+                                "start": "2024-06-25T10:55:05.829Z",
+                                "end": "2024-06-25T11:00:05.829Z"
+                            }
+                        }
+                    },
+                    "end": {
+                        "location": {
+                            "gps": "17.448144,78.367474",
+                            "address": {
+                                "name": "Gagandeep Singh",
+                                "building": "MaasERP",
+                                "locality": "Street Number 14",
+                                "city": "Hyderabad",
+                                "state": "Telangana",
+                                "country": "IND",
+                                "area_code": "500081"
+                            }
+                        },
+                        "time": {
+                            "range": {
+                                "start": "2024-06-25T11:09:05.829Z",
+                                "end": "2024-06-25T11:14:05.829Z"
+                            }
+                        },
+                        "contact": {
+                            "phone": "9872520660",
+                            "email": "gagandeep.singh@mailinator.com"
+                        },
+                        "person": {
+                            "name": "Gagandeep Singh"
+                        }
+                    },
+                    "tags": [
+                        {
+                            "code": "tracking",
+                            "list": [
+                                {
+                                    "code": "gps_enabled",
+                                    "value": "no"
+                                },
+                                {
+                                    "code": "url_enabled",
+                                    "value": "yes"
+                                },
+                                {
+                                    "code": "url",
+                                    "value": "https://bbc.maaserp.com/ondc/tracking/13693"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "quote": {
+                "price": {
+                    "currency": "INR",
+                    "value": "266.00"
+                },
+                "breakup": [
+                    {
+                        "@ondc/org/item_id": "I51422",
+                        "@ondc/org/item_quantity": {
+                            "count": 2
+                        },
+                        "title": "rin ala fabric whitener 200 milli_litre",
+                        "@ondc/org/title_type": "item",
+                        "price": {
+                            "currency": "INR",
+                            "value": "88.00"
+                        },
+                        "item": {
+                            "price": {
+                                "currency": "INR",
+                                "value": "44.00"
+                            }
+                        }
+                    },
+                    {
+                        "@ondc/org/item_id": "I51423",
+                        "@ondc/org/item_quantity": {
+                            "count": 2
+                        },
+                        "title": "rin ala fabric whitener 500 milli_litre",
+                        "@ondc/org/title_type": "item",
+                        "price": {
+                            "currency": "INR",
+                            "value": "178.00"
+                        },
+                        "item": {
+                            "price": {
+                                "currency": "INR",
+                                "value": "89.00"
+                            }
+                        }
+                    },
+                    {
+                        "@ondc/org/item_id": "F3943",
+                        "title": "Delivery charges",
+                        "@ondc/org/title_type": "delivery",
+                        "price": {
+                            "currency": "INR",
+                            "value": "0"
+                        }
+                    }
+                ],
+                "ttl": "P1D"
+            },
+            "payment": {
+                "uri": "https://razorpay.com/",
+                "tl_method": "http/get",
+                "params": {
+                    "amount": "266.00",
+                    "currency": "INR",
+                    "transaction_id": "order_OQxtynUFAqAY4r"
+                },
+                "status": "PAID",
+                "type": "ON-ORDER",
+                "collected_by": "BAP",
+                "@ondc/org/buyer_app_finder_fee_type": "percent",
+                "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+                "@ondc/org/settlement_details": [
+                    {
+                        "settlement_counterparty": "seller-app",
+                        "settlement_phase": "sale-amount",
+                        "settlement_type": "neft",
+                        "beneficiary_name": "MAAS ERP SOLUTIONS PRIVATE LIMITED",
+                        "settlement_bank_account_no": "59112345678901",
+                        "settlement_ifsc_code": "HDFC0000001",
+                        "bank_name": "HDFC",
+                        "branch_name": "Hyderabad"
+                    }
+                ]
+            },
+            "created_at": "2024-06-25T10:45:00.665Z",
+            "updated_at": "2024-06-25T10:45:03.000Z",
+            "tags": [
+                {
+                    "code": "bpp_terms",
+                    "list": [
+                        {
+                            "code": "provider_tax_number",
+                            "value": "DMNPR5885P"
+                        },
+                        {
+                            "code": "tax_number",
+                            "value": "36AAPCM0450Q1ZX"
+                        },
+                        {
+                            "code": "np_type",
+                            "value": "MSN"
+                        }
+                    ]
+                },
+                {
+                    "code": "bap_terms",
+                    "list": [
+                        {
+                            "code": "tax_number",
+                            "value": "GSTIN1234567890"
+                        }
+                    ]
+                }
+            ]
+        }
+    }
+}

--- a/MaasERP_Solutions/Retail/RET10/2024-06-25/Flow 2/on_init.json
+++ b/MaasERP_Solutions/Retail/RET10/2024-06-25/Flow 2/on_init.json
@@ -1,0 +1,176 @@
+{
+    "context": {
+        "domain": "ONDC:RET10",
+        "country": "IND",
+        "city": "std:040",
+        "action": "on_init",
+        "core_version": "1.2.0",
+        "bap_id": "buyer-app-preprod-v2.ondc.org",
+        "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+        "bpp_uri": "https://seller.dhihyperlocal.com/api/v1",
+        "transaction_id": "5fc6780b-10bb-4583-9424-37a764dd3019",
+        "message_id": "e6c56a5b-fade-4a39-8cf1-953285827b86",
+        "timestamp": "2024-06-25T10:44:31.310Z",
+        "bpp_id": "seller.dhihyperlocal.com",
+        "ttl": "PT30S"
+    },
+    "message": {
+        "order": {
+            "provider": {
+                "id": "P1104",
+                "locations": [
+                    {
+                        "id": "L1104"
+                    }
+                ]
+            },
+            "items": [
+                {
+                    "id": "I51422",
+                    "quantity": {
+                        "count": 2
+                    },
+                    "fulfillment_id": "F3943"
+                },
+                {
+                    "id": "I51423",
+                    "quantity": {
+                        "count": 2
+                    },
+                    "fulfillment_id": "F3943"
+                }
+            ],
+            "billing": {
+                "name": "Gagandeep Singh",
+                "address": {
+                    "name": "Gagandeep Singh",
+                    "building": "MaasERP",
+                    "locality": "Street Number 14",
+                    "city": "Hyderabad",
+                    "state": "Telangana",
+                    "country": "IND",
+                    "area_code": "500081"
+                },
+                "email": "gagandeep.singh@mailinator.com",
+                "phone": "9872520660",
+                "created_at": "2024-06-25T10:44:27.747Z",
+                "updated_at": "2024-06-25T10:44:27.747Z"
+            },
+            "fulfillments": [
+                {
+                    "id": "F3943",
+                    "type": "Delivery",
+                    "tracking": true,
+                    "end": {
+                        "location": {
+                            "gps": "17.448144,78.367474",
+                            "address": {
+                                "name": "Gagandeep Singh",
+                                "building": "MaasERP",
+                                "locality": "Street Number 14",
+                                "city": "Hyderabad",
+                                "state": "Telangana",
+                                "country": "IND",
+                                "area_code": "500081"
+                            }
+                        },
+                        "contact": {
+                            "phone": "9872520660",
+                            "email": "gagandeep.singh@mailinator.com"
+                        }
+                    },
+                    "@ondc/org/TAT": "P0DT19M"
+                }
+            ],
+            "quote": {
+                "price": {
+                    "currency": "INR",
+                    "value": "266.00"
+                },
+                "breakup": [
+                    {
+                        "@ondc/org/item_id": "I51422",
+                        "@ondc/org/item_quantity": {
+                            "count": 2
+                        },
+                        "@ondc/org/title_type": "item",
+                        "item": {
+                            "price": {
+                                "currency": "INR",
+                                "value": "44.00"
+                            }
+                        },
+                        "title": "rin ala fabric whitener 200 milli_litre",
+                        "price": {
+                            "currency": "INR",
+                            "value": "88.00"
+                        }
+                    },
+                    {
+                        "@ondc/org/item_id": "I51423",
+                        "@ondc/org/item_quantity": {
+                            "count": 2
+                        },
+                        "@ondc/org/title_type": "item",
+                        "item": {
+                            "price": {
+                                "currency": "INR",
+                                "value": "89.00"
+                            }
+                        },
+                        "title": "rin ala fabric whitener 500 milli_litre",
+                        "price": {
+                            "currency": "INR",
+                            "value": "178.00"
+                        }
+                    },
+                    {
+                        "@ondc/org/item_id": "F3943",
+                        "title": "Delivery charges",
+                        "@ondc/org/title_type": "delivery",
+                        "price": {
+                            "currency": "INR",
+                            "value": "0"
+                        }
+                    }
+                ],
+                "ttl": "P1D"
+            },
+            "payment": {
+                "@ondc/org/buyer_app_finder_fee_type": "percent",
+                "@ondc/org/buyer_app_finder_fee_amount": "3",
+                "@ondc/org/settlement_details": [
+                    {
+                        "settlement_counterparty": "seller-app",
+                        "settlement_phase": "sale-amount",
+                        "settlement_type": "neft",
+                        "beneficiary_name": "MAAS ERP SOLUTIONS PRIVATE LIMITED",
+                        "settlement_bank_account_no": "59112345678901",
+                        "settlement_ifsc_code": "HDFC0000001",
+                        "bank_name": "HDFC",
+                        "branch_name": "Hyderabad"
+                    }
+                ]
+            },
+            "tags": [
+                {
+                    "code": "bpp_terms",
+                    "list": [
+                        {
+                            "code": "provider_tax_number",
+                            "value": "DMNPR5885P"
+                        },
+                        {
+                            "code": "tax_number",
+                            "value": "36AAPCM0450Q1ZX"
+                        },
+                        {
+                            "code": "np_type",
+                            "value": "MSN"
+                        }
+                    ]
+                }
+            ]
+        }
+    }
+}

--- a/MaasERP_Solutions/Retail/RET10/2024-06-25/Flow 2/on_select.json
+++ b/MaasERP_Solutions/Retail/RET10/2024-06-25/Flow 2/on_select.json
@@ -1,0 +1,137 @@
+{
+    "context": {
+        "domain": "ONDC:RET10",
+        "country": "IND",
+        "city": "std:040",
+        "action": "on_select",
+        "core_version": "1.2.0",
+        "bap_id": "buyer-app-preprod-v2.ondc.org",
+        "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+        "bpp_uri": "https://seller.dhihyperlocal.com/api/v1",
+        "transaction_id": "5fc6780b-10bb-4583-9424-37a764dd3019",
+        "message_id": "06105a52-f1f1-4644-a702-681196b9183f",
+        "timestamp": "2024-06-25T10:43:44.208Z",
+        "bpp_id": "seller.dhihyperlocal.com",
+        "ttl": "PT30S"
+    },
+    "message": {
+        "order": {
+            "provider": {
+                "id": "P1104",
+                "locations": [
+                    {
+                        "id": "L1104"
+                    }
+                ]
+            },
+            "items": [
+                {
+                    "fulfillment_id": "F3943",
+                    "id": "I51422"
+                },
+                {
+                    "fulfillment_id": "F3943",
+                    "id": "I51423"
+                }
+            ],
+            "fulfillments": [
+                {
+                    "id": "F3943",
+                    "@ondc/org/provider_name": "sangameshwara super market",
+                    "tracking": true,
+                    "type": "Delivery",
+                    "@ondc/org/category": "Standard Delivery",
+                    "@ondc/org/TAT": "P0DT19M",
+                    "state": {
+                        "descriptor": {
+                            "code": "Serviceable"
+                        }
+                    }
+                },
+                {
+                    "id": "F3944",
+                    "type": "Self-Pickup",
+                    "@ondc/org/provider_name": "",
+                    "tracking": false,
+                    "@ondc/org/category": "Takeaway",
+                    "@ondc/org/TAT": "PT10M",
+                    "state": {
+                        "descriptor": {
+                            "code": "Serviceable"
+                        }
+                    }
+                }
+            ],
+            "quote": {
+                "price": {
+                    "currency": "INR",
+                    "value": "266.00"
+                },
+                "breakup": [
+                    {
+                        "@ondc/org/item_id": "I51422",
+                        "@ondc/org/item_quantity": {
+                            "count": 2
+                        },
+                        "title": "rin ala fabric whitener 200 milli_litre",
+                        "@ondc/org/title_type": "item",
+                        "price": {
+                            "currency": "INR",
+                            "value": "88.00"
+                        },
+                        "item": {
+                            "quantity": {
+                                "available": {
+                                    "count": "99"
+                                },
+                                "maximum": {
+                                    "count": "5"
+                                }
+                            },
+                            "price": {
+                                "currency": "INR",
+                                "value": "44.00"
+                            }
+                        }
+                    },
+                    {
+                        "@ondc/org/item_id": "I51423",
+                        "@ondc/org/item_quantity": {
+                            "count": 2
+                        },
+                        "title": "rin ala fabric whitener 500 milli_litre",
+                        "@ondc/org/title_type": "item",
+                        "price": {
+                            "currency": "INR",
+                            "value": "178.00"
+                        },
+                        "item": {
+                            "quantity": {
+                                "available": {
+                                    "count": "99"
+                                },
+                                "maximum": {
+                                    "count": "5"
+                                }
+                            },
+                            "price": {
+                                "currency": "INR",
+                                "value": "89.00"
+                            }
+                        }
+                    },
+                    {
+                        "@ondc/org/item_id": "F3943",
+                        "title": "Delivery charges",
+                        "@ondc/org/title_type": "delivery",
+                        "price": {
+                            "currency": "INR",
+                            "value": "0"
+                        }
+                    }
+                ],
+                "ttl": "P1D"
+            }
+        }
+    }
+}

--- a/MaasERP_Solutions/Retail/RET10/2024-06-25/Flow 2/on_status_agent-assigned.json
+++ b/MaasERP_Solutions/Retail/RET10/2024-06-25/Flow 2/on_status_agent-assigned.json
@@ -1,0 +1,239 @@
+{
+    "context": {
+        "domain": "ONDC:RET10",
+        "country": "IND",
+        "city": "std:040",
+        "action": "on_status",
+        "core_version": "1.2.0",
+        "bap_id": "buyer-app-preprod-v2.ondc.org",
+        "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+        "bpp_uri": "https://seller.dhihyperlocal.com/api/v1",
+        "transaction_id": "5fc6780b-10bb-4583-9424-37a764dd3019",
+        "message_id": "96fb890a-5103-4650-975f-42157e3b76ef",
+        "timestamp": "2024-06-25T10:53:22.000Z",
+        "bpp_id": "seller.dhihyperlocal.com",
+        "ttl": "PT30S"
+    },
+    "message": {
+        "order": {
+            "id": "2024-06-25-512778",
+            "state": "In-progress",
+            "provider": {
+                "id": "P1104",
+                "locations": [
+                    {
+                        "id": "L1104"
+                    }
+                ]
+            },
+            "items": [
+                {
+                    "id": "I51422",
+                    "fulfillment_id": "F3943",
+                    "quantity": {
+                        "count": 2
+                    }
+                },
+                {
+                    "id": "I51423",
+                    "fulfillment_id": "F3943",
+                    "quantity": {
+                        "count": 2
+                    }
+                }
+            ],
+            "billing": {
+                "name": "Gagandeep Singh",
+                "address": {
+                    "name": "Gagandeep Singh",
+                    "building": "MaasERP",
+                    "locality": "Street Number 14",
+                    "city": "Hyderabad",
+                    "state": "Telangana",
+                    "country": "IND",
+                    "area_code": "500081"
+                },
+                "email": "gagandeep.singh@mailinator.com",
+                "phone": "9872520660",
+                "created_at": "2024-06-25T10:44:27.747Z",
+                "updated_at": "2024-06-25T10:44:27.747Z"
+            },
+            "fulfillments": [
+                {
+                    "id": "F3943",
+                    "@ondc/org/provider_name": "sangameshwara super market",
+                    "type": "Delivery",
+                    "tracking": true,
+                    "@ondc/org/TAT": "P0DT19M",
+                    "state": {
+                        "descriptor": {
+                            "code": "Agent-assigned"
+                        }
+                    },
+                    "start": {
+                        "location": {
+                            "descriptor": {
+                                "name": "sangameshwara super market"
+                            },
+                            "id": "L1104",
+                            "gps": "17.462485,78.365312",
+                            "address": {
+                                "locality": "Lalitha Nilayam, Hanuman Nagar, Prashanth Nagar Colony, Kondapur, Telangana, India",
+                                "city": "Kondapur",
+                                "area_code": "500084",
+                                "state": "Telangana"
+                            }
+                        },
+                        "contact": {
+                            "phone": "8555051431",
+                            "email": "vamshikailasa0207@gmail.com"
+                        },
+                        "time": {
+                            "range": {
+                                "start": "2024-06-25T10:55:05.829Z",
+                                "end": "2024-06-25T11:00:05.829Z"
+                            }
+                        }
+                    },
+                    "tags": [
+                        {
+                            "code": "routing",
+                            "list": [
+                                {
+                                    "code": "type",
+                                    "value": "P2P"
+                                }
+                            ]
+                        },
+                        {
+                            "code": "tracking",
+                            "list": [
+                                {
+                                    "code": "gps_enabled",
+                                    "value": "no"
+                                },
+                                {
+                                    "code": "url_enabled",
+                                    "value": "yes"
+                                },
+                                {
+                                    "code": "url",
+                                    "value": "https://bbc.maaserp.com/ondc/tracking/13693"
+                                }
+                            ]
+                        }
+                    ],
+                    "end": {
+                        "location": {
+                            "gps": "17.448144,78.367474",
+                            "address": {
+                                "name": "Gagandeep Singh",
+                                "building": "MaasERP",
+                                "locality": "Street Number 14",
+                                "city": "Hyderabad",
+                                "state": "Telangana",
+                                "country": "IND",
+                                "area_code": "500081"
+                            }
+                        },
+                        "time": {
+                            "range": {
+                                "start": "2024-06-25T11:09:05.829Z",
+                                "end": "2024-06-25T11:14:05.829Z"
+                            }
+                        },
+                        "contact": {
+                            "phone": "9872520660",
+                            "email": "gagandeep.singh@mailinator.com"
+                        },
+                        "person": {
+                            "name": "Gagandeep Singh"
+                        }
+                    }
+                }
+            ],
+            "quote": {
+                "price": {
+                    "currency": "INR",
+                    "value": "266.00"
+                },
+                "breakup": [
+                    {
+                        "@ondc/org/item_id": "I51422",
+                        "@ondc/org/item_quantity": {
+                            "count": 2
+                        },
+                        "title": "rin ala fabric whitener 200 milli_litre",
+                        "@ondc/org/title_type": "item",
+                        "price": {
+                            "currency": "INR",
+                            "value": "88.00"
+                        },
+                        "item": {
+                            "price": {
+                                "currency": "INR",
+                                "value": "44.00"
+                            }
+                        }
+                    },
+                    {
+                        "@ondc/org/item_id": "I51423",
+                        "@ondc/org/item_quantity": {
+                            "count": 2
+                        },
+                        "title": "rin ala fabric whitener 500 milli_litre",
+                        "@ondc/org/title_type": "item",
+                        "price": {
+                            "currency": "INR",
+                            "value": "178.00"
+                        },
+                        "item": {
+                            "price": {
+                                "currency": "INR",
+                                "value": "89.00"
+                            }
+                        }
+                    },
+                    {
+                        "@ondc/org/item_id": "F3943",
+                        "title": "Delivery charges",
+                        "@ondc/org/title_type": "delivery",
+                        "price": {
+                            "currency": "INR",
+                            "value": "0"
+                        }
+                    }
+                ],
+                "ttl": "P1D"
+            },
+            "payment": {
+                "uri": "https://razorpay.com/",
+                "tl_method": "http/get",
+                "params": {
+                    "amount": "266.00",
+                    "currency": "INR",
+                    "transaction_id": "order_OQxtynUFAqAY4r"
+                },
+                "status": "PAID",
+                "type": "ON-ORDER",
+                "collected_by": "BAP",
+                "@ondc/org/buyer_app_finder_fee_type": "percent",
+                "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+                "@ondc/org/settlement_details": [
+                    {
+                        "settlement_counterparty": "seller-app",
+                        "settlement_phase": "sale-amount",
+                        "settlement_type": "neft",
+                        "beneficiary_name": "MAAS ERP SOLUTIONS PRIVATE LIMITED",
+                        "settlement_bank_account_no": "59112345678901",
+                        "settlement_ifsc_code": "HDFC0000001",
+                        "bank_name": "HDFC",
+                        "branch_name": "Hyderabad"
+                    }
+                ]
+            },
+            "created_at": "2024-06-25T10:45:00.665Z",
+            "updated_at": "2024-06-25T10:53:22.000Z"
+        }
+    }
+}

--- a/MaasERP_Solutions/Retail/RET10/2024-06-25/Flow 2/on_status_order-delivered.json
+++ b/MaasERP_Solutions/Retail/RET10/2024-06-25/Flow 2/on_status_order-delivered.json
@@ -1,0 +1,247 @@
+{
+    "context": {
+        "domain": "ONDC:RET10",
+        "country": "IND",
+        "city": "std:040",
+        "action": "on_status",
+        "core_version": "1.2.0",
+        "bap_id": "buyer-app-preprod-v2.ondc.org",
+        "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+        "bpp_uri": "https://seller.dhihyperlocal.com/api/v1",
+        "transaction_id": "5fc6780b-10bb-4583-9424-37a764dd3019",
+        "message_id": "e429ab3b-844b-40cb-9b87-ec2a6f342352",
+        "timestamp": "2024-06-25T11:12:41.000Z",
+        "bpp_id": "seller.dhihyperlocal.com",
+        "ttl": "PT30S"
+    },
+    "message": {
+        "order": {
+            "id": "2024-06-25-512778",
+            "state": "Completed",
+            "provider": {
+                "id": "P1104",
+                "locations": [
+                    {
+                        "id": "L1104"
+                    }
+                ]
+            },
+            "items": [
+                {
+                    "id": "I51422",
+                    "fulfillment_id": "F3943",
+                    "quantity": {
+                        "count": 2
+                    }
+                },
+                {
+                    "id": "I51423",
+                    "fulfillment_id": "F3943",
+                    "quantity": {
+                        "count": 2
+                    }
+                }
+            ],
+            "billing": {
+                "name": "Gagandeep Singh",
+                "address": {
+                    "name": "Gagandeep Singh",
+                    "building": "MaasERP",
+                    "locality": "Street Number 14",
+                    "city": "Hyderabad",
+                    "state": "Telangana",
+                    "country": "IND",
+                    "area_code": "500081"
+                },
+                "email": "gagandeep.singh@mailinator.com",
+                "phone": "9872520660",
+                "created_at": "2024-06-25T10:44:27.747Z",
+                "updated_at": "2024-06-25T10:44:27.747Z"
+            },
+            "fulfillments": [
+                {
+                    "id": "F3943",
+                    "@ondc/org/provider_name": "sangameshwara super market",
+                    "type": "Delivery",
+                    "tracking": true,
+                    "@ondc/org/TAT": "P0DT19M",
+                    "state": {
+                        "descriptor": {
+                            "code": "Order-delivered"
+                        }
+                    },
+                    "start": {
+                        "location": {
+                            "descriptor": {
+                                "name": "sangameshwara super market"
+                            },
+                            "id": "L1104",
+                            "gps": "17.462485,78.365312",
+                            "address": {
+                                "locality": "Lalitha Nilayam, Hanuman Nagar, Prashanth Nagar Colony, Kondapur, Telangana, India",
+                                "city": "Kondapur",
+                                "area_code": "500084",
+                                "state": "Telangana"
+                            }
+                        },
+                        "contact": {
+                            "phone": "8555051431",
+                            "email": "vamshikailasa0207@gmail.com"
+                        },
+                        "time": {
+                            "range": {
+                                "start": "2024-06-25T10:55:05.829Z",
+                                "end": "2024-06-25T11:00:05.829Z"
+                            },
+                            "timestamp": "2024-06-25T10:56:16.000Z"
+                        }
+                    },
+                    "tags": [
+                        {
+                            "code": "routing",
+                            "list": [
+                                {
+                                    "code": "type",
+                                    "value": "P2P"
+                                }
+                            ]
+                        },
+                        {
+                            "code": "tracking",
+                            "list": [
+                                {
+                                    "code": "gps_enabled",
+                                    "value": "no"
+                                },
+                                {
+                                    "code": "url_enabled",
+                                    "value": "yes"
+                                },
+                                {
+                                    "code": "url",
+                                    "value": "https://bbc.maaserp.com/ondc/tracking/13693"
+                                }
+                            ]
+                        }
+                    ],
+                    "end": {
+                        "location": {
+                            "gps": "17.448144,78.367474",
+                            "address": {
+                                "name": "Gagandeep Singh",
+                                "building": "MaasERP",
+                                "locality": "Street Number 14",
+                                "city": "Hyderabad",
+                                "state": "Telangana",
+                                "country": "IND",
+                                "area_code": "500081"
+                            }
+                        },
+                        "time": {
+                            "range": {
+                                "start": "2024-06-25T11:09:05.829Z",
+                                "end": "2024-06-25T11:14:05.829Z"
+                            },
+                            "timestamp": "2024-06-25T11:12:41.000Z"
+                        },
+                        "contact": {
+                            "phone": "9872520660",
+                            "email": "gagandeep.singh@mailinator.com"
+                        },
+                        "person": {
+                            "name": "Gagandeep Singh"
+                        }
+                    }
+                }
+            ],
+            "quote": {
+                "price": {
+                    "currency": "INR",
+                    "value": "266.00"
+                },
+                "breakup": [
+                    {
+                        "@ondc/org/item_id": "I51422",
+                        "@ondc/org/item_quantity": {
+                            "count": 2
+                        },
+                        "title": "rin ala fabric whitener 200 milli_litre",
+                        "@ondc/org/title_type": "item",
+                        "price": {
+                            "currency": "INR",
+                            "value": "88.00"
+                        },
+                        "item": {
+                            "price": {
+                                "currency": "INR",
+                                "value": "44.00"
+                            }
+                        }
+                    },
+                    {
+                        "@ondc/org/item_id": "I51423",
+                        "@ondc/org/item_quantity": {
+                            "count": 2
+                        },
+                        "title": "rin ala fabric whitener 500 milli_litre",
+                        "@ondc/org/title_type": "item",
+                        "price": {
+                            "currency": "INR",
+                            "value": "178.00"
+                        },
+                        "item": {
+                            "price": {
+                                "currency": "INR",
+                                "value": "89.00"
+                            }
+                        }
+                    },
+                    {
+                        "@ondc/org/item_id": "F3943",
+                        "title": "Delivery charges",
+                        "@ondc/org/title_type": "delivery",
+                        "price": {
+                            "currency": "INR",
+                            "value": "0"
+                        }
+                    }
+                ],
+                "ttl": "P1D"
+            },
+            "payment": {
+                "uri": "https://razorpay.com/",
+                "tl_method": "http/get",
+                "params": {
+                    "amount": "266.00",
+                    "currency": "INR",
+                    "transaction_id": "order_OQxtynUFAqAY4r"
+                },
+                "status": "PAID",
+                "type": "ON-ORDER",
+                "collected_by": "BAP",
+                "@ondc/org/buyer_app_finder_fee_type": "percent",
+                "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+                "@ondc/org/settlement_details": [
+                    {
+                        "settlement_counterparty": "seller-app",
+                        "settlement_phase": "sale-amount",
+                        "settlement_type": "neft",
+                        "beneficiary_name": "MAAS ERP SOLUTIONS PRIVATE LIMITED",
+                        "settlement_bank_account_no": "59112345678901",
+                        "settlement_ifsc_code": "HDFC0000001",
+                        "bank_name": "HDFC",
+                        "branch_name": "Hyderabad"
+                    }
+                ]
+            },
+            "created_at": "2024-06-25T10:45:00.665Z",
+            "updated_at": "2024-06-25T11:12:41.000Z",
+            "documents": [
+                {
+                    "url": "https://newnfresume.s3-us-west-2.amazonaws.com/Orderinvoices/INV_1719318227_1121659209_34224_13693.pdf",
+                    "label": "Invoice"
+                }
+            ]
+        }
+    }
+}

--- a/MaasERP_Solutions/Retail/RET10/2024-06-25/Flow 2/on_status_order-picked-up.json
+++ b/MaasERP_Solutions/Retail/RET10/2024-06-25/Flow 2/on_status_order-picked-up.json
@@ -1,0 +1,246 @@
+{
+    "context": {
+        "domain": "ONDC:RET10",
+        "country": "IND",
+        "city": "std:040",
+        "action": "on_status",
+        "core_version": "1.2.0",
+        "bap_id": "buyer-app-preprod-v2.ondc.org",
+        "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+        "bpp_uri": "https://seller.dhihyperlocal.com/api/v1",
+        "transaction_id": "5fc6780b-10bb-4583-9424-37a764dd3019",
+        "message_id": "344bc98c-bee1-4eee-afe1-bf88f2c62bf9",
+        "timestamp": "2024-06-25T10:56:16.000Z",
+        "bpp_id": "seller.dhihyperlocal.com",
+        "ttl": "PT30S"
+    },
+    "message": {
+        "order": {
+            "id": "2024-06-25-512778",
+            "state": "In-progress",
+            "provider": {
+                "id": "P1104",
+                "locations": [
+                    {
+                        "id": "L1104"
+                    }
+                ]
+            },
+            "items": [
+                {
+                    "id": "I51422",
+                    "fulfillment_id": "F3943",
+                    "quantity": {
+                        "count": 2
+                    }
+                },
+                {
+                    "id": "I51423",
+                    "fulfillment_id": "F3943",
+                    "quantity": {
+                        "count": 2
+                    }
+                }
+            ],
+            "billing": {
+                "name": "Gagandeep Singh",
+                "address": {
+                    "name": "Gagandeep Singh",
+                    "building": "MaasERP",
+                    "locality": "Street Number 14",
+                    "city": "Hyderabad",
+                    "state": "Telangana",
+                    "country": "IND",
+                    "area_code": "500081"
+                },
+                "email": "gagandeep.singh@mailinator.com",
+                "phone": "9872520660",
+                "created_at": "2024-06-25T10:44:27.747Z",
+                "updated_at": "2024-06-25T10:44:27.747Z"
+            },
+            "fulfillments": [
+                {
+                    "id": "F3943",
+                    "@ondc/org/provider_name": "sangameshwara super market",
+                    "type": "Delivery",
+                    "tracking": true,
+                    "@ondc/org/TAT": "P0DT19M",
+                    "state": {
+                        "descriptor": {
+                            "code": "Order-picked-up"
+                        }
+                    },
+                    "start": {
+                        "location": {
+                            "descriptor": {
+                                "name": "sangameshwara super market"
+                            },
+                            "id": "L1104",
+                            "gps": "17.462485,78.365312",
+                            "address": {
+                                "locality": "Lalitha Nilayam, Hanuman Nagar, Prashanth Nagar Colony, Kondapur, Telangana, India",
+                                "city": "Kondapur",
+                                "area_code": "500084",
+                                "state": "Telangana"
+                            }
+                        },
+                        "contact": {
+                            "phone": "8555051431",
+                            "email": "vamshikailasa0207@gmail.com"
+                        },
+                        "time": {
+                            "range": {
+                                "start": "2024-06-25T10:55:05.829Z",
+                                "end": "2024-06-25T11:00:05.829Z"
+                            },
+                            "timestamp": "2024-06-25T10:56:16.000Z"
+                        }
+                    },
+                    "tags": [
+                        {
+                            "code": "routing",
+                            "list": [
+                                {
+                                    "code": "type",
+                                    "value": "P2P"
+                                }
+                            ]
+                        },
+                        {
+                            "code": "tracking",
+                            "list": [
+                                {
+                                    "code": "gps_enabled",
+                                    "value": "no"
+                                },
+                                {
+                                    "code": "url_enabled",
+                                    "value": "yes"
+                                },
+                                {
+                                    "code": "url",
+                                    "value": "https://bbc.maaserp.com/ondc/tracking/13693"
+                                }
+                            ]
+                        }
+                    ],
+                    "end": {
+                        "location": {
+                            "gps": "17.448144,78.367474",
+                            "address": {
+                                "name": "Gagandeep Singh",
+                                "building": "MaasERP",
+                                "locality": "Street Number 14",
+                                "city": "Hyderabad",
+                                "state": "Telangana",
+                                "country": "IND",
+                                "area_code": "500081"
+                            }
+                        },
+                        "time": {
+                            "range": {
+                                "start": "2024-06-25T11:09:05.829Z",
+                                "end": "2024-06-25T11:14:05.829Z"
+                            }
+                        },
+                        "contact": {
+                            "phone": "9872520660",
+                            "email": "gagandeep.singh@mailinator.com"
+                        },
+                        "person": {
+                            "name": "Gagandeep Singh"
+                        }
+                    }
+                }
+            ],
+            "quote": {
+                "price": {
+                    "currency": "INR",
+                    "value": "266.00"
+                },
+                "breakup": [
+                    {
+                        "@ondc/org/item_id": "I51422",
+                        "@ondc/org/item_quantity": {
+                            "count": 2
+                        },
+                        "title": "rin ala fabric whitener 200 milli_litre",
+                        "@ondc/org/title_type": "item",
+                        "price": {
+                            "currency": "INR",
+                            "value": "88.00"
+                        },
+                        "item": {
+                            "price": {
+                                "currency": "INR",
+                                "value": "44.00"
+                            }
+                        }
+                    },
+                    {
+                        "@ondc/org/item_id": "I51423",
+                        "@ondc/org/item_quantity": {
+                            "count": 2
+                        },
+                        "title": "rin ala fabric whitener 500 milli_litre",
+                        "@ondc/org/title_type": "item",
+                        "price": {
+                            "currency": "INR",
+                            "value": "178.00"
+                        },
+                        "item": {
+                            "price": {
+                                "currency": "INR",
+                                "value": "89.00"
+                            }
+                        }
+                    },
+                    {
+                        "@ondc/org/item_id": "F3943",
+                        "title": "Delivery charges",
+                        "@ondc/org/title_type": "delivery",
+                        "price": {
+                            "currency": "INR",
+                            "value": "0"
+                        }
+                    }
+                ],
+                "ttl": "P1D"
+            },
+            "payment": {
+                "uri": "https://razorpay.com/",
+                "tl_method": "http/get",
+                "params": {
+                    "amount": "266.00",
+                    "currency": "INR",
+                    "transaction_id": "order_OQxtynUFAqAY4r"
+                },
+                "status": "PAID",
+                "type": "ON-ORDER",
+                "collected_by": "BAP",
+                "@ondc/org/buyer_app_finder_fee_type": "percent",
+                "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+                "@ondc/org/settlement_details": [
+                    {
+                        "settlement_counterparty": "seller-app",
+                        "settlement_phase": "sale-amount",
+                        "settlement_type": "neft",
+                        "beneficiary_name": "MAAS ERP SOLUTIONS PRIVATE LIMITED",
+                        "settlement_bank_account_no": "59112345678901",
+                        "settlement_ifsc_code": "HDFC0000001",
+                        "bank_name": "HDFC",
+                        "branch_name": "Hyderabad"
+                    }
+                ]
+            },
+            "created_at": "2024-06-25T10:45:00.665Z",
+            "updated_at": "2024-06-25T10:56:16.000Z",
+            "documents": [
+                {
+                    "url": "https://newnfresume.s3-us-west-2.amazonaws.com/Orderinvoices/INV_1719318227_1121659209_34224_13693.pdf",
+                    "label": "Invoice"
+                }
+            ]
+        }
+    }
+}

--- a/MaasERP_Solutions/Retail/RET10/2024-06-25/Flow 2/on_status_out-for-delivery.json
+++ b/MaasERP_Solutions/Retail/RET10/2024-06-25/Flow 2/on_status_out-for-delivery.json
@@ -1,0 +1,246 @@
+{
+    "context": {
+        "domain": "ONDC:RET10",
+        "country": "IND",
+        "city": "std:040",
+        "action": "on_status",
+        "core_version": "1.2.0",
+        "bap_id": "buyer-app-preprod-v2.ondc.org",
+        "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+        "bpp_uri": "https://seller.dhihyperlocal.com/api/v1",
+        "transaction_id": "5fc6780b-10bb-4583-9424-37a764dd3019",
+        "message_id": "0d94bf63-fdf1-4a9d-bb12-feba8918bcd2",
+        "timestamp": "2024-06-25T10:57:22.000Z",
+        "bpp_id": "seller.dhihyperlocal.com",
+        "ttl": "PT30S"
+    },
+    "message": {
+        "order": {
+            "id": "2024-06-25-512778",
+            "state": "In-progress",
+            "provider": {
+                "id": "P1104",
+                "locations": [
+                    {
+                        "id": "L1104"
+                    }
+                ]
+            },
+            "items": [
+                {
+                    "id": "I51422",
+                    "fulfillment_id": "F3943",
+                    "quantity": {
+                        "count": 2
+                    }
+                },
+                {
+                    "id": "I51423",
+                    "fulfillment_id": "F3943",
+                    "quantity": {
+                        "count": 2
+                    }
+                }
+            ],
+            "billing": {
+                "name": "Gagandeep Singh",
+                "address": {
+                    "name": "Gagandeep Singh",
+                    "building": "MaasERP",
+                    "locality": "Street Number 14",
+                    "city": "Hyderabad",
+                    "state": "Telangana",
+                    "country": "IND",
+                    "area_code": "500081"
+                },
+                "email": "gagandeep.singh@mailinator.com",
+                "phone": "9872520660",
+                "created_at": "2024-06-25T10:44:27.747Z",
+                "updated_at": "2024-06-25T10:44:27.747Z"
+            },
+            "fulfillments": [
+                {
+                    "id": "F3943",
+                    "@ondc/org/provider_name": "sangameshwara super market",
+                    "type": "Delivery",
+                    "tracking": true,
+                    "@ondc/org/TAT": "P0DT19M",
+                    "state": {
+                        "descriptor": {
+                            "code": "Out-for-delivery"
+                        }
+                    },
+                    "start": {
+                        "location": {
+                            "descriptor": {
+                                "name": "sangameshwara super market"
+                            },
+                            "id": "L1104",
+                            "gps": "17.462485,78.365312",
+                            "address": {
+                                "locality": "Lalitha Nilayam, Hanuman Nagar, Prashanth Nagar Colony, Kondapur, Telangana, India",
+                                "city": "Kondapur",
+                                "area_code": "500084",
+                                "state": "Telangana"
+                            }
+                        },
+                        "contact": {
+                            "phone": "8555051431",
+                            "email": "vamshikailasa0207@gmail.com"
+                        },
+                        "time": {
+                            "range": {
+                                "start": "2024-06-25T10:55:05.829Z",
+                                "end": "2024-06-25T11:00:05.829Z"
+                            },
+                            "timestamp": "2024-06-25T10:56:16.000Z"
+                        }
+                    },
+                    "tags": [
+                        {
+                            "code": "routing",
+                            "list": [
+                                {
+                                    "code": "type",
+                                    "value": "P2P"
+                                }
+                            ]
+                        },
+                        {
+                            "code": "tracking",
+                            "list": [
+                                {
+                                    "code": "gps_enabled",
+                                    "value": "no"
+                                },
+                                {
+                                    "code": "url_enabled",
+                                    "value": "yes"
+                                },
+                                {
+                                    "code": "url",
+                                    "value": "https://bbc.maaserp.com/ondc/tracking/13693"
+                                }
+                            ]
+                        }
+                    ],
+                    "end": {
+                        "location": {
+                            "gps": "17.448144,78.367474",
+                            "address": {
+                                "name": "Gagandeep Singh",
+                                "building": "MaasERP",
+                                "locality": "Street Number 14",
+                                "city": "Hyderabad",
+                                "state": "Telangana",
+                                "country": "IND",
+                                "area_code": "500081"
+                            }
+                        },
+                        "time": {
+                            "range": {
+                                "start": "2024-06-25T11:09:05.829Z",
+                                "end": "2024-06-25T11:14:05.829Z"
+                            }
+                        },
+                        "contact": {
+                            "phone": "9872520660",
+                            "email": "gagandeep.singh@mailinator.com"
+                        },
+                        "person": {
+                            "name": "Gagandeep Singh"
+                        }
+                    }
+                }
+            ],
+            "quote": {
+                "price": {
+                    "currency": "INR",
+                    "value": "266.00"
+                },
+                "breakup": [
+                    {
+                        "@ondc/org/item_id": "I51422",
+                        "@ondc/org/item_quantity": {
+                            "count": 2
+                        },
+                        "title": "rin ala fabric whitener 200 milli_litre",
+                        "@ondc/org/title_type": "item",
+                        "price": {
+                            "currency": "INR",
+                            "value": "88.00"
+                        },
+                        "item": {
+                            "price": {
+                                "currency": "INR",
+                                "value": "44.00"
+                            }
+                        }
+                    },
+                    {
+                        "@ondc/org/item_id": "I51423",
+                        "@ondc/org/item_quantity": {
+                            "count": 2
+                        },
+                        "title": "rin ala fabric whitener 500 milli_litre",
+                        "@ondc/org/title_type": "item",
+                        "price": {
+                            "currency": "INR",
+                            "value": "178.00"
+                        },
+                        "item": {
+                            "price": {
+                                "currency": "INR",
+                                "value": "89.00"
+                            }
+                        }
+                    },
+                    {
+                        "@ondc/org/item_id": "F3943",
+                        "title": "Delivery charges",
+                        "@ondc/org/title_type": "delivery",
+                        "price": {
+                            "currency": "INR",
+                            "value": "0"
+                        }
+                    }
+                ],
+                "ttl": "P1D"
+            },
+            "payment": {
+                "uri": "https://razorpay.com/",
+                "tl_method": "http/get",
+                "params": {
+                    "amount": "266.00",
+                    "currency": "INR",
+                    "transaction_id": "order_OQxtynUFAqAY4r"
+                },
+                "status": "PAID",
+                "type": "ON-ORDER",
+                "collected_by": "BAP",
+                "@ondc/org/buyer_app_finder_fee_type": "percent",
+                "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+                "@ondc/org/settlement_details": [
+                    {
+                        "settlement_counterparty": "seller-app",
+                        "settlement_phase": "sale-amount",
+                        "settlement_type": "neft",
+                        "beneficiary_name": "MAAS ERP SOLUTIONS PRIVATE LIMITED",
+                        "settlement_bank_account_no": "59112345678901",
+                        "settlement_ifsc_code": "HDFC0000001",
+                        "bank_name": "HDFC",
+                        "branch_name": "Hyderabad"
+                    }
+                ]
+            },
+            "created_at": "2024-06-25T10:45:00.665Z",
+            "updated_at": "2024-06-25T10:57:22.000Z",
+            "documents": [
+                {
+                    "url": "https://newnfresume.s3-us-west-2.amazonaws.com/Orderinvoices/INV_1719318227_1121659209_34224_13693.pdf",
+                    "label": "Invoice"
+                }
+            ]
+        }
+    }
+}

--- a/MaasERP_Solutions/Retail/RET10/2024-06-25/Flow 2/on_status_packed.json
+++ b/MaasERP_Solutions/Retail/RET10/2024-06-25/Flow 2/on_status_packed.json
@@ -1,0 +1,230 @@
+{
+    "context": {
+        "domain": "ONDC:RET10",
+        "country": "IND",
+        "city": "std:040",
+        "action": "on_status",
+        "core_version": "1.2.0",
+        "bap_id": "buyer-app-preprod-v2.ondc.org",
+        "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+        "bpp_uri": "https://seller.dhihyperlocal.com/api/v1",
+        "transaction_id": "5fc6780b-10bb-4583-9424-37a764dd3019",
+        "message_id": "5c1b9668-74b8-4f58-b660-8d2ecde33e72",
+        "timestamp": "2024-06-25T10:52:46.000Z",
+        "bpp_id": "seller.dhihyperlocal.com",
+        "ttl": "PT30S"
+    },
+    "message": {
+        "order": {
+            "id": "2024-06-25-512778",
+            "state": "In-progress",
+            "provider": {
+                "id": "P1104",
+                "locations": [
+                    {
+                        "id": "L1104"
+                    }
+                ]
+            },
+            "items": [
+                {
+                    "id": "I51422",
+                    "fulfillment_id": "F3943",
+                    "quantity": {
+                        "count": 2
+                    }
+                },
+                {
+                    "id": "I51423",
+                    "fulfillment_id": "F3943",
+                    "quantity": {
+                        "count": 2
+                    }
+                }
+            ],
+            "billing": {
+                "name": "Gagandeep Singh",
+                "address": {
+                    "name": "Gagandeep Singh",
+                    "building": "MaasERP",
+                    "locality": "Street Number 14",
+                    "city": "Hyderabad",
+                    "state": "Telangana",
+                    "country": "IND",
+                    "area_code": "500081"
+                },
+                "email": "gagandeep.singh@mailinator.com",
+                "phone": "9872520660",
+                "created_at": "2024-06-25T10:44:27.747Z",
+                "updated_at": "2024-06-25T10:44:27.747Z"
+            },
+            "fulfillments": [
+                {
+                    "id": "F3943",
+                    "@ondc/org/provider_name": "sangameshwara super market",
+                    "type": "Delivery",
+                    "tracking": true,
+                    "@ondc/org/TAT": "P0DT19M",
+                    "state": {
+                        "descriptor": {
+                            "code": "Packed"
+                        }
+                    },
+                    "start": {
+                        "location": {
+                            "descriptor": {
+                                "name": "sangameshwara super market"
+                            },
+                            "id": "L1104",
+                            "gps": "17.462485,78.365312",
+                            "address": {
+                                "locality": "Lalitha Nilayam, Hanuman Nagar, Prashanth Nagar Colony, Kondapur, Telangana, India",
+                                "city": "Kondapur",
+                                "area_code": "500084",
+                                "state": "Telangana"
+                            }
+                        },
+                        "contact": {
+                            "phone": "8555051431",
+                            "email": "vamshikailasa0207@gmail.com"
+                        },
+                        "time": {
+                            "range": {
+                                "start": "2024-06-25T10:55:05.829Z",
+                                "end": "2024-06-25T11:00:05.829Z"
+                            }
+                        }
+                    },
+                    "end": {
+                        "location": {
+                            "gps": "17.448144,78.367474",
+                            "address": {
+                                "name": "Gagandeep Singh",
+                                "building": "MaasERP",
+                                "locality": "Street Number 14",
+                                "city": "Hyderabad",
+                                "state": "Telangana",
+                                "country": "IND",
+                                "area_code": "500081"
+                            }
+                        },
+                        "time": {
+                            "range": {
+                                "start": "2024-06-25T11:09:05.829Z",
+                                "end": "2024-06-25T11:14:05.829Z"
+                            }
+                        },
+                        "contact": {
+                            "phone": "9872520660",
+                            "email": "gagandeep.singh@mailinator.com"
+                        },
+                        "person": {
+                            "name": "Gagandeep Singh"
+                        }
+                    },
+                    "tags": [
+                        {
+                            "code": "tracking",
+                            "list": [
+                                {
+                                    "code": "gps_enabled",
+                                    "value": "no"
+                                },
+                                {
+                                    "code": "url_enabled",
+                                    "value": "yes"
+                                },
+                                {
+                                    "code": "url",
+                                    "value": "https://bbc.maaserp.com/ondc/tracking/13693"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "quote": {
+                "price": {
+                    "currency": "INR",
+                    "value": "266.00"
+                },
+                "breakup": [
+                    {
+                        "@ondc/org/item_id": "I51422",
+                        "@ondc/org/item_quantity": {
+                            "count": 2
+                        },
+                        "title": "rin ala fabric whitener 200 milli_litre",
+                        "@ondc/org/title_type": "item",
+                        "price": {
+                            "currency": "INR",
+                            "value": "88.00"
+                        },
+                        "item": {
+                            "price": {
+                                "currency": "INR",
+                                "value": "44.00"
+                            }
+                        }
+                    },
+                    {
+                        "@ondc/org/item_id": "I51423",
+                        "@ondc/org/item_quantity": {
+                            "count": 2
+                        },
+                        "title": "rin ala fabric whitener 500 milli_litre",
+                        "@ondc/org/title_type": "item",
+                        "price": {
+                            "currency": "INR",
+                            "value": "178.00"
+                        },
+                        "item": {
+                            "price": {
+                                "currency": "INR",
+                                "value": "89.00"
+                            }
+                        }
+                    },
+                    {
+                        "@ondc/org/item_id": "F3943",
+                        "title": "Delivery charges",
+                        "@ondc/org/title_type": "delivery",
+                        "price": {
+                            "currency": "INR",
+                            "value": "0"
+                        }
+                    }
+                ],
+                "ttl": "P1D"
+            },
+            "payment": {
+                "uri": "https://razorpay.com/",
+                "tl_method": "http/get",
+                "params": {
+                    "amount": "266.00",
+                    "currency": "INR",
+                    "transaction_id": "order_OQxtynUFAqAY4r"
+                },
+                "status": "PAID",
+                "type": "ON-ORDER",
+                "collected_by": "BAP",
+                "@ondc/org/buyer_app_finder_fee_type": "percent",
+                "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+                "@ondc/org/settlement_details": [
+                    {
+                        "settlement_counterparty": "seller-app",
+                        "settlement_phase": "sale-amount",
+                        "settlement_type": "neft",
+                        "beneficiary_name": "MAAS ERP SOLUTIONS PRIVATE LIMITED",
+                        "settlement_bank_account_no": "59112345678901",
+                        "settlement_ifsc_code": "HDFC0000001",
+                        "bank_name": "HDFC",
+                        "branch_name": "Hyderabad"
+                    }
+                ]
+            },
+            "created_at": "2024-06-25T10:45:00.665Z",
+            "updated_at": "2024-06-25T10:52:46.000Z"
+        }
+    }
+}

--- a/MaasERP_Solutions/Retail/RET10/2024-06-25/Flow 2/on_status_pending.json
+++ b/MaasERP_Solutions/Retail/RET10/2024-06-25/Flow 2/on_status_pending.json
@@ -1,0 +1,230 @@
+{
+    "context": {
+        "domain": "ONDC:RET10",
+        "country": "IND",
+        "city": "std:040",
+        "action": "on_status",
+        "core_version": "1.2.0",
+        "bap_id": "buyer-app-preprod-v2.ondc.org",
+        "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+        "bpp_uri": "https://seller.dhihyperlocal.com/api/v1",
+        "transaction_id": "5fc6780b-10bb-4583-9424-37a764dd3019",
+        "message_id": "1596d439-1294-46f7-b3ad-2f974a449de2",
+        "timestamp": "2024-06-25T10:49:27.000Z",
+        "bpp_id": "seller.dhihyperlocal.com",
+        "ttl": "PT30S"
+    },
+    "message": {
+        "order": {
+            "id": "2024-06-25-512778",
+            "state": "Accepted",
+            "provider": {
+                "id": "P1104",
+                "locations": [
+                    {
+                        "id": "L1104"
+                    }
+                ]
+            },
+            "items": [
+                {
+                    "id": "I51422",
+                    "fulfillment_id": "F3943",
+                    "quantity": {
+                        "count": 2
+                    }
+                },
+                {
+                    "id": "I51423",
+                    "fulfillment_id": "F3943",
+                    "quantity": {
+                        "count": 2
+                    }
+                }
+            ],
+            "billing": {
+                "name": "Gagandeep Singh",
+                "address": {
+                    "name": "Gagandeep Singh",
+                    "building": "MaasERP",
+                    "locality": "Street Number 14",
+                    "city": "Hyderabad",
+                    "state": "Telangana",
+                    "country": "IND",
+                    "area_code": "500081"
+                },
+                "email": "gagandeep.singh@mailinator.com",
+                "phone": "9872520660",
+                "created_at": "2024-06-25T10:44:27.747Z",
+                "updated_at": "2024-06-25T10:44:27.747Z"
+            },
+            "fulfillments": [
+                {
+                    "id": "F3943",
+                    "@ondc/org/provider_name": "sangameshwara super market",
+                    "type": "Delivery",
+                    "tracking": true,
+                    "@ondc/org/TAT": "P0DT19M",
+                    "state": {
+                        "descriptor": {
+                            "code": "Pending"
+                        }
+                    },
+                    "start": {
+                        "location": {
+                            "descriptor": {
+                                "name": "sangameshwara super market"
+                            },
+                            "id": "L1104",
+                            "gps": "17.462485,78.365312",
+                            "address": {
+                                "locality": "Lalitha Nilayam, Hanuman Nagar, Prashanth Nagar Colony, Kondapur, Telangana, India",
+                                "city": "Kondapur",
+                                "area_code": "500084",
+                                "state": "Telangana"
+                            }
+                        },
+                        "contact": {
+                            "phone": "8555051431",
+                            "email": "vamshikailasa0207@gmail.com"
+                        },
+                        "time": {
+                            "range": {
+                                "start": "2024-06-25T10:55:05.829Z",
+                                "end": "2024-06-25T11:00:05.829Z"
+                            }
+                        }
+                    },
+                    "end": {
+                        "location": {
+                            "gps": "17.448144,78.367474",
+                            "address": {
+                                "name": "Gagandeep Singh",
+                                "building": "MaasERP",
+                                "locality": "Street Number 14",
+                                "city": "Hyderabad",
+                                "state": "Telangana",
+                                "country": "IND",
+                                "area_code": "500081"
+                            }
+                        },
+                        "time": {
+                            "range": {
+                                "start": "2024-06-25T11:09:05.829Z",
+                                "end": "2024-06-25T11:14:05.829Z"
+                            }
+                        },
+                        "contact": {
+                            "phone": "9872520660",
+                            "email": "gagandeep.singh@mailinator.com"
+                        },
+                        "person": {
+                            "name": "Gagandeep Singh"
+                        }
+                    },
+                    "tags": [
+                        {
+                            "code": "tracking",
+                            "list": [
+                                {
+                                    "code": "gps_enabled",
+                                    "value": "no"
+                                },
+                                {
+                                    "code": "url_enabled",
+                                    "value": "yes"
+                                },
+                                {
+                                    "code": "url",
+                                    "value": "https://bbc.maaserp.com/ondc/tracking/13693"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "quote": {
+                "price": {
+                    "currency": "INR",
+                    "value": "266.00"
+                },
+                "breakup": [
+                    {
+                        "@ondc/org/item_id": "I51422",
+                        "@ondc/org/item_quantity": {
+                            "count": 2
+                        },
+                        "title": "rin ala fabric whitener 200 milli_litre",
+                        "@ondc/org/title_type": "item",
+                        "price": {
+                            "currency": "INR",
+                            "value": "88.00"
+                        },
+                        "item": {
+                            "price": {
+                                "currency": "INR",
+                                "value": "44.00"
+                            }
+                        }
+                    },
+                    {
+                        "@ondc/org/item_id": "I51423",
+                        "@ondc/org/item_quantity": {
+                            "count": 2
+                        },
+                        "title": "rin ala fabric whitener 500 milli_litre",
+                        "@ondc/org/title_type": "item",
+                        "price": {
+                            "currency": "INR",
+                            "value": "178.00"
+                        },
+                        "item": {
+                            "price": {
+                                "currency": "INR",
+                                "value": "89.00"
+                            }
+                        }
+                    },
+                    {
+                        "@ondc/org/item_id": "F3943",
+                        "title": "Delivery charges",
+                        "@ondc/org/title_type": "delivery",
+                        "price": {
+                            "currency": "INR",
+                            "value": "0"
+                        }
+                    }
+                ],
+                "ttl": "P1D"
+            },
+            "payment": {
+                "uri": "https://razorpay.com/",
+                "tl_method": "http/get",
+                "params": {
+                    "amount": "266.00",
+                    "currency": "INR",
+                    "transaction_id": "order_OQxtynUFAqAY4r"
+                },
+                "status": "PAID",
+                "type": "ON-ORDER",
+                "collected_by": "BAP",
+                "@ondc/org/buyer_app_finder_fee_type": "percent",
+                "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+                "@ondc/org/settlement_details": [
+                    {
+                        "settlement_counterparty": "seller-app",
+                        "settlement_phase": "sale-amount",
+                        "settlement_type": "neft",
+                        "beneficiary_name": "MAAS ERP SOLUTIONS PRIVATE LIMITED",
+                        "settlement_bank_account_no": "59112345678901",
+                        "settlement_ifsc_code": "HDFC0000001",
+                        "bank_name": "HDFC",
+                        "branch_name": "Hyderabad"
+                    }
+                ]
+            },
+            "created_at": "2024-06-25T10:45:00.665Z",
+            "updated_at": "2024-06-25T10:49:27.000Z"
+        }
+    }
+}

--- a/MaasERP_Solutions/Retail/RET10/2024-06-25/Flow 2/select.json
+++ b/MaasERP_Solutions/Retail/RET10/2024-06-25/Flow 2/select.json
@@ -1,0 +1,57 @@
+{
+    "context": {
+        "domain": "ONDC:RET10",
+        "country": "IND",
+        "city": "std:040",
+        "action": "select",
+        "core_version": "1.2.0",
+        "bap_id": "buyer-app-preprod-v2.ondc.org",
+        "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+        "bpp_uri": "https://seller.dhihyperlocal.com/api/v1",
+        "transaction_id": "5fc6780b-10bb-4583-9424-37a764dd3019",
+        "message_id": "06105a52-f1f1-4644-a702-681196b9183f",
+        "timestamp": "2024-06-25T10:43:40.091Z",
+        "bpp_id": "seller.dhihyperlocal.com",
+        "ttl": "PT30S"
+    },
+    "message": {
+        "order": {
+            "items": [
+                {
+                    "id": "I51422",
+                    "quantity": {
+                        "count": 2
+                    },
+                    "location_id": "L1104"
+                },
+                {
+                    "id": "I51423",
+                    "quantity": {
+                        "count": 2
+                    },
+                    "location_id": "L1104"
+                }
+            ],
+            "provider": {
+                "id": "P1104",
+                "locations": [
+                    {
+                        "id": "L1104"
+                    }
+                ]
+            },
+            "fulfillments": [
+                {
+                    "end": {
+                        "location": {
+                            "gps": "17.448144,78.367474",
+                            "address": {
+                                "area_code": "500081"
+                            }
+                        }
+                    }
+                }
+            ]
+        }
+    }
+}


### PR DESCRIPTION
We are submitting the PR for Flow1 and Flow 2 by resolving the following points as per your feedback:

Flow 1
item named as:niine naturally soft sanitary napkin ultra thin 6 piece, shouldn't be in Health and Wellness (Feminine Care)
Resolution: We will be removing this product as we are considering RET10 for now.

item.quantity.unitized.measure should be mapped correctly (ex: rin ala fabric whitener 500 milli litre, it should have unit as millilitre not unit 1)
Explanation: We have updated the the product unit of measure.

is only Cleaning & Household supported ?
Explanation: No, we are supporting all the categories that fall under RET10 but for the logs submission we are using Cleaning and Household.

Other Flows
on_select
how an fulfillment is having @ondc/org/TAT as 6 minutes (P0DT6M) while time_to_ship is 5 minutes
on_confirm
pickup and delivery ranges should be as per @ondc/org/TAT

Resolution: As discussed with you we will be increasing the distance for the delivery location without making any changes in the existing formula.

on_status (picked)
as per provided invoice, payment method is cash, but as per order details its prepaid (please explain)
Resolution: We have updated the payment type in the invoice.