### PR TITLE
Updated RET:14 Logs Submission for Review

### DIFF
--- a/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow1/on_search.json
+++ b/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow1/on_search.json
@@ -1,0 +1,1733 @@
+{
+  "context": {
+    "domain": "ONDC:RET14",
+    "country": "IND",
+    "city": "std:0124",
+    "action": "on_search",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_id": "api.greenreceipt.in",
+    "bpp_uri": "https://api.greenreceipt.in/ondc",
+    "transaction_id": "8b056769-d6c2-46ea-8842-3b82112fd587",
+    "message_id": "a5ffbbf8-ecca-4e9a-835b-af673d286ece",
+    "timestamp": "2024-07-04T18:00:04.719Z"
+  },
+  "message": {
+    "catalog": {
+      "bpp/descriptor": {
+        "name": "Green Receipt",
+        "symbol": "https://greenreceipt.in/images/logos/greenreceipt.png",
+        "short_desc": "Green Receipt",
+        "long_desc": "Green Receipt",
+        "images": [
+          "https://greenreceipt.in/images/logos/greenreceipt.png"
+        ],
+        "tags": [
+          {
+            "code": "bpp_terms",
+            "list": [
+              {
+                "code": "np_type",
+                "value": "MSN"
+              }
+            ]
+          }
+        ]
+      },
+      "bpp/providers": [
+        {
+          "id": "24932",
+          "time": {
+            "label": "enable",
+            "timestamp": "2024-07-04T18:00:04.719Z"
+          },
+          "fulfillments": [
+            {
+              "id": "24932_F1",
+              "type": "Delivery",
+              "contact": {
+                "phone": "8076362934",
+                "email": "Demo3@gmail.com"
+              }
+            }
+          ],
+          "descriptor": {
+            "name": "Ajay Electronics",
+            "symbol": "https://greenreceipt.in/images/logos/24930.png",
+            "short_desc": "Ajay Electronics",
+            "long_desc": "Ajay Electronics",
+            "images": [
+              "https://greenreceipt.in/images/logos/24930.png"
+            ]
+          },
+          "ttl": "P1D",
+          "locations": [
+            {
+              "id": "24932",
+              "time": {
+                "label": "enable",
+                "timestamp": "2024-07-04T18:00:04.719Z",
+                "days": "1,2,3,4,5,6,7",
+                "schedule": {
+                  "holidays": [
+                    
+                  ]
+                },
+                "range": {
+                  "start": "0001",
+                  "end": "2359"
+                }
+              },
+              "gps": "28.41430316,77.06620157",
+              "address": {
+                "locality": "Nirvana Country",
+                "street": "265, Nirvana Country, Sector 50, Gurugram, Haryana 122018",
+                "city": "Gurgaon",
+                "area_code": "122018",
+                "state": "Haryana"
+              },
+              "circle": {
+                "gps": "28.41430316,77.06620157",
+                "radius": {
+                  "unit": "km",
+                  "value": "10"
+                }
+              }
+            }
+          ],
+          "categories": [
+            {
+              "id": "iphone_14",
+              "descriptor": {
+                "name": "iPhone14"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "variant_group"
+                    }
+                  ]
+                },
+                {
+                  "code": "attr",
+                  "list": [
+                    {
+                      "code": "name",
+                      "value": "item.tags.attribute.colour"
+                    },
+                    {
+                      "code": "seq",
+                      "value": "1"
+                    }
+                  ]
+                },
+                {
+                  "code": "attr",
+                  "list": [
+                    {
+                      "code": "name",
+                      "value": "item.tags.attribute.ram"
+                    },
+                    {
+                      "code": "seq",
+                      "value": "2"
+                    }
+                  ]
+                },
+                {
+                  "code": "attr",
+                  "list": [
+                    {
+                      "code": "name",
+                      "value": "item.tags.attribute.rom"
+                    },
+                    {
+                      "code": "seq",
+                      "value": "3"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "iphone_13",
+              "descriptor": {
+                "name": "iPhone13"
+              },
+              "tags": [
+                {
+                  "code": "type",
+                  "list": [
+                    {
+                      "code": "type",
+                      "value": "variant_group"
+                    }
+                  ]
+                },
+                {
+                  "code": "attr",
+                  "list": [
+                    {
+                      "code": "name",
+                      "value": "item.tags.attribute.colour"
+                    },
+                    {
+                      "code": "seq",
+                      "value": "1"
+                    }
+                  ]
+                },
+                {
+                  "code": "attr",
+                  "list": [
+                    {
+                      "code": "name",
+                      "value": "item.tags.attribute.ram"
+                    },
+                    {
+                      "code": "seq",
+                      "value": "2"
+                    }
+                  ]
+                },
+                {
+                  "code": "attr",
+                  "list": [
+                    {
+                      "code": "name",
+                      "value": "item.tags.attribute.rom"
+                    },
+                    {
+                      "code": "seq",
+                      "value": "3"
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "items": [
+            {
+              "id": "24932_2740436",
+              "time": {
+                "label": "enable",
+                "timestamp": "2024-07-04T18:00:04.719Z"
+              },
+              "parent_item_id": "iphone_14",
+              "descriptor": {
+                "name": "IPHONE 14 256GB MIDNIGHT",
+                "code": "3:194253380450",
+                "symbol": "https://lsmedia.linker-cdn.net/291628/2023/8117978.jpeg",
+                "short_desc": "IPHONE 14 256GB MIDNIGHT",
+                "long_desc": "Product Specification - IPHONE 14 256GB MIDNIGHT",
+                "images": [
+                  "https://lsmedia.linker-cdn.net/291628/2023/8117978.jpeg"
+                ]
+              },
+              "quantity": {
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                },
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "82990",
+                "maximum_value": "82990"
+              },
+              "category_id": "Mobile Phone",
+              "fulfillment_id": "24932_F1",
+              "location_id": "24932",
+              "@ondc/org/returnable": true,
+              "@ondc/org/seller_pickup_return": false,
+              "@ondc/org/return_window": "P7D",
+              "@ondc/org/cancellable": true,
+              "@ondc/org/time_to_ship": "PT3H",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "Mithlesh,Demo3@gmail.com,8076362934",
+              "@ondc/org/statutory_reqs_packaged_commodities": {
+                "manufacturer_or_packer_name": "Foxconn Ltd",
+                "manufacturer_or_packer_address": "A-1, Chennai-Bangalore National Highway, Nh-4, Sriperumbudur, Kanchipuram, Tamil Nadu 602105",
+                "common_or_generic_name_of_commodity": "Mobile Phone",
+                "month_year_of_manufacture_packing_import": "06/2023"
+              },
+              "tags": [
+                {
+                  "code": "origin",
+                  "list": [
+                    {
+                      "code": "country",
+                      "value": "IND"
+                    }
+                  ]
+                },
+                {
+                  "code": "attribute",
+                  "list": [
+                    {
+                      "code": "battery_capacity",
+                      "value": "3200"
+                    },
+                    {
+                      "code": "brand",
+                      "value": "iPhone"
+                    },
+                    {
+                      "code": "breadth",
+                      "value": "7.15"
+                    },
+                    {
+                      "code": "colour",
+                      "value": "#191970"
+                    },
+                    {
+                      "code": "colour_name",
+                      "value": "midnight blue"
+                    },
+                    {
+                      "code": "connectivity",
+                      "value": "5G"
+                    },
+                    {
+                      "code": "form_factor",
+                      "value": "touchscreen"
+                    },
+                    {
+                      "code": "height",
+                      "value": "0.78"
+                    },
+                    {
+                      "code": "length",
+                      "value": "14.67"
+                    },
+                    {
+                      "code": "model",
+                      "value": "iPhone 14"
+                    },
+                    {
+                      "code": "model_year",
+                      "value": "2022"
+                    },
+                    {
+                      "code": "os_type",
+                      "value": "iOS"
+                    },
+                    {
+                      "code": "os_version",
+                      "value": "16.5"
+                    },
+                    {
+                      "code": "primary_camera",
+                      "value": "48"
+                    },
+                    {
+                      "code": "ram",
+                      "value": "6"
+                    },
+                    {
+                      "code": "ram_unit",
+                      "value": "GB"
+                    },
+                    {
+                      "code": "rom",
+                      "value": "256"
+                    },
+                    {
+                      "code": "rom_unit",
+                      "value": "GB"
+                    },
+                    {
+                      "code": "screen_size",
+                      "value": "6.1"
+                    },
+                    {
+                      "code": "secondary_camera",
+                      "value": "24"
+                    },
+                    {
+                      "code": "storage",
+                      "value": "256"
+                    },
+                    {
+                      "code": "storage_unit",
+                      "value": "GB"
+                    },
+                    {
+                      "code": "weight",
+                      "value": "175"
+                    }
+                  ]
+                }
+              ],
+              "related": false
+            },
+            {
+              "id": "24932_2740437",
+              "time": {
+                "label": "enable",
+                "timestamp": "2024-07-04T18:00:04.719Z"
+              },
+              "parent_item_id": "iphone_14",
+              "descriptor": {
+                "name": "IPHONE 14 256GB STARLIGHT",
+                "code": "3:194253380689",
+                "symbol": "https://lsmedia.linker-cdn.net/291628/2023/8117988.jpeg",
+                "short_desc": "IPHONE 14 256GB STARLIGHT",
+                "long_desc": "Product Specification - IPHONE 14 256GB STARLIGHT",
+                "images": [
+                  "https://lsmedia.linker-cdn.net/291628/2023/8117988.jpeg"
+                ]
+              },
+              "quantity": {
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                },
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "82990",
+                "maximum_value": "82990"
+              },
+              "category_id": "Mobile Phone",
+              "fulfillment_id": "24932_F1",
+              "location_id": "24932",
+              "@ondc/org/returnable": true,
+              "@ondc/org/seller_pickup_return": false,
+              "@ondc/org/return_window": "P7D",
+              "@ondc/org/cancellable": true,
+              "@ondc/org/time_to_ship": "PT3H",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "Mithlesh,Demo3@gmail.com,8076362934",
+              "@ondc/org/statutory_reqs_packaged_commodities": {
+                "manufacturer_or_packer_name": "Foxconn Ltd",
+                "manufacturer_or_packer_address": "A-1, Chennai-Bangalore National Highway, Nh-4, Sriperumbudur, Kanchipuram, Tamil Nadu 602105",
+                "common_or_generic_name_of_commodity": "Mobile Phone",
+                "month_year_of_manufacture_packing_import": "06/2023"
+              },
+              "tags": [
+                {
+                  "code": "origin",
+                  "list": [
+                    {
+                      "code": "country",
+                      "value": "IND"
+                    }
+                  ]
+                },
+                {
+                  "code": "attribute",
+                  "list": [
+                    {
+                      "code": "battery_capacity",
+                      "value": "3200"
+                    },
+                    {
+                      "code": "brand",
+                      "value": "iPhone"
+                    },
+                    {
+                      "code": "breadth",
+                      "value": "7.15"
+                    },
+                    {
+                      "code": "colour",
+                      "value": "#FFFFFF"
+                    },
+                    {
+                      "code": "colour_name",
+                      "value": "white"
+                    },
+                    {
+                      "code": "connectivity",
+                      "value": "5G"
+                    },
+                    {
+                      "code": "form_factor",
+                      "value": "touchscreen"
+                    },
+                    {
+                      "code": "height",
+                      "value": "0.78"
+                    },
+                    {
+                      "code": "length",
+                      "value": "14.67"
+                    },
+                    {
+                      "code": "model",
+                      "value": "iPhone 14"
+                    },
+                    {
+                      "code": "model_year",
+                      "value": "2022"
+                    },
+                    {
+                      "code": "os_type",
+                      "value": "iOS"
+                    },
+                    {
+                      "code": "os_version",
+                      "value": "16.5"
+                    },
+                    {
+                      "code": "primary_camera",
+                      "value": "48"
+                    },
+                    {
+                      "code": "ram",
+                      "value": "6"
+                    },
+                    {
+                      "code": "ram_unit",
+                      "value": "GB"
+                    },
+                    {
+                      "code": "rom",
+                      "value": "256"
+                    },
+                    {
+                      "code": "rom_unit",
+                      "value": "GB"
+                    },
+                    {
+                      "code": "screen_size",
+                      "value": "6.1"
+                    },
+                    {
+                      "code": "secondary_camera",
+                      "value": "24"
+                    },
+                    {
+                      "code": "storage",
+                      "value": "256"
+                    },
+                    {
+                      "code": "storage_unit",
+                      "value": "GB"
+                    },
+                    {
+                      "code": "weight",
+                      "value": "175"
+                    }
+                  ]
+                }
+              ],
+              "related": false
+            },
+            {
+              "id": "24932_2740440",
+              "time": {
+                "label": "enable",
+                "timestamp": "2024-07-04T18:00:04.719Z"
+              },
+              "parent_item_id": "iphone_13",
+              "descriptor": {
+                "name": "IPHONE 13 128GB BLUE",
+                "code": "3:194253380917",
+                "symbol": "https://lsmedia.linker-cdn.net/291628/2023/8118032.jpeg",
+                "short_desc": "IPHONE 13 128GB BLUE",
+                "long_desc": "Product Specification - IPHONE 13 128GB BLUE",
+                "images": [
+                  "https://lsmedia.linker-cdn.net/291628/2023/8118032.jpeg"
+                ]
+              },
+              "quantity": {
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                },
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "62990",
+                "maximum_value": "62990"
+              },
+              "category_id": "Mobile Phone",
+              "fulfillment_id": "24932_F1",
+              "location_id": "24932",
+              "@ondc/org/returnable": true,
+              "@ondc/org/seller_pickup_return": false,
+              "@ondc/org/return_window": "P7D",
+              "@ondc/org/cancellable": true,
+              "@ondc/org/time_to_ship": "PT3H",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "Mithlesh,Demo3@gmail.com,8076362934",
+              "@ondc/org/statutory_reqs_packaged_commodities": {
+                "manufacturer_or_packer_name": "Foxconn Ltd",
+                "manufacturer_or_packer_address": "A-1, Chennai-Bangalore National Highway, Nh-4, Sriperumbudur, Kanchipuram, Tamil Nadu 602105",
+                "common_or_generic_name_of_commodity": "Mobile Phone",
+                "month_year_of_manufacture_packing_import": "06/2023"
+              },
+              "tags": [
+                {
+                  "code": "origin",
+                  "list": [
+                    {
+                      "code": "country",
+                      "value": "IND"
+                    }
+                  ]
+                },
+                {
+                  "code": "attribute",
+                  "list": [
+                    {
+                      "code": "battery_capacity",
+                      "value": "3200"
+                    },
+                    {
+                      "code": "brand",
+                      "value": "iPhone"
+                    },
+                    {
+                      "code": "breadth",
+                      "value": "7.15"
+                    },
+                    {
+                      "code": "colour",
+                      "value": "#0000FF"
+                    },
+                    {
+                      "code": "colour_name",
+                      "value": "blue"
+                    },
+                    {
+                      "code": "connectivity",
+                      "value": "4G"
+                    },
+                    {
+                      "code": "form_factor",
+                      "value": "touchscreen"
+                    },
+                    {
+                      "code": "height",
+                      "value": "0.78"
+                    },
+                    {
+                      "code": "length",
+                      "value": "14.67"
+                    },
+                    {
+                      "code": "model",
+                      "value": "iPhone 13"
+                    },
+                    {
+                      "code": "model_year",
+                      "value": "2021"
+                    },
+                    {
+                      "code": "os_type",
+                      "value": "iOS"
+                    },
+                    {
+                      "code": "os_version",
+                      "value": "16.1"
+                    },
+                    {
+                      "code": "primary_camera",
+                      "value": "48"
+                    },
+                    {
+                      "code": "ram",
+                      "value": "4"
+                    },
+                    {
+                      "code": "ram_unit",
+                      "value": "GB"
+                    },
+                    {
+                      "code": "rom",
+                      "value": "128"
+                    },
+                    {
+                      "code": "rom_unit",
+                      "value": "GB"
+                    },
+                    {
+                      "code": "screen_size",
+                      "value": "6.1"
+                    },
+                    {
+                      "code": "secondary_camera",
+                      "value": "24"
+                    },
+                    {
+                      "code": "storage",
+                      "value": "128"
+                    },
+                    {
+                      "code": "storage_unit",
+                      "value": "GB"
+                    },
+                    {
+                      "code": "weight",
+                      "value": "175"
+                    }
+                  ]
+                }
+              ],
+              "related": false
+            },
+            {
+              "id": "24932_2740441",
+              "time": {
+                "label": "enable",
+                "timestamp": "2024-07-04T18:00:04.719Z"
+              },
+              "parent_item_id": "iphone_13",
+              "descriptor": {
+                "name": "IPHONE 13 128GB MIDNIGHT",
+                "code": "3:194253381143",
+                "symbol": "https://lsmedia.linker-cdn.net/291628/2023/8118036.jpeg",
+                "short_desc": "IPHONE 13 128GB MIDNIGHT",
+                "long_desc": "Product Specification - IPHONE 13 128GB MIDNIGHT",
+                "images": [
+                  "https://lsmedia.linker-cdn.net/291628/2023/8118036.jpeg"
+                ]
+              },
+              "quantity": {
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                },
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "62990",
+                "maximum_value": "62990"
+              },
+              "category_id": "Mobile Phone",
+              "fulfillment_id": "24932_F1",
+              "location_id": "24932",
+              "@ondc/org/returnable": true,
+              "@ondc/org/seller_pickup_return": false,
+              "@ondc/org/return_window": "P7D",
+              "@ondc/org/cancellable": true,
+              "@ondc/org/time_to_ship": "PT3H",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "Mithlesh,Demo3@gmail.com,8076362934",
+              "@ondc/org/statutory_reqs_packaged_commodities": {
+                "manufacturer_or_packer_name": "Foxconn Ltd",
+                "manufacturer_or_packer_address": "A-1, Chennai-Bangalore National Highway, Nh-4, Sriperumbudur, Kanchipuram, Tamil Nadu 602105",
+                "common_or_generic_name_of_commodity": "Mobile Phone",
+                "month_year_of_manufacture_packing_import": "06/2023"
+              },
+              "tags": [
+                {
+                  "code": "origin",
+                  "list": [
+                    {
+                      "code": "country",
+                      "value": "IND"
+                    }
+                  ]
+                },
+                {
+                  "code": "attribute",
+                  "list": [
+                    {
+                      "code": "battery_capacity",
+                      "value": "3200"
+                    },
+                    {
+                      "code": "brand",
+                      "value": "iPhone"
+                    },
+                    {
+                      "code": "breadth",
+                      "value": "7.15"
+                    },
+                    {
+                      "code": "colour",
+                      "value": "#191970"
+                    },
+                    {
+                      "code": "colour_name",
+                      "value": "midnight blue"
+                    },
+                    {
+                      "code": "connectivity",
+                      "value": "4G"
+                    },
+                    {
+                      "code": "form_factor",
+                      "value": "touchscreen"
+                    },
+                    {
+                      "code": "height",
+                      "value": "0.78"
+                    },
+                    {
+                      "code": "length",
+                      "value": "14.67"
+                    },
+                    {
+                      "code": "model",
+                      "value": "iPhone 13"
+                    },
+                    {
+                      "code": "model_year",
+                      "value": "2021"
+                    },
+                    {
+                      "code": "os_type",
+                      "value": "iOS"
+                    },
+                    {
+                      "code": "os_version",
+                      "value": "16.1"
+                    },
+                    {
+                      "code": "primary_camera",
+                      "value": "48"
+                    },
+                    {
+                      "code": "ram",
+                      "value": "4"
+                    },
+                    {
+                      "code": "ram_unit",
+                      "value": "GB"
+                    },
+                    {
+                      "code": "rom",
+                      "value": "128"
+                    },
+                    {
+                      "code": "rom_unit",
+                      "value": "GB"
+                    },
+                    {
+                      "code": "screen_size",
+                      "value": "6.1"
+                    },
+                    {
+                      "code": "secondary_camera",
+                      "value": "24"
+                    },
+                    {
+                      "code": "storage",
+                      "value": "128"
+                    },
+                    {
+                      "code": "storage_unit",
+                      "value": "GB"
+                    },
+                    {
+                      "code": "weight",
+                      "value": "175"
+                    }
+                  ]
+                }
+              ],
+              "related": false
+            },
+            {
+              "id": "24932_2740442",
+              "time": {
+                "label": "enable",
+                "timestamp": "2024-07-04T18:00:04.719Z"
+              },
+              "parent_item_id": "iphone_13",
+              "descriptor": {
+                "name": "IPHONE 13 128GB GREEN",
+                "code": "3:194253381372",
+                "symbol": "https://lsmedia.linker-cdn.net/291628/2023/8118038.jpeg",
+                "short_desc": "IPHONE 13 128GB GREEN",
+                "long_desc": "Product Specification - IPHONE 13 128GB GREEN",
+                "images": [
+                  "https://lsmedia.linker-cdn.net/291628/2023/8118038.jpeg"
+                ]
+              },
+              "quantity": {
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                },
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "62990",
+                "maximum_value": "62990"
+              },
+              "category_id": "Mobile Phone",
+              "fulfillment_id": "24932_F1",
+              "location_id": "24932",
+              "@ondc/org/returnable": true,
+              "@ondc/org/seller_pickup_return": false,
+              "@ondc/org/return_window": "P7D",
+              "@ondc/org/cancellable": true,
+              "@ondc/org/time_to_ship": "PT3H",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "Mithlesh,Demo3@gmail.com,8076362934",
+              "@ondc/org/statutory_reqs_packaged_commodities": {
+                "manufacturer_or_packer_name": "Foxconn Ltd",
+                "manufacturer_or_packer_address": "A-1, Chennai-Bangalore National Highway, Nh-4, Sriperumbudur, Kanchipuram, Tamil Nadu 602105",
+                "common_or_generic_name_of_commodity": "Mobile Phone",
+                "month_year_of_manufacture_packing_import": "06/2023"
+              },
+              "tags": [
+                {
+                  "code": "origin",
+                  "list": [
+                    {
+                      "code": "country",
+                      "value": "IND"
+                    }
+                  ]
+                },
+                {
+                  "code": "attribute",
+                  "list": [
+                    {
+                      "code": "battery_capacity",
+                      "value": "3200"
+                    },
+                    {
+                      "code": "brand",
+                      "value": "iPhone"
+                    },
+                    {
+                      "code": "breadth",
+                      "value": "7.15"
+                    },
+                    {
+                      "code": "colour",
+                      "value": "#008000"
+                    },
+                    {
+                      "code": "colour_name",
+                      "value": "green"
+                    },
+                    {
+                      "code": "connectivity",
+                      "value": "4G"
+                    },
+                    {
+                      "code": "form_factor",
+                      "value": "touchscreen"
+                    },
+                    {
+                      "code": "height",
+                      "value": "0.78"
+                    },
+                    {
+                      "code": "length",
+                      "value": "14.67"
+                    },
+                    {
+                      "code": "model",
+                      "value": "iPhone 13"
+                    },
+                    {
+                      "code": "model_year",
+                      "value": "2021"
+                    },
+                    {
+                      "code": "os_type",
+                      "value": "iOS"
+                    },
+                    {
+                      "code": "os_version",
+                      "value": "16.1"
+                    },
+                    {
+                      "code": "primary_camera",
+                      "value": "48"
+                    },
+                    {
+                      "code": "ram",
+                      "value": "4"
+                    },
+                    {
+                      "code": "ram_unit",
+                      "value": "GB"
+                    },
+                    {
+                      "code": "rom",
+                      "value": "128"
+                    },
+                    {
+                      "code": "rom_unit",
+                      "value": "GB"
+                    },
+                    {
+                      "code": "screen_size",
+                      "value": "6.1"
+                    },
+                    {
+                      "code": "secondary_camera",
+                      "value": "24"
+                    },
+                    {
+                      "code": "storage",
+                      "value": "128"
+                    },
+                    {
+                      "code": "storage_unit",
+                      "value": "GB"
+                    },
+                    {
+                      "code": "weight",
+                      "value": "175"
+                    }
+                  ]
+                }
+              ],
+              "related": false
+            },
+            {
+              "id": "24932_2740443",
+              "time": {
+                "label": "enable",
+                "timestamp": "2024-07-04T18:00:04.719Z"
+              },
+              "parent_item_id": "iphone_13",
+              "descriptor": {
+                "name": "IPHONE 13 256GB STARLIGHT",
+                "code": "3:194253381600",
+                "symbol": "https://lsmedia.linker-cdn.net/291628/2023/8117988.jpeg",
+                "short_desc": "IPHONE 13 256GB STARLIGHT",
+                "long_desc": "Product Specification - IPHONE 13 256GB STARLIGHT",
+                "images": [
+                  "https://lsmedia.linker-cdn.net/291628/2023/8117988.jpeg"
+                ]
+              },
+              "quantity": {
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                },
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "72990",
+                "maximum_value": "72990"
+              },
+              "category_id": "Mobile Phone",
+              "fulfillment_id": "24932_F1",
+              "location_id": "24932",
+              "@ondc/org/returnable": true,
+              "@ondc/org/seller_pickup_return": false,
+              "@ondc/org/return_window": "P7D",
+              "@ondc/org/cancellable": true,
+              "@ondc/org/time_to_ship": "PT3H",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "Mithlesh,Demo3@gmail.com,8076362934",
+              "@ondc/org/statutory_reqs_packaged_commodities": {
+                "manufacturer_or_packer_name": "Foxconn Ltd",
+                "manufacturer_or_packer_address": "A-1, Chennai-Bangalore National Highway, Nh-4, Sriperumbudur, Kanchipuram, Tamil Nadu 602105",
+                "common_or_generic_name_of_commodity": "Mobile Phone",
+                "month_year_of_manufacture_packing_import": "06/2023"
+              },
+              "tags": [
+                {
+                  "code": "origin",
+                  "list": [
+                    {
+                      "code": "country",
+                      "value": "IND"
+                    }
+                  ]
+                },
+                {
+                  "code": "attribute",
+                  "list": [
+                    {
+                      "code": "battery_capacity",
+                      "value": "3200"
+                    },
+                    {
+                      "code": "brand",
+                      "value": "iPhone"
+                    },
+                    {
+                      "code": "breadth",
+                      "value": "7.15"
+                    },
+                    {
+                      "code": "colour",
+                      "value": "#FFFFFF"
+                    },
+                    {
+                      "code": "colour_name",
+                      "value": "white"
+                    },
+                    {
+                      "code": "connectivity",
+                      "value": "4G"
+                    },
+                    {
+                      "code": "form_factor",
+                      "value": "touchscreen"
+                    },
+                    {
+                      "code": "height",
+                      "value": "0.78"
+                    },
+                    {
+                      "code": "length",
+                      "value": "14.67"
+                    },
+                    {
+                      "code": "model",
+                      "value": "iPhone 13"
+                    },
+                    {
+                      "code": "model_year",
+                      "value": "2021"
+                    },
+                    {
+                      "code": "os_type",
+                      "value": "iOS"
+                    },
+                    {
+                      "code": "os_version",
+                      "value": "16.1"
+                    },
+                    {
+                      "code": "primary_camera",
+                      "value": "48"
+                    },
+                    {
+                      "code": "ram",
+                      "value": "6"
+                    },
+                    {
+                      "code": "ram_unit",
+                      "value": "GB"
+                    },
+                    {
+                      "code": "rom",
+                      "value": "256"
+                    },
+                    {
+                      "code": "rom_unit",
+                      "value": "GB"
+                    },
+                    {
+                      "code": "screen_size",
+                      "value": "6.1"
+                    },
+                    {
+                      "code": "secondary_camera",
+                      "value": "24"
+                    },
+                    {
+                      "code": "storage",
+                      "value": "256"
+                    },
+                    {
+                      "code": "storage_unit",
+                      "value": "GB"
+                    },
+                    {
+                      "code": "weight",
+                      "value": "175"
+                    }
+                  ]
+                }
+              ],
+              "related": false
+            },
+            {
+              "id": "24932_2740435",
+              "time": {
+                "label": "enable",
+                "timestamp": "2024-07-04T18:00:04.719Z"
+              },
+              "parent_item_id": "iphone_14",
+              "descriptor": {
+                "name": "IPHONE 14 128GB MIDNIGHT",
+                "code": "3:194253380221",
+                "symbol": "https://lsmedia.linker-cdn.net/291628/2023/8117978.jpeg",
+                "short_desc": "IPHONE 14 128GB MIDNIGHT",
+                "long_desc": "Product Specification - IPHONE 14 128GB MIDNIGHT",
+                "images": [
+                  "https://lsmedia.linker-cdn.net/291628/2023/8117978.jpeg"
+                ]
+              },
+              "quantity": {
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                },
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "72990",
+                "maximum_value": "72990"
+              },
+              "category_id": "Mobile Phone",
+              "fulfillment_id": "24932_F1",
+              "location_id": "24932",
+              "@ondc/org/returnable": true,
+              "@ondc/org/seller_pickup_return": false,
+              "@ondc/org/return_window": "P7D",
+              "@ondc/org/cancellable": true,
+              "@ondc/org/time_to_ship": "PT3H",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "Mithlesh,Demo3@gmail.com,8076362934",
+              "@ondc/org/statutory_reqs_packaged_commodities": {
+                "manufacturer_or_packer_name": "Foxconn Ltd",
+                "manufacturer_or_packer_address": "A-1, Chennai-Bangalore National Highway, Nh-4, Sriperumbudur, Kanchipuram, Tamil Nadu 602105",
+                "common_or_generic_name_of_commodity": "Mobile Phone",
+                "month_year_of_manufacture_packing_import": "06/2023"
+              },
+              "tags": [
+                {
+                  "code": "origin",
+                  "list": [
+                    {
+                      "code": "country",
+                      "value": "IND"
+                    }
+                  ]
+                },
+                {
+                  "code": "attribute",
+                  "list": [
+                    {
+                      "code": "battery_capacity",
+                      "value": "3200"
+                    },
+                    {
+                      "code": "brand",
+                      "value": "iPhone"
+                    },
+                    {
+                      "code": "breadth",
+                      "value": "7.15"
+                    },
+                    {
+                      "code": "colour",
+                      "value": "#191970"
+                    },
+                    {
+                      "code": "colour_name",
+                      "value": "midnight blue"
+                    },
+                    {
+                      "code": "connectivity",
+                      "value": "5G"
+                    },
+                    {
+                      "code": "form_factor",
+                      "value": "touchscreen"
+                    },
+                    {
+                      "code": "height",
+                      "value": "0.78"
+                    },
+                    {
+                      "code": "length",
+                      "value": "14.67"
+                    },
+                    {
+                      "code": "model",
+                      "value": "iPhone 14"
+                    },
+                    {
+                      "code": "model_year",
+                      "value": "2022"
+                    },
+                    {
+                      "code": "os_type",
+                      "value": "iOS"
+                    },
+                    {
+                      "code": "os_version",
+                      "value": "16.5"
+                    },
+                    {
+                      "code": "primary_camera",
+                      "value": "48"
+                    },
+                    {
+                      "code": "ram",
+                      "value": "6"
+                    },
+                    {
+                      "code": "ram_unit",
+                      "value": "GB"
+                    },
+                    {
+                      "code": "rom",
+                      "value": "128"
+                    },
+                    {
+                      "code": "rom_unit",
+                      "value": "GB"
+                    },
+                    {
+                      "code": "screen_size",
+                      "value": "6.1"
+                    },
+                    {
+                      "code": "secondary_camera",
+                      "value": "24"
+                    },
+                    {
+                      "code": "storage",
+                      "value": "128"
+                    },
+                    {
+                      "code": "storage_unit",
+                      "value": "GB"
+                    },
+                    {
+                      "code": "weight",
+                      "value": "175"
+                    }
+                  ]
+                }
+              ],
+              "related": false
+            },
+            {
+              "id": "24932_2740434",
+              "time": {
+                "label": "enable",
+                "timestamp": "2024-07-04T18:00:04.719Z"
+              },
+              "parent_item_id": "iphone_14",
+              "descriptor": {
+                "name": "IPHONE 14 256GB YELLOW",
+                "code": "3:194253379997",
+                "symbol": "https://lsmedia.linker-cdn.net/291628/2023/8117986.jpeg",
+                "short_desc": "IPHONE 14 256GB YELLOW",
+                "long_desc": "Product Specification - IPHONE 14 256GB YELLOW",
+                "images": [
+                  "https://lsmedia.linker-cdn.net/291628/2023/8117986.jpeg"
+                ]
+              },
+              "quantity": {
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                },
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "82990",
+                "maximum_value": "82990"
+              },
+              "category_id": "Mobile Phone",
+              "fulfillment_id": "24932_F1",
+              "location_id": "24932",
+              "@ondc/org/returnable": true,
+              "@ondc/org/seller_pickup_return": false,
+              "@ondc/org/return_window": "P7D",
+              "@ondc/org/cancellable": true,
+              "@ondc/org/time_to_ship": "PT3H",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "Mithlesh,Demo3@gmail.com,8076362934",
+              "@ondc/org/statutory_reqs_packaged_commodities": {
+                "manufacturer_or_packer_name": "Foxconn Ltd",
+                "manufacturer_or_packer_address": "A-1, Chennai-Bangalore National Highway, Nh-4, Sriperumbudur, Kanchipuram, Tamil Nadu 602105",
+                "common_or_generic_name_of_commodity": "Mobile Phone",
+                "month_year_of_manufacture_packing_import": "06/2023"
+              },
+              "tags": [
+                {
+                  "code": "origin",
+                  "list": [
+                    {
+                      "code": "country",
+                      "value": "IND"
+                    }
+                  ]
+                },
+                {
+                  "code": "attribute",
+                  "list": [
+                    {
+                      "code": "battery_capacity",
+                      "value": "3200"
+                    },
+                    {
+                      "code": "brand",
+                      "value": "iPhone"
+                    },
+                    {
+                      "code": "breadth",
+                      "value": "7.15"
+                    },
+                    {
+                      "code": "colour",
+                      "value": "#FFFF00"
+                    },
+                    {
+                      "code": "colour_name",
+                      "value": "yellow"
+                    },
+                    {
+                      "code": "connectivity",
+                      "value": "5G"
+                    },
+                    {
+                      "code": "form_factor",
+                      "value": "touchscreen"
+                    },
+                    {
+                      "code": "height",
+                      "value": "0.78"
+                    },
+                    {
+                      "code": "length",
+                      "value": "14.67"
+                    },
+                    {
+                      "code": "model",
+                      "value": "iPhone 14"
+                    },
+                    {
+                      "code": "model_year",
+                      "value": "2022"
+                    },
+                    {
+                      "code": "os_type",
+                      "value": "iOS"
+                    },
+                    {
+                      "code": "os_version",
+                      "value": "16.5"
+                    },
+                    {
+                      "code": "primary_camera",
+                      "value": "48"
+                    },
+                    {
+                      "code": "ram",
+                      "value": "6"
+                    },
+                    {
+                      "code": "ram_unit",
+                      "value": "GB"
+                    },
+                    {
+                      "code": "rom",
+                      "value": "256"
+                    },
+                    {
+                      "code": "rom_unit",
+                      "value": "GB"
+                    },
+                    {
+                      "code": "screen_size",
+                      "value": "6.1"
+                    },
+                    {
+                      "code": "secondary_camera",
+                      "value": "24"
+                    },
+                    {
+                      "code": "storage",
+                      "value": "256"
+                    },
+                    {
+                      "code": "storage_unit",
+                      "value": "GB"
+                    },
+                    {
+                      "code": "weight",
+                      "value": "175"
+                    }
+                  ]
+                }
+              ],
+              "related": false
+            },
+            {
+              "id": "24932_2740433",
+              "time": {
+                "label": "enable",
+                "timestamp": "2024-07-04T18:00:04.719Z"
+              },
+              "parent_item_id": "iphone_14",
+              "descriptor": {
+                "name": "IPHONE 14 128GB YELLOW",
+                "code": "3:194253379768",
+                "symbol": "https://lsmedia.linker-cdn.net/291628/2023/8117986.jpeg",
+                "short_desc": "IPHONE 14 128GB YELLOW",
+                "long_desc": "Product Specification - IPHONE 14 128GB YELLOW",
+                "images": [
+                  "https://lsmedia.linker-cdn.net/291628/2023/8117986.jpeg"
+                ]
+              },
+              "quantity": {
+                "unitized": {
+                  "measure": {
+                    "unit": "unit",
+                    "value": "1"
+                  }
+                },
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "72990",
+                "maximum_value": "72990"
+              },
+              "category_id": "Mobile Phone",
+              "fulfillment_id": "24932_F1",
+              "location_id": "24932",
+              "@ondc/org/returnable": true,
+              "@ondc/org/seller_pickup_return": false,
+              "@ondc/org/return_window": "P7D",
+              "@ondc/org/cancellable": true,
+              "@ondc/org/time_to_ship": "PT3H",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "Mithlesh,Demo3@gmail.com,8076362934",
+              "@ondc/org/statutory_reqs_packaged_commodities": {
+                "manufacturer_or_packer_name": "Foxconn Ltd",
+                "manufacturer_or_packer_address": "A-1, Chennai-Bangalore National Highway, Nh-4, Sriperumbudur, Kanchipuram, Tamil Nadu 602105",
+                "common_or_generic_name_of_commodity": "Mobile Phone",
+                "month_year_of_manufacture_packing_import": "06/2023"
+              },
+              "tags": [
+                {
+                  "code": "origin",
+                  "list": [
+                    {
+                      "code": "country",
+                      "value": "IND"
+                    }
+                  ]
+                },
+                {
+                  "code": "attribute",
+                  "list": [
+                    {
+                      "code": "battery_capacity",
+                      "value": "3200"
+                    },
+                    {
+                      "code": "brand",
+                      "value": "iPhone"
+                    },
+                    {
+                      "code": "breadth",
+                      "value": "7.15"
+                    },
+                    {
+                      "code": "colour",
+                      "value": "#FFFF00"
+                    },
+                    {
+                      "code": "colour_name",
+                      "value": "yellow"
+                    },
+                    {
+                      "code": "connectivity",
+                      "value": "5G"
+                    },
+                    {
+                      "code": "form_factor",
+                      "value": "touchscreen"
+                    },
+                    {
+                      "code": "height",
+                      "value": "0.78"
+                    },
+                    {
+                      "code": "length",
+                      "value": "14.67"
+                    },
+                    {
+                      "code": "model",
+                      "value": "iPhone 14"
+                    },
+                    {
+                      "code": "model_year",
+                      "value": "2022"
+                    },
+                    {
+                      "code": "os_type",
+                      "value": "iOS"
+                    },
+                    {
+                      "code": "os_version",
+                      "value": "16.5"
+                    },
+                    {
+                      "code": "primary_camera",
+                      "value": "48"
+                    },
+                    {
+                      "code": "ram",
+                      "value": "6"
+                    },
+                    {
+                      "code": "ram_unit",
+                      "value": "GB"
+                    },
+                    {
+                      "code": "rom",
+                      "value": "128"
+                    },
+                    {
+                      "code": "rom_unit",
+                      "value": "GB"
+                    },
+                    {
+                      "code": "screen_size",
+                      "value": "6.1"
+                    },
+                    {
+                      "code": "secondary_camera",
+                      "value": "24"
+                    },
+                    {
+                      "code": "storage",
+                      "value": "128"
+                    },
+                    {
+                      "code": "storage_unit",
+                      "value": "GB"
+                    },
+                    {
+                      "code": "weight",
+                      "value": "175"
+                    }
+                  ]
+                }
+              ],
+              "related": false
+            }
+          ],
+          "tags": [
+            {
+              "code": "serviceability",
+              "list": [
+                {
+                  "code": "location",
+                  "value": "24932"
+                },
+                {
+                  "code": "category",
+                  "value": "Mobile Phone"
+                },
+                {
+                  "code": "type",
+                  "value": "12"
+                },
+                {
+                  "code": "val",
+                  "value": "IND"
+                },
+                {
+                  "code": "unit",
+                  "value": "country"
+                }
+              ]
+            },
+            {
+              "code": "timing",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "All"
+                },
+                {
+                  "code": "location",
+                  "value": "24932"
+                },
+                {
+                  "code": "day_from",
+                  "value": "1"
+                },
+                {
+                  "code": "day_to",
+                  "value": "7"
+                },
+                {
+                  "code": "time_from",
+                  "value": "0001"
+                },
+                {
+                  "code": "time_to",
+                  "value": "2359"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow1/on_search_inc_store_close.json
+++ b/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow1/on_search_inc_store_close.json
@@ -1,0 +1,39 @@
+{
+  "context": {
+    "domain": "ONDC:RET14",
+    "action": "on_search",
+    "country": "IND",
+    "city": "*",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_id": "api.greenreceipt.in",
+    "bpp_uri": "https://api.greenreceipt.in/ondc",
+    "transaction_id": "f90b25b6-694d-412d-bcfa-7d14d32f92ff",
+    "message_id": "798d100c-0379-4287-9655-7036cd30298b",
+    "timestamp": "2024-07-05T10:00:02.187Z",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "catalog": {
+      "bpp/providers": [
+        {
+          "id": "24932",
+          "locations": [
+            {
+              "id": "24932",
+              "time": {
+                "label": "close",
+                "timestamp": "2024-07-05T10:00:02.187Z",
+                "range": {
+                  "start": "2024-07-05T10:00:00.000Z",
+                  "end": "2024-07-05T13:00:00.000Z"
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow1/on_search_inc_store_open.json
+++ b/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow1/on_search_inc_store_open.json
@@ -1,0 +1,35 @@
+{
+  "context": {
+    "domain": "ONDC:RET14",
+    "action": "on_search",
+    "country": "IND",
+    "city": "*",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_id": "api.greenreceipt.in",
+    "bpp_uri": "https://api.greenreceipt.in/ondc",
+    "transaction_id": "f90b25b6-694d-412d-bcfa-7d14d32f92ff",
+    "message_id": "752cbdc9-e1b9-4cf2-8562-d53f61a8c8a6",
+    "timestamp": "2024-07-05T13:00:03.482Z",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "catalog": {
+      "bpp/providers": [
+        {
+          "id": "24932",
+          "locations": [
+            {
+              "id": "24932",
+              "time": {
+                "label": "open",
+                "timestamp": "2024-07-05T13:00:03.482Z"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow1/search.json
+++ b/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow1/search.json
@@ -1,0 +1,26 @@
+{
+  "context": {
+    "domain": "ONDC:RET14",
+    "action": "search",
+    "country": "IND",
+    "city": "std:0124",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "transaction_id": "8b056769-d6c2-46ea-8842-3b82112fd587",
+    "message_id": "a5ffbbf8-ecca-4e9a-835b-af673d286ece",
+    "timestamp": "2024-07-04T18:00:01.319Z",
+    "ttl": "PT30M"
+  },
+  "message": {
+    "intent": {
+      "fulfillment": {
+        "type": "Delivery"
+      },
+      "payment": {
+        "@ondc/org/buyer_app_finder_fee_type": "percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "3"
+      }
+    }
+  }
+}

--- a/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow1/search_inc_start.json
+++ b/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow1/search_inc_start.json
@@ -1,0 +1,34 @@
+{
+  "context": {
+    "domain": "ONDC:RET14",
+    "action": "search",
+    "country": "IND",
+    "city": "*",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "transaction_id": "f90b25b6-694d-412d-bcfa-7d14d32f92ff",
+    "message_id": "17f73462-89d7-49c8-bb5f-4774bdbf4699",
+    "timestamp": "2024-07-04T21:30:15.492Z",
+    "ttl": "PT30M"
+  },
+  "message": {
+    "intent": {
+      "payment": {
+        "@ondc/org/buyer_app_finder_fee_type": "percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "3"
+      },
+      "tags": [
+        {
+          "code": "catalog_inc",
+          "list": [
+            {
+              "code": "mode",
+              "value": "start"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow1_log_utility_resp.json
+++ b/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow1_log_utility_resp.json
@@ -1,0 +1,13 @@
+{
+    "success": true,
+    "response": {
+        "message": "Logs were verified successfully",
+        "report": {},
+        "bpp_id": "api.greenreceipt.in",
+        "bap_id": "buyer-app-preprod-v2.ondc.org",
+        "domain": "ONDC:RET14",
+        "reportTimestamp": "2024-07-11T11:38:21.839Z"
+    },
+    "signature": "vZlWdn2l2mhJ9ecoVtCrihvs5GOSDMxQvsEETHYOHZq9oX8GplrdKDI78qc+1F/icfgAsl9wSisHK2ZMXdn/Dg==",
+    "signTimestamp": "2024-07-11T11:38:21.839Z"
+}

--- a/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow2/confirm.json
+++ b/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow2/confirm.json
@@ -1,0 +1,199 @@
+{
+  "context": {
+    "domain": "ONDC:RET14",
+    "country": "IND",
+    "city": "std:0124",
+    "action": "confirm",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_uri": "https://api.greenreceipt.in/ondc",
+    "transaction_id": "851c331a-49d3-47a3-b74b-7ade4ed6de94",
+    "message_id": "4c31836d-5dbd-4208-8b59-048eea57216d",
+    "timestamp": "2024-07-07T04:25:07.778Z",
+    "bpp_id": "api.greenreceipt.in",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "id": "2024-07-07-489122",
+      "state": "Created",
+      "billing": {
+        "address": {
+          "name": "Aryan Sharma",
+          "building": "Club Patio",
+          "locality": "Sector Road",
+          "city": "Gurugram",
+          "state": "Haryana",
+          "country": "IND",
+          "area_code": "122007"
+        },
+        "phone": "8923136015",
+        "name": "Aryan Sharma",
+        "email": "aryan@buynxt.in",
+        "created_at": "2024-07-07T04:24:38.077Z",
+        "updated_at": "2024-07-07T04:24:38.077Z"
+      },
+      "items": [
+        {
+          "id": "24932_2740436",
+          "quantity": {
+            "count": 1
+          },
+          "fulfillment_id": "24932_F1"
+        },
+        {
+          "id": "24932_2740440",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "24932_F1"
+        }
+      ],
+      "provider": {
+        "id": "24932",
+        "locations": [
+          {
+            "id": "24932"
+          }
+        ]
+      },
+      "fulfillments": [
+        {
+          "@ondc/org/TAT": "PT4H",
+          "id": "24932_F1",
+          "tracking": false,
+          "end": {
+            "contact": {
+              "email": "aryan@buynxt.in",
+              "phone": "8923136015"
+            },
+            "person": {
+              "name": "Aryan Sharma"
+            },
+            "location": {
+              "gps": "28.457929,77.067815",
+              "address": {
+                "name": "Aryan Sharma",
+                "building": "Club Patio",
+                "locality": "Sector Road",
+                "city": "Gurugram",
+                "state": "Haryana",
+                "country": "IND",
+                "area_code": "122007"
+              }
+            }
+          },
+          "type": "Delivery"
+        }
+      ],
+      "payment": {
+        "uri": "https://razorpay.com/",
+        "tl_method": "http/get",
+        "params": {
+          "amount": "208970.00",
+          "currency": "INR",
+          "transaction_id": "order_OVbq6MCyPF7Sg1"
+        },
+        "status": "PAID",
+        "type": "ON-ORDER",
+        "collected_by": "BAP",
+        "@ondc/org/buyer_app_finder_fee_type": "percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "seller-app",
+            "settlement_phase": "sale-amount",
+            "settlement_type": "neft",
+            "beneficiary_name": "Buynxt Private Limited",
+            "upi_address": "buynxt@okidfc",
+            "settlement_bank_account_no": "10129914936",
+            "settlement_ifsc_code": "IDFB0021001",
+            "bank_name": "IDFC First Bank Limited",
+            "branch_name": "Golf Course Road, Gurgaon"
+          }
+        ]
+      },
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "208970.00"
+        },
+        "breakup": [
+          {
+            "@ondc/org/item_id": "24932_2740436",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "title": "IPHONE 14 256GB MIDNIGHT",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "82990.00"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "82990.00"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "24932_2740440",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "title": "IPHONE 13 128GB BLUE",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "125980.00"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "62990.00"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "24932_F1",
+            "title": "Delivery charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "0.00"
+            }
+          }
+        ],
+        "ttl": "P1D"
+      },
+      "tags": [
+        {
+          "code": "bpp_terms",
+          "list": [
+            {
+              "code": "tax_number",
+              "value": "09ALZPS7205J2ZP"
+            },
+            {
+              "code": "provider_tax_number",
+              "value": "CKABS4783R"
+            }
+          ]
+        },
+        {
+          "code": "bap_terms",
+          "list": [
+            {
+              "code": "tax_number",
+              "value": "GSTIN1234567890"
+            }
+          ]
+        }
+      ],
+      "created_at": "2024-07-07T04:25:07.778Z",
+      "updated_at": "2024-07-07T04:25:07.778Z"
+    }
+  }
+}

--- a/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow2/init.json
+++ b/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow2/init.json
@@ -1,0 +1,87 @@
+{
+  "context": {
+    "domain": "ONDC:RET14",
+    "country": "IND",
+    "city": "std:0124",
+    "action": "init",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_uri": "https://api.greenreceipt.in/ondc",
+    "transaction_id": "851c331a-49d3-47a3-b74b-7ade4ed6de94",
+    "message_id": "605423b2-b1b4-4129-96d6-14aeddcc1543",
+    "timestamp": "2024-07-07T04:24:38.077Z",
+    "bpp_id": "api.greenreceipt.in",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "provider": {
+        "id": "24932",
+        "locations": [
+          {
+            "id": "24932"
+          }
+        ]
+      },
+      "items": [
+        {
+          "id": "24932_2740436",
+          "quantity": {
+            "count": 1
+          },
+          "location_id": "24932",
+          "fulfillment_id": "24932_F1"
+        },
+        {
+          "id": "24932_2740440",
+          "quantity": {
+            "count": 2
+          },
+          "location_id": "24932",
+          "fulfillment_id": "24932_F1"
+        }
+      ],
+      "billing": {
+        "address": {
+          "building": "Club Patio",
+          "city": "Gurugram",
+          "state": "Haryana",
+          "country": "IND",
+          "area_code": "122007",
+          "locality": "Sector Road",
+          "name": "Aryan Sharma"
+        },
+        "phone": "8923136015",
+        "name": "Aryan Sharma",
+        "email": "aryan@buynxt.in",
+        "created_at": "2024-07-07T04:24:38.077Z",
+        "updated_at": "2024-07-07T04:24:38.077Z"
+      },
+      "fulfillments": [
+        {
+          "id": "24932_F1",
+          "type": "Delivery",
+          "end": {
+            "contact": {
+              "email": "aryan@buynxt.in",
+              "phone": "8923136015"
+            },
+            "location": {
+              "gps": "28.457929,77.067815",
+              "address": {
+                "building": "Club Patio",
+                "city": "Gurugram",
+                "state": "Haryana",
+                "country": "IND",
+                "area_code": "122007",
+                "locality": "Sector Road",
+                "name": "Aryan Sharma"
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow2/on_confirm.json
+++ b/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow2/on_confirm.json
@@ -1,0 +1,239 @@
+{
+  "context": {
+    "domain": "ONDC:RET14",
+    "action": "on_confirm",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_id": "api.greenreceipt.in",
+    "bpp_uri": "https://api.greenreceipt.in/ondc",
+    "transaction_id": "851c331a-49d3-47a3-b74b-7ade4ed6de94",
+    "message_id": "4c31836d-5dbd-4208-8b59-048eea57216d",
+    "city": "std:0124",
+    "country": "IND",
+    "timestamp": "2024-07-07T04:25:07.984Z"
+  },
+  "message": {
+    "order": {
+      "id": "2024-07-07-489122",
+      "state": "Created",
+      "provider": {
+        "id": "24932",
+        "locations": [
+          {
+            "id": "24932"
+          }
+        ]
+      },
+      "items": [
+        {
+          "id": "24932_2740436",
+          "fulfillment_id": "24932_F1",
+          "quantity": {
+            "count": 1
+          }
+        },
+        {
+          "id": "24932_2740440",
+          "fulfillment_id": "24932_F1",
+          "quantity": {
+            "count": 2
+          }
+        }
+      ],
+      "billing": {
+        "name": "Aryan Sharma",
+        "address": {
+          "name": "Aryan Sharma",
+          "building": "Club Patio",
+          "locality": "Sector Road",
+          "city": "Gurugram",
+          "state": "Haryana",
+          "country": "IND",
+          "area_code": "122007"
+        },
+        "email": "aryan@buynxt.in",
+        "phone": "8923136015",
+        "created_at": "2024-07-07T04:24:38.077Z",
+        "updated_at": "2024-07-07T04:24:38.077Z"
+      },
+      "fulfillments": [
+        {
+          "id": "24932_F1",
+          "@ondc/org/provider_name": "Ajay Electronics",
+          "state": {
+            "descriptor": {
+              "code": "Pending"
+            }
+          },
+          "type": "Delivery",
+          "tracking": false,
+          "@ondc/org/TAT": "PT4H",
+          "start": {
+            "location": {
+              "id": "24932",
+              "descriptor": {
+                "name": "Ajay Electronics"
+              },
+              "gps": "28.41430316,77.06620157",
+              "address": {
+                "locality": "Nirvana Country",
+                "city": "Gurgaon",
+                "area_code": "122018",
+                "state": "Haryana"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2024-07-07T04:35:07.984Z",
+                "end": "2024-07-07T05:35:07.984Z"
+              }
+            },
+            "contact": {
+              "phone": "8076362934",
+              "email": "Demo3@gmail.com"
+            }
+          },
+          "end": {
+            "location": {
+              "gps": "28.457929,77.067815",
+              "address": {
+                "name": "Aryan Sharma",
+                "building": "Club Patio",
+                "locality": "Sector Road",
+                "city": "Gurugram",
+                "state": "Haryana",
+                "country": "IND",
+                "area_code": "122007"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2024-07-07T07:35:07.984Z",
+                "end": "2024-07-07T08:35:07.984Z"
+              }
+            },
+            "person": {
+              "name": "Aryan Sharma"
+            },
+            "contact": {
+              "phone": "8923136015",
+              "email": "aryan@buynxt.in"
+            }
+          }
+        }
+      ],
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "208970.00"
+        },
+        "breakup": [
+          {
+            "@ondc/org/item_id": "24932_2740436",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "title": "IPHONE 14 256GB MIDNIGHT",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "82990.00"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "82990.00"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "24932_2740440",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "title": "IPHONE 13 128GB BLUE",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "125980.00"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "62990.00"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "24932_F1",
+            "title": "Delivery charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "0.00"
+            }
+          }
+        ],
+        "ttl": "P1D"
+      },
+      "payment": {
+        "uri": "https://razorpay.com/",
+        "tl_method": "http/get",
+        "params": {
+          "currency": "INR",
+          "transaction_id": "order_OVbq6MCyPF7Sg1",
+          "amount": "208970.00"
+        },
+        "status": "PAID",
+        "type": "ON-ORDER",
+        "collected_by": "BAP",
+        "@ondc/org/buyer_app_finder_fee_type": "percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "seller-app",
+            "settlement_phase": "sale-amount",
+            "beneficiary_name": "Buynxt Private Limited",
+            "settlement_type": "neft",
+            "upi_address": "buynxt@okidfc",
+            "settlement_bank_account_no": "10129914936",
+            "settlement_ifsc_code": "IDFB0021001",
+            "bank_name": "IDFC First Bank Limited",
+            "branch_name": "Golf Course Road, Gurgaon"
+          }
+        ]
+      },
+      "tags": [
+        {
+          "code": "bpp_terms",
+          "list": [
+            {
+              "code": "np_type",
+              "value": "MSN"
+            },
+            {
+              "code": "tax_number",
+              "value": "09ALZPS7205J2ZP"
+            },
+            {
+              "code": "provider_tax_number",
+              "value": "CKABS4783R"
+            }
+          ]
+        },
+        {
+          "code": "bap_terms",
+          "list": [
+            {
+              "code": "tax_number",
+              "value": "GSTIN1234567890"
+            }
+          ]
+        }
+      ],
+      "created_at": "2024-07-07T04:25:07.778Z",
+      "updated_at": "2024-07-07T04:25:07.984Z"
+    }
+  }
+}

--- a/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow2/on_init.json
+++ b/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow2/on_init.json
@@ -1,0 +1,171 @@
+{
+  "context": {
+    "domain": "ONDC:RET14",
+    "action": "on_init",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_id": "api.greenreceipt.in",
+    "bpp_uri": "https://api.greenreceipt.in/ondc",
+    "transaction_id": "851c331a-49d3-47a3-b74b-7ade4ed6de94",
+    "message_id": "605423b2-b1b4-4129-96d6-14aeddcc1543",
+    "city": "std:0124",
+    "country": "IND",
+    "timestamp": "2024-07-07T04:24:38.173Z"
+  },
+  "message": {
+    "order": {
+      "provider": {
+        "id": "24932",
+        "locations": [
+          {
+            "id": "24932"
+          }
+        ]
+      },
+      "items": [
+        {
+          "id": "24932_2740436",
+          "fulfillment_id": "24932_F1",
+          "quantity": {
+            "count": 1
+          }
+        },
+        {
+          "id": "24932_2740440",
+          "fulfillment_id": "24932_F1",
+          "quantity": {
+            "count": 2
+          }
+        }
+      ],
+      "billing": {
+        "name": "Aryan Sharma",
+        "address": {
+          "name": "Aryan Sharma",
+          "building": "Club Patio",
+          "locality": "Sector Road",
+          "city": "Gurugram",
+          "state": "Haryana",
+          "country": "IND",
+          "area_code": "122007"
+        },
+        "email": "aryan@buynxt.in",
+        "phone": "8923136015",
+        "created_at": "2024-07-07T04:24:38.077Z",
+        "updated_at": "2024-07-07T04:24:38.077Z"
+      },
+      "fulfillments": [
+        {
+          "id": "24932_F1",
+          "type": "Delivery",
+          "tracking": false,
+          "end": {
+            "location": {
+              "gps": "28.457929,77.067815",
+              "address": {
+                "name": "Aryan Sharma",
+                "building": "Club Patio",
+                "locality": "Sector Road",
+                "city": "Gurugram",
+                "state": "Haryana",
+                "country": "IND",
+                "area_code": "122007"
+              }
+            },
+            "contact": {
+              "phone": "8923136015",
+              "email": "aryan@buynxt.in"
+            }
+          }
+        }
+      ],
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "208970.00"
+        },
+        "breakup": [
+          {
+            "@ondc/org/item_id": "24932_2740436",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "title": "IPHONE 14 256GB MIDNIGHT",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "82990.00"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "82990.00"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "24932_2740440",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "title": "IPHONE 13 128GB BLUE",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "125980.00"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "62990.00"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "24932_F1",
+            "title": "Delivery charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "0.00"
+            }
+          }
+        ],
+        "ttl": "P1D"
+      },
+      "payment": {
+        "@ondc/org/buyer_app_finder_fee_type": "percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "seller-app",
+            "settlement_phase": "sale-amount",
+            "settlement_type": "neft",
+            "beneficiary_name": "Buynxt Private Limited",
+            "upi_address": "buynxt@okidfc",
+            "settlement_bank_account_no": "10129914936",
+            "settlement_ifsc_code": "IDFB0021001",
+            "bank_name": "IDFC First Bank Limited",
+            "branch_name": "Golf Course Road, Gurgaon"
+          }
+        ]
+      },
+      "tags": [
+        {
+          "code": "bpp_terms",
+          "list": [
+            {
+              "code": "tax_number",
+              "value": "09ALZPS7205J2ZP"
+            },
+            {
+              "code": "provider_tax_number",
+              "value": "CKABS4783R"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow2/on_select.json
+++ b/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow2/on_select.json
@@ -1,0 +1,123 @@
+{
+  "context": {
+    "domain": "ONDC:RET14",
+    "action": "on_select",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_id": "api.greenreceipt.in",
+    "bpp_uri": "https://api.greenreceipt.in/ondc",
+    "transaction_id": "851c331a-49d3-47a3-b74b-7ade4ed6de94",
+    "message_id": "f57e25a3-564d-4c0e-984f-8c7f58d5b752",
+    "city": "std:0124",
+    "country": "IND",
+    "timestamp": "2024-07-07T04:24:27.312Z"
+  },
+  "message": {
+    "order": {
+      "provider": {
+        "id": "24932",
+        "locations": [
+          {
+            "id": "24932"
+          }
+        ]
+      },
+      "items": [
+        {
+          "fulfillment_id": "24932_F1",
+          "id": "24932_2740436"
+        },
+        {
+          "fulfillment_id": "24932_F1",
+          "id": "24932_2740440"
+        }
+      ],
+      "fulfillments": [
+        {
+          "id": "24932_F1",
+          "type": "Delivery",
+          "@ondc/org/provider_name": "Ajay Electronics",
+          "tracking": false,
+          "@ondc/org/category": "Standard Delivery",
+          "@ondc/org/TAT": "PT4H",
+          "state": {
+            "descriptor": {
+              "code": "Serviceable"
+            }
+          }
+        }
+      ],
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "208970.00"
+        },
+        "breakup": [
+          {
+            "@ondc/org/item_id": "24932_2740436",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "title": "IPHONE 14 256GB MIDNIGHT",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "82990.00"
+            },
+            "item": {
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "82990.00"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "24932_2740440",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "title": "IPHONE 13 128GB BLUE",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "125980.00"
+            },
+            "item": {
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "62990.00"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "24932_F1",
+            "title": "Delivery charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "0.00"
+            }
+          }
+        ],
+        "ttl": "PT4H"
+      }
+    }
+  }
+}

--- a/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow2/on_status_delivered.json
+++ b/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow2/on_status_delivered.json
@@ -1,0 +1,230 @@
+{
+  "context": {
+    "domain": "ONDC:RET14",
+    "action": "on_status",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_id": "api.greenreceipt.in",
+    "bpp_uri": "https://api.greenreceipt.in/ondc",
+    "transaction_id": "851c331a-49d3-47a3-b74b-7ade4ed6de94",
+    "message_id": "172847e5-c7ba-44e9-9ad3-b5dd2847ec92",
+    "city": "std:0124",
+    "country": "IND",
+    "timestamp": "2024-07-07T04:35:28.918Z",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "id": "2024-07-07-489122",
+      "state": "Completed",
+      "provider": {
+        "id": "24932",
+        "locations": [
+          {
+            "id": "24932"
+          }
+        ]
+      },
+      "items": [
+        {
+          "id": "24932_2740436",
+          "fulfillment_id": "24932_F1",
+          "quantity": {
+            "count": 1
+          }
+        },
+        {
+          "id": "24932_2740440",
+          "fulfillment_id": "24932_F1",
+          "quantity": {
+            "count": 2
+          }
+        }
+      ],
+      "billing": {
+        "name": "Aryan Sharma",
+        "address": {
+          "name": "Aryan Sharma",
+          "building": "Club Patio",
+          "locality": "Sector Road",
+          "city": "Gurugram",
+          "state": "Haryana",
+          "country": "IND",
+          "area_code": "122007"
+        },
+        "email": "aryan@buynxt.in",
+        "phone": "8923136015",
+        "created_at": "2024-07-07T04:24:38.077Z",
+        "updated_at": "2024-07-07T04:24:38.077Z"
+      },
+      "fulfillments": [
+        {
+          "id": "24932_F1",
+          "@ondc/org/provider_name": "Ajay Electronics",
+          "type": "Delivery",
+          "tracking": false,
+          "@ondc/org/TAT": "PT4H",
+          "state": {
+            "descriptor": {
+              "code": "Order-delivered"
+            }
+          },
+          "start": {
+            "location": {
+              "descriptor": {
+                "name": "Ajay Electronics"
+              },
+              "gps": "28.41430316,77.06620157",
+              "address": {
+                "locality": "Nirvana Country",
+                "city": "Gurgaon",
+                "state": "Haryana",
+                "area_code": "122018"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2024-07-07T04:35:07.984Z",
+                "end": "2024-07-07T05:35:07.984Z"
+              },
+              "timestamp": "2024-07-07T04:31:48.593Z"
+            },
+            "contact": {
+              "phone": "8076362934",
+              "email": "Demo3@gmail.com"
+            }
+          },
+          "end": {
+            "location": {
+              "gps": "28.457929,77.067815",
+              "address": {
+                "name": "Aryan Sharma",
+                "building": "Club Patio",
+                "locality": "Sector Road",
+                "city": "Gurugram",
+                "state": "Haryana",
+                "country": "IND",
+                "area_code": "122007"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2024-07-07T07:35:07.984Z",
+                "end": "2024-07-07T08:35:07.984Z"
+              },
+              "timestamp": "2024-07-07T04:35:28.820Z"
+            },
+            "person": {
+              "name": "Aryan Sharma"
+            },
+            "contact": {
+              "phone": "8923136015",
+              "email": "aryan@buynxt.in"
+            }
+          },
+          "tags": [
+            {
+              "code": "routing",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "P2P"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "208970.00"
+        },
+        "breakup": [
+          {
+            "@ondc/org/item_id": "24932_2740436",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "title": "IPHONE 14 256GB MIDNIGHT",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "82990.00"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "82990.00"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "24932_2740440",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "title": "IPHONE 13 128GB BLUE",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "125980.00"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "62990.00"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "24932_F1",
+            "title": "Delivery charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "0.00"
+            }
+          }
+        ],
+        "ttl": "PT4H"
+      },
+      "payment": {
+        "uri": "https://razorpay.com/",
+        "tl_method": "http/get",
+        "params": {
+          "currency": "INR",
+          "transaction_id": "order_OVbq6MCyPF7Sg1",
+          "amount": "208970.00"
+        },
+        "status": "PAID",
+        "type": "ON-ORDER",
+        "collected_by": "BAP",
+        "@ondc/org/buyer_app_finder_fee_type": "percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "seller-app",
+            "settlement_phase": "sale-amount",
+            "beneficiary_name": "Buynxt Private Limited",
+            "settlement_type": "neft",
+            "upi_address": "buynxt@okidfc",
+            "settlement_bank_account_no": "10129914936",
+            "settlement_ifsc_code": "IDFB0021001",
+            "bank_name": "IDFC First Bank Limited",
+            "branch_name": "Golf Course Road, Gurgaon"
+          }
+        ]
+      },
+      "documents": [
+        {
+          "url": "https://greenreceipt.in/invoices/2024-07-07-489122.pdf",
+          "label": "Invoice"
+        }
+      ],
+      "created_at": "2024-07-07T04:25:07.778Z",
+      "updated_at": "2024-07-07T04:35:28.918Z"
+    }
+  }
+}

--- a/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow2/on_status_out_for_delivery.json
+++ b/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow2/on_status_out_for_delivery.json
@@ -1,0 +1,229 @@
+{
+  "context": {
+    "domain": "ONDC:RET14",
+    "action": "on_status",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_id": "api.greenreceipt.in",
+    "bpp_uri": "https://api.greenreceipt.in/ondc",
+    "transaction_id": "851c331a-49d3-47a3-b74b-7ade4ed6de94",
+    "message_id": "98e8f440-ce6f-4e10-9c7e-a0d15c924da4",
+    "city": "std:0124",
+    "country": "IND",
+    "timestamp": "2024-07-07T04:32:58.237Z",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "id": "2024-07-07-489122",
+      "state": "In-progress",
+      "provider": {
+        "id": "24932",
+        "locations": [
+          {
+            "id": "24932"
+          }
+        ]
+      },
+      "items": [
+        {
+          "id": "24932_2740436",
+          "fulfillment_id": "24932_F1",
+          "quantity": {
+            "count": 1
+          }
+        },
+        {
+          "id": "24932_2740440",
+          "fulfillment_id": "24932_F1",
+          "quantity": {
+            "count": 2
+          }
+        }
+      ],
+      "billing": {
+        "name": "Aryan Sharma",
+        "address": {
+          "name": "Aryan Sharma",
+          "building": "Club Patio",
+          "locality": "Sector Road",
+          "city": "Gurugram",
+          "state": "Haryana",
+          "country": "IND",
+          "area_code": "122007"
+        },
+        "email": "aryan@buynxt.in",
+        "phone": "8923136015",
+        "created_at": "2024-07-07T04:24:38.077Z",
+        "updated_at": "2024-07-07T04:24:38.077Z"
+      },
+      "fulfillments": [
+        {
+          "id": "24932_F1",
+          "@ondc/org/provider_name": "Ajay Electronics",
+          "type": "Delivery",
+          "tracking": false,
+          "@ondc/org/TAT": "PT4H",
+          "state": {
+            "descriptor": {
+              "code": "Out-for-delivery"
+            }
+          },
+          "start": {
+            "location": {
+              "descriptor": {
+                "name": "Ajay Electronics"
+              },
+              "gps": "28.41430316,77.06620157",
+              "address": {
+                "locality": "Nirvana Country",
+                "city": "Gurgaon",
+                "state": "Haryana",
+                "area_code": "122018"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2024-07-07T04:35:07.984Z",
+                "end": "2024-07-07T05:35:07.984Z"
+              },
+              "timestamp": "2024-07-07T04:31:48.593Z"
+            },
+            "contact": {
+              "phone": "8076362934",
+              "email": "Demo3@gmail.com"
+            }
+          },
+          "end": {
+            "location": {
+              "gps": "28.457929,77.067815",
+              "address": {
+                "name": "Aryan Sharma",
+                "building": "Club Patio",
+                "locality": "Sector Road",
+                "city": "Gurugram",
+                "state": "Haryana",
+                "country": "IND",
+                "area_code": "122007"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2024-07-07T07:35:07.984Z",
+                "end": "2024-07-07T08:35:07.984Z"
+              }
+            },
+            "person": {
+              "name": "Aryan Sharma"
+            },
+            "contact": {
+              "phone": "8923136015",
+              "email": "aryan@buynxt.in"
+            }
+          },
+          "tags": [
+            {
+              "code": "routing",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "P2P"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "208970.00"
+        },
+        "breakup": [
+          {
+            "@ondc/org/item_id": "24932_2740436",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "title": "IPHONE 14 256GB MIDNIGHT",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "82990.00"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "82990.00"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "24932_2740440",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "title": "IPHONE 13 128GB BLUE",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "125980.00"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "62990.00"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "24932_F1",
+            "title": "Delivery charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "0.00"
+            }
+          }
+        ],
+        "ttl": "PT4H"
+      },
+      "payment": {
+        "uri": "https://razorpay.com/",
+        "tl_method": "http/get",
+        "params": {
+          "currency": "INR",
+          "transaction_id": "order_OVbq6MCyPF7Sg1",
+          "amount": "208970.00"
+        },
+        "status": "PAID",
+        "type": "ON-ORDER",
+        "collected_by": "BAP",
+        "@ondc/org/buyer_app_finder_fee_type": "percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "seller-app",
+            "settlement_phase": "sale-amount",
+            "beneficiary_name": "Buynxt Private Limited",
+            "settlement_type": "neft",
+            "upi_address": "buynxt@okidfc",
+            "settlement_bank_account_no": "10129914936",
+            "settlement_ifsc_code": "IDFB0021001",
+            "bank_name": "IDFC First Bank Limited",
+            "branch_name": "Golf Course Road, Gurgaon"
+          }
+        ]
+      },
+      "documents": [
+        {
+          "url": "https://greenreceipt.in/invoices/2024-07-07-489122.pdf",
+          "label": "Invoice"
+        }
+      ],
+      "created_at": "2024-07-07T04:25:07.778Z",
+      "updated_at": "2024-07-07T04:32:58.237Z"
+    }
+  }
+}

--- a/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow2/on_status_packed.json
+++ b/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow2/on_status_packed.json
@@ -1,0 +1,222 @@
+{
+  "context": {
+    "domain": "ONDC:RET14",
+    "action": "on_status",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_id": "api.greenreceipt.in",
+    "bpp_uri": "https://api.greenreceipt.in/ondc",
+    "transaction_id": "851c331a-49d3-47a3-b74b-7ade4ed6de94",
+    "message_id": "89443138-15b9-49c7-b175-65e5c4a9cbf3",
+    "city": "std:0124",
+    "country": "IND",
+    "timestamp": "2024-07-07T04:31:48.673Z",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "id": "2024-07-07-489122",
+      "state": "In-progress",
+      "provider": {
+        "id": "24932",
+        "locations": [
+          {
+            "id": "24932"
+          }
+        ]
+      },
+      "items": [
+        {
+          "id": "24932_2740436",
+          "fulfillment_id": "24932_F1",
+          "quantity": {
+            "count": 1
+          }
+        },
+        {
+          "id": "24932_2740440",
+          "fulfillment_id": "24932_F1",
+          "quantity": {
+            "count": 2
+          }
+        }
+      ],
+      "billing": {
+        "name": "Aryan Sharma",
+        "address": {
+          "name": "Aryan Sharma",
+          "building": "Club Patio",
+          "locality": "Sector Road",
+          "city": "Gurugram",
+          "state": "Haryana",
+          "country": "IND",
+          "area_code": "122007"
+        },
+        "email": "aryan@buynxt.in",
+        "phone": "8923136015",
+        "created_at": "2024-07-07T04:24:38.077Z",
+        "updated_at": "2024-07-07T04:24:38.077Z"
+      },
+      "fulfillments": [
+        {
+          "id": "24932_F1",
+          "@ondc/org/provider_name": "Ajay Electronics",
+          "type": "Delivery",
+          "tracking": false,
+          "@ondc/org/TAT": "PT4H",
+          "state": {
+            "descriptor": {
+              "code": "Packed"
+            }
+          },
+          "start": {
+            "location": {
+              "descriptor": {
+                "name": "Ajay Electronics"
+              },
+              "gps": "28.41430316,77.06620157",
+              "address": {
+                "locality": "Nirvana Country",
+                "city": "Gurgaon",
+                "state": "Haryana",
+                "area_code": "122018"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2024-07-07T04:35:07.984Z",
+                "end": "2024-07-07T05:35:07.984Z"
+              }
+            },
+            "contact": {
+              "phone": "8076362934",
+              "email": "Demo3@gmail.com"
+            }
+          },
+          "end": {
+            "location": {
+              "gps": "28.457929,77.067815",
+              "address": {
+                "name": "Aryan Sharma",
+                "building": "Club Patio",
+                "locality": "Sector Road",
+                "city": "Gurugram",
+                "state": "Haryana",
+                "country": "IND",
+                "area_code": "122007"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2024-07-07T07:35:07.984Z",
+                "end": "2024-07-07T08:35:07.984Z"
+              }
+            },
+            "person": {
+              "name": "Aryan Sharma"
+            },
+            "contact": {
+              "phone": "8923136015",
+              "email": "aryan@buynxt.in"
+            }
+          },
+          "tags": [
+            {
+              "code": "routing",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "P2P"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "208970.00"
+        },
+        "breakup": [
+          {
+            "@ondc/org/item_id": "24932_2740436",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "title": "IPHONE 14 256GB MIDNIGHT",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "82990.00"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "82990.00"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "24932_2740440",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "title": "IPHONE 13 128GB BLUE",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "125980.00"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "62990.00"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "24932_F1",
+            "title": "Delivery charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "0.00"
+            }
+          }
+        ],
+        "ttl": "PT4H"
+      },
+      "payment": {
+        "uri": "https://razorpay.com/",
+        "tl_method": "http/get",
+        "params": {
+          "currency": "INR",
+          "transaction_id": "order_OVbq6MCyPF7Sg1",
+          "amount": "208970.00"
+        },
+        "status": "PAID",
+        "type": "ON-ORDER",
+        "collected_by": "BAP",
+        "@ondc/org/buyer_app_finder_fee_type": "percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "seller-app",
+            "settlement_phase": "sale-amount",
+            "beneficiary_name": "Buynxt Private Limited",
+            "settlement_type": "neft",
+            "upi_address": "buynxt@okidfc",
+            "settlement_bank_account_no": "10129914936",
+            "settlement_ifsc_code": "IDFB0021001",
+            "bank_name": "IDFC First Bank Limited",
+            "branch_name": "Golf Course Road, Gurgaon"
+          }
+        ]
+      },
+      "created_at": "2024-07-07T04:25:07.778Z",
+      "updated_at": "2024-07-07T04:31:48.673Z"
+    }
+  }
+}

--- a/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow2/on_status_pending.json
+++ b/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow2/on_status_pending.json
@@ -1,0 +1,222 @@
+{
+  "context": {
+    "domain": "ONDC:RET14",
+    "action": "on_status",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_id": "api.greenreceipt.in",
+    "bpp_uri": "https://api.greenreceipt.in/ondc",
+    "transaction_id": "851c331a-49d3-47a3-b74b-7ade4ed6de94",
+    "message_id": "3a118b8d-aef9-4753-8eb9-b1173a464776",
+    "city": "std:0124",
+    "country": "IND",
+    "timestamp": "2024-07-07T04:31:03.513Z",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "id": "2024-07-07-489122",
+      "state": "Accepted",
+      "provider": {
+        "id": "24932",
+        "locations": [
+          {
+            "id": "24932"
+          }
+        ]
+      },
+      "items": [
+        {
+          "id": "24932_2740436",
+          "fulfillment_id": "24932_F1",
+          "quantity": {
+            "count": 1
+          }
+        },
+        {
+          "id": "24932_2740440",
+          "fulfillment_id": "24932_F1",
+          "quantity": {
+            "count": 2
+          }
+        }
+      ],
+      "billing": {
+        "name": "Aryan Sharma",
+        "address": {
+          "name": "Aryan Sharma",
+          "building": "Club Patio",
+          "locality": "Sector Road",
+          "city": "Gurugram",
+          "state": "Haryana",
+          "country": "IND",
+          "area_code": "122007"
+        },
+        "email": "aryan@buynxt.in",
+        "phone": "8923136015",
+        "created_at": "2024-07-07T04:24:38.077Z",
+        "updated_at": "2024-07-07T04:24:38.077Z"
+      },
+      "fulfillments": [
+        {
+          "id": "24932_F1",
+          "@ondc/org/provider_name": "Ajay Electronics",
+          "type": "Delivery",
+          "tracking": false,
+          "@ondc/org/TAT": "PT4H",
+          "state": {
+            "descriptor": {
+              "code": "Pending"
+            }
+          },
+          "start": {
+            "location": {
+              "descriptor": {
+                "name": "Ajay Electronics"
+              },
+              "gps": "28.41430316,77.06620157",
+              "address": {
+                "locality": "Nirvana Country",
+                "city": "Gurgaon",
+                "state": "Haryana",
+                "area_code": "122018"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2024-07-07T04:35:07.984Z",
+                "end": "2024-07-07T05:35:07.984Z"
+              }
+            },
+            "contact": {
+              "phone": "8076362934",
+              "email": "Demo3@gmail.com"
+            }
+          },
+          "end": {
+            "location": {
+              "gps": "28.457929,77.067815",
+              "address": {
+                "name": "Aryan Sharma",
+                "building": "Club Patio",
+                "locality": "Sector Road",
+                "city": "Gurugram",
+                "state": "Haryana",
+                "country": "IND",
+                "area_code": "122007"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2024-07-07T07:35:07.984Z",
+                "end": "2024-07-07T08:35:07.984Z"
+              }
+            },
+            "person": {
+              "name": "Aryan Sharma"
+            },
+            "contact": {
+              "phone": "8923136015",
+              "email": "aryan@buynxt.in"
+            }
+          },
+          "tags": [
+            {
+              "code": "routing",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "P2P"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "208970.00"
+        },
+        "breakup": [
+          {
+            "@ondc/org/item_id": "24932_2740436",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "title": "IPHONE 14 256GB MIDNIGHT",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "82990.00"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "82990.00"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "24932_2740440",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "title": "IPHONE 13 128GB BLUE",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "125980.00"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "62990.00"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "24932_F1",
+            "title": "Delivery charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "0.00"
+            }
+          }
+        ],
+        "ttl": "PT4H"
+      },
+      "payment": {
+        "uri": "https://razorpay.com/",
+        "tl_method": "http/get",
+        "params": {
+          "currency": "INR",
+          "transaction_id": "order_OVbq6MCyPF7Sg1",
+          "amount": "208970.00"
+        },
+        "status": "PAID",
+        "type": "ON-ORDER",
+        "collected_by": "BAP",
+        "@ondc/org/buyer_app_finder_fee_type": "percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "seller-app",
+            "settlement_phase": "sale-amount",
+            "beneficiary_name": "Buynxt Private Limited",
+            "settlement_type": "neft",
+            "upi_address": "buynxt@okidfc",
+            "settlement_bank_account_no": "10129914936",
+            "settlement_ifsc_code": "IDFB0021001",
+            "bank_name": "IDFC First Bank Limited",
+            "branch_name": "Golf Course Road, Gurgaon"
+          }
+        ]
+      },
+      "created_at": "2024-07-07T04:25:07.778Z",
+      "updated_at": "2024-07-07T04:31:03.513Z"
+    }
+  }
+}

--- a/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow2/on_status_picked.json
+++ b/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow2/on_status_picked.json
@@ -1,0 +1,229 @@
+{
+  "context": {
+    "domain": "ONDC:RET14",
+    "action": "on_status",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_id": "api.greenreceipt.in",
+    "bpp_uri": "https://api.greenreceipt.in/ondc",
+    "transaction_id": "851c331a-49d3-47a3-b74b-7ade4ed6de94",
+    "message_id": "f7a27d21-7300-43ac-a91b-2bc8aad716c1",
+    "city": "std:0124",
+    "country": "IND",
+    "timestamp": "2024-07-07T04:31:51.729Z",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "id": "2024-07-07-489122",
+      "state": "In-progress",
+      "provider": {
+        "id": "24932",
+        "locations": [
+          {
+            "id": "24932"
+          }
+        ]
+      },
+      "items": [
+        {
+          "id": "24932_2740436",
+          "fulfillment_id": "24932_F1",
+          "quantity": {
+            "count": 1
+          }
+        },
+        {
+          "id": "24932_2740440",
+          "fulfillment_id": "24932_F1",
+          "quantity": {
+            "count": 2
+          }
+        }
+      ],
+      "billing": {
+        "name": "Aryan Sharma",
+        "address": {
+          "name": "Aryan Sharma",
+          "building": "Club Patio",
+          "locality": "Sector Road",
+          "city": "Gurugram",
+          "state": "Haryana",
+          "country": "IND",
+          "area_code": "122007"
+        },
+        "email": "aryan@buynxt.in",
+        "phone": "8923136015",
+        "created_at": "2024-07-07T04:24:38.077Z",
+        "updated_at": "2024-07-07T04:24:38.077Z"
+      },
+      "fulfillments": [
+        {
+          "id": "24932_F1",
+          "@ondc/org/provider_name": "Ajay Electronics",
+          "type": "Delivery",
+          "tracking": false,
+          "@ondc/org/TAT": "PT4H",
+          "state": {
+            "descriptor": {
+              "code": "Order-picked-up"
+            }
+          },
+          "start": {
+            "location": {
+              "descriptor": {
+                "name": "Ajay Electronics"
+              },
+              "gps": "28.41430316,77.06620157",
+              "address": {
+                "locality": "Nirvana Country",
+                "city": "Gurgaon",
+                "state": "Haryana",
+                "area_code": "122018"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2024-07-07T04:35:07.984Z",
+                "end": "2024-07-07T05:35:07.984Z"
+              },
+              "timestamp": "2024-07-07T04:31:48.593Z"
+            },
+            "contact": {
+              "phone": "8076362934",
+              "email": "Demo3@gmail.com"
+            }
+          },
+          "end": {
+            "location": {
+              "gps": "28.457929,77.067815",
+              "address": {
+                "name": "Aryan Sharma",
+                "building": "Club Patio",
+                "locality": "Sector Road",
+                "city": "Gurugram",
+                "state": "Haryana",
+                "country": "IND",
+                "area_code": "122007"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2024-07-07T07:35:07.984Z",
+                "end": "2024-07-07T08:35:07.984Z"
+              }
+            },
+            "person": {
+              "name": "Aryan Sharma"
+            },
+            "contact": {
+              "phone": "8923136015",
+              "email": "aryan@buynxt.in"
+            }
+          },
+          "tags": [
+            {
+              "code": "routing",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "P2P"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "208970.00"
+        },
+        "breakup": [
+          {
+            "@ondc/org/item_id": "24932_2740436",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "title": "IPHONE 14 256GB MIDNIGHT",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "82990.00"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "82990.00"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "24932_2740440",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "title": "IPHONE 13 128GB BLUE",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "125980.00"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "62990.00"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "24932_F1",
+            "title": "Delivery charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "0.00"
+            }
+          }
+        ],
+        "ttl": "PT4H"
+      },
+      "payment": {
+        "uri": "https://razorpay.com/",
+        "tl_method": "http/get",
+        "params": {
+          "currency": "INR",
+          "transaction_id": "order_OVbq6MCyPF7Sg1",
+          "amount": "208970.00"
+        },
+        "status": "PAID",
+        "type": "ON-ORDER",
+        "collected_by": "BAP",
+        "@ondc/org/buyer_app_finder_fee_type": "percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "seller-app",
+            "settlement_phase": "sale-amount",
+            "beneficiary_name": "Buynxt Private Limited",
+            "settlement_type": "neft",
+            "upi_address": "buynxt@okidfc",
+            "settlement_bank_account_no": "10129914936",
+            "settlement_ifsc_code": "IDFB0021001",
+            "bank_name": "IDFC First Bank Limited",
+            "branch_name": "Golf Course Road, Gurgaon"
+          }
+        ]
+      },
+      "documents": [
+        {
+          "url": "https://greenreceipt.in/invoices/2024-07-07-489122.pdf",
+          "label": "Invoice"
+        }
+      ],
+      "created_at": "2024-07-07T04:25:07.778Z",
+      "updated_at": "2024-07-07T04:31:51.729Z"
+    }
+  }
+}

--- a/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow2/select.json
+++ b/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow2/select.json
@@ -1,0 +1,57 @@
+{
+  "context": {
+    "domain": "ONDC:RET14",
+    "country": "IND",
+    "city": "std:0124",
+    "action": "select",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_uri": "https://api.greenreceipt.in/ondc",
+    "transaction_id": "851c331a-49d3-47a3-b74b-7ade4ed6de94",
+    "message_id": "f57e25a3-564d-4c0e-984f-8c7f58d5b752",
+    "timestamp": "2024-07-07T04:24:27.208Z",
+    "bpp_id": "api.greenreceipt.in",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "items": [
+        {
+          "id": "24932_2740436",
+          "quantity": {
+            "count": 1
+          },
+          "location_id": "24932"
+        },
+        {
+          "id": "24932_2740440",
+          "quantity": {
+            "count": 2
+          },
+          "location_id": "24932"
+        }
+      ],
+      "provider": {
+        "id": "24932",
+        "locations": [
+          {
+            "id": "24932"
+          }
+        ]
+      },
+      "fulfillments": [
+        {
+          "end": {
+            "location": {
+              "gps": "28.457929,77.067815",
+              "address": {
+                "area_code": "122007"
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow2_log_utility_resp.json
+++ b/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow2_log_utility_resp.json
@@ -1,0 +1,13 @@
+{
+    "success": true,
+    "response": {
+        "message": "Logs were verified successfully",
+        "report": {},
+        "bpp_id": "api.greenreceipt.in",
+        "bap_id": "buyer-app-preprod-v2.ondc.org",
+        "domain": "ONDC:RET14",
+        "reportTimestamp": "2024-07-11T11:38:58.588Z"
+    },
+    "signature": "JE/ngf6IKFRqCrNNFml1wcDon9/11OlmbMKmmppbrn0qtIo/UqiC/t7uZ4VShPgt0zZtiGpMcwSPnnc9no0cAw==",
+    "signTimestamp": "2024-07-11T11:38:58.588Z"
+}

--- a/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow3/confirm.json
+++ b/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow3/confirm.json
@@ -1,0 +1,199 @@
+{
+  "context": {
+    "domain": "ONDC:RET14",
+    "country": "IND",
+    "city": "std:0124",
+    "action": "confirm",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_uri": "https://api.greenreceipt.in/ondc",
+    "transaction_id": "2e1d802c-f70a-4a13-ba24-df754af1f04e",
+    "message_id": "8bcdaa5e-77d3-4c61-8b5c-0790f78aede9",
+    "timestamp": "2024-07-07T04:53:42.012Z",
+    "bpp_id": "api.greenreceipt.in",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "id": "2024-07-07-605590",
+      "state": "Created",
+      "billing": {
+        "address": {
+          "name": "Aryan Sharma",
+          "building": "Club Patio",
+          "locality": "Sector Road",
+          "city": "Gurugram",
+          "state": "Haryana",
+          "country": "IND",
+          "area_code": "122007"
+        },
+        "phone": "8923136015",
+        "name": "Aryan Sharma",
+        "email": "aryan@buynxt.in",
+        "created_at": "2024-07-07T04:53:17.043Z",
+        "updated_at": "2024-07-07T04:53:17.043Z"
+      },
+      "items": [
+        {
+          "id": "24932_2740436",
+          "quantity": {
+            "count": 1
+          },
+          "fulfillment_id": "24932_F1"
+        },
+        {
+          "id": "24932_2740440",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "24932_F1"
+        }
+      ],
+      "provider": {
+        "id": "24932",
+        "locations": [
+          {
+            "id": "24932"
+          }
+        ]
+      },
+      "fulfillments": [
+        {
+          "@ondc/org/TAT": "PT4H",
+          "id": "24932_F1",
+          "tracking": false,
+          "end": {
+            "contact": {
+              "email": "aryan@buynxt.in",
+              "phone": "8923136015"
+            },
+            "person": {
+              "name": "Aryan Sharma"
+            },
+            "location": {
+              "gps": "28.457929,77.067815",
+              "address": {
+                "name": "Aryan Sharma",
+                "building": "Club Patio",
+                "locality": "Sector Road",
+                "city": "Gurugram",
+                "state": "Haryana",
+                "country": "IND",
+                "area_code": "122007"
+              }
+            }
+          },
+          "type": "Delivery"
+        }
+      ],
+      "payment": {
+        "uri": "https://razorpay.com/",
+        "tl_method": "http/get",
+        "params": {
+          "amount": "208970.00",
+          "currency": "INR",
+          "transaction_id": "order_OVcKLtellmT7Rg"
+        },
+        "status": "PAID",
+        "type": "ON-ORDER",
+        "collected_by": "BAP",
+        "@ondc/org/buyer_app_finder_fee_type": "percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "seller-app",
+            "settlement_phase": "sale-amount",
+            "settlement_type": "neft",
+            "beneficiary_name": "Buynxt Private Limited",
+            "upi_address": "buynxt@okidfc",
+            "settlement_bank_account_no": "10129914936",
+            "settlement_ifsc_code": "IDFB0021001",
+            "bank_name": "IDFC First Bank Limited",
+            "branch_name": "Golf Course Road, Gurgaon"
+          }
+        ]
+      },
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "208970.00"
+        },
+        "breakup": [
+          {
+            "@ondc/org/item_id": "24932_2740436",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "title": "IPHONE 14 256GB MIDNIGHT",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "82990.00"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "82990.00"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "24932_2740440",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "title": "IPHONE 13 128GB BLUE",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "125980.00"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "62990.00"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "24932_F1",
+            "title": "Delivery charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "0.00"
+            }
+          }
+        ],
+        "ttl": "P1D"
+      },
+      "tags": [
+        {
+          "code": "bpp_terms",
+          "list": [
+            {
+              "code": "tax_number",
+              "value": "09ALZPS7205J2ZP"
+            },
+            {
+              "code": "provider_tax_number",
+              "value": "CKABS4783R"
+            }
+          ]
+        },
+        {
+          "code": "bap_terms",
+          "list": [
+            {
+              "code": "tax_number",
+              "value": "GSTIN1234567890"
+            }
+          ]
+        }
+      ],
+      "created_at": "2024-07-07T04:53:42.012Z",
+      "updated_at": "2024-07-07T04:53:42.012Z"
+    }
+  }
+}

--- a/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow3/init.json
+++ b/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow3/init.json
@@ -1,0 +1,87 @@
+{
+  "context": {
+    "domain": "ONDC:RET14",
+    "country": "IND",
+    "city": "std:0124",
+    "action": "init",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_uri": "https://api.greenreceipt.in/ondc",
+    "transaction_id": "2e1d802c-f70a-4a13-ba24-df754af1f04e",
+    "message_id": "22ccd0a5-5fc9-47f6-9d8c-f8ed7232d795",
+    "timestamp": "2024-07-07T04:53:17.043Z",
+    "bpp_id": "api.greenreceipt.in",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "provider": {
+        "id": "24932",
+        "locations": [
+          {
+            "id": "24932"
+          }
+        ]
+      },
+      "items": [
+        {
+          "id": "24932_2740436",
+          "quantity": {
+            "count": 1
+          },
+          "location_id": "24932",
+          "fulfillment_id": "24932_F1"
+        },
+        {
+          "id": "24932_2740440",
+          "quantity": {
+            "count": 2
+          },
+          "location_id": "24932",
+          "fulfillment_id": "24932_F1"
+        }
+      ],
+      "billing": {
+        "address": {
+          "building": "Club Patio",
+          "city": "Gurugram",
+          "state": "Haryana",
+          "country": "IND",
+          "area_code": "122007",
+          "locality": "Sector Road",
+          "name": "Aryan Sharma"
+        },
+        "phone": "8923136015",
+        "name": "Aryan Sharma",
+        "email": "aryan@buynxt.in",
+        "created_at": "2024-07-07T04:53:17.043Z",
+        "updated_at": "2024-07-07T04:53:17.043Z"
+      },
+      "fulfillments": [
+        {
+          "id": "24932_F1",
+          "type": "Delivery",
+          "end": {
+            "contact": {
+              "email": "aryan@buynxt.in",
+              "phone": "8923136015"
+            },
+            "location": {
+              "gps": "28.457929,77.067815",
+              "address": {
+                "building": "Club Patio",
+                "city": "Gurugram",
+                "state": "Haryana",
+                "country": "IND",
+                "area_code": "122007",
+                "locality": "Sector Road",
+                "name": "Aryan Sharma"
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow3/on_confirm.json
+++ b/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow3/on_confirm.json
@@ -1,0 +1,239 @@
+{
+  "context": {
+    "domain": "ONDC:RET14",
+    "action": "on_confirm",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_id": "api.greenreceipt.in",
+    "bpp_uri": "https://api.greenreceipt.in/ondc",
+    "transaction_id": "2e1d802c-f70a-4a13-ba24-df754af1f04e",
+    "message_id": "8bcdaa5e-77d3-4c61-8b5c-0790f78aede9",
+    "city": "std:0124",
+    "country": "IND",
+    "timestamp": "2024-07-07T04:53:42.096Z"
+  },
+  "message": {
+    "order": {
+      "id": "2024-07-07-605590",
+      "state": "Created",
+      "provider": {
+        "id": "24932",
+        "locations": [
+          {
+            "id": "24932"
+          }
+        ]
+      },
+      "items": [
+        {
+          "id": "24932_2740436",
+          "fulfillment_id": "24932_F1",
+          "quantity": {
+            "count": 1
+          }
+        },
+        {
+          "id": "24932_2740440",
+          "fulfillment_id": "24932_F1",
+          "quantity": {
+            "count": 2
+          }
+        }
+      ],
+      "billing": {
+        "name": "Aryan Sharma",
+        "address": {
+          "name": "Aryan Sharma",
+          "building": "Club Patio",
+          "locality": "Sector Road",
+          "city": "Gurugram",
+          "state": "Haryana",
+          "country": "IND",
+          "area_code": "122007"
+        },
+        "email": "aryan@buynxt.in",
+        "phone": "8923136015",
+        "created_at": "2024-07-07T04:53:17.043Z",
+        "updated_at": "2024-07-07T04:53:17.043Z"
+      },
+      "fulfillments": [
+        {
+          "id": "24932_F1",
+          "@ondc/org/provider_name": "Ajay Electronics",
+          "state": {
+            "descriptor": {
+              "code": "Pending"
+            }
+          },
+          "type": "Delivery",
+          "tracking": false,
+          "@ondc/org/TAT": "PT4H",
+          "start": {
+            "location": {
+              "id": "24932",
+              "descriptor": {
+                "name": "Ajay Electronics"
+              },
+              "gps": "28.41430316,77.06620157",
+              "address": {
+                "locality": "Nirvana Country",
+                "city": "Gurgaon",
+                "area_code": "122018",
+                "state": "Haryana"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2024-07-07T05:03:42.096Z",
+                "end": "2024-07-07T06:03:42.096Z"
+              }
+            },
+            "contact": {
+              "phone": "8076362934",
+              "email": "Demo3@gmail.com"
+            }
+          },
+          "end": {
+            "location": {
+              "gps": "28.457929,77.067815",
+              "address": {
+                "name": "Aryan Sharma",
+                "building": "Club Patio",
+                "locality": "Sector Road",
+                "city": "Gurugram",
+                "state": "Haryana",
+                "country": "IND",
+                "area_code": "122007"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2024-07-07T08:03:42.096Z",
+                "end": "2024-07-07T09:03:42.096Z"
+              }
+            },
+            "person": {
+              "name": "Aryan Sharma"
+            },
+            "contact": {
+              "phone": "8923136015",
+              "email": "aryan@buynxt.in"
+            }
+          }
+        }
+      ],
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "208970.00"
+        },
+        "breakup": [
+          {
+            "@ondc/org/item_id": "24932_2740436",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "title": "IPHONE 14 256GB MIDNIGHT",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "82990.00"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "82990.00"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "24932_2740440",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "title": "IPHONE 13 128GB BLUE",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "125980.00"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "62990.00"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "24932_F1",
+            "title": "Delivery charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "0.00"
+            }
+          }
+        ],
+        "ttl": "P1D"
+      },
+      "payment": {
+        "uri": "https://razorpay.com/",
+        "tl_method": "http/get",
+        "params": {
+          "currency": "INR",
+          "transaction_id": "order_OVcKLtellmT7Rg",
+          "amount": "208970.00"
+        },
+        "status": "PAID",
+        "type": "ON-ORDER",
+        "collected_by": "BAP",
+        "@ondc/org/buyer_app_finder_fee_type": "percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "seller-app",
+            "settlement_phase": "sale-amount",
+            "beneficiary_name": "Buynxt Private Limited",
+            "settlement_type": "neft",
+            "upi_address": "buynxt@okidfc",
+            "settlement_bank_account_no": "10129914936",
+            "settlement_ifsc_code": "IDFB0021001",
+            "bank_name": "IDFC First Bank Limited",
+            "branch_name": "Golf Course Road, Gurgaon"
+          }
+        ]
+      },
+      "tags": [
+        {
+          "code": "bpp_terms",
+          "list": [
+            {
+              "code": "np_type",
+              "value": "MSN"
+            },
+            {
+              "code": "tax_number",
+              "value": "09ALZPS7205J2ZP"
+            },
+            {
+              "code": "provider_tax_number",
+              "value": "CKABS4783R"
+            }
+          ]
+        },
+        {
+          "code": "bap_terms",
+          "list": [
+            {
+              "code": "tax_number",
+              "value": "GSTIN1234567890"
+            }
+          ]
+        }
+      ],
+      "created_at": "2024-07-07T04:53:42.012Z",
+      "updated_at": "2024-07-07T04:53:42.096Z"
+    }
+  }
+}

--- a/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow3/on_init.json
+++ b/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow3/on_init.json
@@ -1,0 +1,171 @@
+{
+  "context": {
+    "domain": "ONDC:RET14",
+    "action": "on_init",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_id": "api.greenreceipt.in",
+    "bpp_uri": "https://api.greenreceipt.in/ondc",
+    "transaction_id": "2e1d802c-f70a-4a13-ba24-df754af1f04e",
+    "message_id": "22ccd0a5-5fc9-47f6-9d8c-f8ed7232d795",
+    "city": "std:0124",
+    "country": "IND",
+    "timestamp": "2024-07-07T04:53:17.117Z"
+  },
+  "message": {
+    "order": {
+      "provider": {
+        "id": "24932",
+        "locations": [
+          {
+            "id": "24932"
+          }
+        ]
+      },
+      "items": [
+        {
+          "id": "24932_2740436",
+          "fulfillment_id": "24932_F1",
+          "quantity": {
+            "count": 1
+          }
+        },
+        {
+          "id": "24932_2740440",
+          "fulfillment_id": "24932_F1",
+          "quantity": {
+            "count": 2
+          }
+        }
+      ],
+      "billing": {
+        "name": "Aryan Sharma",
+        "address": {
+          "name": "Aryan Sharma",
+          "building": "Club Patio",
+          "locality": "Sector Road",
+          "city": "Gurugram",
+          "state": "Haryana",
+          "country": "IND",
+          "area_code": "122007"
+        },
+        "email": "aryan@buynxt.in",
+        "phone": "8923136015",
+        "created_at": "2024-07-07T04:53:17.043Z",
+        "updated_at": "2024-07-07T04:53:17.043Z"
+      },
+      "fulfillments": [
+        {
+          "id": "24932_F1",
+          "type": "Delivery",
+          "tracking": false,
+          "end": {
+            "location": {
+              "gps": "28.457929,77.067815",
+              "address": {
+                "name": "Aryan Sharma",
+                "building": "Club Patio",
+                "locality": "Sector Road",
+                "city": "Gurugram",
+                "state": "Haryana",
+                "country": "IND",
+                "area_code": "122007"
+              }
+            },
+            "contact": {
+              "phone": "8923136015",
+              "email": "aryan@buynxt.in"
+            }
+          }
+        }
+      ],
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "208970.00"
+        },
+        "breakup": [
+          {
+            "@ondc/org/item_id": "24932_2740436",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "title": "IPHONE 14 256GB MIDNIGHT",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "82990.00"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "82990.00"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "24932_2740440",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "title": "IPHONE 13 128GB BLUE",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "125980.00"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "62990.00"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "24932_F1",
+            "title": "Delivery charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "0.00"
+            }
+          }
+        ],
+        "ttl": "P1D"
+      },
+      "payment": {
+        "@ondc/org/buyer_app_finder_fee_type": "percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "seller-app",
+            "settlement_phase": "sale-amount",
+            "settlement_type": "neft",
+            "beneficiary_name": "Buynxt Private Limited",
+            "upi_address": "buynxt@okidfc",
+            "settlement_bank_account_no": "10129914936",
+            "settlement_ifsc_code": "IDFB0021001",
+            "bank_name": "IDFC First Bank Limited",
+            "branch_name": "Golf Course Road, Gurgaon"
+          }
+        ]
+      },
+      "tags": [
+        {
+          "code": "bpp_terms",
+          "list": [
+            {
+              "code": "tax_number",
+              "value": "09ALZPS7205J2ZP"
+            },
+            {
+              "code": "provider_tax_number",
+              "value": "CKABS4783R"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow3/on_select.json
+++ b/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow3/on_select.json
@@ -1,0 +1,123 @@
+{
+  "context": {
+    "domain": "ONDC:RET14",
+    "action": "on_select",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_id": "api.greenreceipt.in",
+    "bpp_uri": "https://api.greenreceipt.in/ondc",
+    "transaction_id": "2e1d802c-f70a-4a13-ba24-df754af1f04e",
+    "message_id": "457c27fa-29fc-4949-b1da-d89549f3ab13",
+    "city": "std:0124",
+    "country": "IND",
+    "timestamp": "2024-07-07T04:53:05.266Z"
+  },
+  "message": {
+    "order": {
+      "provider": {
+        "id": "24932",
+        "locations": [
+          {
+            "id": "24932"
+          }
+        ]
+      },
+      "items": [
+        {
+          "fulfillment_id": "24932_F1",
+          "id": "24932_2740436"
+        },
+        {
+          "fulfillment_id": "24932_F1",
+          "id": "24932_2740440"
+        }
+      ],
+      "fulfillments": [
+        {
+          "id": "24932_F1",
+          "type": "Delivery",
+          "@ondc/org/provider_name": "Ajay Electronics",
+          "tracking": false,
+          "@ondc/org/category": "Standard Delivery",
+          "@ondc/org/TAT": "PT4H",
+          "state": {
+            "descriptor": {
+              "code": "Serviceable"
+            }
+          }
+        }
+      ],
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "208970.00"
+        },
+        "breakup": [
+          {
+            "@ondc/org/item_id": "24932_2740436",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "title": "IPHONE 14 256GB MIDNIGHT",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "82990.00"
+            },
+            "item": {
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "82990.00"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "24932_2740440",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "title": "IPHONE 13 128GB BLUE",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "125980.00"
+            },
+            "item": {
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "62990.00"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "24932_F1",
+            "title": "Delivery charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "0.00"
+            }
+          }
+        ],
+        "ttl": "PT4H"
+      }
+    }
+  }
+}

--- a/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow3/on_select_out_of_stock.json
+++ b/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow3/on_select_out_of_stock.json
@@ -1,0 +1,158 @@
+{
+  "context": {
+    "domain": "ONDC:RET14",
+    "action": "on_select",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_id": "api.greenreceipt.in",
+    "bpp_uri": "https://api.greenreceipt.in/ondc",
+    "transaction_id": "2e1d802c-f70a-4a13-ba24-df754af1f04e",
+    "message_id": "6eb08289-ad04-4cf0-925f-290b248ef7cd",
+    "city": "std:0124",
+    "country": "IND",
+    "timestamp": "2024-07-07T04:52:47.145Z"
+  },
+  "message": {
+    "order": {
+      "provider": {
+        "id": "24932",
+        "locations": [
+          {
+            "id": "24932"
+          }
+        ]
+      },
+      "items": [
+        {
+          "fulfillment_id": "24932_F1",
+          "id": "24932_2740436"
+        },
+        {
+          "fulfillment_id": "24932_F1",
+          "id": "24932_2740440"
+        },
+        {
+          "fulfillment_id": "24932_F1",
+          "id": "24932_2740441"
+        }
+      ],
+      "fulfillments": [
+        {
+          "id": "24932_F1",
+          "type": "Delivery",
+          "@ondc/org/provider_name": "Ajay Electronics",
+          "tracking": false,
+          "@ondc/org/category": "Standard Delivery",
+          "@ondc/org/TAT": "PT4H",
+          "state": {
+            "descriptor": {
+              "code": "Serviceable"
+            }
+          }
+        }
+      ],
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "208970.00"
+        },
+        "breakup": [
+          {
+            "@ondc/org/item_id": "24932_2740436",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "title": "IPHONE 14 256GB MIDNIGHT",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "82990.00"
+            },
+            "item": {
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "82990.00"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "24932_2740440",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "title": "IPHONE 13 128GB BLUE",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "125980.00"
+            },
+            "item": {
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "62990.00"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "24932_2740441",
+            "@ondc/org/item_quantity": {
+              "count": 0
+            },
+            "title": "IPHONE 13 128GB MIDNIGHT",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "0.00"
+            },
+            "item": {
+              "quantity": {
+                "available": {
+                  "count": "0"
+                },
+                "maximum": {
+                  "count": "0"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "62990.00"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "24932_F1",
+            "title": "Delivery charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "0.00"
+            }
+          }
+        ],
+        "ttl": "PT4H"
+      }
+    }
+  },
+  "error": {
+    "type": "DOMAIN-ERROR",
+    "code": "40002",
+    "message": "[{\"item_id\":\"24932_2740441\",\"error\":\"40002\"}]"
+  }
+}

--- a/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow3/on_status_delivered.json
+++ b/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow3/on_status_delivered.json
@@ -1,0 +1,230 @@
+{
+  "context": {
+    "domain": "ONDC:RET14",
+    "action": "on_status",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_id": "api.greenreceipt.in",
+    "bpp_uri": "https://api.greenreceipt.in/ondc",
+    "transaction_id": "2e1d802c-f70a-4a13-ba24-df754af1f04e",
+    "message_id": "3f6e8833-c3ba-418f-9939-31aea063c24c",
+    "city": "std:0124",
+    "country": "IND",
+    "timestamp": "2024-07-07T04:59:42.609Z",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "id": "2024-07-07-605590",
+      "state": "Completed",
+      "provider": {
+        "id": "24932",
+        "locations": [
+          {
+            "id": "24932"
+          }
+        ]
+      },
+      "items": [
+        {
+          "id": "24932_2740436",
+          "fulfillment_id": "24932_F1",
+          "quantity": {
+            "count": 1
+          }
+        },
+        {
+          "id": "24932_2740440",
+          "fulfillment_id": "24932_F1",
+          "quantity": {
+            "count": 2
+          }
+        }
+      ],
+      "billing": {
+        "name": "Aryan Sharma",
+        "address": {
+          "name": "Aryan Sharma",
+          "building": "Club Patio",
+          "locality": "Sector Road",
+          "city": "Gurugram",
+          "state": "Haryana",
+          "country": "IND",
+          "area_code": "122007"
+        },
+        "email": "aryan@buynxt.in",
+        "phone": "8923136015",
+        "created_at": "2024-07-07T04:53:17.043Z",
+        "updated_at": "2024-07-07T04:53:17.043Z"
+      },
+      "fulfillments": [
+        {
+          "id": "24932_F1",
+          "@ondc/org/provider_name": "Ajay Electronics",
+          "type": "Delivery",
+          "tracking": false,
+          "@ondc/org/TAT": "PT4H",
+          "state": {
+            "descriptor": {
+              "code": "Order-delivered"
+            }
+          },
+          "start": {
+            "location": {
+              "descriptor": {
+                "name": "Ajay Electronics"
+              },
+              "gps": "28.41430316,77.06620157",
+              "address": {
+                "locality": "Nirvana Country",
+                "city": "Gurgaon",
+                "state": "Haryana",
+                "area_code": "122018"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2024-07-07T05:03:42.096Z",
+                "end": "2024-07-07T06:03:42.096Z"
+              },
+              "timestamp": "2024-07-07T04:57:23.360Z"
+            },
+            "contact": {
+              "phone": "8076362934",
+              "email": "Demo3@gmail.com"
+            }
+          },
+          "end": {
+            "location": {
+              "gps": "28.457929,77.067815",
+              "address": {
+                "name": "Aryan Sharma",
+                "building": "Club Patio",
+                "locality": "Sector Road",
+                "city": "Gurugram",
+                "state": "Haryana",
+                "country": "IND",
+                "area_code": "122007"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2024-07-07T08:03:42.096Z",
+                "end": "2024-07-07T09:03:42.096Z"
+              },
+              "timestamp": "2024-07-07T04:59:42.530Z"
+            },
+            "person": {
+              "name": "Aryan Sharma"
+            },
+            "contact": {
+              "phone": "8923136015",
+              "email": "aryan@buynxt.in"
+            }
+          },
+          "tags": [
+            {
+              "code": "routing",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "P2P"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "208970.00"
+        },
+        "breakup": [
+          {
+            "@ondc/org/item_id": "24932_2740436",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "title": "IPHONE 14 256GB MIDNIGHT",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "82990.00"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "82990.00"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "24932_2740440",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "title": "IPHONE 13 128GB BLUE",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "125980.00"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "62990.00"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "24932_F1",
+            "title": "Delivery charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "0.00"
+            }
+          }
+        ],
+        "ttl": "PT4H"
+      },
+      "payment": {
+        "uri": "https://razorpay.com/",
+        "tl_method": "http/get",
+        "params": {
+          "currency": "INR",
+          "transaction_id": "order_OVcKLtellmT7Rg",
+          "amount": "208970.00"
+        },
+        "status": "PAID",
+        "type": "ON-ORDER",
+        "collected_by": "BAP",
+        "@ondc/org/buyer_app_finder_fee_type": "percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "seller-app",
+            "settlement_phase": "sale-amount",
+            "beneficiary_name": "Buynxt Private Limited",
+            "settlement_type": "neft",
+            "upi_address": "buynxt@okidfc",
+            "settlement_bank_account_no": "10129914936",
+            "settlement_ifsc_code": "IDFB0021001",
+            "bank_name": "IDFC First Bank Limited",
+            "branch_name": "Golf Course Road, Gurgaon"
+          }
+        ]
+      },
+      "documents": [
+        {
+          "url": "https://greenreceipt.in/invoices/2024-07-07-605590.pdf",
+          "label": "Invoice"
+        }
+      ],
+      "created_at": "2024-07-07T04:53:42.012Z",
+      "updated_at": "2024-07-07T04:59:42.609Z"
+    }
+  }
+}

--- a/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow3/on_status_out_for_delivery.json
+++ b/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow3/on_status_out_for_delivery.json
@@ -1,0 +1,229 @@
+{
+  "context": {
+    "domain": "ONDC:RET14",
+    "action": "on_status",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_id": "api.greenreceipt.in",
+    "bpp_uri": "https://api.greenreceipt.in/ondc",
+    "transaction_id": "2e1d802c-f70a-4a13-ba24-df754af1f04e",
+    "message_id": "d463e117-4ac9-4e69-b077-ddc3fafa84bf",
+    "city": "std:0124",
+    "country": "IND",
+    "timestamp": "2024-07-07T04:58:32.738Z",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "id": "2024-07-07-605590",
+      "state": "In-progress",
+      "provider": {
+        "id": "24932",
+        "locations": [
+          {
+            "id": "24932"
+          }
+        ]
+      },
+      "items": [
+        {
+          "id": "24932_2740436",
+          "fulfillment_id": "24932_F1",
+          "quantity": {
+            "count": 1
+          }
+        },
+        {
+          "id": "24932_2740440",
+          "fulfillment_id": "24932_F1",
+          "quantity": {
+            "count": 2
+          }
+        }
+      ],
+      "billing": {
+        "name": "Aryan Sharma",
+        "address": {
+          "name": "Aryan Sharma",
+          "building": "Club Patio",
+          "locality": "Sector Road",
+          "city": "Gurugram",
+          "state": "Haryana",
+          "country": "IND",
+          "area_code": "122007"
+        },
+        "email": "aryan@buynxt.in",
+        "phone": "8923136015",
+        "created_at": "2024-07-07T04:53:17.043Z",
+        "updated_at": "2024-07-07T04:53:17.043Z"
+      },
+      "fulfillments": [
+        {
+          "id": "24932_F1",
+          "@ondc/org/provider_name": "Ajay Electronics",
+          "type": "Delivery",
+          "tracking": false,
+          "@ondc/org/TAT": "PT4H",
+          "state": {
+            "descriptor": {
+              "code": "Out-for-delivery"
+            }
+          },
+          "start": {
+            "location": {
+              "descriptor": {
+                "name": "Ajay Electronics"
+              },
+              "gps": "28.41430316,77.06620157",
+              "address": {
+                "locality": "Nirvana Country",
+                "city": "Gurgaon",
+                "state": "Haryana",
+                "area_code": "122018"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2024-07-07T05:03:42.096Z",
+                "end": "2024-07-07T06:03:42.096Z"
+              },
+              "timestamp": "2024-07-07T04:57:23.360Z"
+            },
+            "contact": {
+              "phone": "8076362934",
+              "email": "Demo3@gmail.com"
+            }
+          },
+          "end": {
+            "location": {
+              "gps": "28.457929,77.067815",
+              "address": {
+                "name": "Aryan Sharma",
+                "building": "Club Patio",
+                "locality": "Sector Road",
+                "city": "Gurugram",
+                "state": "Haryana",
+                "country": "IND",
+                "area_code": "122007"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2024-07-07T08:03:42.096Z",
+                "end": "2024-07-07T09:03:42.096Z"
+              }
+            },
+            "person": {
+              "name": "Aryan Sharma"
+            },
+            "contact": {
+              "phone": "8923136015",
+              "email": "aryan@buynxt.in"
+            }
+          },
+          "tags": [
+            {
+              "code": "routing",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "P2P"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "208970.00"
+        },
+        "breakup": [
+          {
+            "@ondc/org/item_id": "24932_2740436",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "title": "IPHONE 14 256GB MIDNIGHT",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "82990.00"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "82990.00"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "24932_2740440",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "title": "IPHONE 13 128GB BLUE",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "125980.00"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "62990.00"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "24932_F1",
+            "title": "Delivery charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "0.00"
+            }
+          }
+        ],
+        "ttl": "PT4H"
+      },
+      "payment": {
+        "uri": "https://razorpay.com/",
+        "tl_method": "http/get",
+        "params": {
+          "currency": "INR",
+          "transaction_id": "order_OVcKLtellmT7Rg",
+          "amount": "208970.00"
+        },
+        "status": "PAID",
+        "type": "ON-ORDER",
+        "collected_by": "BAP",
+        "@ondc/org/buyer_app_finder_fee_type": "percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "seller-app",
+            "settlement_phase": "sale-amount",
+            "beneficiary_name": "Buynxt Private Limited",
+            "settlement_type": "neft",
+            "upi_address": "buynxt@okidfc",
+            "settlement_bank_account_no": "10129914936",
+            "settlement_ifsc_code": "IDFB0021001",
+            "bank_name": "IDFC First Bank Limited",
+            "branch_name": "Golf Course Road, Gurgaon"
+          }
+        ]
+      },
+      "documents": [
+        {
+          "url": "https://greenreceipt.in/invoices/2024-07-07-605590.pdf",
+          "label": "Invoice"
+        }
+      ],
+      "created_at": "2024-07-07T04:53:42.012Z",
+      "updated_at": "2024-07-07T04:58:32.738Z"
+    }
+  }
+}

--- a/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow3/on_status_packed.json
+++ b/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow3/on_status_packed.json
@@ -1,0 +1,222 @@
+{
+  "context": {
+    "domain": "ONDC:RET14",
+    "action": "on_status",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_id": "api.greenreceipt.in",
+    "bpp_uri": "https://api.greenreceipt.in/ondc",
+    "transaction_id": "2e1d802c-f70a-4a13-ba24-df754af1f04e",
+    "message_id": "a5eef1ba-bffc-45a7-9061-ca4716fb9a12",
+    "city": "std:0124",
+    "country": "IND",
+    "timestamp": "2024-07-07T04:57:23.428Z",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "id": "2024-07-07-605590",
+      "state": "In-progress",
+      "provider": {
+        "id": "24932",
+        "locations": [
+          {
+            "id": "24932"
+          }
+        ]
+      },
+      "items": [
+        {
+          "id": "24932_2740436",
+          "fulfillment_id": "24932_F1",
+          "quantity": {
+            "count": 1
+          }
+        },
+        {
+          "id": "24932_2740440",
+          "fulfillment_id": "24932_F1",
+          "quantity": {
+            "count": 2
+          }
+        }
+      ],
+      "billing": {
+        "name": "Aryan Sharma",
+        "address": {
+          "name": "Aryan Sharma",
+          "building": "Club Patio",
+          "locality": "Sector Road",
+          "city": "Gurugram",
+          "state": "Haryana",
+          "country": "IND",
+          "area_code": "122007"
+        },
+        "email": "aryan@buynxt.in",
+        "phone": "8923136015",
+        "created_at": "2024-07-07T04:53:17.043Z",
+        "updated_at": "2024-07-07T04:53:17.043Z"
+      },
+      "fulfillments": [
+        {
+          "id": "24932_F1",
+          "@ondc/org/provider_name": "Ajay Electronics",
+          "type": "Delivery",
+          "tracking": false,
+          "@ondc/org/TAT": "PT4H",
+          "state": {
+            "descriptor": {
+              "code": "Packed"
+            }
+          },
+          "start": {
+            "location": {
+              "descriptor": {
+                "name": "Ajay Electronics"
+              },
+              "gps": "28.41430316,77.06620157",
+              "address": {
+                "locality": "Nirvana Country",
+                "city": "Gurgaon",
+                "state": "Haryana",
+                "area_code": "122018"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2024-07-07T05:03:42.096Z",
+                "end": "2024-07-07T06:03:42.096Z"
+              }
+            },
+            "contact": {
+              "phone": "8076362934",
+              "email": "Demo3@gmail.com"
+            }
+          },
+          "end": {
+            "location": {
+              "gps": "28.457929,77.067815",
+              "address": {
+                "name": "Aryan Sharma",
+                "building": "Club Patio",
+                "locality": "Sector Road",
+                "city": "Gurugram",
+                "state": "Haryana",
+                "country": "IND",
+                "area_code": "122007"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2024-07-07T08:03:42.096Z",
+                "end": "2024-07-07T09:03:42.096Z"
+              }
+            },
+            "person": {
+              "name": "Aryan Sharma"
+            },
+            "contact": {
+              "phone": "8923136015",
+              "email": "aryan@buynxt.in"
+            }
+          },
+          "tags": [
+            {
+              "code": "routing",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "P2P"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "208970.00"
+        },
+        "breakup": [
+          {
+            "@ondc/org/item_id": "24932_2740436",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "title": "IPHONE 14 256GB MIDNIGHT",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "82990.00"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "82990.00"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "24932_2740440",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "title": "IPHONE 13 128GB BLUE",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "125980.00"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "62990.00"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "24932_F1",
+            "title": "Delivery charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "0.00"
+            }
+          }
+        ],
+        "ttl": "PT4H"
+      },
+      "payment": {
+        "uri": "https://razorpay.com/",
+        "tl_method": "http/get",
+        "params": {
+          "currency": "INR",
+          "transaction_id": "order_OVcKLtellmT7Rg",
+          "amount": "208970.00"
+        },
+        "status": "PAID",
+        "type": "ON-ORDER",
+        "collected_by": "BAP",
+        "@ondc/org/buyer_app_finder_fee_type": "percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "seller-app",
+            "settlement_phase": "sale-amount",
+            "beneficiary_name": "Buynxt Private Limited",
+            "settlement_type": "neft",
+            "upi_address": "buynxt@okidfc",
+            "settlement_bank_account_no": "10129914936",
+            "settlement_ifsc_code": "IDFB0021001",
+            "bank_name": "IDFC First Bank Limited",
+            "branch_name": "Golf Course Road, Gurgaon"
+          }
+        ]
+      },
+      "created_at": "2024-07-07T04:53:42.012Z",
+      "updated_at": "2024-07-07T04:57:23.428Z"
+    }
+  }
+}

--- a/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow3/on_status_pending.json
+++ b/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow3/on_status_pending.json
@@ -1,0 +1,222 @@
+{
+  "context": {
+    "domain": "ONDC:RET14",
+    "action": "on_status",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_id": "api.greenreceipt.in",
+    "bpp_uri": "https://api.greenreceipt.in/ondc",
+    "transaction_id": "2e1d802c-f70a-4a13-ba24-df754af1f04e",
+    "message_id": "b2ab3746-377d-4f09-874e-1448aabe262b",
+    "city": "std:0124",
+    "country": "IND",
+    "timestamp": "2024-07-07T04:55:44.744Z",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "id": "2024-07-07-605590",
+      "state": "Accepted",
+      "provider": {
+        "id": "24932",
+        "locations": [
+          {
+            "id": "24932"
+          }
+        ]
+      },
+      "items": [
+        {
+          "id": "24932_2740436",
+          "fulfillment_id": "24932_F1",
+          "quantity": {
+            "count": 1
+          }
+        },
+        {
+          "id": "24932_2740440",
+          "fulfillment_id": "24932_F1",
+          "quantity": {
+            "count": 2
+          }
+        }
+      ],
+      "billing": {
+        "name": "Aryan Sharma",
+        "address": {
+          "name": "Aryan Sharma",
+          "building": "Club Patio",
+          "locality": "Sector Road",
+          "city": "Gurugram",
+          "state": "Haryana",
+          "country": "IND",
+          "area_code": "122007"
+        },
+        "email": "aryan@buynxt.in",
+        "phone": "8923136015",
+        "created_at": "2024-07-07T04:53:17.043Z",
+        "updated_at": "2024-07-07T04:53:17.043Z"
+      },
+      "fulfillments": [
+        {
+          "id": "24932_F1",
+          "@ondc/org/provider_name": "Ajay Electronics",
+          "type": "Delivery",
+          "tracking": false,
+          "@ondc/org/TAT": "PT4H",
+          "state": {
+            "descriptor": {
+              "code": "Pending"
+            }
+          },
+          "start": {
+            "location": {
+              "descriptor": {
+                "name": "Ajay Electronics"
+              },
+              "gps": "28.41430316,77.06620157",
+              "address": {
+                "locality": "Nirvana Country",
+                "city": "Gurgaon",
+                "state": "Haryana",
+                "area_code": "122018"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2024-07-07T05:03:42.096Z",
+                "end": "2024-07-07T06:03:42.096Z"
+              }
+            },
+            "contact": {
+              "phone": "8076362934",
+              "email": "Demo3@gmail.com"
+            }
+          },
+          "end": {
+            "location": {
+              "gps": "28.457929,77.067815",
+              "address": {
+                "name": "Aryan Sharma",
+                "building": "Club Patio",
+                "locality": "Sector Road",
+                "city": "Gurugram",
+                "state": "Haryana",
+                "country": "IND",
+                "area_code": "122007"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2024-07-07T08:03:42.096Z",
+                "end": "2024-07-07T09:03:42.096Z"
+              }
+            },
+            "person": {
+              "name": "Aryan Sharma"
+            },
+            "contact": {
+              "phone": "8923136015",
+              "email": "aryan@buynxt.in"
+            }
+          },
+          "tags": [
+            {
+              "code": "routing",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "P2P"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "208970.00"
+        },
+        "breakup": [
+          {
+            "@ondc/org/item_id": "24932_2740436",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "title": "IPHONE 14 256GB MIDNIGHT",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "82990.00"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "82990.00"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "24932_2740440",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "title": "IPHONE 13 128GB BLUE",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "125980.00"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "62990.00"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "24932_F1",
+            "title": "Delivery charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "0.00"
+            }
+          }
+        ],
+        "ttl": "PT4H"
+      },
+      "payment": {
+        "uri": "https://razorpay.com/",
+        "tl_method": "http/get",
+        "params": {
+          "currency": "INR",
+          "transaction_id": "order_OVcKLtellmT7Rg",
+          "amount": "208970.00"
+        },
+        "status": "PAID",
+        "type": "ON-ORDER",
+        "collected_by": "BAP",
+        "@ondc/org/buyer_app_finder_fee_type": "percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "seller-app",
+            "settlement_phase": "sale-amount",
+            "beneficiary_name": "Buynxt Private Limited",
+            "settlement_type": "neft",
+            "upi_address": "buynxt@okidfc",
+            "settlement_bank_account_no": "10129914936",
+            "settlement_ifsc_code": "IDFB0021001",
+            "bank_name": "IDFC First Bank Limited",
+            "branch_name": "Golf Course Road, Gurgaon"
+          }
+        ]
+      },
+      "created_at": "2024-07-07T04:53:42.012Z",
+      "updated_at": "2024-07-07T04:55:44.744Z"
+    }
+  }
+}

--- a/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow3/on_status_picked.json
+++ b/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow3/on_status_picked.json
@@ -1,0 +1,229 @@
+{
+  "context": {
+    "domain": "ONDC:RET14",
+    "action": "on_status",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_id": "api.greenreceipt.in",
+    "bpp_uri": "https://api.greenreceipt.in/ondc",
+    "transaction_id": "2e1d802c-f70a-4a13-ba24-df754af1f04e",
+    "message_id": "a1504b19-f835-48c9-8068-4512be517657",
+    "city": "std:0124",
+    "country": "IND",
+    "timestamp": "2024-07-07T04:57:26.738Z",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "id": "2024-07-07-605590",
+      "state": "In-progress",
+      "provider": {
+        "id": "24932",
+        "locations": [
+          {
+            "id": "24932"
+          }
+        ]
+      },
+      "items": [
+        {
+          "id": "24932_2740436",
+          "fulfillment_id": "24932_F1",
+          "quantity": {
+            "count": 1
+          }
+        },
+        {
+          "id": "24932_2740440",
+          "fulfillment_id": "24932_F1",
+          "quantity": {
+            "count": 2
+          }
+        }
+      ],
+      "billing": {
+        "name": "Aryan Sharma",
+        "address": {
+          "name": "Aryan Sharma",
+          "building": "Club Patio",
+          "locality": "Sector Road",
+          "city": "Gurugram",
+          "state": "Haryana",
+          "country": "IND",
+          "area_code": "122007"
+        },
+        "email": "aryan@buynxt.in",
+        "phone": "8923136015",
+        "created_at": "2024-07-07T04:53:17.043Z",
+        "updated_at": "2024-07-07T04:53:17.043Z"
+      },
+      "fulfillments": [
+        {
+          "id": "24932_F1",
+          "@ondc/org/provider_name": "Ajay Electronics",
+          "type": "Delivery",
+          "tracking": false,
+          "@ondc/org/TAT": "PT4H",
+          "state": {
+            "descriptor": {
+              "code": "Order-picked-up"
+            }
+          },
+          "start": {
+            "location": {
+              "descriptor": {
+                "name": "Ajay Electronics"
+              },
+              "gps": "28.41430316,77.06620157",
+              "address": {
+                "locality": "Nirvana Country",
+                "city": "Gurgaon",
+                "state": "Haryana",
+                "area_code": "122018"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2024-07-07T05:03:42.096Z",
+                "end": "2024-07-07T06:03:42.096Z"
+              },
+              "timestamp": "2024-07-07T04:57:23.360Z"
+            },
+            "contact": {
+              "phone": "8076362934",
+              "email": "Demo3@gmail.com"
+            }
+          },
+          "end": {
+            "location": {
+              "gps": "28.457929,77.067815",
+              "address": {
+                "name": "Aryan Sharma",
+                "building": "Club Patio",
+                "locality": "Sector Road",
+                "city": "Gurugram",
+                "state": "Haryana",
+                "country": "IND",
+                "area_code": "122007"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2024-07-07T08:03:42.096Z",
+                "end": "2024-07-07T09:03:42.096Z"
+              }
+            },
+            "person": {
+              "name": "Aryan Sharma"
+            },
+            "contact": {
+              "phone": "8923136015",
+              "email": "aryan@buynxt.in"
+            }
+          },
+          "tags": [
+            {
+              "code": "routing",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "P2P"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "208970.00"
+        },
+        "breakup": [
+          {
+            "@ondc/org/item_id": "24932_2740436",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "title": "IPHONE 14 256GB MIDNIGHT",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "82990.00"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "82990.00"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "24932_2740440",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "title": "IPHONE 13 128GB BLUE",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "125980.00"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "62990.00"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "24932_F1",
+            "title": "Delivery charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "0.00"
+            }
+          }
+        ],
+        "ttl": "PT4H"
+      },
+      "payment": {
+        "uri": "https://razorpay.com/",
+        "tl_method": "http/get",
+        "params": {
+          "currency": "INR",
+          "transaction_id": "order_OVcKLtellmT7Rg",
+          "amount": "208970.00"
+        },
+        "status": "PAID",
+        "type": "ON-ORDER",
+        "collected_by": "BAP",
+        "@ondc/org/buyer_app_finder_fee_type": "percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "seller-app",
+            "settlement_phase": "sale-amount",
+            "beneficiary_name": "Buynxt Private Limited",
+            "settlement_type": "neft",
+            "upi_address": "buynxt@okidfc",
+            "settlement_bank_account_no": "10129914936",
+            "settlement_ifsc_code": "IDFB0021001",
+            "bank_name": "IDFC First Bank Limited",
+            "branch_name": "Golf Course Road, Gurgaon"
+          }
+        ]
+      },
+      "documents": [
+        {
+          "url": "https://greenreceipt.in/invoices/2024-07-07-605590.pdf",
+          "label": "Invoice"
+        }
+      ],
+      "created_at": "2024-07-07T04:53:42.012Z",
+      "updated_at": "2024-07-07T04:57:26.738Z"
+    }
+  }
+}

--- a/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow3/select.json
+++ b/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow3/select.json
@@ -1,0 +1,57 @@
+{
+  "context": {
+    "domain": "ONDC:RET14",
+    "country": "IND",
+    "city": "std:0124",
+    "action": "select",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_uri": "https://api.greenreceipt.in/ondc",
+    "transaction_id": "2e1d802c-f70a-4a13-ba24-df754af1f04e",
+    "message_id": "457c27fa-29fc-4949-b1da-d89549f3ab13",
+    "timestamp": "2024-07-07T04:53:05.198Z",
+    "bpp_id": "api.greenreceipt.in",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "items": [
+        {
+          "id": "24932_2740436",
+          "quantity": {
+            "count": 1
+          },
+          "location_id": "24932"
+        },
+        {
+          "id": "24932_2740440",
+          "quantity": {
+            "count": 2
+          },
+          "location_id": "24932"
+        }
+      ],
+      "provider": {
+        "id": "24932",
+        "locations": [
+          {
+            "id": "24932"
+          }
+        ]
+      },
+      "fulfillments": [
+        {
+          "end": {
+            "location": {
+              "gps": "28.457929,77.067815",
+              "address": {
+                "area_code": "122007"
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow3/select_out_of_stock.json
+++ b/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow3/select_out_of_stock.json
@@ -1,0 +1,64 @@
+{
+  "context": {
+    "domain": "ONDC:RET14",
+    "country": "IND",
+    "city": "std:0124",
+    "action": "select",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_uri": "https://api.greenreceipt.in/ondc",
+    "transaction_id": "2e1d802c-f70a-4a13-ba24-df754af1f04e",
+    "message_id": "6eb08289-ad04-4cf0-925f-290b248ef7cd",
+    "timestamp": "2024-07-07T04:52:47.065Z",
+    "bpp_id": "api.greenreceipt.in",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "items": [
+        {
+          "id": "24932_2740436",
+          "quantity": {
+            "count": 1
+          },
+          "location_id": "24932"
+        },
+        {
+          "id": "24932_2740440",
+          "quantity": {
+            "count": 2
+          },
+          "location_id": "24932"
+        },
+        {
+          "id": "24932_2740441",
+          "quantity": {
+            "count": 1
+          },
+          "location_id": "24932"
+        }
+      ],
+      "provider": {
+        "id": "24932",
+        "locations": [
+          {
+            "id": "24932"
+          }
+        ]
+      },
+      "fulfillments": [
+        {
+          "end": {
+            "location": {
+              "gps": "28.457929,77.067815",
+              "address": {
+                "area_code": "122007"
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow3_log_utility_resp.json
+++ b/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow3_log_utility_resp.json
@@ -1,0 +1,13 @@
+{
+    "success": true,
+    "response": {
+        "message": "Logs were verified successfully",
+        "report": {},
+        "bpp_id": "api.greenreceipt.in",
+        "bap_id": "buyer-app-preprod-v2.ondc.org",
+        "domain": "ONDC:RET14",
+        "reportTimestamp": "2024-07-11T11:39:16.619Z"
+    },
+    "signature": "l4K46YnqNZaswspNZ9fqttb3Dut72uFpn5afyn0Wjx2aUQRZaL4EMVyvRALBBqWwhcZFVQfCQlahDQ11lyyZCg==",
+    "signTimestamp": "2024-07-11T11:39:16.619Z"
+}

--- a/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow4/cancel.json
+++ b/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow4/cancel.json
@@ -1,0 +1,21 @@
+{
+  "context": {
+    "domain": "ONDC:RET14",
+    "country": "IND",
+    "city": "std:0124",
+    "action": "cancel",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_uri": "https://api.greenreceipt.in/ondc",
+    "transaction_id": "5a32ae09-3fe7-4d8f-9108-8b83d86cba0a",
+    "message_id": "c53d1bc0-0c93-479d-a305-27ad19575494",
+    "timestamp": "2024-07-07T04:38:58.836Z",
+    "bpp_id": "api.greenreceipt.in",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order_id": "2024-07-07-227368",
+    "cancellation_reason_id": "003"
+  }
+}

--- a/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow4/confirm.json
+++ b/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow4/confirm.json
@@ -1,0 +1,199 @@
+{
+    "context": {
+      "domain": "ONDC:RET14",
+      "country": "IND",
+      "city": "std:0124",
+      "action": "confirm",
+      "core_version": "1.2.0",
+      "bap_id": "buyer-app-preprod-v2.ondc.org",
+      "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+      "bpp_uri": "https://api.greenreceipt.in/ondc",
+      "transaction_id": "5a32ae09-3fe7-4d8f-9108-8b83d86cba0a",
+      "message_id": "ded8e6a5-9cd3-474f-94e9-6550a07130b3",
+      "timestamp": "2024-07-07T04:38:30.363Z",
+      "bpp_id": "api.greenreceipt.in",
+      "ttl": "PT30S"
+    },
+    "message": {
+      "order": {
+        "id": "2024-07-07-227368",
+        "state": "Created",
+        "billing": {
+          "address": {
+            "name": "Aryan Sharma",
+            "building": "Club Patio",
+            "locality": "Sector Road",
+            "city": "Gurugram",
+            "state": "Haryana",
+            "country": "IND",
+            "area_code": "122007"
+          },
+          "phone": "8923136015",
+          "name": "Aryan Sharma",
+          "email": "aryan@buynxt.in",
+          "created_at": "2024-07-07T04:37:50.437Z",
+          "updated_at": "2024-07-07T04:37:50.437Z"
+        },
+        "items": [
+          {
+            "id": "24932_2740436",
+            "quantity": {
+              "count": 1
+            },
+            "fulfillment_id": "24932_F1"
+          },
+          {
+            "id": "24932_2740440",
+            "quantity": {
+              "count": 2
+            },
+            "fulfillment_id": "24932_F1"
+          }
+        ],
+        "provider": {
+          "id": "24932",
+          "locations": [
+            {
+              "id": "24932"
+            }
+          ]
+        },
+        "fulfillments": [
+          {
+            "@ondc/org/TAT": "PT4H",
+            "id": "24932_F1",
+            "tracking": false,
+            "end": {
+              "contact": {
+                "email": "aryan@buynxt.in",
+                "phone": "8923136015"
+              },
+              "person": {
+                "name": "Aryan Sharma"
+              },
+              "location": {
+                "gps": "28.457929,77.067815",
+                "address": {
+                  "name": "Aryan Sharma",
+                  "building": "Club Patio",
+                  "locality": "Sector Road",
+                  "city": "Gurugram",
+                  "state": "Haryana",
+                  "country": "IND",
+                  "area_code": "122007"
+                }
+              }
+            },
+            "type": "Delivery"
+          }
+        ],
+        "payment": {
+          "uri": "https://razorpay.com/",
+          "tl_method": "http/get",
+          "params": {
+            "amount": "208970.00",
+            "currency": "INR",
+            "transaction_id": "order_OVc47z53qOcieR"
+          },
+          "status": "PAID",
+          "type": "ON-ORDER",
+          "collected_by": "BAP",
+          "@ondc/org/buyer_app_finder_fee_type": "percent",
+          "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+          "@ondc/org/settlement_details": [
+            {
+              "settlement_counterparty": "seller-app",
+              "settlement_phase": "sale-amount",
+              "settlement_type": "neft",
+              "beneficiary_name": "Buynxt Private Limited",
+              "upi_address": "buynxt@okidfc",
+              "settlement_bank_account_no": "10129914936",
+              "settlement_ifsc_code": "IDFB0021001",
+              "bank_name": "IDFC First Bank Limited",
+              "branch_name": "Golf Course Road, Gurgaon"
+            }
+          ]
+        },
+        "quote": {
+          "price": {
+            "currency": "INR",
+            "value": "208970.00"
+          },
+          "breakup": [
+            {
+              "@ondc/org/item_id": "24932_2740436",
+              "@ondc/org/item_quantity": {
+                "count": 1
+              },
+              "title": "IPHONE 14 256GB MIDNIGHT",
+              "@ondc/org/title_type": "item",
+              "price": {
+                "currency": "INR",
+                "value": "82990.00"
+              },
+              "item": {
+                "price": {
+                  "currency": "INR",
+                  "value": "82990.00"
+                }
+              }
+            },
+            {
+              "@ondc/org/item_id": "24932_2740440",
+              "@ondc/org/item_quantity": {
+                "count": 2
+              },
+              "title": "IPHONE 13 128GB BLUE",
+              "@ondc/org/title_type": "item",
+              "price": {
+                "currency": "INR",
+                "value": "125980.00"
+              },
+              "item": {
+                "price": {
+                  "currency": "INR",
+                  "value": "62990.00"
+                }
+              }
+            },
+            {
+              "@ondc/org/item_id": "24932_F1",
+              "title": "Delivery charges",
+              "@ondc/org/title_type": "delivery",
+              "price": {
+                "currency": "INR",
+                "value": "0.00"
+              }
+            }
+          ],
+          "ttl": "P1D"
+        },
+        "tags": [
+          {
+            "code": "bpp_terms",
+            "list": [
+              {
+                "code": "tax_number",
+                "value": "09ALZPS7205J2ZP"
+              },
+              {
+                "code": "provider_tax_number",
+                "value": "CKABS4783R"
+              }
+            ]
+          },
+          {
+            "code": "bap_terms",
+            "list": [
+              {
+                "code": "tax_number",
+                "value": "GSTIN1234567890"
+              }
+            ]
+          }
+        ],
+        "created_at": "2024-07-07T04:38:30.363Z",
+        "updated_at": "2024-07-07T04:38:30.363Z"
+      }
+    }
+  }

--- a/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow4/init.json
+++ b/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow4/init.json
@@ -1,0 +1,87 @@
+{
+    "context": {
+      "domain": "ONDC:RET14",
+      "country": "IND",
+      "city": "std:0124",
+      "action": "init",
+      "core_version": "1.2.0",
+      "bap_id": "buyer-app-preprod-v2.ondc.org",
+      "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+      "bpp_uri": "https://api.greenreceipt.in/ondc",
+      "transaction_id": "5a32ae09-3fe7-4d8f-9108-8b83d86cba0a",
+      "message_id": "10084072-861f-4a12-b4b1-0576de9bf359",
+      "timestamp": "2024-07-07T04:37:50.437Z",
+      "bpp_id": "api.greenreceipt.in",
+      "ttl": "PT30S"
+    },
+    "message": {
+      "order": {
+        "provider": {
+          "id": "24932",
+          "locations": [
+            {
+              "id": "24932"
+            }
+          ]
+        },
+        "items": [
+          {
+            "id": "24932_2740436",
+            "quantity": {
+              "count": 1
+            },
+            "location_id": "24932",
+            "fulfillment_id": "24932_F1"
+          },
+          {
+            "id": "24932_2740440",
+            "quantity": {
+              "count": 2
+            },
+            "location_id": "24932",
+            "fulfillment_id": "24932_F1"
+          }
+        ],
+        "billing": {
+          "address": {
+            "building": "Club Patio",
+            "city": "Gurugram",
+            "state": "Haryana",
+            "country": "IND",
+            "area_code": "122007",
+            "locality": "Sector Road",
+            "name": "Aryan Sharma"
+          },
+          "phone": "8923136015",
+          "name": "Aryan Sharma",
+          "email": "aryan@buynxt.in",
+          "created_at": "2024-07-07T04:37:50.437Z",
+          "updated_at": "2024-07-07T04:37:50.437Z"
+        },
+        "fulfillments": [
+          {
+            "id": "24932_F1",
+            "type": "Delivery",
+            "end": {
+              "contact": {
+                "email": "aryan@buynxt.in",
+                "phone": "8923136015"
+              },
+              "location": {
+                "gps": "28.457929,77.067815",
+                "address": {
+                  "building": "Club Patio",
+                  "city": "Gurugram",
+                  "state": "Haryana",
+                  "country": "IND",
+                  "area_code": "122007",
+                  "locality": "Sector Road",
+                  "name": "Aryan Sharma"
+                }
+              }
+            }
+          }
+        ]
+      }
+    }
+  }

--- a/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow4/on_cancel.json
+++ b/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow4/on_cancel.json
@@ -1,0 +1,314 @@
+{
+    "context": {
+      "domain": "ONDC:RET14",
+      "country": "IND",
+      "city": "std:0124",
+      "action": "on_cancel",
+      "core_version": "1.2.0",
+      "bap_id": "buyer-app-preprod-v2.ondc.org",
+      "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+      "bpp_id": "api.greenreceipt.in",
+      "bpp_uri": "https://api.greenreceipt.in/ondc",
+      "transaction_id": "5a32ae09-3fe7-4d8f-9108-8b83d86cba0a",
+      "message_id": "c53d1bc0-0c93-479d-a305-27ad19575494",
+      "timestamp": "2024-07-07T04:38:59.054Z",
+      "ttl": "PT30S"
+    },
+    "message": {
+      "order": {
+        "id": "2024-07-07-227368",
+        "state": "Cancelled",
+        "provider": {
+          "id": "24932",
+          "locations": [
+            {
+              "id": "24932"
+            }
+          ]
+        },
+        "items": [
+          {
+            "id": "24932_2740436",
+            "fulfillment_id": "24932_F1",
+            "quantity": {
+              "count": 0
+            }
+          },
+          {
+            "id": "24932_2740440",
+            "fulfillment_id": "24932_F1",
+            "quantity": {
+              "count": 0
+            }
+          },
+          {
+            "id": "24932_2740436",
+            "fulfillment_id": "24932_C1",
+            "quantity": {
+              "count": 1
+            }
+          },
+          {
+            "id": "24932_2740440",
+            "fulfillment_id": "24932_C1",
+            "quantity": {
+              "count": 2
+            }
+          }
+        ],
+        "billing": {
+          "name": "Aryan Sharma",
+          "address": {
+            "name": "Aryan Sharma",
+            "building": "Club Patio",
+            "locality": "Sector Road",
+            "city": "Gurugram",
+            "state": "Haryana",
+            "country": "IND",
+            "area_code": "122007"
+          },
+          "email": "aryan@buynxt.in",
+          "phone": "8923136015",
+          "created_at": "2024-07-07T04:37:50.437Z",
+          "updated_at": "2024-07-07T04:37:50.437Z"
+        },
+        "cancellation": {
+          "cancelled_by": "buyer-app-preprod-v2.ondc.org",
+          "reason": {
+            "id": "003"
+          }
+        },
+        "fulfillments": [
+          {
+            "id": "24932_F1",
+            "@ondc/org/provider_name": "Ajay Electronics",
+            "state": {
+              "descriptor": {
+                "code": "Cancelled"
+              }
+            },
+            "type": "Delivery",
+            "tracking": false,
+            "@ondc/org/TAT": "PT4H",
+            "start": {
+              "location": {
+                "id": "24932",
+                "descriptor": {
+                  "name": "Ajay Electronics"
+                },
+                "gps": "28.41430316,77.06620157",
+                "address": {
+                  "locality": "Nirvana Country",
+                  "city": "Gurgaon",
+                  "state": "Haryana",
+                  "area_code": "122018"
+                }
+              },
+              "time": {
+                "range": {
+                  "start": "2024-07-07T04:48:30.468Z",
+                  "end": "2024-07-07T08:48:30.468Z"
+                }
+              },
+              "contact": {
+                "phone": "8076362934",
+                "email": "Demo3@gmail.com"
+              }
+            },
+            "end": {
+              "location": {
+                "gps": "28.457929,77.067815",
+                "address": {
+                  "name": "Aryan Sharma",
+                  "building": "Club Patio",
+                  "locality": "Sector Road",
+                  "city": "Gurugram",
+                  "state": "Haryana",
+                  "country": "IND",
+                  "area_code": "122007"
+                }
+              },
+              "time": {
+                "range": {
+                  "start": "2024-07-07T04:48:30.468Z",
+                  "end": "2024-07-07T08:48:30.468Z"
+                }
+              },
+              "person": {
+                "name": "Aryan Sharma"
+              },
+              "contact": {
+                "phone": "8923136015",
+                "email": "aryan@buynxt.in"
+              }
+            },
+            "tags": [
+              {
+                "code": "cancel_request",
+                "list": [
+                  {
+                    "code": "reason_id",
+                    "value": "003"
+                  },
+                  {
+                    "code": "initiated_by",
+                    "value": "buyer-app-preprod-v2.ondc.org"
+                  }
+                ]
+              },
+              {
+                "code": "precancel_state",
+                "list": [
+                  {
+                    "code": "fulfillment_state",
+                    "value": "Pending"
+                  },
+                  {
+                    "code": "updated_at",
+                    "value": "2024-07-07T04:38:30.468Z"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "24932_C1",
+            "state": {
+              "descriptor": {
+                "code": "Cancelled"
+              }
+            },
+            "type": "Cancel",
+            "tracking": false,
+            "tags": [
+              {
+                "code": "quote_trail",
+                "list": [
+                  {
+                    "code": "type",
+                    "value": "item"
+                  },
+                  {
+                    "code": "id",
+                    "value": "24932_2740436"
+                  },
+                  {
+                    "code": "currency",
+                    "value": "INR"
+                  },
+                  {
+                    "code": "value",
+                    "value": "-82990.00"
+                  }
+                ]
+              },
+              {
+                "code": "quote_trail",
+                "list": [
+                  {
+                    "code": "type",
+                    "value": "item"
+                  },
+                  {
+                    "code": "id",
+                    "value": "24932_2740440"
+                  },
+                  {
+                    "code": "currency",
+                    "value": "INR"
+                  },
+                  {
+                    "code": "value",
+                    "value": "-125980.00"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "quote": {
+          "price": {
+            "currency": "INR",
+            "value": "0"
+          },
+          "breakup": [
+            {
+              "@ondc/org/item_id": "24932_2740436",
+              "@ondc/org/item_quantity": {
+                "count": 0
+              },
+              "title": "IPHONE 14 256GB MIDNIGHT",
+              "@ondc/org/title_type": "item",
+              "price": {
+                "currency": "INR",
+                "value": "0.00"
+              },
+              "item": {
+                "price": {
+                  "currency": "INR",
+                  "value": "82990.00"
+                }
+              }
+            },
+            {
+              "@ondc/org/item_id": "24932_2740440",
+              "@ondc/org/item_quantity": {
+                "count": 0
+              },
+              "title": "IPHONE 13 128GB BLUE",
+              "@ondc/org/title_type": "item",
+              "price": {
+                "currency": "INR",
+                "value": "0.00"
+              },
+              "item": {
+                "price": {
+                  "currency": "INR",
+                  "value": "62990.00"
+                }
+              }
+            },
+            {
+              "@ondc/org/item_id": "24932_F1",
+              "title": "Delivery charges",
+              "@ondc/org/title_type": "delivery",
+              "price": {
+                "currency": "INR",
+                "value": "0.00"
+              }
+            }
+          ],
+          "ttl": "P1D"
+        },
+        "payment": {
+          "uri": "https://razorpay.com/",
+          "tl_method": "http/get",
+          "params": {
+            "currency": "INR",
+            "transaction_id": "order_OVc47z53qOcieR",
+            "amount": "208970.00"
+          },
+          "status": "PAID",
+          "type": "ON-ORDER",
+          "collected_by": "BAP",
+          "@ondc/org/buyer_app_finder_fee_type": "percent",
+          "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+          "@ondc/org/settlement_details": [
+            {
+              "settlement_counterparty": "seller-app",
+              "settlement_phase": "sale-amount",
+              "beneficiary_name": "Buynxt Private Limited",
+              "settlement_type": "neft",
+              "upi_address": "buynxt@okidfc",
+              "settlement_bank_account_no": "10129914936",
+              "settlement_ifsc_code": "IDFB0021001",
+              "bank_name": "IDFC First Bank Limited",
+              "branch_name": "Golf Course Road, Gurgaon"
+            }
+          ]
+        },
+        "created_at": "2024-07-07T04:38:30.363Z",
+        "updated_at": "2024-07-07T04:38:30.468Z"
+      }
+    }
+  }

--- a/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow4/on_confirm.json
+++ b/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow4/on_confirm.json
@@ -1,0 +1,239 @@
+{
+    "context": {
+      "domain": "ONDC:RET14",
+      "action": "on_confirm",
+      "core_version": "1.2.0",
+      "bap_id": "buyer-app-preprod-v2.ondc.org",
+      "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+      "bpp_id": "api.greenreceipt.in",
+      "bpp_uri": "https://api.greenreceipt.in/ondc",
+      "transaction_id": "5a32ae09-3fe7-4d8f-9108-8b83d86cba0a",
+      "message_id": "ded8e6a5-9cd3-474f-94e9-6550a07130b3",
+      "city": "std:0124",
+      "country": "IND",
+      "timestamp": "2024-07-07T04:38:30.468Z"
+    },
+    "message": {
+      "order": {
+        "id": "2024-07-07-227368",
+        "state": "Created",
+        "provider": {
+          "id": "24932",
+          "locations": [
+            {
+              "id": "24932"
+            }
+          ]
+        },
+        "items": [
+          {
+            "id": "24932_2740436",
+            "fulfillment_id": "24932_F1",
+            "quantity": {
+              "count": 1
+            }
+          },
+          {
+            "id": "24932_2740440",
+            "fulfillment_id": "24932_F1",
+            "quantity": {
+              "count": 2
+            }
+          }
+        ],
+        "billing": {
+          "name": "Aryan Sharma",
+          "address": {
+            "name": "Aryan Sharma",
+            "building": "Club Patio",
+            "locality": "Sector Road",
+            "city": "Gurugram",
+            "state": "Haryana",
+            "country": "IND",
+            "area_code": "122007"
+          },
+          "email": "aryan@buynxt.in",
+          "phone": "8923136015",
+          "created_at": "2024-07-07T04:37:50.437Z",
+          "updated_at": "2024-07-07T04:37:50.437Z"
+        },
+        "fulfillments": [
+          {
+            "id": "24932_F1",
+            "@ondc/org/provider_name": "Ajay Electronics",
+            "state": {
+              "descriptor": {
+                "code": "Pending"
+              }
+            },
+            "type": "Delivery",
+            "tracking": false,
+            "@ondc/org/TAT": "PT4H",
+            "start": {
+              "location": {
+                "id": "24932",
+                "descriptor": {
+                  "name": "Ajay Electronics"
+                },
+                "gps": "28.41430316,77.06620157",
+                "address": {
+                  "locality": "Nirvana Country",
+                  "city": "Gurgaon",
+                  "area_code": "122018",
+                  "state": "Haryana"
+                }
+              },
+              "time": {
+                "range": {
+                  "start": "2024-07-07T04:48:30.468Z",
+                  "end": "2024-07-07T05:48:30.468Z"
+                }
+              },
+              "contact": {
+                "phone": "8076362934",
+                "email": "Demo3@gmail.com"
+              }
+            },
+            "end": {
+              "location": {
+                "gps": "28.457929,77.067815",
+                "address": {
+                  "name": "Aryan Sharma",
+                  "building": "Club Patio",
+                  "locality": "Sector Road",
+                  "city": "Gurugram",
+                  "state": "Haryana",
+                  "country": "IND",
+                  "area_code": "122007"
+                }
+              },
+              "time": {
+                "range": {
+                  "start": "2024-07-07T07:48:30.468Z",
+                  "end": "2024-07-07T08:48:30.468Z"
+                }
+              },
+              "person": {
+                "name": "Aryan Sharma"
+              },
+              "contact": {
+                "phone": "8923136015",
+                "email": "aryan@buynxt.in"
+              }
+            }
+          }
+        ],
+        "quote": {
+          "price": {
+            "currency": "INR",
+            "value": "208970.00"
+          },
+          "breakup": [
+            {
+              "@ondc/org/item_id": "24932_2740436",
+              "@ondc/org/item_quantity": {
+                "count": 1
+              },
+              "title": "IPHONE 14 256GB MIDNIGHT",
+              "@ondc/org/title_type": "item",
+              "price": {
+                "currency": "INR",
+                "value": "82990.00"
+              },
+              "item": {
+                "price": {
+                  "currency": "INR",
+                  "value": "82990.00"
+                }
+              }
+            },
+            {
+              "@ondc/org/item_id": "24932_2740440",
+              "@ondc/org/item_quantity": {
+                "count": 2
+              },
+              "title": "IPHONE 13 128GB BLUE",
+              "@ondc/org/title_type": "item",
+              "price": {
+                "currency": "INR",
+                "value": "125980.00"
+              },
+              "item": {
+                "price": {
+                  "currency": "INR",
+                  "value": "62990.00"
+                }
+              }
+            },
+            {
+              "@ondc/org/item_id": "24932_F1",
+              "title": "Delivery charges",
+              "@ondc/org/title_type": "delivery",
+              "price": {
+                "currency": "INR",
+                "value": "0.00"
+              }
+            }
+          ],
+          "ttl": "P1D"
+        },
+        "payment": {
+          "uri": "https://razorpay.com/",
+          "tl_method": "http/get",
+          "params": {
+            "currency": "INR",
+            "transaction_id": "order_OVc47z53qOcieR",
+            "amount": "208970.00"
+          },
+          "status": "PAID",
+          "type": "ON-ORDER",
+          "collected_by": "BAP",
+          "@ondc/org/buyer_app_finder_fee_type": "percent",
+          "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+          "@ondc/org/settlement_details": [
+            {
+              "settlement_counterparty": "seller-app",
+              "settlement_phase": "sale-amount",
+              "beneficiary_name": "Buynxt Private Limited",
+              "settlement_type": "neft",
+              "upi_address": "buynxt@okidfc",
+              "settlement_bank_account_no": "10129914936",
+              "settlement_ifsc_code": "IDFB0021001",
+              "bank_name": "IDFC First Bank Limited",
+              "branch_name": "Golf Course Road, Gurgaon"
+            }
+          ]
+        },
+        "tags": [
+          {
+            "code": "bpp_terms",
+            "list": [
+              {
+                "code": "np_type",
+                "value": "MSN"
+              },
+              {
+                "code": "tax_number",
+                "value": "09ALZPS7205J2ZP"
+              },
+              {
+                "code": "provider_tax_number",
+                "value": "CKABS4783R"
+              }
+            ]
+          },
+          {
+            "code": "bap_terms",
+            "list": [
+              {
+                "code": "tax_number",
+                "value": "GSTIN1234567890"
+              }
+            ]
+          }
+        ],
+        "created_at": "2024-07-07T04:38:30.363Z",
+        "updated_at": "2024-07-07T04:38:30.468Z"
+      }
+    }
+  }

--- a/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow4/on_init.json
+++ b/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow4/on_init.json
@@ -1,0 +1,171 @@
+{
+    "context": {
+      "domain": "ONDC:RET14",
+      "action": "on_init",
+      "core_version": "1.2.0",
+      "bap_id": "buyer-app-preprod-v2.ondc.org",
+      "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+      "bpp_id": "api.greenreceipt.in",
+      "bpp_uri": "https://api.greenreceipt.in/ondc",
+      "transaction_id": "5a32ae09-3fe7-4d8f-9108-8b83d86cba0a",
+      "message_id": "10084072-861f-4a12-b4b1-0576de9bf359",
+      "city": "std:0124",
+      "country": "IND",
+      "timestamp": "2024-07-07T04:37:50.495Z"
+    },
+    "message": {
+      "order": {
+        "provider": {
+          "id": "24932",
+          "locations": [
+            {
+              "id": "24932"
+            }
+          ]
+        },
+        "items": [
+          {
+            "id": "24932_2740436",
+            "fulfillment_id": "24932_F1",
+            "quantity": {
+              "count": 1
+            }
+          },
+          {
+            "id": "24932_2740440",
+            "fulfillment_id": "24932_F1",
+            "quantity": {
+              "count": 2
+            }
+          }
+        ],
+        "billing": {
+          "name": "Aryan Sharma",
+          "address": {
+            "name": "Aryan Sharma",
+            "building": "Club Patio",
+            "locality": "Sector Road",
+            "city": "Gurugram",
+            "state": "Haryana",
+            "country": "IND",
+            "area_code": "122007"
+          },
+          "email": "aryan@buynxt.in",
+          "phone": "8923136015",
+          "created_at": "2024-07-07T04:37:50.437Z",
+          "updated_at": "2024-07-07T04:37:50.437Z"
+        },
+        "fulfillments": [
+          {
+            "id": "24932_F1",
+            "type": "Delivery",
+            "tracking": false,
+            "end": {
+              "location": {
+                "gps": "28.457929,77.067815",
+                "address": {
+                  "name": "Aryan Sharma",
+                  "building": "Club Patio",
+                  "locality": "Sector Road",
+                  "city": "Gurugram",
+                  "state": "Haryana",
+                  "country": "IND",
+                  "area_code": "122007"
+                }
+              },
+              "contact": {
+                "phone": "8923136015",
+                "email": "aryan@buynxt.in"
+              }
+            }
+          }
+        ],
+        "quote": {
+          "price": {
+            "currency": "INR",
+            "value": "208970.00"
+          },
+          "breakup": [
+            {
+              "@ondc/org/item_id": "24932_2740436",
+              "@ondc/org/item_quantity": {
+                "count": 1
+              },
+              "title": "IPHONE 14 256GB MIDNIGHT",
+              "@ondc/org/title_type": "item",
+              "price": {
+                "currency": "INR",
+                "value": "82990.00"
+              },
+              "item": {
+                "price": {
+                  "currency": "INR",
+                  "value": "82990.00"
+                }
+              }
+            },
+            {
+              "@ondc/org/item_id": "24932_2740440",
+              "@ondc/org/item_quantity": {
+                "count": 2
+              },
+              "title": "IPHONE 13 128GB BLUE",
+              "@ondc/org/title_type": "item",
+              "price": {
+                "currency": "INR",
+                "value": "125980.00"
+              },
+              "item": {
+                "price": {
+                  "currency": "INR",
+                  "value": "62990.00"
+                }
+              }
+            },
+            {
+              "@ondc/org/item_id": "24932_F1",
+              "title": "Delivery charges",
+              "@ondc/org/title_type": "delivery",
+              "price": {
+                "currency": "INR",
+                "value": "0.00"
+              }
+            }
+          ],
+          "ttl": "P1D"
+        },
+        "payment": {
+          "@ondc/org/buyer_app_finder_fee_type": "percent",
+          "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+          "@ondc/org/settlement_details": [
+            {
+              "settlement_counterparty": "seller-app",
+              "settlement_phase": "sale-amount",
+              "settlement_type": "neft",
+              "beneficiary_name": "Buynxt Private Limited",
+              "upi_address": "buynxt@okidfc",
+              "settlement_bank_account_no": "10129914936",
+              "settlement_ifsc_code": "IDFB0021001",
+              "bank_name": "IDFC First Bank Limited",
+              "branch_name": "Golf Course Road, Gurgaon"
+            }
+          ]
+        },
+        "tags": [
+          {
+            "code": "bpp_terms",
+            "list": [
+              {
+                "code": "tax_number",
+                "value": "09ALZPS7205J2ZP"
+              },
+              {
+                "code": "provider_tax_number",
+                "value": "CKABS4783R"
+              }
+            ]
+          }
+        ]
+      }
+    }
+  }

--- a/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow4/on_select.json
+++ b/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow4/on_select.json
@@ -1,0 +1,123 @@
+{
+    "context": {
+      "domain": "ONDC:RET14",
+      "action": "on_select",
+      "core_version": "1.2.0",
+      "bap_id": "buyer-app-preprod-v2.ondc.org",
+      "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+      "bpp_id": "api.greenreceipt.in",
+      "bpp_uri": "https://api.greenreceipt.in/ondc",
+      "transaction_id": "5a32ae09-3fe7-4d8f-9108-8b83d86cba0a",
+      "message_id": "9ff49491-54f2-4c5b-afe7-026bedf6299c",
+      "city": "std:0124",
+      "country": "IND",
+      "timestamp": "2024-07-07T04:37:36.528Z"
+    },
+    "message": {
+      "order": {
+        "provider": {
+          "id": "24932",
+          "locations": [
+            {
+              "id": "24932"
+            }
+          ]
+        },
+        "items": [
+          {
+            "fulfillment_id": "24932_F1",
+            "id": "24932_2740436"
+          },
+          {
+            "fulfillment_id": "24932_F1",
+            "id": "24932_2740440"
+          }
+        ],
+        "fulfillments": [
+          {
+            "id": "24932_F1",
+            "type": "Delivery",
+            "@ondc/org/provider_name": "Ajay Electronics",
+            "tracking": false,
+            "@ondc/org/category": "Standard Delivery",
+            "@ondc/org/TAT": "PT4H",
+            "state": {
+              "descriptor": {
+                "code": "Serviceable"
+              }
+            }
+          }
+        ],
+        "quote": {
+          "price": {
+            "currency": "INR",
+            "value": "208970.00"
+          },
+          "breakup": [
+            {
+              "@ondc/org/item_id": "24932_2740436",
+              "@ondc/org/item_quantity": {
+                "count": 1
+              },
+              "title": "IPHONE 14 256GB MIDNIGHT",
+              "@ondc/org/title_type": "item",
+              "price": {
+                "currency": "INR",
+                "value": "82990.00"
+              },
+              "item": {
+                "quantity": {
+                  "available": {
+                    "count": "99"
+                  },
+                  "maximum": {
+                    "count": "99"
+                  }
+                },
+                "price": {
+                  "currency": "INR",
+                  "value": "82990.00"
+                }
+              }
+            },
+            {
+              "@ondc/org/item_id": "24932_2740440",
+              "@ondc/org/item_quantity": {
+                "count": 2
+              },
+              "title": "IPHONE 13 128GB BLUE",
+              "@ondc/org/title_type": "item",
+              "price": {
+                "currency": "INR",
+                "value": "125980.00"
+              },
+              "item": {
+                "quantity": {
+                  "available": {
+                    "count": "99"
+                  },
+                  "maximum": {
+                    "count": "99"
+                  }
+                },
+                "price": {
+                  "currency": "INR",
+                  "value": "62990.00"
+                }
+              }
+            },
+            {
+              "@ondc/org/item_id": "24932_F1",
+              "title": "Delivery charges",
+              "@ondc/org/title_type": "delivery",
+              "price": {
+                "currency": "INR",
+                "value": "0.00"
+              }
+            }
+          ],
+          "ttl": "PT4H"
+        }
+      }
+    }
+  }

--- a/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow4/select.json
+++ b/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow4/select.json
@@ -1,0 +1,57 @@
+{
+    "context": {
+      "domain": "ONDC:RET14",
+      "country": "IND",
+      "city": "std:0124",
+      "action": "select",
+      "core_version": "1.2.0",
+      "bap_id": "buyer-app-preprod-v2.ondc.org",
+      "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+      "bpp_uri": "https://api.greenreceipt.in/ondc",
+      "transaction_id": "5a32ae09-3fe7-4d8f-9108-8b83d86cba0a",
+      "message_id": "9ff49491-54f2-4c5b-afe7-026bedf6299c",
+      "timestamp": "2024-07-07T04:37:36.459Z",
+      "bpp_id": "api.greenreceipt.in",
+      "ttl": "PT30S"
+    },
+    "message": {
+      "order": {
+        "items": [
+          {
+            "id": "24932_2740436",
+            "quantity": {
+              "count": 1
+            },
+            "location_id": "24932"
+          },
+          {
+            "id": "24932_2740440",
+            "quantity": {
+              "count": 2
+            },
+            "location_id": "24932"
+          }
+        ],
+        "provider": {
+          "id": "24932",
+          "locations": [
+            {
+              "id": "24932"
+            }
+          ]
+        },
+        "fulfillments": [
+          {
+            "end": {
+              "location": {
+                "gps": "28.457929,77.067815",
+                "address": {
+                  "area_code": "122007"
+                }
+              }
+            }
+          }
+        ]
+      }
+    }
+  }

--- a/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow4_log_utility_resp.json
+++ b/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow4_log_utility_resp.json
@@ -1,0 +1,13 @@
+{
+    "success": true,
+    "response": {
+        "message": "Logs were verified successfully",
+        "report": {},
+        "bpp_id": "api.greenreceipt.in",
+        "bap_id": "buyer-app-preprod-v2.ondc.org",
+        "domain": "ONDC:RET14",
+        "reportTimestamp": "2024-07-11T11:41:14.214Z"
+    },
+    "signature": "t1fNZliVUeaNxUd8fXbcD53+gi3e2YaegD4OBV/k7iikcN+256Ggi+wmVXpu99HOZWPq00NMek0HIEqtmLfzBw==",
+    "signTimestamp": "2024-07-11T11:41:14.214Z"
+}

--- a/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow5/confirm.json
+++ b/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow5/confirm.json
@@ -1,0 +1,199 @@
+{
+  "context": {
+    "domain": "ONDC:RET14",
+    "country": "IND",
+    "city": "std:0124",
+    "action": "confirm",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_uri": "https://api.greenreceipt.in/ondc",
+    "transaction_id": "9d9856b4-8996-468a-8433-4dcdce60e434",
+    "message_id": "fcd48fd7-8150-43e1-95c4-cde89008bdb1",
+    "timestamp": "2024-07-11T11:03:14.356Z",
+    "bpp_id": "api.greenreceipt.in",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "id": "2024-07-11-353919",
+      "state": "Created",
+      "billing": {
+        "address": {
+          "name": "Aryan Sharma",
+          "building": "Club Patio",
+          "locality": "Sector Road",
+          "city": "Gurugram",
+          "state": "Haryana",
+          "country": "IND",
+          "area_code": "122007"
+        },
+        "phone": "8923136015",
+        "name": "Aryan Sharma",
+        "email": "aryan@buynxt.in",
+        "created_at": "2024-07-11T11:02:45.161Z",
+        "updated_at": "2024-07-11T11:02:45.161Z"
+      },
+      "items": [
+        {
+          "id": "24932_2740436",
+          "quantity": {
+            "count": 1
+          },
+          "fulfillment_id": "24932_F1"
+        },
+        {
+          "id": "24932_2740440",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "24932_F1"
+        }
+      ],
+      "provider": {
+        "id": "24932",
+        "locations": [
+          {
+            "id": "24932"
+          }
+        ]
+      },
+      "fulfillments": [
+        {
+          "@ondc/org/TAT": "PT4H",
+          "id": "24932_F1",
+          "tracking": false,
+          "end": {
+            "contact": {
+              "email": "aryan@buynxt.in",
+              "phone": "8923136015"
+            },
+            "person": {
+              "name": "Aryan Sharma"
+            },
+            "location": {
+              "gps": "28.457929,77.067815",
+              "address": {
+                "name": "Aryan Sharma",
+                "building": "Club Patio",
+                "locality": "Sector Road",
+                "city": "Gurugram",
+                "state": "Haryana",
+                "country": "IND",
+                "area_code": "122007"
+              }
+            }
+          },
+          "type": "Delivery"
+        }
+      ],
+      "payment": {
+        "uri": "https://razorpay.com/",
+        "tl_method": "http/get",
+        "params": {
+          "amount": "208970.00",
+          "currency": "INR",
+          "transaction_id": "order_OXIl7cKrBBemhr"
+        },
+        "status": "PAID",
+        "type": "ON-ORDER",
+        "collected_by": "BAP",
+        "@ondc/org/buyer_app_finder_fee_type": "percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "seller-app",
+            "settlement_phase": "sale-amount",
+            "settlement_type": "neft",
+            "beneficiary_name": "Buynxt Private Limited",
+            "upi_address": "buynxt@okidfc",
+            "settlement_bank_account_no": "10129914936",
+            "settlement_ifsc_code": "IDFB0021001",
+            "bank_name": "IDFC First Bank Limited",
+            "branch_name": "Golf Course Road, Gurgaon"
+          }
+        ]
+      },
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "208970.00"
+        },
+        "breakup": [
+          {
+            "@ondc/org/item_id": "24932_2740436",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "title": "IPHONE 14 256GB MIDNIGHT",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "82990.00"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "82990.00"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "24932_2740440",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "title": "IPHONE 13 128GB BLUE",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "125980.00"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "62990.00"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "24932_F1",
+            "title": "Delivery charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "0.00"
+            }
+          }
+        ],
+        "ttl": "P1D"
+      },
+      "tags": [
+        {
+          "code": "bpp_terms",
+          "list": [
+            {
+              "code": "tax_number",
+              "value": "09ALZPS7205J2ZP"
+            },
+            {
+              "code": "provider_tax_number",
+              "value": "CKABS4783R"
+            }
+          ]
+        },
+        {
+          "code": "bap_terms",
+          "list": [
+            {
+              "code": "tax_number",
+              "value": "GSTIN1234567890"
+            }
+          ]
+        }
+      ],
+      "created_at": "2024-07-11T11:03:14.356Z",
+      "updated_at": "2024-07-11T11:03:14.356Z"
+    }
+  }
+}

--- a/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow5/init.json
+++ b/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow5/init.json
@@ -1,0 +1,87 @@
+{
+  "context": {
+    "domain": "ONDC:RET14",
+    "country": "IND",
+    "city": "std:0124",
+    "action": "init",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_uri": "https://api.greenreceipt.in/ondc",
+    "transaction_id": "9d9856b4-8996-468a-8433-4dcdce60e434",
+    "message_id": "12537d54-7d9c-4f9a-b3ea-06ee58b067b9",
+    "timestamp": "2024-07-11T11:02:45.161Z",
+    "bpp_id": "api.greenreceipt.in",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "provider": {
+        "id": "24932",
+        "locations": [
+          {
+            "id": "24932"
+          }
+        ]
+      },
+      "items": [
+        {
+          "id": "24932_2740436",
+          "quantity": {
+            "count": 1
+          },
+          "location_id": "24932",
+          "fulfillment_id": "24932_F1"
+        },
+        {
+          "id": "24932_2740440",
+          "quantity": {
+            "count": 2
+          },
+          "location_id": "24932",
+          "fulfillment_id": "24932_F1"
+        }
+      ],
+      "billing": {
+        "address": {
+          "building": "Club Patio",
+          "city": "Gurugram",
+          "state": "Haryana",
+          "country": "IND",
+          "area_code": "122007",
+          "locality": "Sector Road",
+          "name": "Aryan Sharma"
+        },
+        "phone": "8923136015",
+        "name": "Aryan Sharma",
+        "email": "aryan@buynxt.in",
+        "created_at": "2024-07-11T11:02:45.161Z",
+        "updated_at": "2024-07-11T11:02:45.161Z"
+      },
+      "fulfillments": [
+        {
+          "id": "24932_F1",
+          "type": "Delivery",
+          "end": {
+            "contact": {
+              "email": "aryan@buynxt.in",
+              "phone": "8923136015"
+            },
+            "location": {
+              "gps": "28.457929,77.067815",
+              "address": {
+                "building": "Club Patio",
+                "city": "Gurugram",
+                "state": "Haryana",
+                "country": "IND",
+                "area_code": "122007",
+                "locality": "Sector Road",
+                "name": "Aryan Sharma"
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow5/on_cancel.json
+++ b/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow5/on_cancel.json
@@ -1,0 +1,378 @@
+{
+  "context": {
+    "domain": "ONDC:RET14",
+    "country": "IND",
+    "city": "std:0124",
+    "action": "on_cancel",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_id": "api.greenreceipt.in",
+    "bpp_uri": "https://api.greenreceipt.in/ondc",
+    "transaction_id": "9d9856b4-8996-468a-8433-4dcdce60e434",
+    "message_id": "c3a76d0d-31a1-4054-a8fd-be9191fd7c0f",
+    "timestamp": "2024-07-11T11:10:00.597Z",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "id": "2024-07-11-353919",
+      "state": "Cancelled",
+      "provider": {
+        "id": "24932",
+        "locations": [
+          {
+            "id": "24932"
+          }
+        ]
+      },
+      "items": [
+        {
+          "id": "24932_2740436",
+          "fulfillment_id": "24932_F1",
+          "quantity": {
+            "count": 0
+          }
+        },
+        {
+          "id": "24932_2740436",
+          "fulfillment_id": "24932_F1-RTO",
+          "quantity": {
+            "count": 1
+          }
+        },
+        {
+          "id": "24932_2740440",
+          "fulfillment_id": "24932_F1",
+          "quantity": {
+            "count": 0
+          }
+        },
+        {
+          "id": "24932_2740440",
+          "fulfillment_id": "24932_F1-RTO",
+          "quantity": {
+            "count": 2
+          }
+        }
+      ],
+      "billing": {
+        "name": "Aryan Sharma",
+        "address": {
+          "name": "Aryan Sharma",
+          "building": "Club Patio",
+          "locality": "Sector Road",
+          "city": "Gurugram",
+          "state": "Haryana",
+          "country": "IND",
+          "area_code": "122007"
+        },
+        "email": "aryan@buynxt.in",
+        "phone": "8923136015",
+        "created_at": "2024-07-11T11:02:45.161Z",
+        "updated_at": "2024-07-11T11:02:45.161Z"
+      },
+      "fulfillments": [
+        {
+          "id": "24932_F1",
+          "@ondc/org/provider_name": "Ajay Electronics",
+          "state": {
+            "descriptor": {
+              "code": "Cancelled"
+            }
+          },
+          "type": "Delivery",
+          "tracking": false,
+          "@ondc/org/TAT": "PT4H",
+          "start": {
+            "location": {
+              "id": "24932",
+              "descriptor": {
+                "name": "Ajay Electronics"
+              },
+              "gps": "28.41430316,77.06620157",
+              "address": {
+                "locality": "Nirvana Country",
+                "city": "Gurgaon",
+                "state": "Haryana",
+                "area_code": "122018"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2024-07-11T11:13:14.553Z",
+                "end": "2024-07-11T12:13:14.553Z"
+              }
+            },
+            "contact": {
+              "phone": "8076362931",
+              "email": "Demo3@gmail.com"
+            }
+          },
+          "end": {
+            "location": {
+              "gps": "28.457929,77.067815",
+              "address": {
+                "name": "Aryan Sharma",
+                "building": "Club Patio",
+                "locality": "Sector Road",
+                "city": "Gurugram",
+                "state": "Haryana",
+                "country": "IND",
+                "area_code": "122007"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2024-07-11T14:13:14.553Z",
+                "end": "2024-07-11T15:13:14.553Z"
+              }
+            },
+            "person": {
+              "name": "Aryan Sharma"
+            },
+            "contact": {
+              "phone": "8923136015",
+              "email": "aryan@buynxt.in"
+            }
+          },
+          "tags": [
+            {
+              "code": "cancel_request",
+              "list": [
+                {
+                  "code": "retry_count",
+                  "value": "3"
+                },
+                {
+                  "code": "rto_id",
+                  "value": "24932_F1-RTO"
+                },
+                {
+                  "code": "reason_id",
+                  "value": "005"
+                },
+                {
+                  "code": "initiated_by",
+                  "value": "api.greenreceipt.in"
+                }
+              ]
+            },
+            {
+              "code": "precancel_state",
+              "list": [
+                {
+                  "code": "fulfillment_state",
+                  "value": "Out-for-delivery"
+                },
+                {
+                  "code": "updated_at",
+                  "value": "2024-07-11T11:05:52.697Z"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "id": "24932_F1-RTO",
+          "state": {
+            "descriptor": {
+              "code": "RTO-Initiated"
+            }
+          },
+          "type": "RTO",
+          "tracking": false,
+          "start": {
+            "location": {
+              "gps": "28.457929,77.067815",
+              "address": {
+                "name": "Aryan Sharma",
+                "building": "Club Patio",
+                "locality": "Sector Road",
+                "city": "Gurugram",
+                "state": "Haryana",
+                "country": "IND",
+                "area_code": "122007"
+              }
+            },
+            "time": {
+              "timestamp": "2024-07-11T11:10:00.597Z"
+            }
+          },
+          "end": {
+            "location": {
+              "id": "24932",
+              "descriptor": {
+                "name": "Ajay Electronics"
+              },
+              "gps": "28.41430316,77.06620157",
+              "address": {
+                "locality": "Nirvana Country",
+                "city": "Gurgaon",
+                "state": "Haryana",
+                "area_code": "122018"
+              }
+            }
+          },
+          "tags": [
+            {
+              "code": "quote_trail",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "delivery"
+                },
+                {
+                  "code": "id",
+                  "value": "24932_F1-RTO"
+                },
+                {
+                  "code": "currency",
+                  "value": "INR"
+                },
+                {
+                  "code": "value",
+                  "value": "0.00"
+                }
+              ]
+            },
+            {
+              "code": "quote_trail",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "item"
+                },
+                {
+                  "code": "id",
+                  "value": "24932_2740436"
+                },
+                {
+                  "code": "currency",
+                  "value": "INR"
+                },
+                {
+                  "code": "value",
+                  "value": "-82990.00"
+                }
+              ]
+            },
+            {
+              "code": "quote_trail",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "item"
+                },
+                {
+                  "code": "id",
+                  "value": "24932_2740440"
+                },
+                {
+                  "code": "currency",
+                  "value": "INR"
+                },
+                {
+                  "code": "value",
+                  "value": "-125980.00"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "0"
+        },
+        "breakup": [
+          {
+            "@ondc/org/item_id": "24932_2740436",
+            "@ondc/org/item_quantity": {
+              "count": 0
+            },
+            "title": "IPHONE 14 256GB MIDNIGHT",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "0.00"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "82990.00"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "24932_2740440",
+            "@ondc/org/item_quantity": {
+              "count": 0
+            },
+            "title": "IPHONE 13 128GB BLUE",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "0.00"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "62990.00"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "24932_F1",
+            "title": "Delivery charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "0.00"
+            }
+          },
+          {
+            "@ondc/org/item_id": "24932_F1-RTO",
+            "title": "Delivery charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "0.00"
+            }
+          }
+        ],
+        "ttl": "P1D"
+      },
+      "payment": {
+        "uri": "https://razorpay.com/",
+        "tl_method": "http/get",
+        "params": {
+          "currency": "INR",
+          "transaction_id": "order_OXIl7cKrBBemhr",
+          "amount": "208970.00"
+        },
+        "status": "PAID",
+        "type": "ON-ORDER",
+        "collected_by": "BAP",
+        "@ondc/org/buyer_app_finder_fee_type": "percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "seller-app",
+            "settlement_phase": "sale-amount",
+            "beneficiary_name": "Buynxt Private Limited",
+            "settlement_type": "neft",
+            "upi_address": "buynxt@okidfc",
+            "settlement_bank_account_no": "10129914936",
+            "settlement_ifsc_code": "IDFB0021001",
+            "bank_name": "IDFC First Bank Limited",
+            "branch_name": "Golf Course Road, Gurgaon"
+          }
+        ]
+      },
+      "created_at": "2024-07-11T11:03:14.356Z",
+      "updated_at": "2024-07-11T11:10:00.597Z"
+    }
+  }
+}

--- a/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow5/on_confirm.json
+++ b/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow5/on_confirm.json
@@ -1,0 +1,239 @@
+{
+  "context": {
+    "domain": "ONDC:RET14",
+    "action": "on_confirm",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_id": "api.greenreceipt.in",
+    "bpp_uri": "https://api.greenreceipt.in/ondc",
+    "transaction_id": "9d9856b4-8996-468a-8433-4dcdce60e434",
+    "message_id": "fcd48fd7-8150-43e1-95c4-cde89008bdb1",
+    "city": "std:0124",
+    "country": "IND",
+    "timestamp": "2024-07-11T11:03:14.553Z"
+  },
+  "message": {
+    "order": {
+      "id": "2024-07-11-353919",
+      "state": "Created",
+      "provider": {
+        "id": "24932",
+        "locations": [
+          {
+            "id": "24932"
+          }
+        ]
+      },
+      "items": [
+        {
+          "id": "24932_2740436",
+          "fulfillment_id": "24932_F1",
+          "quantity": {
+            "count": 1
+          }
+        },
+        {
+          "id": "24932_2740440",
+          "fulfillment_id": "24932_F1",
+          "quantity": {
+            "count": 2
+          }
+        }
+      ],
+      "billing": {
+        "name": "Aryan Sharma",
+        "address": {
+          "name": "Aryan Sharma",
+          "building": "Club Patio",
+          "locality": "Sector Road",
+          "city": "Gurugram",
+          "state": "Haryana",
+          "country": "IND",
+          "area_code": "122007"
+        },
+        "email": "aryan@buynxt.in",
+        "phone": "8923136015",
+        "created_at": "2024-07-11T11:02:45.161Z",
+        "updated_at": "2024-07-11T11:02:45.161Z"
+      },
+      "fulfillments": [
+        {
+          "id": "24932_F1",
+          "@ondc/org/provider_name": "Ajay Electronics",
+          "state": {
+            "descriptor": {
+              "code": "Pending"
+            }
+          },
+          "type": "Delivery",
+          "tracking": false,
+          "@ondc/org/TAT": "PT4H",
+          "start": {
+            "location": {
+              "id": "24932",
+              "descriptor": {
+                "name": "Ajay Electronics"
+              },
+              "gps": "28.41430316,77.06620157",
+              "address": {
+                "locality": "Nirvana Country",
+                "city": "Gurgaon",
+                "area_code": "122018",
+                "state": "Haryana"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2024-07-11T11:13:14.553Z",
+                "end": "2024-07-11T12:13:14.553Z"
+              }
+            },
+            "contact": {
+              "phone": "8076362931",
+              "email": "Demo3@gmail.com"
+            }
+          },
+          "end": {
+            "location": {
+              "gps": "28.457929,77.067815",
+              "address": {
+                "name": "Aryan Sharma",
+                "building": "Club Patio",
+                "locality": "Sector Road",
+                "city": "Gurugram",
+                "state": "Haryana",
+                "country": "IND",
+                "area_code": "122007"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2024-07-11T14:13:14.553Z",
+                "end": "2024-07-11T15:13:14.553Z"
+              }
+            },
+            "person": {
+              "name": "Aryan Sharma"
+            },
+            "contact": {
+              "phone": "8923136015",
+              "email": "aryan@buynxt.in"
+            }
+          }
+        }
+      ],
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "208970.00"
+        },
+        "breakup": [
+          {
+            "@ondc/org/item_id": "24932_2740436",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "title": "IPHONE 14 256GB MIDNIGHT",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "82990.00"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "82990.00"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "24932_2740440",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "title": "IPHONE 13 128GB BLUE",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "125980.00"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "62990.00"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "24932_F1",
+            "title": "Delivery charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "0.00"
+            }
+          }
+        ],
+        "ttl": "P1D"
+      },
+      "payment": {
+        "uri": "https://razorpay.com/",
+        "tl_method": "http/get",
+        "params": {
+          "currency": "INR",
+          "transaction_id": "order_OXIl7cKrBBemhr",
+          "amount": "208970.00"
+        },
+        "status": "PAID",
+        "type": "ON-ORDER",
+        "collected_by": "BAP",
+        "@ondc/org/buyer_app_finder_fee_type": "percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "seller-app",
+            "settlement_phase": "sale-amount",
+            "beneficiary_name": "Buynxt Private Limited",
+            "settlement_type": "neft",
+            "upi_address": "buynxt@okidfc",
+            "settlement_bank_account_no": "10129914936",
+            "settlement_ifsc_code": "IDFB0021001",
+            "bank_name": "IDFC First Bank Limited",
+            "branch_name": "Golf Course Road, Gurgaon"
+          }
+        ]
+      },
+      "tags": [
+        {
+          "code": "bpp_terms",
+          "list": [
+            {
+              "code": "np_type",
+              "value": "MSN"
+            },
+            {
+              "code": "tax_number",
+              "value": "09ALZPS7205J2ZP"
+            },
+            {
+              "code": "provider_tax_number",
+              "value": "CKABS4783R"
+            }
+          ]
+        },
+        {
+          "code": "bap_terms",
+          "list": [
+            {
+              "code": "tax_number",
+              "value": "GSTIN1234567890"
+            }
+          ]
+        }
+      ],
+      "created_at": "2024-07-11T11:03:14.356Z",
+      "updated_at": "2024-07-11T11:03:14.553Z"
+    }
+  }
+}

--- a/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow5/on_init.json
+++ b/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow5/on_init.json
@@ -1,0 +1,171 @@
+{
+  "context": {
+    "domain": "ONDC:RET14",
+    "action": "on_init",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_id": "api.greenreceipt.in",
+    "bpp_uri": "https://api.greenreceipt.in/ondc",
+    "transaction_id": "9d9856b4-8996-468a-8433-4dcdce60e434",
+    "message_id": "12537d54-7d9c-4f9a-b3ea-06ee58b067b9",
+    "city": "std:0124",
+    "country": "IND",
+    "timestamp": "2024-07-11T11:02:45.346Z"
+  },
+  "message": {
+    "order": {
+      "provider": {
+        "id": "24932",
+        "locations": [
+          {
+            "id": "24932"
+          }
+        ]
+      },
+      "items": [
+        {
+          "id": "24932_2740436",
+          "fulfillment_id": "24932_F1",
+          "quantity": {
+            "count": 1
+          }
+        },
+        {
+          "id": "24932_2740440",
+          "fulfillment_id": "24932_F1",
+          "quantity": {
+            "count": 2
+          }
+        }
+      ],
+      "billing": {
+        "name": "Aryan Sharma",
+        "address": {
+          "name": "Aryan Sharma",
+          "building": "Club Patio",
+          "locality": "Sector Road",
+          "city": "Gurugram",
+          "state": "Haryana",
+          "country": "IND",
+          "area_code": "122007"
+        },
+        "email": "aryan@buynxt.in",
+        "phone": "8923136015",
+        "created_at": "2024-07-11T11:02:45.161Z",
+        "updated_at": "2024-07-11T11:02:45.161Z"
+      },
+      "fulfillments": [
+        {
+          "id": "24932_F1",
+          "type": "Delivery",
+          "tracking": false,
+          "end": {
+            "location": {
+              "gps": "28.457929,77.067815",
+              "address": {
+                "name": "Aryan Sharma",
+                "building": "Club Patio",
+                "locality": "Sector Road",
+                "city": "Gurugram",
+                "state": "Haryana",
+                "country": "IND",
+                "area_code": "122007"
+              }
+            },
+            "contact": {
+              "phone": "8923136015",
+              "email": "aryan@buynxt.in"
+            }
+          }
+        }
+      ],
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "208970.00"
+        },
+        "breakup": [
+          {
+            "@ondc/org/item_id": "24932_2740436",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "title": "IPHONE 14 256GB MIDNIGHT",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "82990.00"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "82990.00"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "24932_2740440",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "title": "IPHONE 13 128GB BLUE",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "125980.00"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "62990.00"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "24932_F1",
+            "title": "Delivery charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "0.00"
+            }
+          }
+        ],
+        "ttl": "P1D"
+      },
+      "payment": {
+        "@ondc/org/buyer_app_finder_fee_type": "percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "seller-app",
+            "settlement_phase": "sale-amount",
+            "settlement_type": "neft",
+            "beneficiary_name": "Buynxt Private Limited",
+            "upi_address": "buynxt@okidfc",
+            "settlement_bank_account_no": "10129914936",
+            "settlement_ifsc_code": "IDFB0021001",
+            "bank_name": "IDFC First Bank Limited",
+            "branch_name": "Golf Course Road, Gurgaon"
+          }
+        ]
+      },
+      "tags": [
+        {
+          "code": "bpp_terms",
+          "list": [
+            {
+              "code": "tax_number",
+              "value": "09ALZPS7205J2ZP"
+            },
+            {
+              "code": "provider_tax_number",
+              "value": "CKABS4783R"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow5/on_select.json
+++ b/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow5/on_select.json
@@ -1,0 +1,123 @@
+{
+  "context": {
+    "domain": "ONDC:RET14",
+    "action": "on_select",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_id": "api.greenreceipt.in",
+    "bpp_uri": "https://api.greenreceipt.in/ondc",
+    "transaction_id": "9d9856b4-8996-468a-8433-4dcdce60e434",
+    "message_id": "cdd05cfd-144e-4edc-8692-36d4df142c78",
+    "city": "std:0124",
+    "country": "IND",
+    "timestamp": "2024-07-11T11:02:35.049Z"
+  },
+  "message": {
+    "order": {
+      "provider": {
+        "id": "24932",
+        "locations": [
+          {
+            "id": "24932"
+          }
+        ]
+      },
+      "items": [
+        {
+          "fulfillment_id": "24932_F1",
+          "id": "24932_2740436"
+        },
+        {
+          "fulfillment_id": "24932_F1",
+          "id": "24932_2740440"
+        }
+      ],
+      "fulfillments": [
+        {
+          "id": "24932_F1",
+          "type": "Delivery",
+          "@ondc/org/provider_name": "Ajay Electronics",
+          "tracking": false,
+          "@ondc/org/category": "Standard Delivery",
+          "@ondc/org/TAT": "PT4H",
+          "state": {
+            "descriptor": {
+              "code": "Serviceable"
+            }
+          }
+        }
+      ],
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "208970.00"
+        },
+        "breakup": [
+          {
+            "@ondc/org/item_id": "24932_2740436",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "title": "IPHONE 14 256GB MIDNIGHT",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "82990.00"
+            },
+            "item": {
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "82990.00"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "24932_2740440",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "title": "IPHONE 13 128GB BLUE",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "125980.00"
+            },
+            "item": {
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                }
+              },
+              "price": {
+                "currency": "INR",
+                "value": "62990.00"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "24932_F1",
+            "title": "Delivery charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "0.00"
+            }
+          }
+        ],
+        "ttl": "PT4H"
+      }
+    }
+  }
+}

--- a/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow5/on_status_out_for_delivery.json
+++ b/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow5/on_status_out_for_delivery.json
@@ -1,0 +1,229 @@
+{
+  "context": {
+    "domain": "ONDC:RET14",
+    "action": "on_status",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_id": "api.greenreceipt.in",
+    "bpp_uri": "https://api.greenreceipt.in/ondc",
+    "transaction_id": "9d9856b4-8996-468a-8433-4dcdce60e434",
+    "message_id": "164abe32-4e94-4803-8e55-9a14af6a08d7",
+    "city": "std:0124",
+    "country": "IND",
+    "timestamp": "2024-07-11T11:05:52.697Z",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "id": "2024-07-11-353919",
+      "state": "In-progress",
+      "provider": {
+        "id": "24932",
+        "locations": [
+          {
+            "id": "24932"
+          }
+        ]
+      },
+      "items": [
+        {
+          "id": "24932_2740436",
+          "fulfillment_id": "24932_F1",
+          "quantity": {
+            "count": 1
+          }
+        },
+        {
+          "id": "24932_2740440",
+          "fulfillment_id": "24932_F1",
+          "quantity": {
+            "count": 2
+          }
+        }
+      ],
+      "billing": {
+        "name": "Aryan Sharma",
+        "address": {
+          "name": "Aryan Sharma",
+          "building": "Club Patio",
+          "locality": "Sector Road",
+          "city": "Gurugram",
+          "state": "Haryana",
+          "country": "IND",
+          "area_code": "122007"
+        },
+        "email": "aryan@buynxt.in",
+        "phone": "8923136015",
+        "created_at": "2024-07-11T11:02:45.161Z",
+        "updated_at": "2024-07-11T11:02:45.161Z"
+      },
+      "fulfillments": [
+        {
+          "id": "24932_F1",
+          "@ondc/org/provider_name": "Ajay Electronics",
+          "type": "Delivery",
+          "tracking": false,
+          "@ondc/org/TAT": "PT4H",
+          "state": {
+            "descriptor": {
+              "code": "Out-for-delivery"
+            }
+          },
+          "start": {
+            "location": {
+              "descriptor": {
+                "name": "Ajay Electronics"
+              },
+              "gps": "28.41430316,77.06620157",
+              "address": {
+                "locality": "Nirvana Country",
+                "city": "Gurgaon",
+                "state": "Haryana",
+                "area_code": "122018"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2024-07-11T11:13:14.553Z",
+                "end": "2024-07-11T12:13:14.553Z"
+              },
+              "timestamp": "2024-07-11T11:04:26.877Z"
+            },
+            "contact": {
+              "phone": "8076362931",
+              "email": "Demo3@gmail.com"
+            }
+          },
+          "end": {
+            "location": {
+              "gps": "28.457929,77.067815",
+              "address": {
+                "name": "Aryan Sharma",
+                "building": "Club Patio",
+                "locality": "Sector Road",
+                "city": "Gurugram",
+                "state": "Haryana",
+                "country": "IND",
+                "area_code": "122007"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2024-07-11T14:13:14.553Z",
+                "end": "2024-07-11T15:13:14.553Z"
+              }
+            },
+            "person": {
+              "name": "Aryan Sharma"
+            },
+            "contact": {
+              "phone": "8923136015",
+              "email": "aryan@buynxt.in"
+            }
+          },
+          "tags": [
+            {
+              "code": "routing",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "P2P"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "208970.00"
+        },
+        "breakup": [
+          {
+            "@ondc/org/item_id": "24932_2740436",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "title": "IPHONE 14 256GB MIDNIGHT",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "82990.00"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "82990.00"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "24932_2740440",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "title": "IPHONE 13 128GB BLUE",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "125980.00"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "62990.00"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "24932_F1",
+            "title": "Delivery charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "0.00"
+            }
+          }
+        ],
+        "ttl": "PT4H"
+      },
+      "payment": {
+        "uri": "https://razorpay.com/",
+        "tl_method": "http/get",
+        "params": {
+          "currency": "INR",
+          "transaction_id": "order_OXIl7cKrBBemhr",
+          "amount": "208970.00"
+        },
+        "status": "PAID",
+        "type": "ON-ORDER",
+        "collected_by": "BAP",
+        "@ondc/org/buyer_app_finder_fee_type": "percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "seller-app",
+            "settlement_phase": "sale-amount",
+            "beneficiary_name": "Buynxt Private Limited",
+            "settlement_type": "neft",
+            "upi_address": "buynxt@okidfc",
+            "settlement_bank_account_no": "10129914936",
+            "settlement_ifsc_code": "IDFB0021001",
+            "bank_name": "IDFC First Bank Limited",
+            "branch_name": "Golf Course Road, Gurgaon"
+          }
+        ]
+      },
+      "documents": [
+        {
+          "url": "https://greenreceipt.in/invoices/2024-07-11-353919.pdf",
+          "label": "Invoice"
+        }
+      ],
+      "created_at": "2024-07-11T11:03:14.356Z",
+      "updated_at": "2024-07-11T11:05:52.697Z"
+    }
+  }
+}

--- a/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow5/on_status_packed.json
+++ b/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow5/on_status_packed.json
@@ -1,0 +1,222 @@
+{
+  "context": {
+    "domain": "ONDC:RET14",
+    "action": "on_status",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_id": "api.greenreceipt.in",
+    "bpp_uri": "https://api.greenreceipt.in/ondc",
+    "transaction_id": "9d9856b4-8996-468a-8433-4dcdce60e434",
+    "message_id": "4945882b-1f14-41c8-ae07-e53f9c664b02",
+    "city": "std:0124",
+    "country": "IND",
+    "timestamp": "2024-07-11T11:04:26.952Z",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "id": "2024-07-11-353919",
+      "state": "In-progress",
+      "provider": {
+        "id": "24932",
+        "locations": [
+          {
+            "id": "24932"
+          }
+        ]
+      },
+      "items": [
+        {
+          "id": "24932_2740436",
+          "fulfillment_id": "24932_F1",
+          "quantity": {
+            "count": 1
+          }
+        },
+        {
+          "id": "24932_2740440",
+          "fulfillment_id": "24932_F1",
+          "quantity": {
+            "count": 2
+          }
+        }
+      ],
+      "billing": {
+        "name": "Aryan Sharma",
+        "address": {
+          "name": "Aryan Sharma",
+          "building": "Club Patio",
+          "locality": "Sector Road",
+          "city": "Gurugram",
+          "state": "Haryana",
+          "country": "IND",
+          "area_code": "122007"
+        },
+        "email": "aryan@buynxt.in",
+        "phone": "8923136015",
+        "created_at": "2024-07-11T11:02:45.161Z",
+        "updated_at": "2024-07-11T11:02:45.161Z"
+      },
+      "fulfillments": [
+        {
+          "id": "24932_F1",
+          "@ondc/org/provider_name": "Ajay Electronics",
+          "type": "Delivery",
+          "tracking": false,
+          "@ondc/org/TAT": "PT4H",
+          "state": {
+            "descriptor": {
+              "code": "Packed"
+            }
+          },
+          "start": {
+            "location": {
+              "descriptor": {
+                "name": "Ajay Electronics"
+              },
+              "gps": "28.41430316,77.06620157",
+              "address": {
+                "locality": "Nirvana Country",
+                "city": "Gurgaon",
+                "state": "Haryana",
+                "area_code": "122018"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2024-07-11T11:13:14.553Z",
+                "end": "2024-07-11T12:13:14.553Z"
+              }
+            },
+            "contact": {
+              "phone": "8076362931",
+              "email": "Demo3@gmail.com"
+            }
+          },
+          "end": {
+            "location": {
+              "gps": "28.457929,77.067815",
+              "address": {
+                "name": "Aryan Sharma",
+                "building": "Club Patio",
+                "locality": "Sector Road",
+                "city": "Gurugram",
+                "state": "Haryana",
+                "country": "IND",
+                "area_code": "122007"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2024-07-11T14:13:14.553Z",
+                "end": "2024-07-11T15:13:14.553Z"
+              }
+            },
+            "person": {
+              "name": "Aryan Sharma"
+            },
+            "contact": {
+              "phone": "8923136015",
+              "email": "aryan@buynxt.in"
+            }
+          },
+          "tags": [
+            {
+              "code": "routing",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "P2P"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "208970.00"
+        },
+        "breakup": [
+          {
+            "@ondc/org/item_id": "24932_2740436",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "title": "IPHONE 14 256GB MIDNIGHT",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "82990.00"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "82990.00"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "24932_2740440",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "title": "IPHONE 13 128GB BLUE",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "125980.00"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "62990.00"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "24932_F1",
+            "title": "Delivery charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "0.00"
+            }
+          }
+        ],
+        "ttl": "PT4H"
+      },
+      "payment": {
+        "uri": "https://razorpay.com/",
+        "tl_method": "http/get",
+        "params": {
+          "currency": "INR",
+          "transaction_id": "order_OXIl7cKrBBemhr",
+          "amount": "208970.00"
+        },
+        "status": "PAID",
+        "type": "ON-ORDER",
+        "collected_by": "BAP",
+        "@ondc/org/buyer_app_finder_fee_type": "percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "seller-app",
+            "settlement_phase": "sale-amount",
+            "beneficiary_name": "Buynxt Private Limited",
+            "settlement_type": "neft",
+            "upi_address": "buynxt@okidfc",
+            "settlement_bank_account_no": "10129914936",
+            "settlement_ifsc_code": "IDFB0021001",
+            "bank_name": "IDFC First Bank Limited",
+            "branch_name": "Golf Course Road, Gurgaon"
+          }
+        ]
+      },
+      "created_at": "2024-07-11T11:03:14.356Z",
+      "updated_at": "2024-07-11T11:04:26.952Z"
+    }
+  }
+}

--- a/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow5/on_status_pending.json
+++ b/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow5/on_status_pending.json
@@ -1,0 +1,222 @@
+{
+  "context": {
+    "domain": "ONDC:RET14",
+    "action": "on_status",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_id": "api.greenreceipt.in",
+    "bpp_uri": "https://api.greenreceipt.in/ondc",
+    "transaction_id": "9d9856b4-8996-468a-8433-4dcdce60e434",
+    "message_id": "bf5d9815-3bef-4f7c-80b4-ed62da67aef6",
+    "city": "std:0124",
+    "country": "IND",
+    "timestamp": "2024-07-11T11:04:21.467Z",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "id": "2024-07-11-353919",
+      "state": "Accepted",
+      "provider": {
+        "id": "24932",
+        "locations": [
+          {
+            "id": "24932"
+          }
+        ]
+      },
+      "items": [
+        {
+          "id": "24932_2740436",
+          "fulfillment_id": "24932_F1",
+          "quantity": {
+            "count": 1
+          }
+        },
+        {
+          "id": "24932_2740440",
+          "fulfillment_id": "24932_F1",
+          "quantity": {
+            "count": 2
+          }
+        }
+      ],
+      "billing": {
+        "name": "Aryan Sharma",
+        "address": {
+          "name": "Aryan Sharma",
+          "building": "Club Patio",
+          "locality": "Sector Road",
+          "city": "Gurugram",
+          "state": "Haryana",
+          "country": "IND",
+          "area_code": "122007"
+        },
+        "email": "aryan@buynxt.in",
+        "phone": "8923136015",
+        "created_at": "2024-07-11T11:02:45.161Z",
+        "updated_at": "2024-07-11T11:02:45.161Z"
+      },
+      "fulfillments": [
+        {
+          "id": "24932_F1",
+          "@ondc/org/provider_name": "Ajay Electronics",
+          "type": "Delivery",
+          "tracking": false,
+          "@ondc/org/TAT": "PT4H",
+          "state": {
+            "descriptor": {
+              "code": "Pending"
+            }
+          },
+          "start": {
+            "location": {
+              "descriptor": {
+                "name": "Ajay Electronics"
+              },
+              "gps": "28.41430316,77.06620157",
+              "address": {
+                "locality": "Nirvana Country",
+                "city": "Gurgaon",
+                "state": "Haryana",
+                "area_code": "122018"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2024-07-11T11:13:14.553Z",
+                "end": "2024-07-11T12:13:14.553Z"
+              }
+            },
+            "contact": {
+              "phone": "8076362931",
+              "email": "Demo3@gmail.com"
+            }
+          },
+          "end": {
+            "location": {
+              "gps": "28.457929,77.067815",
+              "address": {
+                "name": "Aryan Sharma",
+                "building": "Club Patio",
+                "locality": "Sector Road",
+                "city": "Gurugram",
+                "state": "Haryana",
+                "country": "IND",
+                "area_code": "122007"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2024-07-11T14:13:14.553Z",
+                "end": "2024-07-11T15:13:14.553Z"
+              }
+            },
+            "person": {
+              "name": "Aryan Sharma"
+            },
+            "contact": {
+              "phone": "8923136015",
+              "email": "aryan@buynxt.in"
+            }
+          },
+          "tags": [
+            {
+              "code": "routing",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "P2P"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "208970.00"
+        },
+        "breakup": [
+          {
+            "@ondc/org/item_id": "24932_2740436",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "title": "IPHONE 14 256GB MIDNIGHT",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "82990.00"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "82990.00"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "24932_2740440",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "title": "IPHONE 13 128GB BLUE",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "125980.00"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "62990.00"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "24932_F1",
+            "title": "Delivery charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "0.00"
+            }
+          }
+        ],
+        "ttl": "PT4H"
+      },
+      "payment": {
+        "uri": "https://razorpay.com/",
+        "tl_method": "http/get",
+        "params": {
+          "currency": "INR",
+          "transaction_id": "order_OXIl7cKrBBemhr",
+          "amount": "208970.00"
+        },
+        "status": "PAID",
+        "type": "ON-ORDER",
+        "collected_by": "BAP",
+        "@ondc/org/buyer_app_finder_fee_type": "percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "seller-app",
+            "settlement_phase": "sale-amount",
+            "beneficiary_name": "Buynxt Private Limited",
+            "settlement_type": "neft",
+            "upi_address": "buynxt@okidfc",
+            "settlement_bank_account_no": "10129914936",
+            "settlement_ifsc_code": "IDFB0021001",
+            "bank_name": "IDFC First Bank Limited",
+            "branch_name": "Golf Course Road, Gurgaon"
+          }
+        ]
+      },
+      "created_at": "2024-07-11T11:03:14.356Z",
+      "updated_at": "2024-07-11T11:04:21.467Z"
+    }
+  }
+}

--- a/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow5/on_status_picked.json
+++ b/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow5/on_status_picked.json
@@ -1,0 +1,229 @@
+{
+  "context": {
+    "domain": "ONDC:RET14",
+    "action": "on_status",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_id": "api.greenreceipt.in",
+    "bpp_uri": "https://api.greenreceipt.in/ondc",
+    "transaction_id": "9d9856b4-8996-468a-8433-4dcdce60e434",
+    "message_id": "c9827467-7d8b-4fb4-9df9-b08d34cb309e",
+    "city": "std:0124",
+    "country": "IND",
+    "timestamp": "2024-07-11T11:04:30.014Z",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "id": "2024-07-11-353919",
+      "state": "In-progress",
+      "provider": {
+        "id": "24932",
+        "locations": [
+          {
+            "id": "24932"
+          }
+        ]
+      },
+      "items": [
+        {
+          "id": "24932_2740436",
+          "fulfillment_id": "24932_F1",
+          "quantity": {
+            "count": 1
+          }
+        },
+        {
+          "id": "24932_2740440",
+          "fulfillment_id": "24932_F1",
+          "quantity": {
+            "count": 2
+          }
+        }
+      ],
+      "billing": {
+        "name": "Aryan Sharma",
+        "address": {
+          "name": "Aryan Sharma",
+          "building": "Club Patio",
+          "locality": "Sector Road",
+          "city": "Gurugram",
+          "state": "Haryana",
+          "country": "IND",
+          "area_code": "122007"
+        },
+        "email": "aryan@buynxt.in",
+        "phone": "8923136015",
+        "created_at": "2024-07-11T11:02:45.161Z",
+        "updated_at": "2024-07-11T11:02:45.161Z"
+      },
+      "fulfillments": [
+        {
+          "id": "24932_F1",
+          "@ondc/org/provider_name": "Ajay Electronics",
+          "type": "Delivery",
+          "tracking": false,
+          "@ondc/org/TAT": "PT4H",
+          "state": {
+            "descriptor": {
+              "code": "Order-picked-up"
+            }
+          },
+          "start": {
+            "location": {
+              "descriptor": {
+                "name": "Ajay Electronics"
+              },
+              "gps": "28.41430316,77.06620157",
+              "address": {
+                "locality": "Nirvana Country",
+                "city": "Gurgaon",
+                "state": "Haryana",
+                "area_code": "122018"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2024-07-11T11:13:14.553Z",
+                "end": "2024-07-11T12:13:14.553Z"
+              },
+              "timestamp": "2024-07-11T11:04:26.877Z"
+            },
+            "contact": {
+              "phone": "8076362931",
+              "email": "Demo3@gmail.com"
+            }
+          },
+          "end": {
+            "location": {
+              "gps": "28.457929,77.067815",
+              "address": {
+                "name": "Aryan Sharma",
+                "building": "Club Patio",
+                "locality": "Sector Road",
+                "city": "Gurugram",
+                "state": "Haryana",
+                "country": "IND",
+                "area_code": "122007"
+              }
+            },
+            "time": {
+              "range": {
+                "start": "2024-07-11T14:13:14.553Z",
+                "end": "2024-07-11T15:13:14.553Z"
+              }
+            },
+            "person": {
+              "name": "Aryan Sharma"
+            },
+            "contact": {
+              "phone": "8923136015",
+              "email": "aryan@buynxt.in"
+            }
+          },
+          "tags": [
+            {
+              "code": "routing",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "P2P"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "208970.00"
+        },
+        "breakup": [
+          {
+            "@ondc/org/item_id": "24932_2740436",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "title": "IPHONE 14 256GB MIDNIGHT",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "82990.00"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "82990.00"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "24932_2740440",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "title": "IPHONE 13 128GB BLUE",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "125980.00"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "62990.00"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "24932_F1",
+            "title": "Delivery charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "0.00"
+            }
+          }
+        ],
+        "ttl": "PT4H"
+      },
+      "payment": {
+        "uri": "https://razorpay.com/",
+        "tl_method": "http/get",
+        "params": {
+          "currency": "INR",
+          "transaction_id": "order_OXIl7cKrBBemhr",
+          "amount": "208970.00"
+        },
+        "status": "PAID",
+        "type": "ON-ORDER",
+        "collected_by": "BAP",
+        "@ondc/org/buyer_app_finder_fee_type": "percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "seller-app",
+            "settlement_phase": "sale-amount",
+            "beneficiary_name": "Buynxt Private Limited",
+            "settlement_type": "neft",
+            "upi_address": "buynxt@okidfc",
+            "settlement_bank_account_no": "10129914936",
+            "settlement_ifsc_code": "IDFB0021001",
+            "bank_name": "IDFC First Bank Limited",
+            "branch_name": "Golf Course Road, Gurgaon"
+          }
+        ]
+      },
+      "documents": [
+        {
+          "url": "https://greenreceipt.in/invoices/2024-07-11-353919.pdf",
+          "label": "Invoice"
+        }
+      ],
+      "created_at": "2024-07-11T11:03:14.356Z",
+      "updated_at": "2024-07-11T11:04:30.014Z"
+    }
+  }
+}

--- a/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow5/on_status_rto.json
+++ b/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow5/on_status_rto.json
@@ -1,0 +1,392 @@
+{
+    "context": {
+        "domain": "ONDC:RET14",
+        "action": "on_status",
+        "core_version": "1.2.0",
+        "bap_id": "buyer-app-preprod-v2.ondc.org",
+        "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+        "bpp_id": "api.greenreceipt.in",
+        "bpp_uri": "https://api.greenreceipt.in/ondc",
+        "transaction_id": "9d9856b4-8996-468a-8433-4dcdce60e434",
+        "message_id": "844eabc5-f75c-4a6a-80fc-e30a97024750",
+        "city": "std:0124",
+        "country": "IND",
+        "timestamp": "2024-07-11T11:10:05.498Z",
+        "ttl": "PT30S"
+    },
+    "message": {
+        "order": {
+            "id": "2024-07-11-353919",
+            "state": "Cancelled",
+            "cancellation": {
+                "cancelled_by": "api.greenreceipt.in",
+                "reason": {
+                    "id": "005"
+                }
+            },
+            "provider": {
+                "id": "24932",
+                "locations": [
+                    {
+                        "id": "24932"
+                    }
+                ]
+            },
+            "items": [
+                {
+                    "id": "24932_2740436",
+                    "fulfillment_id": "24932_F1",
+                    "quantity": {
+                        "count": 0
+                    }
+                },
+                {
+                    "id": "24932_2740436",
+                    "fulfillment_id": "24932_C1-RTO",
+                    "quantity": {
+                        "count": 1
+                    }
+                },
+                {
+                    "id": "24932_2740440",
+                    "fulfillment_id": "24932_F1",
+                    "quantity": {
+                        "count": 0
+                    }
+                },
+                {
+                    "id": "24932_2740440",
+                    "fulfillment_id": "24932_C1-RTO",
+                    "quantity": {
+                        "count": 2
+                    }
+                }
+            ],
+            "billing": {
+                "name": "Aryan Sharma",
+                "address": {
+                    "name": "Aryan Sharma",
+                    "building": "Club Patio",
+                    "locality": "Sector Road",
+                    "city": "Gurugram",
+                    "state": "Haryana",
+                    "country": "IND",
+                    "area_code": "122007"
+                },
+                "email": "aryan@buynxt.in",
+                "phone": "8923136015",
+                "created_at": "2024-07-11T11:02:45.161Z",
+                "updated_at": "2024-07-11T11:02:45.161Z"
+            },
+            "fulfillments": [
+                {
+                    "id": "24932_F1",
+                    "@ondc/org/provider_name": "Ajay Electronics",
+                    "type": "Delivery",
+                    "tracking": false,
+                    "@ondc/org/TAT": "PT4H",
+                    "state": {
+                        "descriptor": {
+                            "code": "Cancelled"
+                        }
+                    },
+                    "start": {
+                        "location": {
+                            "descriptor": {
+                                "name": "Ajay Electronics"
+                            },
+                            "gps": "28.41430316,77.06620157",
+                            "address": {
+                                "locality": "Nirvana Country",
+                                "city": "Gurgaon",
+                                "state": "Haryana",
+                                "area_code": "122018"
+                            }
+                        },
+                        "time": {
+                            "range": {
+                                "start": "2024-07-11T11:13:14.553Z",
+                                "end": "2024-07-11T12:13:14.553Z"
+                            },
+                            "timestamp": "2024-07-11T11:04:26.877Z"
+                        },
+                        "contact": {
+                            "phone": "8076362931",
+                            "email": "Demo3@gmail.com"
+                        }
+                    },
+                    "end": {
+                        "location": {
+                            "gps": "28.457929,77.067815",
+                            "address": {
+                                "name": "Aryan Sharma",
+                                "building": "Club Patio",
+                                "locality": "Sector Road",
+                                "city": "Gurugram",
+                                "state": "Haryana",
+                                "country": "IND",
+                                "area_code": "122007"
+                            }
+                        },
+                        "time": {
+                            "range": {
+                                "start": "2024-07-11T14:13:14.553Z",
+                                "end": "2024-07-11T15:13:14.553Z"
+                            }
+                        },
+                        "person": {
+                            "name": "Aryan Sharma"
+                        },
+                        "contact": {
+                            "phone": "8923136015",
+                            "email": "aryan@buynxt.in"
+                        }
+                    },
+                    "tags": [
+                        {
+                            "code": "cancel_request",
+                            "list": [
+                                {
+                                    "code": "retry_count",
+                                    "value": "3"
+                                },
+                                {
+                                    "code": "rto_id",
+                                    "value": "24932_F1-RTO"
+                                },
+                                {
+                                    "code": "reason_id",
+                                    "value": "005"
+                                },
+                                {
+                                    "code": "initiated_by",
+                                    "value": "api.greenreceipt.in"
+                                }
+                            ]
+                        },
+                        {
+                            "code": "precancel_state",
+                            "list": [
+                                {
+                                    "code": "fulfillment_state",
+                                    "value": "Out-for-delivery"
+                                },
+                                {
+                                    "code": "updated_at",
+                                    "value": "2024-07-11T11:05:52.697Z"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "id": "24932_C1-RTO",
+                    "type": "RTO",
+                    "tracking": false,
+                    "state": {
+                        "descriptor": {
+                            "code": "RTO-Delivered"
+                        }
+                    },
+                    "start": {
+                        "location": {
+                            "gps": "28.457929,77.067815",
+                            "address": {
+                                "name": "Aryan Sharma",
+                                "building": "Club Patio",
+                                "locality": "Sector Road",
+                                "city": "Gurugram",
+                                "state": "Haryana",
+                                "country": "IND",
+                                "area_code": "122007"
+                            }
+                        },
+                        "time": {
+                            "timestamp": "2024-07-11T11:10:00.597Z"
+                        }
+                    },
+                    "end": {
+                        "location": {
+                            "id": "24932",
+                            "descriptor": {
+                                "name": "Ajay Electronics"
+                            },
+                            "gps": "28.41430316,77.06620157",
+                            "address": {
+                                "locality": "Nirvana Country",
+                                "city": "Gurgaon",
+                                "state": "Haryana",
+                                "area_code": "122018"
+                            }
+                        },
+                        "time": {
+                            "timestamp": "2024-07-11T11:10:05.498Z"
+                        }
+                    },
+                    "tags": [
+                        {
+                            "code": "cancel_request",
+                            "list": [
+                                {
+                                    "code": "reason_id",
+                                    "value": "005"
+                                },
+                                {
+                                    "code": "initiated_by",
+                                    "value": "api.greenreceipt.in"
+                                }
+                            ]
+                        },
+                        {
+                            "code": "quote_trail",
+                            "list": [
+                                {
+                                    "code": "type",
+                                    "value": "item"
+                                },
+                                {
+                                    "code": "id",
+                                    "value": "24932_2740436"
+                                },
+                                {
+                                    "code": "currency",
+                                    "value": "INR"
+                                },
+                                {
+                                    "code": "value",
+                                    "value": "-82990.00"
+                                }
+                            ]
+                        },
+                        {
+                            "code": "cancel_request",
+                            "list": [
+                                {
+                                    "code": "reason_id",
+                                    "value": "005"
+                                },
+                                {
+                                    "code": "initiated_by",
+                                    "value": "api.greenreceipt.in"
+                                }
+                            ]
+                        },
+                        {
+                            "code": "quote_trail",
+                            "list": [
+                                {
+                                    "code": "type",
+                                    "value": "item"
+                                },
+                                {
+                                    "code": "id",
+                                    "value": "24932_2740440"
+                                },
+                                {
+                                    "code": "currency",
+                                    "value": "INR"
+                                },
+                                {
+                                    "code": "value",
+                                    "value": "-125980.00"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "quote": {
+                "price": {
+                    "currency": "INR",
+                    "value": "0.00"
+                },
+                "breakup": [
+                    {
+                        "@ondc/org/item_id": "24932_2740436",
+                        "@ondc/org/item_quantity": {
+                            "count": 0
+                        },
+                        "title": "IPHONE 14 256GB MIDNIGHT",
+                        "@ondc/org/title_type": "item",
+                        "price": {
+                            "currency": "INR",
+                            "value": "0.00"
+                        },
+                        "item": {
+                            "price": {
+                                "currency": "INR",
+                                "value": "82990.00"
+                            }
+                        }
+                    },
+                    {
+                        "@ondc/org/item_id": "24932_2740440",
+                        "@ondc/org/item_quantity": {
+                            "count": 0
+                        },
+                        "title": "IPHONE 13 128GB BLUE",
+                        "@ondc/org/title_type": "item",
+                        "price": {
+                            "currency": "INR",
+                            "value": "0.00"
+                        },
+                        "item": {
+                            "price": {
+                                "currency": "INR",
+                                "value": "62990.00"
+                            }
+                        }
+                    },
+                    {
+                        "@ondc/org/item_id": "24932_F1",
+                        "title": "Delivery charges",
+                        "@ondc/org/title_type": "delivery",
+                        "price": {
+                            "currency": "INR",
+                            "value": "0.00"
+                        }
+                    },
+                    {
+                        "@ondc/org/item_id": "24932_F1-RTO",
+                        "title": "Delivery charges",
+                        "@ondc/org/title_type": "delivery",
+                        "price": {
+                            "currency": "INR",
+                            "value": "0.00"
+                        }
+                    }
+                ],
+                "ttl": "PT4H"
+            },
+            "payment": {
+                "uri": "https://razorpay.com/",
+                "tl_method": "http/get",
+                "params": {
+                    "currency": "INR",
+                    "transaction_id": "order_OXIl7cKrBBemhr",
+                    "amount": "208970.00"
+                },
+                "status": "PAID",
+                "type": "ON-ORDER",
+                "collected_by": "BAP",
+                "@ondc/org/buyer_app_finder_fee_type": "percent",
+                "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+                "@ondc/org/settlement_details": [
+                    {
+                        "settlement_counterparty": "seller-app",
+                        "settlement_phase": "sale-amount",
+                        "beneficiary_name": "Buynxt Private Limited",
+                        "settlement_type": "neft",
+                        "upi_address": "buynxt@okidfc",
+                        "settlement_bank_account_no": "10129914936",
+                        "settlement_ifsc_code": "IDFB0021001",
+                        "bank_name": "IDFC First Bank Limited",
+                        "branch_name": "Golf Course Road, Gurgaon"
+                    }
+                ]
+            },
+            "created_at": "2024-07-11T11:03:14.356Z",
+            "updated_at": "2024-07-11T11:10:05.498Z"
+        }
+    }
+}

--- a/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow5/select.json
+++ b/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow5/select.json
@@ -1,0 +1,57 @@
+{
+  "context": {
+    "domain": "ONDC:RET14",
+    "country": "IND",
+    "city": "std:0124",
+    "action": "select",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_uri": "https://api.greenreceipt.in/ondc",
+    "transaction_id": "9d9856b4-8996-468a-8433-4dcdce60e434",
+    "message_id": "cdd05cfd-144e-4edc-8692-36d4df142c78",
+    "timestamp": "2024-07-11T11:02:34.049Z",
+    "bpp_id": "api.greenreceipt.in",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "items": [
+        {
+          "id": "24932_2740436",
+          "quantity": {
+            "count": 1
+          },
+          "location_id": "24932"
+        },
+        {
+          "id": "24932_2740440",
+          "quantity": {
+            "count": 2
+          },
+          "location_id": "24932"
+        }
+      ],
+      "provider": {
+        "id": "24932",
+        "locations": [
+          {
+            "id": "24932"
+          }
+        ]
+      },
+      "fulfillments": [
+        {
+          "end": {
+            "location": {
+              "gps": "28.457929,77.067815",
+              "address": {
+                "area_code": "122007"
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow5_log_utility_resp.json
+++ b/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow5_log_utility_resp.json
@@ -1,0 +1,13 @@
+{
+    "success": true,
+    "response": {
+        "message": "Logs were verified successfully",
+        "report": {},
+        "bpp_id": "api.greenreceipt.in",
+        "bap_id": "buyer-app-preprod-v2.ondc.org",
+        "domain": "ONDC:RET14",
+        "reportTimestamp": "2024-07-11T11:41:35.210Z"
+    },
+    "signature": "wanIIpJcq75pg9+wXuhflYAW5o/gphe22UOMshQK/rHvPV+gls6AxtI/t7mXyNpPW5HuBMl+bjamLMSGT/D0Cw==",
+    "signTimestamp": "2024-07-11T11:41:35.210Z"
+}

--- a/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow6/confirm.json
+++ b/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow6/confirm.json
@@ -1,0 +1,249 @@
+{
+  "context": {
+    "domain": "ONDC:RET14",
+    "country": "IND",
+    "city": "std:0124",
+    "action": "confirm",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_uri": "https://api.greenreceipt.in/ondc",
+    "transaction_id": "3b505f52-9f97-44a0-80e2-51ac2c3411b8",
+    "message_id": "42aca09a-d6b0-4862-b702-1eb9d1926fe3",
+    "timestamp": "2024-07-05T10:07:42.787Z",
+    "bpp_id": "api.greenreceipt.in",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "id": "2024-07-05-178086",
+      "state": "Created",
+      "billing": {
+        "address": {
+          "name": "Bhavna",
+          "building": "club patio",
+          "locality": "Sector Road",
+          "city": "Gurugram",
+          "state": "Haryana",
+          "country": "IND",
+          "area_code": "122007"
+        },
+        "phone": "7419096651",
+        "name": "Bhavna",
+        "email": "bhavna@buynxt.in",
+        "created_at": "2024-07-05T10:07:13.125Z",
+        "updated_at": "2024-07-05T10:07:13.125Z"
+      },
+      "items": [
+        {
+          "id": "24932_2740433",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "24932_F1"
+        },
+        {
+          "id": "24932_2740435",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "24932_F1"
+        },
+        {
+          "id": "24932_2740440",
+          "quantity": {
+            "count": 1
+          },
+          "fulfillment_id": "24932_F1"
+        },
+        {
+          "id": "24932_2740442",
+          "quantity": {
+            "count": 1
+          },
+          "fulfillment_id": "24932_F1"
+        }
+      ],
+      "provider": {
+        "id": "24932",
+        "locations": [
+          {
+            "id": "24932"
+          }
+        ]
+      },
+      "fulfillments": [
+        {
+          "@ondc/org/TAT": "PT4H",
+          "id": "24932_F1",
+          "tracking": false,
+          "end": {
+            "contact": {
+              "email": "bhavna@buynxt.in",
+              "phone": "7419096651"
+            },
+            "person": {
+              "name": "Bhavna"
+            },
+            "location": {
+              "gps": "28.457914,77.067837",
+              "address": {
+                "name": "Bhavna",
+                "building": "club patio",
+                "locality": "Sector Road",
+                "city": "Gurugram",
+                "state": "Haryana",
+                "country": "IND",
+                "area_code": "122007"
+              }
+            }
+          },
+          "type": "Delivery"
+        }
+      ],
+      "payment": {
+        "uri": "https://razorpay.com/",
+        "tl_method": "http/get",
+        "params": {
+          "amount": "417940.00",
+          "currency": "INR",
+          "transaction_id": "order_OUubpHLJt1USCZ"
+        },
+        "status": "PAID",
+        "type": "ON-ORDER",
+        "collected_by": "BAP",
+        "@ondc/org/buyer_app_finder_fee_type": "percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "seller-app",
+            "settlement_phase": "sale-amount",
+            "settlement_type": "neft",
+            "beneficiary_name": "Buynxt Private Limited",
+            "upi_address": "buynxt@okidfc",
+            "settlement_bank_account_no": "10129914936",
+            "settlement_ifsc_code": "IDFB0021001",
+            "bank_name": "IDFC First Bank Limited",
+            "branch_name": "Golf Course Road, Gurgaon"
+          }
+        ]
+      },
+      "quote": {
+        "price": {
+          "currency": "INR",
+          "value": "417940.00"
+        },
+        "breakup": [
+          {
+            "@ondc/org/item_id": "24932_2740433",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "title": "IPHONE 14 128GB YELLOW",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "145980.00"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "72990.00"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "24932_2740435",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "title": "IPHONE 14 128GB MIDNIGHT",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "145980.00"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "72990.00"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "24932_2740440",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "title": "IPHONE 13 128GB BLUE",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "62990.00"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "62990.00"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "24932_2740442",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "title": "IPHONE 13 128GB GREEN",
+            "@ondc/org/title_type": "item",
+            "price": {
+              "currency": "INR",
+              "value": "62990.00"
+            },
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "62990.00"
+              }
+            }
+          },
+          {
+            "@ondc/org/item_id": "24932_F1",
+            "title": "Delivery charges",
+            "@ondc/org/title_type": "delivery",
+            "price": {
+              "currency": "INR",
+              "value": "0.00"
+            }
+          }
+        ],
+        "ttl": "P1D"
+      },
+      "tags": [
+        {
+          "code": "bpp_terms",
+          "list": [
+            {
+              "code": "tax_number",
+              "value": "09ALZPS7205J2ZP"
+            },
+            {
+              "code": "provider_tax_number",
+              "value": "CKABS4783R"
+            }
+          ]
+        },
+        {
+          "code": "bap_terms",
+          "list": [
+            {
+              "code": "tax_number",
+              "value": "GSTIN1234567890"
+            }
+          ]
+        }
+      ],
+      "created_at": "2024-07-05T10:07:42.787Z",
+      "updated_at": "2024-07-05T10:07:42.787Z"
+    }
+  }
+}

--- a/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow6/init.json
+++ b/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow6/init.json
@@ -1,0 +1,103 @@
+{
+  "context": {
+    "domain": "ONDC:RET14",
+    "country": "IND",
+    "city": "std:0124",
+    "action": "init",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_uri": "https://api.greenreceipt.in/ondc",
+    "transaction_id": "3b505f52-9f97-44a0-80e2-51ac2c3411b8",
+    "message_id": "e0c85aba-4824-4652-a472-b05f6bb7c7f0",
+    "timestamp": "2024-07-05T10:07:13.125Z",
+    "bpp_id": "api.greenreceipt.in",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "provider": {
+        "id": "24932",
+        "locations": [
+          {
+            "id": "24932"
+          }
+        ]
+      },
+      "items": [
+        {
+          "id": "24932_2740433",
+          "quantity": {
+            "count": 2
+          },
+          "location_id": "24932",
+          "fulfillment_id": "24932_F1"
+        },
+        {
+          "id": "24932_2740435",
+          "quantity": {
+            "count": 2
+          },
+          "location_id": "24932",
+          "fulfillment_id": "24932_F1"
+        },
+        {
+          "id": "24932_2740440",
+          "quantity": {
+            "count": 1
+          },
+          "location_id": "24932",
+          "fulfillment_id": "24932_F1"
+        },
+        {
+          "id": "24932_2740442",
+          "quantity": {
+            "count": 1
+          },
+          "location_id": "24932",
+          "fulfillment_id": "24932_F1"
+        }
+      ],
+      "billing": {
+        "address": {
+          "building": "club patio",
+          "city": "Gurugram",
+          "state": "Haryana",
+          "country": "IND",
+          "area_code": "122007",
+          "locality": "Sector Road",
+          "name": "Bhavna"
+        },
+        "phone": "7419096651",
+        "name": "Bhavna",
+        "email": "bhavna@buynxt.in",
+        "created_at": "2024-07-05T10:07:13.125Z",
+        "updated_at": "2024-07-05T10:07:13.125Z"
+      },
+      "fulfillments": [
+        {
+          "id": "24932_F1",
+          "type": "Delivery",
+          "end": {
+            "contact": {
+              "email": "bhavna@buynxt.in",
+              "phone": "7419096651"
+            },
+            "location": {
+              "gps": "28.457914,77.067837",
+              "address": {
+                "building": "club patio",
+                "city": "Gurugram",
+                "state": "Haryana",
+                "country": "IND",
+                "area_code": "122007",
+                "locality": "Sector Road",
+                "name": "Bhavna"
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow6/on_confirm.json
+++ b/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow6/on_confirm.json
@@ -1,0 +1,289 @@
+{
+    "context": {
+      "domain": "ONDC:RET14",
+      "action": "on_confirm",
+      "core_version": "1.2.0",
+      "bap_id": "buyer-app-preprod-v2.ondc.org",
+      "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+      "bpp_id": "api.greenreceipt.in",
+      "bpp_uri": "https://api.greenreceipt.in/ondc",
+      "transaction_id": "3b505f52-9f97-44a0-80e2-51ac2c3411b8",
+      "message_id": "42aca09a-d6b0-4862-b702-1eb9d1926fe3",
+      "city": "std:0124",
+      "country": "IND",
+      "timestamp": "2024-07-05T10:07:42.897Z"
+    },
+    "message": {
+      "order": {
+        "id": "2024-07-05-178086",
+        "state": "Created",
+        "provider": {
+          "id": "24932",
+          "locations": [
+            {
+              "id": "24932"
+            }
+          ]
+        },
+        "items": [
+          {
+            "id": "24932_2740433",
+            "fulfillment_id": "24932_F1",
+            "quantity": {
+              "count": 2
+            }
+          },
+          {
+            "id": "24932_2740435",
+            "fulfillment_id": "24932_F1",
+            "quantity": {
+              "count": 2
+            }
+          },
+          {
+            "id": "24932_2740440",
+            "fulfillment_id": "24932_F1",
+            "quantity": {
+              "count": 1
+            }
+          },
+          {
+            "id": "24932_2740442",
+            "fulfillment_id": "24932_F1",
+            "quantity": {
+              "count": 1
+            }
+          }
+        ],
+        "billing": {
+          "name": "Bhavna",
+          "address": {
+            "name": "Bhavna",
+            "building": "club patio",
+            "locality": "Sector Road",
+            "city": "Gurugram",
+            "state": "Haryana",
+            "country": "IND",
+            "area_code": "122007"
+          },
+          "email": "bhavna@buynxt.in",
+          "phone": "7419096651",
+          "created_at": "2024-07-05T10:07:13.125Z",
+          "updated_at": "2024-07-05T10:07:13.125Z"
+        },
+        "fulfillments": [
+          {
+            "id": "24932_F1",
+            "@ondc/org/provider_name": "Ajay Electronics",
+            "state": {
+              "descriptor": {
+                "code": "Pending"
+              }
+            },
+            "type": "Delivery",
+            "tracking": false,
+            "@ondc/org/TAT": "PT4H",
+            "start": {
+              "location": {
+                "id": "24932",
+                "descriptor": {
+                  "name": "Ajay Electronics"
+                },
+                "gps": "28.41430316,77.06620157",
+                "address": {
+                  "locality": "Nirvana Country",
+                  "city": "Gurgaon",
+                  "area_code": "122018",
+                  "state": "Haryana"
+                }
+              },
+              "time": {
+                "range": {
+                  "start": "2024-07-05T10:17:42.897Z",
+                  "end": "2024-07-05T11:17:42.897Z"
+                }
+              },
+              "contact": {
+                "phone": "8076362934",
+                "email": "Demo3@gmail.com"
+              }
+            },
+            "end": {
+              "location": {
+                "gps": "28.457914,77.067837",
+                "address": {
+                  "name": "Bhavna",
+                  "building": "club patio",
+                  "locality": "Sector Road",
+                  "city": "Gurugram",
+                  "state": "Haryana",
+                  "country": "IND",
+                  "area_code": "122007"
+                }
+              },
+              "time": {
+                "range": {
+                  "start": "2024-07-05T13:17:42.897Z",
+                  "end": "2024-07-05T14:17:42.897Z"
+                }
+              },
+              "person": {
+                "name": "Bhavna"
+              },
+              "contact": {
+                "phone": "7419096651",
+                "email": "bhavna@buynxt.in"
+              }
+            }
+          }
+        ],
+        "quote": {
+          "price": {
+            "currency": "INR",
+            "value": "417940.00"
+          },
+          "breakup": [
+            {
+              "@ondc/org/item_id": "24932_2740433",
+              "@ondc/org/item_quantity": {
+                "count": 2
+              },
+              "title": "IPHONE 14 128GB YELLOW",
+              "@ondc/org/title_type": "item",
+              "price": {
+                "currency": "INR",
+                "value": "145980.00"
+              },
+              "item": {
+                "price": {
+                  "currency": "INR",
+                  "value": "72990.00"
+                }
+              }
+            },
+            {
+              "@ondc/org/item_id": "24932_2740435",
+              "@ondc/org/item_quantity": {
+                "count": 2
+              },
+              "title": "IPHONE 14 128GB MIDNIGHT",
+              "@ondc/org/title_type": "item",
+              "price": {
+                "currency": "INR",
+                "value": "145980.00"
+              },
+              "item": {
+                "price": {
+                  "currency": "INR",
+                  "value": "72990.00"
+                }
+              }
+            },
+            {
+              "@ondc/org/item_id": "24932_2740440",
+              "@ondc/org/item_quantity": {
+                "count": 1
+              },
+              "title": "IPHONE 13 128GB BLUE",
+              "@ondc/org/title_type": "item",
+              "price": {
+                "currency": "INR",
+                "value": "62990.00"
+              },
+              "item": {
+                "price": {
+                  "currency": "INR",
+                  "value": "62990.00"
+                }
+              }
+            },
+            {
+              "@ondc/org/item_id": "24932_2740442",
+              "@ondc/org/item_quantity": {
+                "count": 1
+              },
+              "title": "IPHONE 13 128GB GREEN",
+              "@ondc/org/title_type": "item",
+              "price": {
+                "currency": "INR",
+                "value": "62990.00"
+              },
+              "item": {
+                "price": {
+                  "currency": "INR",
+                  "value": "62990.00"
+                }
+              }
+            },
+            {
+              "@ondc/org/item_id": "24932_F1",
+              "title": "Delivery charges",
+              "@ondc/org/title_type": "delivery",
+              "price": {
+                "currency": "INR",
+                "value": "0.00"
+              }
+            }
+          ],
+          "ttl": "P1D"
+        },
+        "payment": {
+          "uri": "https://razorpay.com/",
+          "tl_method": "http/get",
+          "params": {
+            "currency": "INR",
+            "transaction_id": "order_OUubpHLJt1USCZ",
+            "amount": "417940.00"
+          },
+          "status": "PAID",
+          "type": "ON-ORDER",
+          "collected_by": "BAP",
+          "@ondc/org/buyer_app_finder_fee_type": "percent",
+          "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+          "@ondc/org/settlement_details": [
+            {
+              "settlement_counterparty": "seller-app",
+              "settlement_phase": "sale-amount",
+              "beneficiary_name": "Buynxt Private Limited",
+              "settlement_type": "neft",
+              "upi_address": "buynxt@okidfc",
+              "settlement_bank_account_no": "10129914936",
+              "settlement_ifsc_code": "IDFB0021001",
+              "bank_name": "IDFC First Bank Limited",
+              "branch_name": "Golf Course Road, Gurgaon"
+            }
+          ]
+        },
+        "tags": [
+          {
+            "code": "bpp_terms",
+            "list": [
+              {
+                "code": "np_type",
+                "value": "MSN"
+              },
+              {
+                "code": "tax_number",
+                "value": "09ALZPS7205J2ZP"
+              },
+              {
+                "code": "provider_tax_number",
+                "value": "CKABS4783R"
+              }
+            ]
+          },
+          {
+            "code": "bap_terms",
+            "list": [
+              {
+                "code": "tax_number",
+                "value": "GSTIN1234567890"
+              }
+            ]
+          }
+        ],
+        "created_at": "2024-07-05T10:07:42.787Z",
+        "updated_at": "2024-07-05T10:07:42.897Z"
+      }
+    }
+  }

--- a/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow6/on_init.json
+++ b/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow6/on_init.json
@@ -1,0 +1,221 @@
+{
+    "context": {
+      "domain": "ONDC:RET14",
+      "action": "on_init",
+      "core_version": "1.2.0",
+      "bap_id": "buyer-app-preprod-v2.ondc.org",
+      "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+      "bpp_id": "api.greenreceipt.in",
+      "bpp_uri": "https://api.greenreceipt.in/ondc",
+      "transaction_id": "3b505f52-9f97-44a0-80e2-51ac2c3411b8",
+      "message_id": "e0c85aba-4824-4652-a472-b05f6bb7c7f0",
+      "city": "std:0124",
+      "country": "IND",
+      "timestamp": "2024-07-05T10:07:13.196Z"
+    },
+    "message": {
+      "order": {
+        "provider": {
+          "id": "24932",
+          "locations": [
+            {
+              "id": "24932"
+            }
+          ]
+        },
+        "items": [
+          {
+            "id": "24932_2740433",
+            "fulfillment_id": "24932_F1",
+            "quantity": {
+              "count": 2
+            }
+          },
+          {
+            "id": "24932_2740435",
+            "fulfillment_id": "24932_F1",
+            "quantity": {
+              "count": 2
+            }
+          },
+          {
+            "id": "24932_2740440",
+            "fulfillment_id": "24932_F1",
+            "quantity": {
+              "count": 1
+            }
+          },
+          {
+            "id": "24932_2740442",
+            "fulfillment_id": "24932_F1",
+            "quantity": {
+              "count": 1
+            }
+          }
+        ],
+        "billing": {
+          "name": "Bhavna",
+          "address": {
+            "name": "Bhavna",
+            "building": "club patio",
+            "locality": "Sector Road",
+            "city": "Gurugram",
+            "state": "Haryana",
+            "country": "IND",
+            "area_code": "122007"
+          },
+          "email": "bhavna@buynxt.in",
+          "phone": "7419096651",
+          "created_at": "2024-07-05T10:07:13.125Z",
+          "updated_at": "2024-07-05T10:07:13.125Z"
+        },
+        "fulfillments": [
+          {
+            "id": "24932_F1",
+            "type": "Delivery",
+            "tracking": false,
+            "end": {
+              "location": {
+                "gps": "28.457914,77.067837",
+                "address": {
+                  "name": "Bhavna",
+                  "building": "club patio",
+                  "locality": "Sector Road",
+                  "city": "Gurugram",
+                  "state": "Haryana",
+                  "country": "IND",
+                  "area_code": "122007"
+                }
+              },
+              "contact": {
+                "phone": "7419096651",
+                "email": "bhavna@buynxt.in"
+              }
+            }
+          }
+        ],
+        "quote": {
+          "price": {
+            "currency": "INR",
+            "value": "417940.00"
+          },
+          "breakup": [
+            {
+              "@ondc/org/item_id": "24932_2740433",
+              "@ondc/org/item_quantity": {
+                "count": 2
+              },
+              "title": "IPHONE 14 128GB YELLOW",
+              "@ondc/org/title_type": "item",
+              "price": {
+                "currency": "INR",
+                "value": "145980.00"
+              },
+              "item": {
+                "price": {
+                  "currency": "INR",
+                  "value": "72990.00"
+                }
+              }
+            },
+            {
+              "@ondc/org/item_id": "24932_2740435",
+              "@ondc/org/item_quantity": {
+                "count": 2
+              },
+              "title": "IPHONE 14 128GB MIDNIGHT",
+              "@ondc/org/title_type": "item",
+              "price": {
+                "currency": "INR",
+                "value": "145980.00"
+              },
+              "item": {
+                "price": {
+                  "currency": "INR",
+                  "value": "72990.00"
+                }
+              }
+            },
+            {
+              "@ondc/org/item_id": "24932_2740440",
+              "@ondc/org/item_quantity": {
+                "count": 1
+              },
+              "title": "IPHONE 13 128GB BLUE",
+              "@ondc/org/title_type": "item",
+              "price": {
+                "currency": "INR",
+                "value": "62990.00"
+              },
+              "item": {
+                "price": {
+                  "currency": "INR",
+                  "value": "62990.00"
+                }
+              }
+            },
+            {
+              "@ondc/org/item_id": "24932_2740442",
+              "@ondc/org/item_quantity": {
+                "count": 1
+              },
+              "title": "IPHONE 13 128GB GREEN",
+              "@ondc/org/title_type": "item",
+              "price": {
+                "currency": "INR",
+                "value": "62990.00"
+              },
+              "item": {
+                "price": {
+                  "currency": "INR",
+                  "value": "62990.00"
+                }
+              }
+            },
+            {
+              "@ondc/org/item_id": "24932_F1",
+              "title": "Delivery charges",
+              "@ondc/org/title_type": "delivery",
+              "price": {
+                "currency": "INR",
+                "value": "0.00"
+              }
+            }
+          ],
+          "ttl": "P1D"
+        },
+        "payment": {
+          "@ondc/org/buyer_app_finder_fee_type": "percent",
+          "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+          "@ondc/org/settlement_details": [
+            {
+              "settlement_counterparty": "seller-app",
+              "settlement_phase": "sale-amount",
+              "settlement_type": "neft",
+              "beneficiary_name": "Buynxt Private Limited",
+              "upi_address": "buynxt@okidfc",
+              "settlement_bank_account_no": "10129914936",
+              "settlement_ifsc_code": "IDFB0021001",
+              "bank_name": "IDFC First Bank Limited",
+              "branch_name": "Golf Course Road, Gurgaon"
+            }
+          ]
+        },
+        "tags": [
+          {
+            "code": "bpp_terms",
+            "list": [
+              {
+                "code": "tax_number",
+                "value": "09ALZPS7205J2ZP"
+              },
+              {
+                "code": "provider_tax_number",
+                "value": "CKABS4783R"
+              }
+            ]
+          }
+        ]
+      }
+    }
+  }

--- a/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow6/on_select.json
+++ b/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow6/on_select.json
@@ -1,0 +1,183 @@
+{
+    "context": {
+      "domain": "ONDC:RET14",
+      "action": "on_select",
+      "core_version": "1.2.0",
+      "bap_id": "buyer-app-preprod-v2.ondc.org",
+      "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+      "bpp_id": "api.greenreceipt.in",
+      "bpp_uri": "https://api.greenreceipt.in/ondc",
+      "transaction_id": "3b505f52-9f97-44a0-80e2-51ac2c3411b8",
+      "message_id": "35216891-77cf-4ab0-8fca-4f09f2033b19",
+      "city": "std:0124",
+      "country": "IND",
+      "timestamp": "2024-07-05T10:07:00.312Z"
+    },
+    "message": {
+      "order": {
+        "provider": {
+          "id": "24932",
+          "locations": [
+            {
+              "id": "24932"
+            }
+          ]
+        },
+        "items": [
+          {
+            "fulfillment_id": "24932_F1",
+            "id": "24932_2740433"
+          },
+          {
+            "fulfillment_id": "24932_F1",
+            "id": "24932_2740435"
+          },
+          {
+            "fulfillment_id": "24932_F1",
+            "id": "24932_2740440"
+          },
+          {
+            "fulfillment_id": "24932_F1",
+            "id": "24932_2740442"
+          }
+        ],
+        "fulfillments": [
+          {
+            "id": "24932_F1",
+            "type": "Delivery",
+            "@ondc/org/provider_name": "Ajay Electronics",
+            "tracking": false,
+            "@ondc/org/category": "Standard Delivery",
+            "@ondc/org/TAT": "PT4H",
+            "state": {
+              "descriptor": {
+                "code": "Serviceable"
+              }
+            }
+          }
+        ],
+        "quote": {
+          "price": {
+            "currency": "INR",
+            "value": "417940.00"
+          },
+          "breakup": [
+            {
+              "@ondc/org/item_id": "24932_2740433",
+              "@ondc/org/item_quantity": {
+                "count": 2
+              },
+              "title": "IPHONE 14 128GB YELLOW",
+              "@ondc/org/title_type": "item",
+              "price": {
+                "currency": "INR",
+                "value": "145980.00"
+              },
+              "item": {
+                "quantity": {
+                  "available": {
+                    "count": "99"
+                  },
+                  "maximum": {
+                    "count": "99"
+                  }
+                },
+                "price": {
+                  "currency": "INR",
+                  "value": "72990.00"
+                }
+              }
+            },
+            {
+              "@ondc/org/item_id": "24932_2740435",
+              "@ondc/org/item_quantity": {
+                "count": 2
+              },
+              "title": "IPHONE 14 128GB MIDNIGHT",
+              "@ondc/org/title_type": "item",
+              "price": {
+                "currency": "INR",
+                "value": "145980.00"
+              },
+              "item": {
+                "quantity": {
+                  "available": {
+                    "count": "99"
+                  },
+                  "maximum": {
+                    "count": "99"
+                  }
+                },
+                "price": {
+                  "currency": "INR",
+                  "value": "72990.00"
+                }
+              }
+            },
+            {
+              "@ondc/org/item_id": "24932_2740440",
+              "@ondc/org/item_quantity": {
+                "count": 1
+              },
+              "title": "IPHONE 13 128GB BLUE",
+              "@ondc/org/title_type": "item",
+              "price": {
+                "currency": "INR",
+                "value": "62990.00"
+              },
+              "item": {
+                "quantity": {
+                  "available": {
+                    "count": "99"
+                  },
+                  "maximum": {
+                    "count": "99"
+                  }
+                },
+                "price": {
+                  "currency": "INR",
+                  "value": "62990.00"
+                }
+              }
+            },
+            {
+              "@ondc/org/item_id": "24932_2740442",
+              "@ondc/org/item_quantity": {
+                "count": 1
+              },
+              "title": "IPHONE 13 128GB GREEN",
+              "@ondc/org/title_type": "item",
+              "price": {
+                "currency": "INR",
+                "value": "62990.00"
+              },
+              "item": {
+                "quantity": {
+                  "available": {
+                    "count": "99"
+                  },
+                  "maximum": {
+                    "count": "99"
+                  }
+                },
+                "price": {
+                  "currency": "INR",
+                  "value": "62990.00"
+                }
+              }
+            },
+            {
+              "@ondc/org/item_id": "24932_F1",
+              "title": "Delivery charges",
+              "@ondc/org/title_type": "delivery",
+              "price": {
+                "currency": "INR",
+                "value": "0.00"
+              }
+            }
+          ],
+          "ttl": "PT4H"
+        }
+      }
+    }
+  }

--- a/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow6/on_status_order_delivered.json
+++ b/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow6/on_status_order_delivered.json
@@ -1,0 +1,340 @@
+{
+    "context": {
+      "domain": "ONDC:RET14",
+      "action": "on_status",
+      "core_version": "1.2.0",
+      "bap_id": "buyer-app-preprod-v2.ondc.org",
+      "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+      "bpp_id": "api.greenreceipt.in",
+      "bpp_uri": "https://api.greenreceipt.in/ondc",
+      "transaction_id": "3b505f52-9f97-44a0-80e2-51ac2c3411b8",
+      "message_id": "e590c927-6f3e-4993-b7bc-d813195ee58c",
+      "city": "std:0124",
+      "country": "IND",
+      "timestamp": "2024-07-05T10:15:15.174Z",
+      "ttl": "PT30S"
+    },
+    "message": {
+      "order": {
+        "id": "2024-07-05-178086",
+        "state": "Completed",
+        "provider": {
+          "id": "24932",
+          "locations": [
+            {
+              "id": "24932"
+            }
+          ]
+        },
+        "items": [
+          {
+            "id": "24932_2740433",
+            "fulfillment_id": "24932_F1",
+            "quantity": {
+              "count": 1
+            }
+          },
+          {
+            "id": "24932_2740435",
+            "fulfillment_id": "24932_F1",
+            "quantity": {
+              "count": 2
+            }
+          },
+          {
+            "id": "24932_2740440",
+            "fulfillment_id": "24932_F1",
+            "quantity": {
+              "count": 1
+            }
+          },
+          {
+            "id": "24932_2740442",
+            "fulfillment_id": "24932_F1",
+            "quantity": {
+              "count": 1
+            }
+          },
+          {
+            "id": "24932_2740433",
+            "fulfillment_id": "24932_C1",
+            "quantity": {
+              "count": 1
+            }
+          }
+        ],
+        "billing": {
+          "name": "Bhavna",
+          "address": {
+            "name": "Bhavna",
+            "building": "club patio",
+            "locality": "Sector Road",
+            "city": "Gurugram",
+            "state": "Haryana",
+            "country": "IND",
+            "area_code": "122007"
+          },
+          "email": "bhavna@buynxt.in",
+          "phone": "7419096651",
+          "created_at": "2024-07-05T10:07:13.125Z",
+          "updated_at": "2024-07-05T10:07:13.125Z"
+        },
+        "fulfillments": [
+          {
+            "id": "24932_F1",
+            "@ondc/org/provider_name": "Ajay Electronics",
+            "type": "Delivery",
+            "tracking": false,
+            "@ondc/org/TAT": "PT4H",
+            "state": {
+              "descriptor": {
+                "code": "Order-delivered"
+              }
+            },
+            "start": {
+              "location": {
+                "descriptor": {
+                  "name": "Ajay Electronics"
+                },
+                "gps": "28.41430316,77.06620157",
+                "address": {
+                  "locality": "Nirvana Country",
+                  "city": "Gurgaon",
+                  "state": "Haryana",
+                  "area_code": "122018"
+                }
+              },
+              "time": {
+                "range": {
+                  "start": "2024-07-05T10:17:42.897Z",
+                  "end": "2024-07-05T11:17:42.897Z"
+                },
+                "timestamp": "2024-07-05T10:12:07.047Z"
+              },
+              "contact": {
+                "phone": "8076362934",
+                "email": "Demo3@gmail.com"
+              }
+            },
+            "end": {
+              "location": {
+                "gps": "28.457914,77.067837",
+                "address": {
+                  "name": "Bhavna",
+                  "building": "club patio",
+                  "locality": "Sector Road",
+                  "city": "Gurugram",
+                  "state": "Haryana",
+                  "country": "IND",
+                  "area_code": "122007"
+                }
+              },
+              "time": {
+                "range": {
+                  "start": "2024-07-05T13:17:42.897Z",
+                  "end": "2024-07-05T14:17:42.897Z"
+                },
+                "timestamp": "2024-07-05T10:15:14.710Z"
+              },
+              "person": {
+                "name": "Bhavna"
+              },
+              "contact": {
+                "phone": "7419096651",
+                "email": "bhavna@buynxt.in"
+              }
+            },
+            "tags": [
+              {
+                "code": "routing",
+                "list": [
+                  {
+                    "code": "type",
+                    "value": "P2P"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "24932_C1",
+            "type": "Cancel",
+            "tracking": false,
+            "state": {
+              "descriptor": {
+                "code": "Cancelled"
+              }
+            },
+            "tags": [
+              {
+                "code": "cancel_request",
+                "list": [
+                  {
+                    "code": "reason_id",
+                    "value": "002"
+                  },
+                  {
+                    "code": "initiated_by",
+                    "value": "api.greenreceipt.in"
+                  }
+                ]
+              },
+              {
+                "code": "quote_trail",
+                "list": [
+                  {
+                    "code": "type",
+                    "value": "item"
+                  },
+                  {
+                    "code": "id",
+                    "value": "24932_2740433"
+                  },
+                  {
+                    "code": "currency",
+                    "value": "INR"
+                  },
+                  {
+                    "code": "value",
+                    "value": "-72990.00"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "quote": {
+          "price": {
+            "currency": "INR",
+            "value": "344950.00"
+          },
+          "breakup": [
+            {
+              "@ondc/org/item_id": "24932_2740433",
+              "@ondc/org/item_quantity": {
+                "count": 1
+              },
+              "title": "IPHONE 14 128GB YELLOW",
+              "@ondc/org/title_type": "item",
+              "price": {
+                "currency": "INR",
+                "value": "72990.00"
+              },
+              "item": {
+                "price": {
+                  "currency": "INR",
+                  "value": "72990.00"
+                }
+              }
+            },
+            {
+              "@ondc/org/item_id": "24932_2740435",
+              "@ondc/org/item_quantity": {
+                "count": 2
+              },
+              "title": "IPHONE 14 128GB MIDNIGHT",
+              "@ondc/org/title_type": "item",
+              "price": {
+                "currency": "INR",
+                "value": "145980.00"
+              },
+              "item": {
+                "price": {
+                  "currency": "INR",
+                  "value": "72990.00"
+                }
+              }
+            },
+            {
+              "@ondc/org/item_id": "24932_2740440",
+              "@ondc/org/item_quantity": {
+                "count": 1
+              },
+              "title": "IPHONE 13 128GB BLUE",
+              "@ondc/org/title_type": "item",
+              "price": {
+                "currency": "INR",
+                "value": "62990.00"
+              },
+              "item": {
+                "price": {
+                  "currency": "INR",
+                  "value": "62990.00"
+                }
+              }
+            },
+            {
+              "@ondc/org/item_id": "24932_2740442",
+              "@ondc/org/item_quantity": {
+                "count": 1
+              },
+              "title": "IPHONE 13 128GB GREEN",
+              "@ondc/org/title_type": "item",
+              "price": {
+                "currency": "INR",
+                "value": "62990.00"
+              },
+              "item": {
+                "price": {
+                  "currency": "INR",
+                  "value": "62990.00"
+                }
+              }
+            },
+            {
+              "@ondc/org/item_id": "24932_F1",
+              "title": "Delivery charges",
+              "@ondc/org/title_type": "delivery",
+              "price": {
+                "currency": "INR",
+                "value": "0.00"
+              }
+            }
+          ],
+          "ttl": "PT4H"
+        },
+        "payment": {
+          "uri": "https://razorpay.com/",
+          "tl_method": "http/get",
+          "params": {
+            "currency": "INR",
+            "transaction_id": "order_OUubpHLJt1USCZ",
+            "amount": "417940.00"
+          },
+          "status": "PAID",
+          "type": "ON-ORDER",
+          "collected_by": "BAP",
+          "@ondc/org/buyer_app_finder_fee_type": "percent",
+          "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+          "@ondc/org/settlement_details": [
+            {
+              "settlement_counterparty": "buyer",
+              "settlement_phase": "refund",
+              "settlement_type": "netbanking",
+              "settlement_timestamp": "2024-07-05T10:10:57.622Z",
+              "settlement_amount": "72990"
+            },
+            {
+              "settlement_counterparty": "seller-app",
+              "settlement_phase": "sale-amount",
+              "beneficiary_name": "Buynxt Private Limited",
+              "settlement_type": "neft",
+              "upi_address": "buynxt@okidfc",
+              "settlement_bank_account_no": "10129914936",
+              "settlement_ifsc_code": "IDFB0021001",
+              "bank_name": "IDFC First Bank Limited",
+              "branch_name": "Golf Course Road, Gurgaon"
+            }
+          ]
+        },
+        "documents": [
+          {
+            "url": "https://greenreceipt.in/invoices/2024-07-05-178086.pdf",
+            "label": "Invoice"
+          }
+        ],
+        "created_at": "2024-07-05T10:07:42.787Z",
+        "updated_at": "2024-07-05T10:15:15.174Z"
+      }
+    }
+  }

--- a/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow6/on_status_order_picked.json
+++ b/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow6/on_status_order_picked.json
@@ -1,0 +1,339 @@
+{
+    "context": {
+      "domain": "ONDC:RET14",
+      "action": "on_status",
+      "core_version": "1.2.0",
+      "bap_id": "buyer-app-preprod-v2.ondc.org",
+      "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+      "bpp_id": "api.greenreceipt.in",
+      "bpp_uri": "https://api.greenreceipt.in/ondc",
+      "transaction_id": "3b505f52-9f97-44a0-80e2-51ac2c3411b8",
+      "message_id": "34f2c36d-df38-4f44-b7b3-edc610650b34",
+      "city": "std:0124",
+      "country": "IND",
+      "timestamp": "2024-07-05T10:12:10.218Z",
+      "ttl": "PT30S"
+    },
+    "message": {
+      "order": {
+        "id": "2024-07-05-178086",
+        "state": "In-progress",
+        "provider": {
+          "id": "24932",
+          "locations": [
+            {
+              "id": "24932"
+            }
+          ]
+        },
+        "items": [
+          {
+            "id": "24932_2740433",
+            "fulfillment_id": "24932_F1",
+            "quantity": {
+              "count": 1
+            }
+          },
+          {
+            "id": "24932_2740435",
+            "fulfillment_id": "24932_F1",
+            "quantity": {
+              "count": 2
+            }
+          },
+          {
+            "id": "24932_2740440",
+            "fulfillment_id": "24932_F1",
+            "quantity": {
+              "count": 1
+            }
+          },
+          {
+            "id": "24932_2740442",
+            "fulfillment_id": "24932_F1",
+            "quantity": {
+              "count": 1
+            }
+          },
+          {
+            "id": "24932_2740433",
+            "fulfillment_id": "24932_C1",
+            "quantity": {
+              "count": 1
+            }
+          }
+        ],
+        "billing": {
+          "name": "Bhavna",
+          "address": {
+            "name": "Bhavna",
+            "building": "club patio",
+            "locality": "Sector Road",
+            "city": "Gurugram",
+            "state": "Haryana",
+            "country": "IND",
+            "area_code": "122007"
+          },
+          "email": "bhavna@buynxt.in",
+          "phone": "7419096651",
+          "created_at": "2024-07-05T10:07:13.125Z",
+          "updated_at": "2024-07-05T10:07:13.125Z"
+        },
+        "fulfillments": [
+          {
+            "id": "24932_F1",
+            "@ondc/org/provider_name": "Ajay Electronics",
+            "type": "Delivery",
+            "tracking": false,
+            "@ondc/org/TAT": "PT4H",
+            "state": {
+              "descriptor": {
+                "code": "Order-picked-up"
+              }
+            },
+            "start": {
+              "location": {
+                "descriptor": {
+                  "name": "Ajay Electronics"
+                },
+                "gps": "28.41430316,77.06620157",
+                "address": {
+                  "locality": "Nirvana Country",
+                  "city": "Gurgaon",
+                  "state": "Haryana",
+                  "area_code": "122018"
+                }
+              },
+              "time": {
+                "range": {
+                  "start": "2024-07-05T10:17:42.897Z",
+                  "end": "2024-07-05T11:17:42.897Z"
+                },
+                "timestamp": "2024-07-05T10:12:07.047Z"
+              },
+              "contact": {
+                "phone": "8076362934",
+                "email": "Demo3@gmail.com"
+              }
+            },
+            "end": {
+              "location": {
+                "gps": "28.457914,77.067837",
+                "address": {
+                  "name": "Bhavna",
+                  "building": "club patio",
+                  "locality": "Sector Road",
+                  "city": "Gurugram",
+                  "state": "Haryana",
+                  "country": "IND",
+                  "area_code": "122007"
+                }
+              },
+              "time": {
+                "range": {
+                  "start": "2024-07-05T13:17:42.897Z",
+                  "end": "2024-07-05T14:17:42.897Z"
+                }
+              },
+              "person": {
+                "name": "Bhavna"
+              },
+              "contact": {
+                "phone": "7419096651",
+                "email": "bhavna@buynxt.in"
+              }
+            },
+            "tags": [
+              {
+                "code": "routing",
+                "list": [
+                  {
+                    "code": "type",
+                    "value": "P2P"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "24932_C1",
+            "type": "Cancel",
+            "tracking": false,
+            "state": {
+              "descriptor": {
+                "code": "Cancelled"
+              }
+            },
+            "tags": [
+              {
+                "code": "cancel_request",
+                "list": [
+                  {
+                    "code": "reason_id",
+                    "value": "002"
+                  },
+                  {
+                    "code": "initiated_by",
+                    "value": "api.greenreceipt.in"
+                  }
+                ]
+              },
+              {
+                "code": "quote_trail",
+                "list": [
+                  {
+                    "code": "type",
+                    "value": "item"
+                  },
+                  {
+                    "code": "id",
+                    "value": "24932_2740433"
+                  },
+                  {
+                    "code": "currency",
+                    "value": "INR"
+                  },
+                  {
+                    "code": "value",
+                    "value": "-72990.00"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "quote": {
+          "price": {
+            "currency": "INR",
+            "value": "344950.00"
+          },
+          "breakup": [
+            {
+              "@ondc/org/item_id": "24932_2740433",
+              "@ondc/org/item_quantity": {
+                "count": 1
+              },
+              "title": "IPHONE 14 128GB YELLOW",
+              "@ondc/org/title_type": "item",
+              "price": {
+                "currency": "INR",
+                "value": "72990.00"
+              },
+              "item": {
+                "price": {
+                  "currency": "INR",
+                  "value": "72990.00"
+                }
+              }
+            },
+            {
+              "@ondc/org/item_id": "24932_2740435",
+              "@ondc/org/item_quantity": {
+                "count": 2
+              },
+              "title": "IPHONE 14 128GB MIDNIGHT",
+              "@ondc/org/title_type": "item",
+              "price": {
+                "currency": "INR",
+                "value": "145980.00"
+              },
+              "item": {
+                "price": {
+                  "currency": "INR",
+                  "value": "72990.00"
+                }
+              }
+            },
+            {
+              "@ondc/org/item_id": "24932_2740440",
+              "@ondc/org/item_quantity": {
+                "count": 1
+              },
+              "title": "IPHONE 13 128GB BLUE",
+              "@ondc/org/title_type": "item",
+              "price": {
+                "currency": "INR",
+                "value": "62990.00"
+              },
+              "item": {
+                "price": {
+                  "currency": "INR",
+                  "value": "62990.00"
+                }
+              }
+            },
+            {
+              "@ondc/org/item_id": "24932_2740442",
+              "@ondc/org/item_quantity": {
+                "count": 1
+              },
+              "title": "IPHONE 13 128GB GREEN",
+              "@ondc/org/title_type": "item",
+              "price": {
+                "currency": "INR",
+                "value": "62990.00"
+              },
+              "item": {
+                "price": {
+                  "currency": "INR",
+                  "value": "62990.00"
+                }
+              }
+            },
+            {
+              "@ondc/org/item_id": "24932_F1",
+              "title": "Delivery charges",
+              "@ondc/org/title_type": "delivery",
+              "price": {
+                "currency": "INR",
+                "value": "0.00"
+              }
+            }
+          ],
+          "ttl": "PT4H"
+        },
+        "payment": {
+          "uri": "https://razorpay.com/",
+          "tl_method": "http/get",
+          "params": {
+            "currency": "INR",
+            "transaction_id": "order_OUubpHLJt1USCZ",
+            "amount": "417940.00"
+          },
+          "status": "PAID",
+          "type": "ON-ORDER",
+          "collected_by": "BAP",
+          "@ondc/org/buyer_app_finder_fee_type": "percent",
+          "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+          "@ondc/org/settlement_details": [
+            {
+              "settlement_counterparty": "buyer",
+              "settlement_phase": "refund",
+              "settlement_type": "netbanking",
+              "settlement_timestamp": "2024-07-05T10:10:57.622Z",
+              "settlement_amount": "72990"
+            },
+            {
+              "settlement_counterparty": "seller-app",
+              "settlement_phase": "sale-amount",
+              "beneficiary_name": "Buynxt Private Limited",
+              "settlement_type": "neft",
+              "upi_address": "buynxt@okidfc",
+              "settlement_bank_account_no": "10129914936",
+              "settlement_ifsc_code": "IDFB0021001",
+              "bank_name": "IDFC First Bank Limited",
+              "branch_name": "Golf Course Road, Gurgaon"
+            }
+          ]
+        },
+        "documents": [
+          {
+            "url": "https://greenreceipt.in/invoices/2024-07-05-178086.pdf",
+            "label": "Invoice"
+          }
+        ],
+        "created_at": "2024-07-05T10:07:42.787Z",
+        "updated_at": "2024-07-05T10:12:10.218Z"
+      }
+    }
+  }

--- a/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow6/on_status_out_for_delivery.json
+++ b/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow6/on_status_out_for_delivery.json
@@ -1,0 +1,339 @@
+{
+    "context": {
+      "domain": "ONDC:RET14",
+      "action": "on_status",
+      "core_version": "1.2.0",
+      "bap_id": "buyer-app-preprod-v2.ondc.org",
+      "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+      "bpp_id": "api.greenreceipt.in",
+      "bpp_uri": "https://api.greenreceipt.in/ondc",
+      "transaction_id": "3b505f52-9f97-44a0-80e2-51ac2c3411b8",
+      "message_id": "fb9d8268-b99f-4d8d-b0bd-cd7bb63e5c0e",
+      "city": "std:0124",
+      "country": "IND",
+      "timestamp": "2024-07-05T10:13:28.345Z",
+      "ttl": "PT30S"
+    },
+    "message": {
+      "order": {
+        "id": "2024-07-05-178086",
+        "state": "In-progress",
+        "provider": {
+          "id": "24932",
+          "locations": [
+            {
+              "id": "24932"
+            }
+          ]
+        },
+        "items": [
+          {
+            "id": "24932_2740433",
+            "fulfillment_id": "24932_F1",
+            "quantity": {
+              "count": 1
+            }
+          },
+          {
+            "id": "24932_2740435",
+            "fulfillment_id": "24932_F1",
+            "quantity": {
+              "count": 2
+            }
+          },
+          {
+            "id": "24932_2740440",
+            "fulfillment_id": "24932_F1",
+            "quantity": {
+              "count": 1
+            }
+          },
+          {
+            "id": "24932_2740442",
+            "fulfillment_id": "24932_F1",
+            "quantity": {
+              "count": 1
+            }
+          },
+          {
+            "id": "24932_2740433",
+            "fulfillment_id": "24932_C1",
+            "quantity": {
+              "count": 1
+            }
+          }
+        ],
+        "billing": {
+          "name": "Bhavna",
+          "address": {
+            "name": "Bhavna",
+            "building": "club patio",
+            "locality": "Sector Road",
+            "city": "Gurugram",
+            "state": "Haryana",
+            "country": "IND",
+            "area_code": "122007"
+          },
+          "email": "bhavna@buynxt.in",
+          "phone": "7419096651",
+          "created_at": "2024-07-05T10:07:13.125Z",
+          "updated_at": "2024-07-05T10:07:13.125Z"
+        },
+        "fulfillments": [
+          {
+            "id": "24932_F1",
+            "@ondc/org/provider_name": "Ajay Electronics",
+            "type": "Delivery",
+            "tracking": false,
+            "@ondc/org/TAT": "PT4H",
+            "state": {
+              "descriptor": {
+                "code": "Out-for-delivery"
+              }
+            },
+            "start": {
+              "location": {
+                "descriptor": {
+                  "name": "Ajay Electronics"
+                },
+                "gps": "28.41430316,77.06620157",
+                "address": {
+                  "locality": "Nirvana Country",
+                  "city": "Gurgaon",
+                  "state": "Haryana",
+                  "area_code": "122018"
+                }
+              },
+              "time": {
+                "range": {
+                  "start": "2024-07-05T10:17:42.897Z",
+                  "end": "2024-07-05T11:17:42.897Z"
+                },
+                "timestamp": "2024-07-05T10:12:07.047Z"
+              },
+              "contact": {
+                "phone": "8076362934",
+                "email": "Demo3@gmail.com"
+              }
+            },
+            "end": {
+              "location": {
+                "gps": "28.457914,77.067837",
+                "address": {
+                  "name": "Bhavna",
+                  "building": "club patio",
+                  "locality": "Sector Road",
+                  "city": "Gurugram",
+                  "state": "Haryana",
+                  "country": "IND",
+                  "area_code": "122007"
+                }
+              },
+              "time": {
+                "range": {
+                  "start": "2024-07-05T13:17:42.897Z",
+                  "end": "2024-07-05T14:17:42.897Z"
+                }
+              },
+              "person": {
+                "name": "Bhavna"
+              },
+              "contact": {
+                "phone": "7419096651",
+                "email": "bhavna@buynxt.in"
+              }
+            },
+            "tags": [
+              {
+                "code": "routing",
+                "list": [
+                  {
+                    "code": "type",
+                    "value": "P2P"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "24932_C1",
+            "type": "Cancel",
+            "tracking": false,
+            "state": {
+              "descriptor": {
+                "code": "Cancelled"
+              }
+            },
+            "tags": [
+              {
+                "code": "cancel_request",
+                "list": [
+                  {
+                    "code": "reason_id",
+                    "value": "002"
+                  },
+                  {
+                    "code": "initiated_by",
+                    "value": "api.greenreceipt.in"
+                  }
+                ]
+              },
+              {
+                "code": "quote_trail",
+                "list": [
+                  {
+                    "code": "type",
+                    "value": "item"
+                  },
+                  {
+                    "code": "id",
+                    "value": "24932_2740433"
+                  },
+                  {
+                    "code": "currency",
+                    "value": "INR"
+                  },
+                  {
+                    "code": "value",
+                    "value": "-72990.00"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "quote": {
+          "price": {
+            "currency": "INR",
+            "value": "344950.00"
+          },
+          "breakup": [
+            {
+              "@ondc/org/item_id": "24932_2740433",
+              "@ondc/org/item_quantity": {
+                "count": 1
+              },
+              "title": "IPHONE 14 128GB YELLOW",
+              "@ondc/org/title_type": "item",
+              "price": {
+                "currency": "INR",
+                "value": "72990.00"
+              },
+              "item": {
+                "price": {
+                  "currency": "INR",
+                  "value": "72990.00"
+                }
+              }
+            },
+            {
+              "@ondc/org/item_id": "24932_2740435",
+              "@ondc/org/item_quantity": {
+                "count": 2
+              },
+              "title": "IPHONE 14 128GB MIDNIGHT",
+              "@ondc/org/title_type": "item",
+              "price": {
+                "currency": "INR",
+                "value": "145980.00"
+              },
+              "item": {
+                "price": {
+                  "currency": "INR",
+                  "value": "72990.00"
+                }
+              }
+            },
+            {
+              "@ondc/org/item_id": "24932_2740440",
+              "@ondc/org/item_quantity": {
+                "count": 1
+              },
+              "title": "IPHONE 13 128GB BLUE",
+              "@ondc/org/title_type": "item",
+              "price": {
+                "currency": "INR",
+                "value": "62990.00"
+              },
+              "item": {
+                "price": {
+                  "currency": "INR",
+                  "value": "62990.00"
+                }
+              }
+            },
+            {
+              "@ondc/org/item_id": "24932_2740442",
+              "@ondc/org/item_quantity": {
+                "count": 1
+              },
+              "title": "IPHONE 13 128GB GREEN",
+              "@ondc/org/title_type": "item",
+              "price": {
+                "currency": "INR",
+                "value": "62990.00"
+              },
+              "item": {
+                "price": {
+                  "currency": "INR",
+                  "value": "62990.00"
+                }
+              }
+            },
+            {
+              "@ondc/org/item_id": "24932_F1",
+              "title": "Delivery charges",
+              "@ondc/org/title_type": "delivery",
+              "price": {
+                "currency": "INR",
+                "value": "0.00"
+              }
+            }
+          ],
+          "ttl": "PT4H"
+        },
+        "payment": {
+          "uri": "https://razorpay.com/",
+          "tl_method": "http/get",
+          "params": {
+            "currency": "INR",
+            "transaction_id": "order_OUubpHLJt1USCZ",
+            "amount": "417940.00"
+          },
+          "status": "PAID",
+          "type": "ON-ORDER",
+          "collected_by": "BAP",
+          "@ondc/org/buyer_app_finder_fee_type": "percent",
+          "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+          "@ondc/org/settlement_details": [
+            {
+              "settlement_counterparty": "buyer",
+              "settlement_phase": "refund",
+              "settlement_type": "netbanking",
+              "settlement_timestamp": "2024-07-05T10:10:57.622Z",
+              "settlement_amount": "72990"
+            },
+            {
+              "settlement_counterparty": "seller-app",
+              "settlement_phase": "sale-amount",
+              "beneficiary_name": "Buynxt Private Limited",
+              "settlement_type": "neft",
+              "upi_address": "buynxt@okidfc",
+              "settlement_bank_account_no": "10129914936",
+              "settlement_ifsc_code": "IDFB0021001",
+              "bank_name": "IDFC First Bank Limited",
+              "branch_name": "Golf Course Road, Gurgaon"
+            }
+          ]
+        },
+        "documents": [
+          {
+            "url": "https://greenreceipt.in/invoices/2024-07-05-178086.pdf",
+            "label": "Invoice"
+          }
+        ],
+        "created_at": "2024-07-05T10:07:42.787Z",
+        "updated_at": "2024-07-05T10:13:28.345Z"
+      }
+    }
+  }

--- a/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow6/on_status_packed.json
+++ b/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow6/on_status_packed.json
@@ -1,0 +1,332 @@
+{
+    "context": {
+      "domain": "ONDC:RET14",
+      "action": "on_status",
+      "core_version": "1.2.0",
+      "bap_id": "buyer-app-preprod-v2.ondc.org",
+      "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+      "bpp_id": "api.greenreceipt.in",
+      "bpp_uri": "https://api.greenreceipt.in/ondc",
+      "transaction_id": "3b505f52-9f97-44a0-80e2-51ac2c3411b8",
+      "message_id": "0fcd002b-10dc-4518-9bb2-605e9a239de5",
+      "city": "std:0124",
+      "country": "IND",
+      "timestamp": "2024-07-05T10:12:07.161Z",
+      "ttl": "PT30S"
+    },
+    "message": {
+      "order": {
+        "id": "2024-07-05-178086",
+        "state": "In-progress",
+        "provider": {
+          "id": "24932",
+          "locations": [
+            {
+              "id": "24932"
+            }
+          ]
+        },
+        "items": [
+          {
+            "id": "24932_2740433",
+            "fulfillment_id": "24932_F1",
+            "quantity": {
+              "count": 1
+            }
+          },
+          {
+            "id": "24932_2740435",
+            "fulfillment_id": "24932_F1",
+            "quantity": {
+              "count": 2
+            }
+          },
+          {
+            "id": "24932_2740440",
+            "fulfillment_id": "24932_F1",
+            "quantity": {
+              "count": 1
+            }
+          },
+          {
+            "id": "24932_2740442",
+            "fulfillment_id": "24932_F1",
+            "quantity": {
+              "count": 1
+            }
+          },
+          {
+            "id": "24932_2740433",
+            "fulfillment_id": "24932_C1",
+            "quantity": {
+              "count": 1
+            }
+          }
+        ],
+        "billing": {
+          "name": "Bhavna",
+          "address": {
+            "name": "Bhavna",
+            "building": "club patio",
+            "locality": "Sector Road",
+            "city": "Gurugram",
+            "state": "Haryana",
+            "country": "IND",
+            "area_code": "122007"
+          },
+          "email": "bhavna@buynxt.in",
+          "phone": "7419096651",
+          "created_at": "2024-07-05T10:07:13.125Z",
+          "updated_at": "2024-07-05T10:07:13.125Z"
+        },
+        "fulfillments": [
+          {
+            "id": "24932_F1",
+            "@ondc/org/provider_name": "Ajay Electronics",
+            "type": "Delivery",
+            "tracking": false,
+            "@ondc/org/TAT": "PT4H",
+            "state": {
+              "descriptor": {
+                "code": "Packed"
+              }
+            },
+            "start": {
+              "location": {
+                "descriptor": {
+                  "name": "Ajay Electronics"
+                },
+                "gps": "28.41430316,77.06620157",
+                "address": {
+                  "locality": "Nirvana Country",
+                  "city": "Gurgaon",
+                  "state": "Haryana",
+                  "area_code": "122018"
+                }
+              },
+              "time": {
+                "range": {
+                  "start": "2024-07-05T10:17:42.897Z",
+                  "end": "2024-07-05T11:17:42.897Z"
+                }
+              },
+              "contact": {
+                "phone": "8076362934",
+                "email": "Demo3@gmail.com"
+              }
+            },
+            "end": {
+              "location": {
+                "gps": "28.457914,77.067837",
+                "address": {
+                  "name": "Bhavna",
+                  "building": "club patio",
+                  "locality": "Sector Road",
+                  "city": "Gurugram",
+                  "state": "Haryana",
+                  "country": "IND",
+                  "area_code": "122007"
+                }
+              },
+              "time": {
+                "range": {
+                  "start": "2024-07-05T13:17:42.897Z",
+                  "end": "2024-07-05T14:17:42.897Z"
+                }
+              },
+              "person": {
+                "name": "Bhavna"
+              },
+              "contact": {
+                "phone": "7419096651",
+                "email": "bhavna@buynxt.in"
+              }
+            },
+            "tags": [
+              {
+                "code": "routing",
+                "list": [
+                  {
+                    "code": "type",
+                    "value": "P2P"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "24932_C1",
+            "type": "Cancel",
+            "tracking": false,
+            "state": {
+              "descriptor": {
+                "code": "Cancelled"
+              }
+            },
+            "tags": [
+              {
+                "code": "cancel_request",
+                "list": [
+                  {
+                    "code": "reason_id",
+                    "value": "002"
+                  },
+                  {
+                    "code": "initiated_by",
+                    "value": "api.greenreceipt.in"
+                  }
+                ]
+              },
+              {
+                "code": "quote_trail",
+                "list": [
+                  {
+                    "code": "type",
+                    "value": "item"
+                  },
+                  {
+                    "code": "id",
+                    "value": "24932_2740433"
+                  },
+                  {
+                    "code": "currency",
+                    "value": "INR"
+                  },
+                  {
+                    "code": "value",
+                    "value": "-72990.00"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "quote": {
+          "price": {
+            "currency": "INR",
+            "value": "344950.00"
+          },
+          "breakup": [
+            {
+              "@ondc/org/item_id": "24932_2740433",
+              "@ondc/org/item_quantity": {
+                "count": 1
+              },
+              "title": "IPHONE 14 128GB YELLOW",
+              "@ondc/org/title_type": "item",
+              "price": {
+                "currency": "INR",
+                "value": "72990.00"
+              },
+              "item": {
+                "price": {
+                  "currency": "INR",
+                  "value": "72990.00"
+                }
+              }
+            },
+            {
+              "@ondc/org/item_id": "24932_2740435",
+              "@ondc/org/item_quantity": {
+                "count": 2
+              },
+              "title": "IPHONE 14 128GB MIDNIGHT",
+              "@ondc/org/title_type": "item",
+              "price": {
+                "currency": "INR",
+                "value": "145980.00"
+              },
+              "item": {
+                "price": {
+                  "currency": "INR",
+                  "value": "72990.00"
+                }
+              }
+            },
+            {
+              "@ondc/org/item_id": "24932_2740440",
+              "@ondc/org/item_quantity": {
+                "count": 1
+              },
+              "title": "IPHONE 13 128GB BLUE",
+              "@ondc/org/title_type": "item",
+              "price": {
+                "currency": "INR",
+                "value": "62990.00"
+              },
+              "item": {
+                "price": {
+                  "currency": "INR",
+                  "value": "62990.00"
+                }
+              }
+            },
+            {
+              "@ondc/org/item_id": "24932_2740442",
+              "@ondc/org/item_quantity": {
+                "count": 1
+              },
+              "title": "IPHONE 13 128GB GREEN",
+              "@ondc/org/title_type": "item",
+              "price": {
+                "currency": "INR",
+                "value": "62990.00"
+              },
+              "item": {
+                "price": {
+                  "currency": "INR",
+                  "value": "62990.00"
+                }
+              }
+            },
+            {
+              "@ondc/org/item_id": "24932_F1",
+              "title": "Delivery charges",
+              "@ondc/org/title_type": "delivery",
+              "price": {
+                "currency": "INR",
+                "value": "0.00"
+              }
+            }
+          ],
+          "ttl": "PT4H"
+        },
+        "payment": {
+          "uri": "https://razorpay.com/",
+          "tl_method": "http/get",
+          "params": {
+            "currency": "INR",
+            "transaction_id": "order_OUubpHLJt1USCZ",
+            "amount": "417940.00"
+          },
+          "status": "PAID",
+          "type": "ON-ORDER",
+          "collected_by": "BAP",
+          "@ondc/org/buyer_app_finder_fee_type": "percent",
+          "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+          "@ondc/org/settlement_details": [
+            {
+              "settlement_counterparty": "buyer",
+              "settlement_phase": "refund",
+              "settlement_type": "netbanking",
+              "settlement_timestamp": "2024-07-05T10:10:57.622Z",
+              "settlement_amount": "72990"
+            },
+            {
+              "settlement_counterparty": "seller-app",
+              "settlement_phase": "sale-amount",
+              "beneficiary_name": "Buynxt Private Limited",
+              "settlement_type": "neft",
+              "upi_address": "buynxt@okidfc",
+              "settlement_bank_account_no": "10129914936",
+              "settlement_ifsc_code": "IDFB0021001",
+              "bank_name": "IDFC First Bank Limited",
+              "branch_name": "Golf Course Road, Gurgaon"
+            }
+          ]
+        },
+        "created_at": "2024-07-05T10:07:42.787Z",
+        "updated_at": "2024-07-05T10:12:07.161Z"
+      }
+    }
+  }

--- a/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow6/on_status_pending.json
+++ b/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow6/on_status_pending.json
@@ -1,0 +1,272 @@
+{
+    "context": {
+      "domain": "ONDC:RET14",
+      "action": "on_status",
+      "core_version": "1.2.0",
+      "bap_id": "buyer-app-preprod-v2.ondc.org",
+      "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+      "bpp_id": "api.greenreceipt.in",
+      "bpp_uri": "https://api.greenreceipt.in/ondc",
+      "transaction_id": "3b505f52-9f97-44a0-80e2-51ac2c3411b8",
+      "message_id": "3a9ca1b1-2814-489b-b16a-fe389cf20c15",
+      "city": "std:0124",
+      "country": "IND",
+      "timestamp": "2024-07-05T10:09:22.928Z",
+      "ttl": "PT30S"
+    },
+    "message": {
+      "order": {
+        "id": "2024-07-05-178086",
+        "state": "Accepted",
+        "provider": {
+          "id": "24932",
+          "locations": [
+            {
+              "id": "24932"
+            }
+          ]
+        },
+        "items": [
+          {
+            "id": "24932_2740433",
+            "fulfillment_id": "24932_F1",
+            "quantity": {
+              "count": 2
+            }
+          },
+          {
+            "id": "24932_2740435",
+            "fulfillment_id": "24932_F1",
+            "quantity": {
+              "count": 2
+            }
+          },
+          {
+            "id": "24932_2740440",
+            "fulfillment_id": "24932_F1",
+            "quantity": {
+              "count": 1
+            }
+          },
+          {
+            "id": "24932_2740442",
+            "fulfillment_id": "24932_F1",
+            "quantity": {
+              "count": 1
+            }
+          }
+        ],
+        "billing": {
+          "name": "Bhavna",
+          "address": {
+            "name": "Bhavna",
+            "building": "club patio",
+            "locality": "Sector Road",
+            "city": "Gurugram",
+            "state": "Haryana",
+            "country": "IND",
+            "area_code": "122007"
+          },
+          "email": "bhavna@buynxt.in",
+          "phone": "7419096651",
+          "created_at": "2024-07-05T10:07:13.125Z",
+          "updated_at": "2024-07-05T10:07:13.125Z"
+        },
+        "fulfillments": [
+          {
+            "id": "24932_F1",
+            "@ondc/org/provider_name": "Ajay Electronics",
+            "type": "Delivery",
+            "tracking": false,
+            "@ondc/org/TAT": "PT4H",
+            "state": {
+              "descriptor": {
+                "code": "Pending"
+              }
+            },
+            "start": {
+              "location": {
+                "descriptor": {
+                  "name": "Ajay Electronics"
+                },
+                "gps": "28.41430316,77.06620157",
+                "address": {
+                  "locality": "Nirvana Country",
+                  "city": "Gurgaon",
+                  "state": "Haryana",
+                  "area_code": "122018"
+                }
+              },
+              "time": {
+                "range": {
+                  "start": "2024-07-05T10:17:42.897Z",
+                  "end": "2024-07-05T11:17:42.897Z"
+                }
+              },
+              "contact": {
+                "phone": "8076362934",
+                "email": "Demo3@gmail.com"
+              }
+            },
+            "end": {
+              "location": {
+                "gps": "28.457914,77.067837",
+                "address": {
+                  "name": "Bhavna",
+                  "building": "club patio",
+                  "locality": "Sector Road",
+                  "city": "Gurugram",
+                  "state": "Haryana",
+                  "country": "IND",
+                  "area_code": "122007"
+                }
+              },
+              "time": {
+                "range": {
+                  "start": "2024-07-05T13:17:42.897Z",
+                  "end": "2024-07-05T14:17:42.897Z"
+                }
+              },
+              "person": {
+                "name": "Bhavna"
+              },
+              "contact": {
+                "phone": "7419096651",
+                "email": "bhavna@buynxt.in"
+              }
+            },
+            "tags": [
+              {
+                "code": "routing",
+                "list": [
+                  {
+                    "code": "type",
+                    "value": "P2P"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "quote": {
+          "price": {
+            "currency": "INR",
+            "value": "417940.00"
+          },
+          "breakup": [
+            {
+              "@ondc/org/item_id": "24932_2740433",
+              "@ondc/org/item_quantity": {
+                "count": 2
+              },
+              "title": "IPHONE 14 128GB YELLOW",
+              "@ondc/org/title_type": "item",
+              "price": {
+                "currency": "INR",
+                "value": "145980.00"
+              },
+              "item": {
+                "price": {
+                  "currency": "INR",
+                  "value": "72990.00"
+                }
+              }
+            },
+            {
+              "@ondc/org/item_id": "24932_2740435",
+              "@ondc/org/item_quantity": {
+                "count": 2
+              },
+              "title": "IPHONE 14 128GB MIDNIGHT",
+              "@ondc/org/title_type": "item",
+              "price": {
+                "currency": "INR",
+                "value": "145980.00"
+              },
+              "item": {
+                "price": {
+                  "currency": "INR",
+                  "value": "72990.00"
+                }
+              }
+            },
+            {
+              "@ondc/org/item_id": "24932_2740440",
+              "@ondc/org/item_quantity": {
+                "count": 1
+              },
+              "title": "IPHONE 13 128GB BLUE",
+              "@ondc/org/title_type": "item",
+              "price": {
+                "currency": "INR",
+                "value": "62990.00"
+              },
+              "item": {
+                "price": {
+                  "currency": "INR",
+                  "value": "62990.00"
+                }
+              }
+            },
+            {
+              "@ondc/org/item_id": "24932_2740442",
+              "@ondc/org/item_quantity": {
+                "count": 1
+              },
+              "title": "IPHONE 13 128GB GREEN",
+              "@ondc/org/title_type": "item",
+              "price": {
+                "currency": "INR",
+                "value": "62990.00"
+              },
+              "item": {
+                "price": {
+                  "currency": "INR",
+                  "value": "62990.00"
+                }
+              }
+            },
+            {
+              "@ondc/org/item_id": "24932_F1",
+              "title": "Delivery charges",
+              "@ondc/org/title_type": "delivery",
+              "price": {
+                "currency": "INR",
+                "value": "0.00"
+              }
+            }
+          ],
+          "ttl": "PT4H"
+        },
+        "payment": {
+          "uri": "https://razorpay.com/",
+          "tl_method": "http/get",
+          "params": {
+            "currency": "INR",
+            "transaction_id": "order_OUubpHLJt1USCZ",
+            "amount": "417940.00"
+          },
+          "status": "PAID",
+          "type": "ON-ORDER",
+          "collected_by": "BAP",
+          "@ondc/org/buyer_app_finder_fee_type": "percent",
+          "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+          "@ondc/org/settlement_details": [
+            {
+              "settlement_counterparty": "seller-app",
+              "settlement_phase": "sale-amount",
+              "beneficiary_name": "Buynxt Private Limited",
+              "settlement_type": "neft",
+              "upi_address": "buynxt@okidfc",
+              "settlement_bank_account_no": "10129914936",
+              "settlement_ifsc_code": "IDFB0021001",
+              "bank_name": "IDFC First Bank Limited",
+              "branch_name": "Golf Course Road, Gurgaon"
+            }
+          ]
+        },
+        "created_at": "2024-07-05T10:07:42.787Z",
+        "updated_at": "2024-07-05T10:09:22.928Z"
+      }
+    }
+  }

--- a/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow6/on_update_part_cancel.json
+++ b/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow6/on_update_part_cancel.json
@@ -1,0 +1,331 @@
+{
+    "context": {
+      "domain": "ONDC:RET14",
+      "action": "on_update",
+      "core_version": "1.2.0",
+      "bap_id": "buyer-app-preprod-v2.ondc.org",
+      "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+      "bpp_id": "api.greenreceipt.in",
+      "bpp_uri": "https://api.greenreceipt.in/ondc",
+      "transaction_id": "3b505f52-9f97-44a0-80e2-51ac2c3411b8",
+      "message_id": "14f6f0f3-b809-4935-9781-035685bca617",
+      "city": "std:0124",
+      "country": "IND",
+      "timestamp": "2024-07-05T10:10:57.235Z"
+    },
+    "message": {
+      "order": {
+        "id": "2024-07-05-178086",
+        "state": "Accepted",
+        "provider": {
+          "id": "24932",
+          "locations": [
+            {
+              "id": "24932"
+            }
+          ]
+        },
+        "items": [
+          {
+            "id": "24932_2740433",
+            "fulfillment_id": "24932_F1",
+            "quantity": {
+              "count": 1
+            }
+          },
+          {
+            "id": "24932_2740435",
+            "fulfillment_id": "24932_F1",
+            "quantity": {
+              "count": 2
+            }
+          },
+          {
+            "id": "24932_2740440",
+            "fulfillment_id": "24932_F1",
+            "quantity": {
+              "count": 1
+            }
+          },
+          {
+            "id": "24932_2740442",
+            "fulfillment_id": "24932_F1",
+            "quantity": {
+              "count": 1
+            }
+          },
+          {
+            "id": "24932_2740433",
+            "fulfillment_id": "24932_C1",
+            "quantity": {
+              "count": 1
+            }
+          }
+        ],
+        "billing": {
+          "name": "Bhavna",
+          "address": {
+            "name": "Bhavna",
+            "building": "club patio",
+            "locality": "Sector Road",
+            "city": "Gurugram",
+            "state": "Haryana",
+            "country": "IND",
+            "area_code": "122007"
+          },
+          "email": "bhavna@buynxt.in",
+          "phone": "7419096651",
+          "created_at": "2024-07-05T10:07:13.125Z",
+          "updated_at": "2024-07-05T10:07:13.125Z"
+        },
+        "fulfillments": [
+          {
+            "id": "24932_F1",
+            "@ondc/org/provider_name": "Ajay Electronics",
+            "type": "Delivery",
+            "tracking": false,
+            "@ondc/org/TAT": "PT4H",
+            "state": {
+              "descriptor": {
+                "code": "Pending"
+              }
+            },
+            "start": {
+              "location": {
+                "id": "24932",
+                "descriptor": {
+                  "name": "Ajay Electronics"
+                },
+                "gps": "28.41430316,77.06620157",
+                "address": {
+                  "locality": "Nirvana Country",
+                  "city": "Gurgaon",
+                  "state": "Haryana",
+                  "area_code": "122018"
+                }
+              },
+              "time": {
+                "range": {
+                  "start": "2024-07-05T10:17:42.897Z",
+                  "end": "2024-07-05T11:17:42.897Z"
+                }
+              },
+              "contact": {
+                "phone": "8076362934",
+                "email": "Demo3@gmail.com"
+              }
+            },
+            "end": {
+              "location": {
+                "gps": "28.457914,77.067837",
+                "address": {
+                  "name": "Bhavna",
+                  "building": "club patio",
+                  "locality": "Sector Road",
+                  "city": "Gurugram",
+                  "state": "Haryana",
+                  "country": "IND",
+                  "area_code": "122007"
+                }
+              },
+              "time": {
+                "range": {
+                  "start": "2024-07-05T13:17:42.897Z",
+                  "end": "2024-07-05T14:17:42.897Z"
+                }
+              },
+              "person": {
+                "name": "Bhavna"
+              },
+              "contact": {
+                "phone": "7419096651",
+                "email": "bhavna@buynxt.in"
+              }
+            }
+          },
+          {
+            "id": "24932_C1",
+            "type": "Cancel",
+            "tracking": false,
+            "state": {
+              "descriptor": {
+                "code": "Cancelled"
+              }
+            },
+            "tags": [
+              {
+                "code": "cancel_request",
+                "list": [
+                  {
+                    "code": "reason_id",
+                    "value": "002"
+                  },
+                  {
+                    "code": "initiated_by",
+                    "value": "api.greenreceipt.in"
+                  }
+                ]
+              },
+              {
+                "code": "quote_trail",
+                "list": [
+                  {
+                    "code": "type",
+                    "value": "item"
+                  },
+                  {
+                    "code": "id",
+                    "value": "24932_2740433"
+                  },
+                  {
+                    "code": "currency",
+                    "value": "INR"
+                  },
+                  {
+                    "code": "value",
+                    "value": "-72990.00"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "quote": {
+          "price": {
+            "currency": "INR",
+            "value": "344950.00"
+          },
+          "breakup": [
+            {
+              "@ondc/org/item_id": "24932_2740433",
+              "@ondc/org/item_quantity": {
+                "count": 0
+              },
+              "title": "IPHONE 14 128GB YELLOW",
+              "@ondc/org/title_type": "item",
+              "price": {
+                "currency": "INR",
+                "value": "0.00"
+              },
+              "item": {
+                "price": {
+                  "currency": "INR",
+                  "value": "72990.00"
+                }
+              }
+            },
+            {
+              "@ondc/org/item_id": "24932_2740433",
+              "@ondc/org/item_quantity": {
+                "count": 1
+              },
+              "title": "IPHONE 14 128GB YELLOW",
+              "@ondc/org/title_type": "item",
+              "price": {
+                "currency": "INR",
+                "value": "72990.00"
+              },
+              "item": {
+                "price": {
+                  "currency": "INR",
+                  "value": "72990.00"
+                }
+              }
+            },
+            {
+              "@ondc/org/item_id": "24932_2740435",
+              "@ondc/org/item_quantity": {
+                "count": 2
+              },
+              "title": "IPHONE 14 128GB MIDNIGHT",
+              "@ondc/org/title_type": "item",
+              "price": {
+                "currency": "INR",
+                "value": "145980.00"
+              },
+              "item": {
+                "price": {
+                  "currency": "INR",
+                  "value": "72990.00"
+                }
+              }
+            },
+            {
+              "@ondc/org/item_id": "24932_2740440",
+              "@ondc/org/item_quantity": {
+                "count": 1
+              },
+              "title": "IPHONE 13 128GB BLUE",
+              "@ondc/org/title_type": "item",
+              "price": {
+                "currency": "INR",
+                "value": "62990.00"
+              },
+              "item": {
+                "price": {
+                  "currency": "INR",
+                  "value": "62990.00"
+                }
+              }
+            },
+            {
+              "@ondc/org/item_id": "24932_2740442",
+              "@ondc/org/item_quantity": {
+                "count": 1
+              },
+              "title": "IPHONE 13 128GB GREEN",
+              "@ondc/org/title_type": "item",
+              "price": {
+                "currency": "INR",
+                "value": "62990.00"
+              },
+              "item": {
+                "price": {
+                  "currency": "INR",
+                  "value": "62990.00"
+                }
+              }
+            },
+            {
+              "@ondc/org/item_id": "24932_F1",
+              "title": "Delivery charges",
+              "@ondc/org/title_type": "delivery",
+              "price": {
+                "currency": "INR",
+                "value": "0"
+              }
+            }
+          ],
+          "ttl": "P1D"
+        },
+        "payment": {
+          "uri": "https://razorpay.com/",
+          "params": {
+            "currency": "INR",
+            "transaction_id": "order_OUubpHLJt1USCZ",
+            "amount": "417940.00"
+          },
+          "status": "PAID",
+          "type": "ON-ORDER",
+          "collected_by": "BAP",
+          "@ondc/org/buyer_app_finder_fee_type": "percent",
+          "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+          "@ondc/org/settlement_details": [
+            {
+              "settlement_counterparty": "seller-app",
+              "settlement_phase": "sale-amount",
+              "beneficiary_name": "Buynxt Private Limited",
+              "settlement_type": "neft",
+              "upi_address": "buynxt@okidfc",
+              "settlement_bank_account_no": "10129914936",
+              "settlement_ifsc_code": "IDFB0021001",
+              "bank_name": "IDFC First Bank Limited",
+              "branch_name": "Golf Course Road, Gurgaon"
+            }
+          ]
+        },
+        "created_at": "2024-07-05T10:07:42.787Z",
+        "updated_at": "2024-07-05T10:10:57.235Z"
+      }
+    }
+  }

--- a/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow6/on_update_return_approved_reverseQC.json
+++ b/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow6/on_update_return_approved_reverseQC.json
@@ -1,0 +1,394 @@
+{
+    "context": {
+      "domain": "ONDC:RET14",
+      "action": "on_update",
+      "core_version": "1.2.0",
+      "bap_id": "buyer-app-preprod-v2.ondc.org",
+      "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+      "bpp_id": "api.greenreceipt.in",
+      "bpp_uri": "https://api.greenreceipt.in/ondc",
+      "transaction_id": "3b505f52-9f97-44a0-80e2-51ac2c3411b8",
+      "message_id": "8528a6cb-a267-432c-8544-2b7ee803a5a8",
+      "city": "std:0124",
+      "country": "IND",
+      "timestamp": "2024-07-05T10:18:56.696Z"
+    },
+    "message": {
+      "order": {
+        "id": "2024-07-05-178086",
+        "state": "Completed",
+        "payment": {
+          "uri": "https://razorpay.com/",
+          "params": {
+            "currency": "INR",
+            "transaction_id": "order_OUubpHLJt1USCZ",
+            "amount": "417940.00"
+          },
+          "status": "PAID",
+          "type": "ON-ORDER",
+          "collected_by": "BAP",
+          "@ondc/org/buyer_app_finder_fee_type": "percent",
+          "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+          "@ondc/org/settlement_details": [
+            {
+              "settlement_counterparty": "buyer",
+              "settlement_phase": "refund",
+              "settlement_type": "netbanking",
+              "settlement_amount": "72990",
+              "settlement_timestamp": "2024-07-05T10:10:57.622Z"
+            },
+            {
+              "settlement_counterparty": "seller-app",
+              "settlement_phase": "sale-amount",
+              "beneficiary_name": "Buynxt Private Limited",
+              "settlement_type": "neft",
+              "upi_address": "buynxt@okidfc",
+              "settlement_bank_account_no": "10129914936",
+              "settlement_ifsc_code": "IDFB0021001",
+              "bank_name": "IDFC First Bank Limited",
+              "branch_name": "Golf Course Road, Gurgaon"
+            }
+          ]
+        },
+        "provider": {
+          "id": "24932",
+          "locations": [
+            {
+              "id": "24932"
+            }
+          ]
+        },
+        "items": [
+          {
+            "id": "24932_2740433",
+            "fulfillment_id": "24932_F1",
+            "quantity": {
+              "count": 1
+            }
+          },
+          {
+            "id": "24932_2740435",
+            "fulfillment_id": "24932_F1",
+            "quantity": {
+              "count": 2
+            }
+          },
+          {
+            "id": "24932_2740440",
+            "fulfillment_id": "24932_F1",
+            "quantity": {
+              "count": 1
+            }
+          },
+          {
+            "id": "24932_2740442",
+            "fulfillment_id": "24932_F1",
+            "quantity": {
+              "count": 1
+            }
+          },
+          {
+            "id": "24932_2740433",
+            "fulfillment_id": "24932_C1",
+            "quantity": {
+              "count": 1
+            }
+          }
+        ],
+        "billing": {
+          "name": "Bhavna",
+          "address": {
+            "name": "Bhavna",
+            "building": "club patio",
+            "locality": "Sector Road",
+            "city": "Gurugram",
+            "state": "Haryana",
+            "country": "IND",
+            "area_code": "122007"
+          },
+          "email": "bhavna@buynxt.in",
+          "phone": "7419096651",
+          "created_at": "2024-07-05T10:07:13.125Z",
+          "updated_at": "2024-07-05T10:07:13.125Z"
+        },
+        "fulfillments": [
+          {
+            "id": "24932_C1",
+            "type": "Cancel",
+            "tracking": false,
+            "state": {
+              "descriptor": {
+                "code": "Cancelled"
+              }
+            },
+            "tags": [
+              {
+                "code": "cancel_request",
+                "list": [
+                  {
+                    "code": "reason_id",
+                    "value": "002"
+                  },
+                  {
+                    "code": "initiated_by",
+                    "value": "api.greenreceipt.in"
+                  }
+                ]
+              },
+              {
+                "code": "quote_trail",
+                "list": [
+                  {
+                    "code": "type",
+                    "value": "item"
+                  },
+                  {
+                    "code": "id",
+                    "value": "24932_2740433"
+                  },
+                  {
+                    "code": "currency",
+                    "value": "INR"
+                  },
+                  {
+                    "code": "value",
+                    "value": "-72990.00"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "24932_F1",
+            "@ondc/org/provider_name": "Ajay Electronics",
+            "type": "Delivery",
+            "tracking": false,
+            "@ondc/org/TAT": "PT4H",
+            "state": {
+              "descriptor": {
+                "code": "Order-delivered"
+              }
+            },
+            "start": {
+              "location": {
+                "id": "24932",
+                "descriptor": {
+                  "name": "Ajay Electronics"
+                },
+                "gps": "28.41430316,77.06620157",
+                "address": {
+                  "locality": "Nirvana Country",
+                  "city": "Gurgaon",
+                  "state": "Haryana",
+                  "area_code": "122018"
+                }
+              },
+              "time": {
+                "timestamp": "2024-07-05T10:12:07.047Z"
+              },
+              "contact": {
+                "phone": "8076362934",
+                "email": "Demo3@gmail.com"
+              }
+            },
+            "end": {
+              "location": {
+                "gps": "28.457914,77.067837",
+                "address": {
+                  "name": "Bhavna",
+                  "building": "club patio",
+                  "locality": "Sector Road",
+                  "city": "Gurugram",
+                  "state": "Haryana",
+                  "country": "IND",
+                  "area_code": "122007"
+                }
+              },
+              "time": {
+                "timestamp": "2024-07-05T10:15:14.710Z"
+              },
+              "person": {
+                "name": "Bhavna"
+              },
+              "contact": {
+                "phone": "7419096651",
+                "email": "bhavna@buynxt.in"
+              }
+            }
+          },
+          {
+            "id": "6687c83251dde107f6751c41",
+            "type": "Return",
+            "tracking": false,
+            "state": {
+              "descriptor": {
+                "code": "Return_Approved"
+              }
+            },
+            "start": {
+              "location": {
+                "gps": "28.457914,77.067837",
+                "address": {
+                  "name": "Bhavna",
+                  "building": "club patio",
+                  "locality": "Sector Road",
+                  "city": "Gurugram",
+                  "state": "Haryana",
+                  "country": "IND",
+                  "area_code": "122007"
+                }
+              },
+              "time": {
+                "range": {
+                  "start": "2024-07-05T10:28:56.180Z",
+                  "end": "2024-07-05T14:28:56.180Z"
+                }
+              }
+            },
+            "end": {
+              "location": {
+                "gps": "28.41430316,77.06620157",
+                "address": {
+                  "locality": "Nirvana Country",
+                  "city": "Gurgaon",
+                  "state": "Haryana",
+                  "area_code": "122018"
+                }
+              }
+            },
+            "tags": [
+              {
+                "code": "return_request",
+                "list": [
+                  {
+                    "code": "item_id",
+                    "value": "24932_2740442"
+                  },
+                  {
+                    "code": "item_quantity",
+                    "value": "1"
+                  },
+                  {
+                    "code": "reason_id",
+                    "value": "001"
+                  },
+                  {
+                    "code": "reason_desc",
+                    "value": "detailed description for return"
+                  },
+                  {
+                    "code": "images",
+                    "value": "https://reference-buyer-app-assets.s3-ap-south-1.amazonaws.com/public-assets/2024-07-05-178086/171ec969-ec7e-4771-9565-67591f9c750f.png"
+                  },
+                  {
+                    "code": "ttl_approval",
+                    "value": "PT24H"
+                  },
+                  {
+                    "code": "ttl_reverseqc",
+                    "value": "P3D"
+                  },
+                  {
+                    "code": "initiated_by",
+                    "value": "buyer-app-preprod-v2.ondc.org"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "quote": {
+          "price": {
+            "currency": "INR",
+            "value": "344950.00"
+          },
+          "breakup": [
+            {
+              "@ondc/org/item_id": "24932_2740433",
+              "@ondc/org/item_quantity": {
+                "count": 1
+              },
+              "title": "IPHONE 14 128GB YELLOW",
+              "@ondc/org/title_type": "item",
+              "price": {
+                "currency": "INR",
+                "value": "72990.00"
+              },
+              "item": {
+                "price": {
+                  "currency": "INR",
+                  "value": "72990.00"
+                }
+              }
+            },
+            {
+              "@ondc/org/item_id": "24932_2740435",
+              "@ondc/org/item_quantity": {
+                "count": 2
+              },
+              "title": "IPHONE 14 128GB MIDNIGHT",
+              "@ondc/org/title_type": "item",
+              "price": {
+                "currency": "INR",
+                "value": "145980.00"
+              },
+              "item": {
+                "price": {
+                  "currency": "INR",
+                  "value": "72990.00"
+                }
+              }
+            },
+            {
+              "@ondc/org/item_id": "24932_2740440",
+              "@ondc/org/item_quantity": {
+                "count": 1
+              },
+              "title": "IPHONE 13 128GB BLUE",
+              "@ondc/org/title_type": "item",
+              "price": {
+                "currency": "INR",
+                "value": "62990.00"
+              },
+              "item": {
+                "price": {
+                  "currency": "INR",
+                  "value": "62990.00"
+                }
+              }
+            },
+            {
+              "@ondc/org/item_id": "24932_2740442",
+              "@ondc/org/item_quantity": {
+                "count": 1
+              },
+              "title": "IPHONE 13 128GB GREEN",
+              "@ondc/org/title_type": "item",
+              "price": {
+                "currency": "INR",
+                "value": "62990.00"
+              },
+              "item": {
+                "price": {
+                  "currency": "INR",
+                  "value": "62990.00"
+                }
+              }
+            },
+            {
+              "@ondc/org/item_id": "24932_F1",
+              "title": "Delivery charges",
+              "@ondc/org/title_type": "delivery",
+              "price": {
+                "currency": "INR",
+                "value": "0.00"
+              }
+            }
+          ],
+          "ttl": "P1D"
+        },
+        "created_at": "2024-07-05T10:07:42.787Z",
+        "updated_at": "2024-07-05T10:18:56.696Z"
+      }
+    }
+  }

--- a/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow6/on_update_return_delivered_reverseQC.json
+++ b/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow6/on_update_return_delivered_reverseQC.json
@@ -1,0 +1,435 @@
+{
+    "context": {
+      "domain": "ONDC:RET14",
+      "action": "on_update",
+      "core_version": "1.2.0",
+      "bap_id": "buyer-app-preprod-v2.ondc.org",
+      "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+      "bpp_id": "api.greenreceipt.in",
+      "bpp_uri": "https://api.greenreceipt.in/ondc",
+      "transaction_id": "3b505f52-9f97-44a0-80e2-51ac2c3411b8",
+      "message_id": "97c95788-8cd2-4aa8-94f5-556f7426d102",
+      "city": "std:0124",
+      "country": "IND",
+      "timestamp": "2024-07-05T10:20:14.466Z"
+    },
+    "message": {
+      "order": {
+        "id": "2024-07-05-178086",
+        "state": "Completed",
+        "payment": {
+          "uri": "https://razorpay.com/",
+          "params": {
+            "currency": "INR",
+            "transaction_id": "order_OUubpHLJt1USCZ",
+            "amount": "417940.00"
+          },
+          "status": "PAID",
+          "type": "ON-ORDER",
+          "collected_by": "BAP",
+          "@ondc/org/buyer_app_finder_fee_type": "percent",
+          "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+          "@ondc/org/settlement_details": [
+            {
+              "settlement_counterparty": "buyer",
+              "settlement_phase": "refund",
+              "settlement_type": "netbanking",
+              "settlement_timestamp": "2024-07-05T10:10:57.622Z",
+              "settlement_amount": "72990"
+            },
+            {
+              "settlement_counterparty": "buyer",
+              "settlement_phase": "refund",
+              "settlement_type": "netbanking",
+              "settlement_amount": "62990",
+              "settlement_timestamp": "2024-07-05T10:19:39.559Z"
+            },
+            {
+              "settlement_counterparty": "seller-app",
+              "settlement_phase": "sale-amount",
+              "beneficiary_name": "Buynxt Private Limited",
+              "settlement_type": "neft",
+              "upi_address": "buynxt@okidfc",
+              "settlement_bank_account_no": "10129914936",
+              "settlement_ifsc_code": "IDFB0021001",
+              "bank_name": "IDFC First Bank Limited",
+              "branch_name": "Golf Course Road, Gurgaon"
+            }
+          ]
+        },
+        "provider": {
+          "id": "24932",
+          "locations": [
+            {
+              "id": "24932"
+            }
+          ]
+        },
+        "items": [
+          {
+            "id": "24932_2740433",
+            "fulfillment_id": "24932_F1",
+            "quantity": {
+              "count": 1
+            }
+          },
+          {
+            "id": "24932_2740435",
+            "fulfillment_id": "24932_F1",
+            "quantity": {
+              "count": 2
+            }
+          },
+          {
+            "id": "24932_2740440",
+            "fulfillment_id": "24932_F1",
+            "quantity": {
+              "count": 1
+            }
+          },
+          {
+            "id": "24932_2740442",
+            "fulfillment_id": "6687c83251dde107f6751c41",
+            "quantity": {
+              "count": 1
+            }
+          },
+          {
+            "id": "24932_2740442",
+            "fulfillment_id": "24932_F1",
+            "quantity": {
+              "count": 0
+            }
+          },
+          {
+            "id": "24932_2740433",
+            "fulfillment_id": "24932_C1",
+            "quantity": {
+              "count": 1
+            }
+          }
+        ],
+        "billing": {
+          "name": "Bhavna",
+          "address": {
+            "name": "Bhavna",
+            "building": "club patio",
+            "locality": "Sector Road",
+            "city": "Gurugram",
+            "state": "Haryana",
+            "country": "IND",
+            "area_code": "122007"
+          },
+          "email": "bhavna@buynxt.in",
+          "phone": "7419096651",
+          "created_at": "2024-07-05T10:07:13.125Z",
+          "updated_at": "2024-07-05T10:07:13.125Z"
+        },
+        "fulfillments": [
+          {
+            "id": "24932_C1",
+            "type": "Cancel",
+            "tracking": false,
+            "state": {
+              "descriptor": {
+                "code": "Cancelled"
+              }
+            },
+            "tags": [
+              {
+                "code": "cancel_request",
+                "list": [
+                  {
+                    "code": "reason_id",
+                    "value": "002"
+                  },
+                  {
+                    "code": "initiated_by",
+                    "value": "api.greenreceipt.in"
+                  }
+                ]
+              },
+              {
+                "code": "quote_trail",
+                "list": [
+                  {
+                    "code": "type",
+                    "value": "item"
+                  },
+                  {
+                    "code": "id",
+                    "value": "24932_2740433"
+                  },
+                  {
+                    "code": "currency",
+                    "value": "INR"
+                  },
+                  {
+                    "code": "value",
+                    "value": "-72990.00"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "24932_F1",
+            "@ondc/org/provider_name": "Ajay Electronics",
+            "type": "Delivery",
+            "tracking": false,
+            "@ondc/org/TAT": "PT4H",
+            "state": {
+              "descriptor": {
+                "code": "Order-delivered"
+              }
+            },
+            "start": {
+              "location": {
+                "id": "24932",
+                "descriptor": {
+                  "name": "Ajay Electronics"
+                },
+                "gps": "28.41430316,77.06620157",
+                "address": {
+                  "locality": "Nirvana Country",
+                  "city": "Gurgaon",
+                  "state": "Haryana",
+                  "area_code": "122018"
+                }
+              },
+              "time": {
+                "timestamp": "2024-07-05T10:12:07.047Z"
+              },
+              "contact": {
+                "phone": "8076362934",
+                "email": "Demo3@gmail.com"
+              }
+            },
+            "end": {
+              "location": {
+                "gps": "28.457914,77.067837",
+                "address": {
+                  "name": "Bhavna",
+                  "building": "club patio",
+                  "locality": "Sector Road",
+                  "city": "Gurugram",
+                  "state": "Haryana",
+                  "country": "IND",
+                  "area_code": "122007"
+                }
+              },
+              "time": {
+                "timestamp": "2024-07-05T10:15:14.710Z"
+              },
+              "person": {
+                "name": "Bhavna"
+              },
+              "contact": {
+                "phone": "7419096651",
+                "email": "bhavna@buynxt.in"
+              }
+            }
+          },
+          {
+            "id": "6687c83251dde107f6751c41",
+            "type": "Return",
+            "tracking": false,
+            "state": {
+              "descriptor": {
+                "code": "Return_Delivered"
+              }
+            },
+            "start": {
+              "location": {
+                "gps": "28.457914,77.067837",
+                "address": {
+                  "name": "Bhavna",
+                  "building": "club patio",
+                  "locality": "Sector Road",
+                  "city": "Gurugram",
+                  "state": "Haryana",
+                  "country": "IND",
+                  "area_code": "122007"
+                }
+              },
+              "time": {
+                "timestamp": "2024-07-05T10:40:38.973Z"
+              }
+            },
+            "end": {
+              "location": {
+                "gps": "28.41430316,77.06620157",
+                "address": {
+                  "locality": "Nirvana Country",
+                  "city": "Gurgaon",
+                  "state": "Haryana",
+                  "area_code": "122018"
+                }
+              },
+              "time": {
+                "timestamp": "2024-07-05T10:20:14.193Z"
+              }
+            },
+            "tags": [
+              {
+                "code": "return_request",
+                "list": [
+                  {
+                    "code": "item_id",
+                    "value": "24932_2740442"
+                  },
+                  {
+                    "code": "item_quantity",
+                    "value": "1"
+                  },
+                  {
+                    "code": "reason_id",
+                    "value": "001"
+                  },
+                  {
+                    "code": "reason_desc",
+                    "value": "detailed description for return"
+                  },
+                  {
+                    "code": "images",
+                    "value": "https://reference-buyer-app-assets.s3-ap-south-1.amazonaws.com/public-assets/2024-07-05-178086/171ec969-ec7e-4771-9565-67591f9c750f.png"
+                  },
+                  {
+                    "code": "ttl_approval",
+                    "value": "PT24H"
+                  },
+                  {
+                    "code": "ttl_reverseqc",
+                    "value": "P3D"
+                  },
+                  {
+                    "code": "initiated_by",
+                    "value": "buyer-app-preprod-v2.ondc.org"
+                  }
+                ]
+              },
+              {
+                "code": "quote_trail",
+                "list": [
+                  {
+                    "code": "type",
+                    "value": "item"
+                  },
+                  {
+                    "code": "id",
+                    "value": "24932_2740442"
+                  },
+                  {
+                    "code": "currency",
+                    "value": "INR"
+                  },
+                  {
+                    "code": "value",
+                    "value": "-62990.00"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "quote": {
+          "price": {
+            "currency": "INR",
+            "value": "281960.00"
+          },
+          "breakup": [
+            {
+              "@ondc/org/item_id": "24932_2740433",
+              "@ondc/org/item_quantity": {
+                "count": 1
+              },
+              "title": "IPHONE 14 128GB YELLOW",
+              "@ondc/org/title_type": "item",
+              "price": {
+                "currency": "INR",
+                "value": "72990.00"
+              },
+              "item": {
+                "price": {
+                  "currency": "INR",
+                  "value": "72990.00"
+                }
+              }
+            },
+            {
+              "@ondc/org/item_id": "24932_2740435",
+              "@ondc/org/item_quantity": {
+                "count": 2
+              },
+              "title": "IPHONE 14 128GB MIDNIGHT",
+              "@ondc/org/title_type": "item",
+              "price": {
+                "currency": "INR",
+                "value": "145980.00"
+              },
+              "item": {
+                "price": {
+                  "currency": "INR",
+                  "value": "72990.00"
+                }
+              }
+            },
+            {
+              "@ondc/org/item_id": "24932_2740440",
+              "@ondc/org/item_quantity": {
+                "count": 1
+              },
+              "title": "IPHONE 13 128GB BLUE",
+              "@ondc/org/title_type": "item",
+              "price": {
+                "currency": "INR",
+                "value": "62990.00"
+              },
+              "item": {
+                "price": {
+                  "currency": "INR",
+                  "value": "62990.00"
+                }
+              }
+            },
+            {
+              "@ondc/org/item_id": "24932_2740442",
+              "@ondc/org/item_quantity": {
+                "count": 0
+              },
+              "title": "IPHONE 13 128GB GREEN",
+              "@ondc/org/title_type": "item",
+              "price": {
+                "currency": "INR",
+                "value": "0.00"
+              },
+              "item": {
+                "price": {
+                  "currency": "INR",
+                  "value": "62990.00"
+                }
+              }
+            },
+            {
+              "@ondc/org/item_id": "24932_F1",
+              "title": "Delivery charges",
+              "@ondc/org/title_type": "delivery",
+              "price": {
+                "currency": "INR",
+                "value": "0.00"
+              }
+            }
+          ],
+          "ttl": "P1D"
+        },
+        "documents": [
+          {
+            "url": "https://greenreceipt.in/invoices/2024-07-05-178086.pdf",
+            "label": "invoice"
+          }
+        ],
+        "created_at": "2024-07-05T10:07:42.787Z",
+        "updated_at": "2024-07-05T10:20:14.466Z"
+      }
+    }
+  }

--- a/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow6/on_update_return_initiated_liquidate.json
+++ b/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow6/on_update_return_initiated_liquidate.json
@@ -1,0 +1,484 @@
+{
+    "context": {
+      "domain": "ONDC:RET14",
+      "action": "on_update",
+      "core_version": "1.2.0",
+      "bap_id": "buyer-app-preprod-v2.ondc.org",
+      "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+      "bpp_id": "api.greenreceipt.in",
+      "bpp_uri": "https://api.greenreceipt.in/ondc",
+      "transaction_id": "3b505f52-9f97-44a0-80e2-51ac2c3411b8",
+      "message_id": "4f6e5d06-2ae8-4164-9c03-6473bc4604e4",
+      "city": "std:0124",
+      "country": "IND",
+      "timestamp": "2024-07-05T10:22:02.222Z"
+    },
+    "message": {
+      "order": {
+        "id": "2024-07-05-178086",
+        "state": "Completed",
+        "provider": {
+          "id": "24932",
+          "locations": [
+            {
+              "id": "24932"
+            }
+          ]
+        },
+        "items": [
+          {
+            "id": "24932_2740433",
+            "fulfillment_id": "24932_F1",
+            "quantity": {
+              "count": 1
+            }
+          },
+          {
+            "id": "24932_2740435",
+            "fulfillment_id": "24932_F1",
+            "quantity": {
+              "count": 2
+            }
+          },
+          {
+            "id": "24932_2740440",
+            "fulfillment_id": "24932_F1",
+            "quantity": {
+              "count": 1
+            }
+          },
+          {
+            "id": "24932_2740442",
+            "fulfillment_id": "6687c83251dde107f6751c41",
+            "quantity": {
+              "count": 1
+            }
+          },
+          {
+            "id": "24932_2740442",
+            "fulfillment_id": "24932_F1",
+            "quantity": {
+              "count": 0
+            }
+          },
+          {
+            "id": "24932_2740433",
+            "fulfillment_id": "24932_C1",
+            "quantity": {
+              "count": 1
+            }
+          }
+        ],
+        "billing": {
+          "name": "Bhavna",
+          "address": {
+            "name": "Bhavna",
+            "building": "club patio",
+            "locality": "Sector Road",
+            "city": "Gurugram",
+            "state": "Haryana",
+            "country": "IND",
+            "area_code": "122007"
+          },
+          "email": "bhavna@buynxt.in",
+          "phone": "7419096651",
+          "created_at": "2024-07-05T10:07:13.125Z",
+          "updated_at": "2024-07-05T10:07:13.125Z"
+        },
+        "fulfillments": [
+          {
+            "id": "24932_C1",
+            "type": "Cancel",
+            "tracking": false,
+            "state": {
+              "descriptor": {
+                "code": "Cancelled"
+              }
+            },
+            "tags": [
+              {
+                "code": "cancel_request",
+                "list": [
+                  {
+                    "code": "reason_id",
+                    "value": "002"
+                  },
+                  {
+                    "code": "initiated_by",
+                    "value": "api.greenreceipt.in"
+                  }
+                ]
+              },
+              {
+                "code": "quote_trail",
+                "list": [
+                  {
+                    "code": "type",
+                    "value": "item"
+                  },
+                  {
+                    "code": "id",
+                    "value": "24932_2740433"
+                  },
+                  {
+                    "code": "currency",
+                    "value": "INR"
+                  },
+                  {
+                    "code": "value",
+                    "value": "-72990.00"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "24932_F1",
+            "@ondc/org/provider_name": "Ajay Electronics",
+            "type": "Delivery",
+            "tracking": false,
+            "@ondc/org/TAT": "PT4H",
+            "state": {
+              "descriptor": {
+                "code": "Order-delivered"
+              }
+            },
+            "start": {
+              "location": {
+                "id": "24932",
+                "descriptor": {
+                  "name": "Ajay Electronics"
+                },
+                "gps": "28.41430316,77.06620157",
+                "address": {
+                  "locality": "Nirvana Country",
+                  "city": "Gurgaon",
+                  "state": "Haryana",
+                  "area_code": "122018"
+                }
+              },
+              "time": {
+                "timestamp": "2024-07-05T10:12:07.047Z"
+              },
+              "contact": {
+                "phone": "8076362934",
+                "email": "Demo3@gmail.com"
+              }
+            },
+            "end": {
+              "location": {
+                "gps": "28.457914,77.067837",
+                "address": {
+                  "name": "Bhavna",
+                  "building": "club patio",
+                  "locality": "Sector Road",
+                  "city": "Gurugram",
+                  "state": "Haryana",
+                  "country": "IND",
+                  "area_code": "122007"
+                }
+              },
+              "time": {
+                "timestamp": "2024-07-05T10:15:14.710Z"
+              },
+              "person": {
+                "name": "Bhavna"
+              },
+              "contact": {
+                "phone": "7419096651",
+                "email": "bhavna@buynxt.in"
+              }
+            }
+          },
+          {
+            "id": "6687c83251dde107f6751c41",
+            "type": "Return",
+            "tracking": false,
+            "state": {
+              "descriptor": {
+                "code": "Return_Delivered"
+              }
+            },
+            "start": {
+              "location": {
+                "gps": "28.457914,77.067837",
+                "address": {
+                  "name": "Bhavna",
+                  "building": "club patio",
+                  "locality": "Sector Road",
+                  "city": "Gurugram",
+                  "state": "Haryana",
+                  "country": "IND",
+                  "area_code": "122007"
+                }
+              },
+              "time": {
+                "timestamp": "2024-07-05T10:19:38.973Z"
+              }
+            },
+            "end": {
+              "location": {
+                "gps": "28.41430316,77.06620157",
+                "address": {
+                  "locality": "Nirvana Country",
+                  "city": "Gurgaon",
+                  "state": "Haryana",
+                  "area_code": "122018"
+                }
+              },
+              "time": {
+                "timestamp": "2024-07-05T10:20:14.193Z"
+              }
+            },
+            "tags": [
+              {
+                "code": "return_request",
+                "list": [
+                  {
+                    "code": "item_id",
+                    "value": "24932_2740442"
+                  },
+                  {
+                    "code": "item_quantity",
+                    "value": "1"
+                  },
+                  {
+                    "code": "reason_id",
+                    "value": "001"
+                  },
+                  {
+                    "code": "reason_desc",
+                    "value": "detailed description for return"
+                  },
+                  {
+                    "code": "images",
+                    "value": "https://reference-buyer-app-assets.s3-ap-south-1.amazonaws.com/public-assets/2024-07-05-178086/171ec969-ec7e-4771-9565-67591f9c750f.png"
+                  },
+                  {
+                    "code": "ttl_approval",
+                    "value": "PT24H"
+                  },
+                  {
+                    "code": "ttl_reverseqc",
+                    "value": "P3D"
+                  },
+                  {
+                    "code": "initiated_by",
+                    "value": "buyer-app-preprod-v2.ondc.org"
+                  }
+                ]
+              },
+              {
+                "code": "quote_trail",
+                "list": [
+                  {
+                    "code": "type",
+                    "value": "item"
+                  },
+                  {
+                    "code": "id",
+                    "value": "24932_2740442"
+                  },
+                  {
+                    "code": "currency",
+                    "value": "INR"
+                  },
+                  {
+                    "code": "value",
+                    "value": "-62990.00"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "6687c94a51dde107f6751ed2",
+            "type": "Return",
+            "tracking": false,
+            "state": {
+              "descriptor": {
+                "code": "Return_Initiated"
+              }
+            },
+            "tags": [
+              {
+                "code": "return_request",
+                "list": [
+                  {
+                    "code": "item_id",
+                    "value": "24932_2740440"
+                  },
+                  {
+                    "code": "item_quantity",
+                    "value": "1"
+                  },
+                  {
+                    "code": "reason_id",
+                    "value": "001"
+                  },
+                  {
+                    "code": "reason_desc",
+                    "value": "detailed description for return"
+                  },
+                  {
+                    "code": "images",
+                    "value": "https://reference-buyer-app-assets.s3-ap-south-1.amazonaws.com/public-assets/2024-07-05-178086/7fd0e3a4-6abe-482b-a103-2326f3408293.png"
+                  },
+                  {
+                    "code": "ttl_approval",
+                    "value": "PT24H"
+                  },
+                  {
+                    "code": "ttl_reverseqc",
+                    "value": "P3D"
+                  },
+                  {
+                    "code": "initiated_by",
+                    "value": "buyer-app-preprod-v2.ondc.org"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "quote": {
+          "price": {
+            "currency": "INR",
+            "value": "281960.00"
+          },
+          "breakup": [
+            {
+              "@ondc/org/item_id": "24932_2740433",
+              "@ondc/org/item_quantity": {
+                "count": 1
+              },
+              "title": "IPHONE 14 128GB YELLOW",
+              "@ondc/org/title_type": "item",
+              "price": {
+                "currency": "INR",
+                "value": "72990.00"
+              },
+              "item": {
+                "price": {
+                  "currency": "INR",
+                  "value": "72990.00"
+                }
+              }
+            },
+            {
+              "@ondc/org/item_id": "24932_2740435",
+              "@ondc/org/item_quantity": {
+                "count": 2
+              },
+              "title": "IPHONE 14 128GB MIDNIGHT",
+              "@ondc/org/title_type": "item",
+              "price": {
+                "currency": "INR",
+                "value": "145980.00"
+              },
+              "item": {
+                "price": {
+                  "currency": "INR",
+                  "value": "72990.00"
+                }
+              }
+            },
+            {
+              "@ondc/org/item_id": "24932_2740440",
+              "@ondc/org/item_quantity": {
+                "count": 1
+              },
+              "title": "IPHONE 13 128GB BLUE",
+              "@ondc/org/title_type": "item",
+              "price": {
+                "currency": "INR",
+                "value": "62990.00"
+              },
+              "item": {
+                "price": {
+                  "currency": "INR",
+                  "value": "62990.00"
+                }
+              }
+            },
+            {
+              "@ondc/org/item_id": "24932_2740442",
+              "@ondc/org/item_quantity": {
+                "count": 0
+              },
+              "title": "IPHONE 13 128GB GREEN",
+              "@ondc/org/title_type": "item",
+              "price": {
+                "currency": "INR",
+                "value": "0.00"
+              },
+              "item": {
+                "price": {
+                  "currency": "INR",
+                  "value": "62990.00"
+                }
+              }
+            },
+            {
+              "@ondc/org/item_id": "24932_F1",
+              "title": "Delivery charges",
+              "@ondc/org/title_type": "delivery",
+              "price": {
+                "currency": "INR",
+                "value": "0.00"
+              }
+            }
+          ],
+          "ttl": "P1D"
+        },
+        "payment": {
+          "uri": "https://razorpay.com/",
+          "params": {
+            "currency": "INR",
+            "transaction_id": "order_OUubpHLJt1USCZ",
+            "amount": "417940.00"
+          },
+          "status": "PAID",
+          "type": "ON-ORDER",
+          "collected_by": "BAP",
+          "@ondc/org/buyer_app_finder_fee_type": "percent",
+          "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+          "@ondc/org/settlement_details": [
+            {
+              "settlement_counterparty": "buyer",
+              "settlement_phase": "refund",
+              "settlement_type": "netbanking",
+              "settlement_timestamp": "2024-07-05T10:10:57.622Z",
+              "settlement_amount": "72990"
+            },
+            {
+              "settlement_counterparty": "buyer",
+              "settlement_phase": "refund",
+              "settlement_type": "netbanking",
+              "settlement_amount": "62990",
+              "settlement_timestamp": "2024-07-05T10:19:39.559Z"
+            },
+            {
+              "settlement_counterparty": "seller-app",
+              "settlement_phase": "sale-amount",
+              "beneficiary_name": "Buynxt Private Limited",
+              "settlement_type": "neft",
+              "upi_address": "buynxt@okidfc",
+              "settlement_bank_account_no": "10129914936",
+              "settlement_ifsc_code": "IDFB0021001",
+              "bank_name": "IDFC First Bank Limited",
+              "branch_name": "Golf Course Road, Gurgaon"
+            }
+          ]
+        },
+        "documents": [
+          {
+            "url": "https://greenreceipt.in/invoices/2024-07-05-178086.pdf",
+            "label": "invoice"
+          }
+        ],
+        "created_at": "2024-07-05T10:07:42.787Z",
+        "updated_at": "2024-07-05T10:22:02.222Z"
+      }
+    }
+  }

--- a/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow6/on_update_return_initiated_reverseQC.json
+++ b/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow6/on_update_return_initiated_reverseQC.json
@@ -1,0 +1,363 @@
+{
+    "context": {
+      "domain": "ONDC:RET14",
+      "action": "on_update",
+      "core_version": "1.2.0",
+      "bap_id": "buyer-app-preprod-v2.ondc.org",
+      "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+      "bpp_id": "api.greenreceipt.in",
+      "bpp_uri": "https://api.greenreceipt.in/ondc",
+      "transaction_id": "3b505f52-9f97-44a0-80e2-51ac2c3411b8",
+      "message_id": "19516de9-dcb6-454e-8af6-cd4f79d8a613",
+      "city": "std:0124",
+      "country": "IND",
+      "timestamp": "2024-07-05T10:17:22.507Z"
+    },
+    "message": {
+      "order": {
+        "id": "2024-07-05-178086",
+        "state": "Completed",
+        "payment": {
+          "uri": "https://razorpay.com/",
+          "params": {
+            "currency": "INR",
+            "transaction_id": "order_OUubpHLJt1USCZ",
+            "amount": "417940.00"
+          },
+          "status": "PAID",
+          "type": "ON-ORDER",
+          "collected_by": "BAP",
+          "@ondc/org/buyer_app_finder_fee_type": "percent",
+          "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+          "@ondc/org/settlement_details": [
+            {
+              "settlement_counterparty": "buyer",
+              "settlement_phase": "refund",
+              "settlement_type": "netbanking",
+              "settlement_amount": "72990",
+              "settlement_timestamp": "2024-07-05T10:10:57.622Z"
+            },
+            {
+              "settlement_counterparty": "seller-app",
+              "settlement_phase": "sale-amount",
+              "beneficiary_name": "Buynxt Private Limited",
+              "settlement_type": "neft",
+              "upi_address": "buynxt@okidfc",
+              "settlement_bank_account_no": "10129914936",
+              "settlement_ifsc_code": "IDFB0021001",
+              "bank_name": "IDFC First Bank Limited",
+              "branch_name": "Golf Course Road, Gurgaon"
+            }
+          ]
+        },
+        "provider": {
+          "id": "24932",
+          "locations": [
+            {
+              "id": "24932"
+            }
+          ]
+        },
+        "items": [
+          {
+            "id": "24932_2740433",
+            "fulfillment_id": "24932_F1",
+            "quantity": {
+              "count": 1
+            }
+          },
+          {
+            "id": "24932_2740435",
+            "fulfillment_id": "24932_F1",
+            "quantity": {
+              "count": 2
+            }
+          },
+          {
+            "id": "24932_2740440",
+            "fulfillment_id": "24932_F1",
+            "quantity": {
+              "count": 1
+            }
+          },
+          {
+            "id": "24932_2740442",
+            "fulfillment_id": "24932_F1",
+            "quantity": {
+              "count": 1
+            }
+          },
+          {
+            "id": "24932_2740433",
+            "fulfillment_id": "24932_C1",
+            "quantity": {
+              "count": 1
+            }
+          }
+        ],
+        "billing": {
+          "name": "Bhavna",
+          "address": {
+            "name": "Bhavna",
+            "building": "club patio",
+            "locality": "Sector Road",
+            "city": "Gurugram",
+            "state": "Haryana",
+            "country": "IND",
+            "area_code": "122007"
+          },
+          "email": "bhavna@buynxt.in",
+          "phone": "7419096651",
+          "created_at": "2024-07-05T10:07:13.125Z",
+          "updated_at": "2024-07-05T10:07:13.125Z"
+        },
+        "fulfillments": [
+          {
+            "id": "24932_C1",
+            "type": "Cancel",
+            "tracking": false,
+            "state": {
+              "descriptor": {
+                "code": "Cancelled"
+              }
+            },
+            "tags": [
+              {
+                "code": "cancel_request",
+                "list": [
+                  {
+                    "code": "reason_id",
+                    "value": "002"
+                  },
+                  {
+                    "code": "initiated_by",
+                    "value": "api.greenreceipt.in"
+                  }
+                ]
+              },
+              {
+                "code": "quote_trail",
+                "list": [
+                  {
+                    "code": "type",
+                    "value": "item"
+                  },
+                  {
+                    "code": "id",
+                    "value": "24932_2740433"
+                  },
+                  {
+                    "code": "currency",
+                    "value": "INR"
+                  },
+                  {
+                    "code": "value",
+                    "value": "-72990.00"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "24932_F1",
+            "@ondc/org/provider_name": "Ajay Electronics",
+            "type": "Delivery",
+            "tracking": false,
+            "@ondc/org/TAT": "PT4H",
+            "state": {
+              "descriptor": {
+                "code": "Order-delivered"
+              }
+            },
+            "start": {
+              "location": {
+                "id": "24932",
+                "descriptor": {
+                  "name": "Ajay Electronics"
+                },
+                "gps": "28.41430316,77.06620157",
+                "address": {
+                  "locality": "Nirvana Country",
+                  "city": "Gurgaon",
+                  "state": "Haryana",
+                  "area_code": "122018"
+                }
+              },
+              "time": {
+                "timestamp": "2024-07-05T10:12:07.047Z"
+              },
+              "contact": {
+                "phone": "8076362934",
+                "email": "Demo3@gmail.com"
+              }
+            },
+            "end": {
+              "location": {
+                "gps": "28.457914,77.067837",
+                "address": {
+                  "name": "Bhavna",
+                  "building": "club patio",
+                  "locality": "Sector Road",
+                  "city": "Gurugram",
+                  "state": "Haryana",
+                  "country": "IND",
+                  "area_code": "122007"
+                }
+              },
+              "time": {
+                "timestamp": "2024-07-05T10:15:14.710Z"
+              },
+              "person": {
+                "name": "Bhavna"
+              },
+              "contact": {
+                "phone": "7419096651",
+                "email": "bhavna@buynxt.in"
+              }
+            }
+          },
+          {
+            "id": "6687c83251dde107f6751c41",
+            "type": "Return",
+            "tracking": false,
+            "state": {
+              "descriptor": {
+                "code": "Return_Initiated"
+              }
+            },
+            "tags": [
+              {
+                "code": "return_request",
+                "list": [
+                  {
+                    "code": "item_id",
+                    "value": "24932_2740442"
+                  },
+                  {
+                    "code": "item_quantity",
+                    "value": "1"
+                  },
+                  {
+                    "code": "reason_id",
+                    "value": "001"
+                  },
+                  {
+                    "code": "reason_desc",
+                    "value": "detailed description for return"
+                  },
+                  {
+                    "code": "images",
+                    "value": "https://reference-buyer-app-assets.s3-ap-south-1.amazonaws.com/public-assets/2024-07-05-178086/171ec969-ec7e-4771-9565-67591f9c750f.png"
+                  },
+                  {
+                    "code": "ttl_approval",
+                    "value": "PT24H"
+                  },
+                  {
+                    "code": "ttl_reverseqc",
+                    "value": "P3D"
+                  },
+                  {
+                    "code": "initiated_by",
+                    "value": "buyer-app-preprod-v2.ondc.org"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "quote": {
+          "price": {
+            "currency": "INR",
+            "value": "344950.00"
+          },
+          "breakup": [
+            {
+              "@ondc/org/item_id": "24932_2740433",
+              "@ondc/org/item_quantity": {
+                "count": 1
+              },
+              "title": "IPHONE 14 128GB YELLOW",
+              "@ondc/org/title_type": "item",
+              "price": {
+                "currency": "INR",
+                "value": "72990.00"
+              },
+              "item": {
+                "price": {
+                  "currency": "INR",
+                  "value": "72990.00"
+                }
+              }
+            },
+            {
+              "@ondc/org/item_id": "24932_2740435",
+              "@ondc/org/item_quantity": {
+                "count": 2
+              },
+              "title": "IPHONE 14 128GB MIDNIGHT",
+              "@ondc/org/title_type": "item",
+              "price": {
+                "currency": "INR",
+                "value": "145980.00"
+              },
+              "item": {
+                "price": {
+                  "currency": "INR",
+                  "value": "72990.00"
+                }
+              }
+            },
+            {
+              "@ondc/org/item_id": "24932_2740440",
+              "@ondc/org/item_quantity": {
+                "count": 1
+              },
+              "title": "IPHONE 13 128GB BLUE",
+              "@ondc/org/title_type": "item",
+              "price": {
+                "currency": "INR",
+                "value": "62990.00"
+              },
+              "item": {
+                "price": {
+                  "currency": "INR",
+                  "value": "62990.00"
+                }
+              }
+            },
+            {
+              "@ondc/org/item_id": "24932_2740442",
+              "@ondc/org/item_quantity": {
+                "count": 1
+              },
+              "title": "IPHONE 13 128GB GREEN",
+              "@ondc/org/title_type": "item",
+              "price": {
+                "currency": "INR",
+                "value": "62990.00"
+              },
+              "item": {
+                "price": {
+                  "currency": "INR",
+                  "value": "62990.00"
+                }
+              }
+            },
+            {
+              "@ondc/org/item_id": "24932_F1",
+              "title": "Delivery charges",
+              "@ondc/org/title_type": "delivery",
+              "price": {
+                "currency": "INR",
+                "value": "0.00"
+              }
+            }
+          ],
+          "ttl": "P1D"
+        },
+        "created_at": "2024-07-05T10:07:42.787Z",
+        "updated_at": "2024-07-05T10:17:22.507Z"
+      }
+    }
+  }

--- a/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow6/on_update_return_liquidated.json
+++ b/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow6/on_update_return_liquidated.json
@@ -1,0 +1,512 @@
+{
+    "context": {
+      "domain": "ONDC:RET14",
+      "action": "on_update",
+      "core_version": "1.2.0",
+      "bap_id": "buyer-app-preprod-v2.ondc.org",
+      "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+      "bpp_id": "api.greenreceipt.in",
+      "bpp_uri": "https://api.greenreceipt.in/ondc",
+      "transaction_id": "3b505f52-9f97-44a0-80e2-51ac2c3411b8",
+      "message_id": "8fb39801-76d3-4999-b0a0-e00af54f12cb",
+      "city": "std:0124",
+      "country": "IND",
+      "timestamp": "2024-07-05T10:23:06.553Z"
+    },
+    "message": {
+      "order": {
+        "id": "2024-07-05-178086",
+        "state": "Completed",
+        "provider": {
+          "id": "24932",
+          "locations": [
+            {
+              "id": "24932"
+            }
+          ]
+        },
+        "items": [
+          {
+            "id": "24932_2740433",
+            "fulfillment_id": "24932_F1",
+            "quantity": {
+              "count": 1
+            }
+          },
+          {
+            "id": "24932_2740435",
+            "fulfillment_id": "24932_F1",
+            "quantity": {
+              "count": 2
+            }
+          },
+          {
+            "id": "24932_2740442",
+            "fulfillment_id": "6687c83251dde107f6751c41",
+            "quantity": {
+              "count": 1
+            }
+          },
+          {
+            "id": "24932_2740442",
+            "fulfillment_id": "24932_F1",
+            "quantity": {
+              "count": 0
+            }
+          },
+          {
+            "id": "24932_2740440",
+            "fulfillment_id": "6687c94a51dde107f6751ed2",
+            "quantity": {
+              "count": 1
+            }
+          },
+          {
+            "id": "24932_2740440",
+            "fulfillment_id": "24932_F1",
+            "quantity": {
+              "count": 0
+            }
+          },
+          {
+            "id": "24932_2740433",
+            "fulfillment_id": "24932_C1",
+            "quantity": {
+              "count": 1
+            }
+          }
+        ],
+        "billing": {
+          "name": "Bhavna",
+          "address": {
+            "name": "Bhavna",
+            "building": "club patio",
+            "locality": "Sector Road",
+            "city": "Gurugram",
+            "state": "Haryana",
+            "country": "IND",
+            "area_code": "122007"
+          },
+          "email": "bhavna@buynxt.in",
+          "phone": "7419096651",
+          "created_at": "2024-07-05T10:07:13.125Z",
+          "updated_at": "2024-07-05T10:07:13.125Z"
+        },
+        "fulfillments": [
+          {
+            "id": "24932_C1",
+            "type": "Cancel",
+            "tracking": false,
+            "state": {
+              "descriptor": {
+                "code": "Cancelled"
+              }
+            },
+            "tags": [
+              {
+                "code": "cancel_request",
+                "list": [
+                  {
+                    "code": "reason_id",
+                    "value": "002"
+                  },
+                  {
+                    "code": "initiated_by",
+                    "value": "api.greenreceipt.in"
+                  }
+                ]
+              },
+              {
+                "code": "quote_trail",
+                "list": [
+                  {
+                    "code": "type",
+                    "value": "item"
+                  },
+                  {
+                    "code": "id",
+                    "value": "24932_2740433"
+                  },
+                  {
+                    "code": "currency",
+                    "value": "INR"
+                  },
+                  {
+                    "code": "value",
+                    "value": "-72990.00"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "24932_F1",
+            "@ondc/org/provider_name": "Ajay Electronics",
+            "type": "Delivery",
+            "tracking": false,
+            "@ondc/org/TAT": "PT4H",
+            "state": {
+              "descriptor": {
+                "code": "Order-delivered"
+              }
+            },
+            "start": {
+              "location": {
+                "id": "24932",
+                "descriptor": {
+                  "name": "Ajay Electronics"
+                },
+                "gps": "28.41430316,77.06620157",
+                "address": {
+                  "locality": "Nirvana Country",
+                  "city": "Gurgaon",
+                  "state": "Haryana",
+                  "area_code": "122018"
+                }
+              },
+              "time": {
+                "timestamp": "2024-07-05T10:12:07.047Z"
+              },
+              "contact": {
+                "phone": "8076362934",
+                "email": "Demo3@gmail.com"
+              }
+            },
+            "end": {
+              "location": {
+                "gps": "28.457914,77.067837",
+                "address": {
+                  "name": "Bhavna",
+                  "building": "club patio",
+                  "locality": "Sector Road",
+                  "city": "Gurugram",
+                  "state": "Haryana",
+                  "country": "IND",
+                  "area_code": "122007"
+                }
+              },
+              "time": {
+                "timestamp": "2024-07-05T10:15:14.710Z"
+              },
+              "person": {
+                "name": "Bhavna"
+              },
+              "contact": {
+                "phone": "7419096651",
+                "email": "bhavna@buynxt.in"
+              }
+            }
+          },
+          {
+            "id": "6687c83251dde107f6751c41",
+            "type": "Return",
+            "tracking": false,
+            "state": {
+              "descriptor": {
+                "code": "Return_Delivered"
+              }
+            },
+            "start": {
+              "location": {
+                "gps": "28.457914,77.067837",
+                "address": {
+                  "name": "Bhavna",
+                  "building": "club patio",
+                  "locality": "Sector Road",
+                  "city": "Gurugram",
+                  "state": "Haryana",
+                  "country": "IND",
+                  "area_code": "122007"
+                }
+              },
+              "time": {
+                "timestamp": "2024-07-05T10:19:38.973Z"
+              }
+            },
+            "end": {
+              "location": {
+                "gps": "28.41430316,77.06620157",
+                "address": {
+                  "locality": "Nirvana Country",
+                  "city": "Gurgaon",
+                  "state": "Haryana",
+                  "area_code": "122018"
+                }
+              },
+              "time": {
+                "timestamp": "2024-07-05T10:20:14.193Z"
+              }
+            },
+            "tags": [
+              {
+                "code": "return_request",
+                "list": [
+                  {
+                    "code": "item_id",
+                    "value": "24932_2740442"
+                  },
+                  {
+                    "code": "item_quantity",
+                    "value": "1"
+                  },
+                  {
+                    "code": "reason_id",
+                    "value": "001"
+                  },
+                  {
+                    "code": "reason_desc",
+                    "value": "detailed description for return"
+                  },
+                  {
+                    "code": "images",
+                    "value": "https://reference-buyer-app-assets.s3-ap-south-1.amazonaws.com/public-assets/2024-07-05-178086/171ec969-ec7e-4771-9565-67591f9c750f.png"
+                  },
+                  {
+                    "code": "ttl_approval",
+                    "value": "PT24H"
+                  },
+                  {
+                    "code": "ttl_reverseqc",
+                    "value": "P3D"
+                  },
+                  {
+                    "code": "initiated_by",
+                    "value": "buyer-app-preprod-v2.ondc.org"
+                  }
+                ]
+              },
+              {
+                "code": "quote_trail",
+                "list": [
+                  {
+                    "code": "type",
+                    "value": "item"
+                  },
+                  {
+                    "code": "id",
+                    "value": "24932_2740442"
+                  },
+                  {
+                    "code": "currency",
+                    "value": "INR"
+                  },
+                  {
+                    "code": "value",
+                    "value": "-62990.00"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "6687c94a51dde107f6751ed2",
+            "type": "Return",
+            "tracking": false,
+            "state": {
+              "descriptor": {
+                "code": "Liquidated"
+              }
+            },
+            "tags": [
+              {
+                "code": "return_request",
+                "list": [
+                  {
+                    "code": "item_id",
+                    "value": "24932_2740440"
+                  },
+                  {
+                    "code": "item_quantity",
+                    "value": "1"
+                  },
+                  {
+                    "code": "reason_id",
+                    "value": "001"
+                  },
+                  {
+                    "code": "reason_desc",
+                    "value": "detailed description for return"
+                  },
+                  {
+                    "code": "images",
+                    "value": "https://reference-buyer-app-assets.s3-ap-south-1.amazonaws.com/public-assets/2024-07-05-178086/7fd0e3a4-6abe-482b-a103-2326f3408293.png"
+                  },
+                  {
+                    "code": "ttl_approval",
+                    "value": "PT24H"
+                  },
+                  {
+                    "code": "ttl_reverseqc",
+                    "value": "P3D"
+                  },
+                  {
+                    "code": "initiated_by",
+                    "value": "buyer-app-preprod-v2.ondc.org"
+                  }
+                ]
+              },
+              {
+                "code": "quote_trail",
+                "list": [
+                  {
+                    "code": "type",
+                    "value": "item"
+                  },
+                  {
+                    "code": "id",
+                    "value": "24932_2740440"
+                  },
+                  {
+                    "code": "currency",
+                    "value": "INR"
+                  },
+                  {
+                    "code": "value",
+                    "value": "-62990.00"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "quote": {
+          "price": {
+            "currency": "INR",
+            "value": "218970.00"
+          },
+          "breakup": [
+            {
+              "@ondc/org/item_id": "24932_2740433",
+              "@ondc/org/item_quantity": {
+                "count": 1
+              },
+              "title": "IPHONE 14 128GB YELLOW",
+              "@ondc/org/title_type": "item",
+              "price": {
+                "currency": "INR",
+                "value": "72990.00"
+              },
+              "item": {
+                "price": {
+                  "currency": "INR",
+                  "value": "72990.00"
+                }
+              }
+            },
+            {
+              "@ondc/org/item_id": "24932_2740435",
+              "@ondc/org/item_quantity": {
+                "count": 2
+              },
+              "title": "IPHONE 14 128GB MIDNIGHT",
+              "@ondc/org/title_type": "item",
+              "price": {
+                "currency": "INR",
+                "value": "145980.00"
+              },
+              "item": {
+                "price": {
+                  "currency": "INR",
+                  "value": "72990.00"
+                }
+              }
+            },
+            {
+              "@ondc/org/item_id": "24932_2740442",
+              "@ondc/org/item_quantity": {
+                "count": 0
+              },
+              "title": "IPHONE 13 128GB GREEN",
+              "@ondc/org/title_type": "item",
+              "price": {
+                "currency": "INR",
+                "value": "0.00"
+              },
+              "item": {
+                "price": {
+                  "currency": "INR",
+                  "value": "62990.00"
+                }
+              }
+            },
+            {
+              "@ondc/org/item_id": "24932_2740440",
+              "@ondc/org/item_quantity": {
+                "count": 0
+              },
+              "title": "IPHONE 13 128GB BLUE",
+              "@ondc/org/title_type": "item",
+              "price": {
+                "currency": "INR",
+                "value": "0.00"
+              },
+              "item": {
+                "price": {
+                  "currency": "INR",
+                  "value": "62990.00"
+                }
+              }
+            },
+            {
+              "@ondc/org/item_id": "24932_F1",
+              "title": "Delivery charges",
+              "@ondc/org/title_type": "delivery",
+              "price": {
+                "currency": "INR",
+                "value": "0.00"
+              }
+            }
+          ],
+          "ttl": "P1D"
+        },
+        "payment": {
+          "uri": "https://razorpay.com/",
+          "params": {
+            "currency": "INR",
+            "transaction_id": "order_OUubpHLJt1USCZ",
+            "amount": "417940.00"
+          },
+          "status": "PAID",
+          "type": "ON-ORDER",
+          "collected_by": "BAP",
+          "@ondc/org/buyer_app_finder_fee_type": "percent",
+          "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+          "@ondc/org/settlement_details": [
+            {
+              "settlement_counterparty": "buyer",
+              "settlement_phase": "refund",
+              "settlement_type": "netbanking",
+              "settlement_timestamp": "2024-07-05T10:10:57.622Z",
+              "settlement_amount": "72990"
+            },
+            {
+              "settlement_counterparty": "buyer",
+              "settlement_phase": "refund",
+              "settlement_type": "netbanking",
+              "settlement_amount": "62990",
+              "settlement_timestamp": "2024-07-05T10:19:39.559Z"
+            },
+            {
+              "settlement_counterparty": "seller-app",
+              "settlement_phase": "sale-amount",
+              "beneficiary_name": "Buynxt Private Limited",
+              "settlement_type": "neft",
+              "upi_address": "buynxt@okidfc",
+              "settlement_bank_account_no": "10129914936",
+              "settlement_ifsc_code": "IDFB0021001",
+              "bank_name": "IDFC First Bank Limited",
+              "branch_name": "Golf Course Road, Gurgaon"
+            }
+          ]
+        },
+        "documents": [
+          {
+            "url": "https://greenreceipt.in/invoices/2024-07-05-178086.pdf",
+            "label": "invoice"
+          }
+        ],
+        "created_at": "2024-07-05T10:07:42.787Z",
+        "updated_at": "2024-07-05T10:23:06.553Z"
+      }
+    }
+  }

--- a/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow6/on_update_return_picked_reverseQC.json
+++ b/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow6/on_update_return_picked_reverseQC.json
@@ -1,0 +1,419 @@
+{
+    "context": {
+      "domain": "ONDC:RET14",
+      "action": "on_update",
+      "core_version": "1.2.0",
+      "bap_id": "buyer-app-preprod-v2.ondc.org",
+      "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+      "bpp_id": "api.greenreceipt.in",
+      "bpp_uri": "https://api.greenreceipt.in/ondc",
+      "transaction_id": "3b505f52-9f97-44a0-80e2-51ac2c3411b8",
+      "message_id": "eec7e65f-ecb0-43ea-91ee-870b8c891d9e",
+      "city": "std:0124",
+      "country": "IND",
+      "timestamp": "2024-07-05T10:19:39.057Z"
+    },
+    "message": {
+      "order": {
+        "id": "2024-07-05-178086",
+        "state": "Completed",
+        "payment": {
+          "uri": "https://razorpay.com/",
+          "params": {
+            "currency": "INR",
+            "transaction_id": "order_OUubpHLJt1USCZ",
+            "amount": "417940.00"
+          },
+          "status": "PAID",
+          "type": "ON-ORDER",
+          "collected_by": "BAP",
+          "@ondc/org/buyer_app_finder_fee_type": "percent",
+          "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+          "@ondc/org/settlement_details": [
+            {
+              "settlement_counterparty": "buyer",
+              "settlement_phase": "refund",
+              "settlement_type": "netbanking",
+              "settlement_amount": "72990",
+              "settlement_timestamp": "2024-07-05T10:10:57.622Z"
+            },
+            {
+              "settlement_counterparty": "seller-app",
+              "settlement_phase": "sale-amount",
+              "beneficiary_name": "Buynxt Private Limited",
+              "settlement_type": "neft",
+              "upi_address": "buynxt@okidfc",
+              "settlement_bank_account_no": "10129914936",
+              "settlement_ifsc_code": "IDFB0021001",
+              "bank_name": "IDFC First Bank Limited",
+              "branch_name": "Golf Course Road, Gurgaon"
+            }
+          ]
+        },
+        "provider": {
+          "id": "24932",
+          "locations": [
+            {
+              "id": "24932"
+            }
+          ]
+        },
+        "items": [
+          {
+            "id": "24932_2740433",
+            "fulfillment_id": "24932_F1",
+            "quantity": {
+              "count": 1
+            }
+          },
+          {
+            "id": "24932_2740435",
+            "fulfillment_id": "24932_F1",
+            "quantity": {
+              "count": 2
+            }
+          },
+          {
+            "id": "24932_2740440",
+            "fulfillment_id": "24932_F1",
+            "quantity": {
+              "count": 1
+            }
+          },
+          {
+            "id": "24932_2740442",
+            "fulfillment_id": "6687c83251dde107f6751c41",
+            "quantity": {
+              "count": 1
+            }
+          },
+          {
+            "id": "24932_2740442",
+            "fulfillment_id": "24932_F1",
+            "quantity": {
+              "count": 0
+            }
+          },
+          {
+            "id": "24932_2740433",
+            "fulfillment_id": "24932_C1",
+            "quantity": {
+              "count": 1
+            }
+          }
+        ],
+        "billing": {
+          "name": "Bhavna",
+          "address": {
+            "name": "Bhavna",
+            "building": "club patio",
+            "locality": "Sector Road",
+            "city": "Gurugram",
+            "state": "Haryana",
+            "country": "IND",
+            "area_code": "122007"
+          },
+          "email": "bhavna@buynxt.in",
+          "phone": "7419096651",
+          "created_at": "2024-07-05T10:07:13.125Z",
+          "updated_at": "2024-07-05T10:07:13.125Z"
+        },
+        "fulfillments": [
+          {
+            "id": "24932_C1",
+            "type": "Cancel",
+            "tracking": false,
+            "state": {
+              "descriptor": {
+                "code": "Cancelled"
+              }
+            },
+            "tags": [
+              {
+                "code": "cancel_request",
+                "list": [
+                  {
+                    "code": "reason_id",
+                    "value": "002"
+                  },
+                  {
+                    "code": "initiated_by",
+                    "value": "api.greenreceipt.in"
+                  }
+                ]
+              },
+              {
+                "code": "quote_trail",
+                "list": [
+                  {
+                    "code": "type",
+                    "value": "item"
+                  },
+                  {
+                    "code": "id",
+                    "value": "24932_2740433"
+                  },
+                  {
+                    "code": "currency",
+                    "value": "INR"
+                  },
+                  {
+                    "code": "value",
+                    "value": "-72990.00"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "24932_F1",
+            "@ondc/org/provider_name": "Ajay Electronics",
+            "type": "Delivery",
+            "tracking": false,
+            "@ondc/org/TAT": "PT4H",
+            "state": {
+              "descriptor": {
+                "code": "Order-delivered"
+              }
+            },
+            "start": {
+              "location": {
+                "id": "24932",
+                "descriptor": {
+                  "name": "Ajay Electronics"
+                },
+                "gps": "28.41430316,77.06620157",
+                "address": {
+                  "locality": "Nirvana Country",
+                  "city": "Gurgaon",
+                  "state": "Haryana",
+                  "area_code": "122018"
+                }
+              },
+              "time": {
+                "timestamp": "2024-07-05T10:12:07.047Z"
+              },
+              "contact": {
+                "phone": "8076362934",
+                "email": "Demo3@gmail.com"
+              }
+            },
+            "end": {
+              "location": {
+                "gps": "28.457914,77.067837",
+                "address": {
+                  "name": "Bhavna",
+                  "building": "club patio",
+                  "locality": "Sector Road",
+                  "city": "Gurugram",
+                  "state": "Haryana",
+                  "country": "IND",
+                  "area_code": "122007"
+                }
+              },
+              "time": {
+                "timestamp": "2024-07-05T10:15:14.710Z"
+              },
+              "person": {
+                "name": "Bhavna"
+              },
+              "contact": {
+                "phone": "7419096651",
+                "email": "bhavna@buynxt.in"
+              }
+            }
+          },
+          {
+            "id": "6687c83251dde107f6751c41",
+            "type": "Return",
+            "tracking": false,
+            "state": {
+              "descriptor": {
+                "code": "Return_Picked"
+              }
+            },
+            "start": {
+              "location": {
+                "gps": "28.457914,77.067837",
+                "address": {
+                  "name": "Bhavna",
+                  "building": "club patio",
+                  "locality": "Sector Road",
+                  "city": "Gurugram",
+                  "state": "Haryana",
+                  "country": "IND",
+                  "area_code": "122007"
+                }
+              },
+              "time": {
+                "timestamp": "2024-07-05T10:42:38.973Z"
+              }
+            },
+            "end": {
+              "location": {
+                "gps": "28.41430316,77.06620157",
+                "address": {
+                  "locality": "Nirvana Country",
+                  "city": "Gurgaon",
+                  "state": "Haryana",
+                  "area_code": "122018"
+                }
+              }
+            },
+            "tags": [
+              {
+                "code": "return_request",
+                "list": [
+                  {
+                    "code": "item_id",
+                    "value": "24932_2740442"
+                  },
+                  {
+                    "code": "item_quantity",
+                    "value": "1"
+                  },
+                  {
+                    "code": "reason_id",
+                    "value": "001"
+                  },
+                  {
+                    "code": "reason_desc",
+                    "value": "detailed description for return"
+                  },
+                  {
+                    "code": "images",
+                    "value": "https://reference-buyer-app-assets.s3-ap-south-1.amazonaws.com/public-assets/2024-07-05-178086/171ec969-ec7e-4771-9565-67591f9c750f.png"
+                  },
+                  {
+                    "code": "ttl_approval",
+                    "value": "PT24H"
+                  },
+                  {
+                    "code": "ttl_reverseqc",
+                    "value": "P3D"
+                  },
+                  {
+                    "code": "initiated_by",
+                    "value": "buyer-app-preprod-v2.ondc.org"
+                  }
+                ]
+              },
+              {
+                "code": "quote_trail",
+                "list": [
+                  {
+                    "code": "type",
+                    "value": "item"
+                  },
+                  {
+                    "code": "id",
+                    "value": "24932_2740442"
+                  },
+                  {
+                    "code": "currency",
+                    "value": "INR"
+                  },
+                  {
+                    "code": "value",
+                    "value": "-62990.00"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "quote": {
+          "price": {
+            "currency": "INR",
+            "value": "281960.00"
+          },
+          "breakup": [
+            {
+              "@ondc/org/item_id": "24932_2740433",
+              "@ondc/org/item_quantity": {
+                "count": 1
+              },
+              "title": "IPHONE 14 128GB YELLOW",
+              "@ondc/org/title_type": "item",
+              "price": {
+                "currency": "INR",
+                "value": "72990.00"
+              },
+              "item": {
+                "price": {
+                  "currency": "INR",
+                  "value": "72990.00"
+                }
+              }
+            },
+            {
+              "@ondc/org/item_id": "24932_2740435",
+              "@ondc/org/item_quantity": {
+                "count": 2
+              },
+              "title": "IPHONE 14 128GB MIDNIGHT",
+              "@ondc/org/title_type": "item",
+              "price": {
+                "currency": "INR",
+                "value": "145980.00"
+              },
+              "item": {
+                "price": {
+                  "currency": "INR",
+                  "value": "72990.00"
+                }
+              }
+            },
+            {
+              "@ondc/org/item_id": "24932_2740440",
+              "@ondc/org/item_quantity": {
+                "count": 1
+              },
+              "title": "IPHONE 13 128GB BLUE",
+              "@ondc/org/title_type": "item",
+              "price": {
+                "currency": "INR",
+                "value": "62990.00"
+              },
+              "item": {
+                "price": {
+                  "currency": "INR",
+                  "value": "62990.00"
+                }
+              }
+            },
+            {
+              "@ondc/org/item_id": "24932_2740442",
+              "@ondc/org/item_quantity": {
+                "count": 0
+              },
+              "title": "IPHONE 13 128GB GREEN",
+              "@ondc/org/title_type": "item",
+              "price": {
+                "currency": "INR",
+                "value": "0.00"
+              },
+              "item": {
+                "price": {
+                  "currency": "INR",
+                  "value": "62990.00"
+                }
+              }
+            },
+            {
+              "@ondc/org/item_id": "24932_F1",
+              "title": "Delivery charges",
+              "@ondc/org/title_type": "delivery",
+              "price": {
+                "currency": "INR",
+                "value": "0.00"
+              }
+            }
+          ],
+          "ttl": "P1D"
+        },
+        "created_at": "2024-07-05T10:07:42.787Z",
+        "updated_at": "2024-07-05T10:19:39.057Z"
+      }
+    }
+  }

--- a/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow6/select.json
+++ b/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow6/select.json
@@ -1,0 +1,71 @@
+{
+  "context": {
+    "domain": "ONDC:RET14",
+    "country": "IND",
+    "city": "std:0124",
+    "action": "select",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_uri": "https://api.greenreceipt.in/ondc",
+    "transaction_id": "3b505f52-9f97-44a0-80e2-51ac2c3411b8",
+    "message_id": "35216891-77cf-4ab0-8fca-4f09f2033b19",
+    "timestamp": "2024-07-05T10:06:59.997Z",
+    "bpp_id": "api.greenreceipt.in",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "order": {
+      "items": [
+        {
+          "id": "24932_2740433",
+          "quantity": {
+            "count": 2
+          },
+          "location_id": "24932"
+        },
+        {
+          "id": "24932_2740435",
+          "quantity": {
+            "count": 2
+          },
+          "location_id": "24932"
+        },
+        {
+          "id": "24932_2740440",
+          "quantity": {
+            "count": 1
+          },
+          "location_id": "24932"
+        },
+        {
+          "id": "24932_2740442",
+          "quantity": {
+            "count": 1
+          },
+          "location_id": "24932"
+        }
+      ],
+      "provider": {
+        "id": "24932",
+        "locations": [
+          {
+            "id": "24932"
+          }
+        ]
+      },
+      "fulfillments": [
+        {
+          "end": {
+            "location": {
+              "gps": "28.457914,77.067837",
+              "address": {
+                "area_code": "122007"
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow6/update_payment_liquidated.json
+++ b/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow6/update_payment_liquidated.json
@@ -1,0 +1,39 @@
+{
+  "context": {
+    "domain": "ONDC:RET14",
+    "action": "update",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_id": "api.greenreceipt.in",
+    "bpp_uri": "https://api.greenreceipt.in/ondc",
+    "transaction_id": "3b505f52-9f97-44a0-80e2-51ac2c3411b8",
+    "message_id": "c781f480-b95c-4e02-a3ba-98d52f6104f5",
+    "city": "std:0124",
+    "country": "IND",
+    "timestamp": "2024-07-05T10:23:07.045Z"
+  },
+  "message": {
+    "update_target": "payment",
+    "order": {
+      "id": "2024-07-05-178086",
+      "fulfillments": [
+        {
+          "id": "6687c94a51dde107f6751ed2",
+          "type": "Return"
+        }
+      ],
+      "payment": {
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "buyer",
+            "settlement_phase": "refund",
+            "settlement_type": "netbanking",
+            "settlement_amount": "62990",
+            "settlement_timestamp": "2024-07-05T10:23:07.045Z"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow6/update_payment_part_cancel.json
+++ b/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow6/update_payment_part_cancel.json
@@ -1,0 +1,39 @@
+{
+  "context": {
+    "domain": "ONDC:RET14",
+    "action": "update",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_id": "api.greenreceipt.in",
+    "bpp_uri": "https://api.greenreceipt.in/ondc",
+    "transaction_id": "3b505f52-9f97-44a0-80e2-51ac2c3411b8",
+    "message_id": "a630e5c8-692a-4c4e-9c0d-62e42f09d96f",
+    "city": "std:0124",
+    "country": "IND",
+    "timestamp": "2024-07-05T10:10:57.622Z"
+  },
+  "message": {
+    "update_target": "payment",
+    "order": {
+      "id": "2024-07-05-178086",
+      "fulfillments": [
+        {
+          "id": "24932_C1",
+          "type": "Cancel"
+        }
+      ],
+      "payment": {
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "buyer",
+            "settlement_phase": "refund",
+            "settlement_type": "netbanking",
+            "settlement_amount": "72990",
+            "settlement_timestamp": "2024-07-05T10:10:57.622Z"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow6/update_payment_reverseQC.json
+++ b/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow6/update_payment_reverseQC.json
@@ -1,0 +1,39 @@
+{
+  "context": {
+    "domain": "ONDC:RET14",
+    "action": "update",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_id": "api.greenreceipt.in",
+    "bpp_uri": "https://api.greenreceipt.in/ondc",
+    "transaction_id": "3b505f52-9f97-44a0-80e2-51ac2c3411b8",
+    "message_id": "377f0d55-da9c-4ae4-a2bc-5f1472d4784d",
+    "city": "std:0124",
+    "country": "IND",
+    "timestamp": "2024-07-05T10:19:39.559Z"
+  },
+  "message": {
+    "update_target": "payment",
+    "order": {
+      "id": "2024-07-05-178086",
+      "fulfillments": [
+        {
+          "id": "6687c83251dde107f6751c41",
+          "type": "Return"
+        }
+      ],
+      "payment": {
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "buyer",
+            "settlement_phase": "refund",
+            "settlement_type": "netbanking",
+            "settlement_amount": "62990",
+            "settlement_timestamp": "2024-07-05T10:19:39.559Z"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow6/update_return_liquidate.json
+++ b/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow6/update_return_liquidate.json
@@ -1,0 +1,71 @@
+{
+  "context": {
+    "domain": "ONDC:RET14",
+    "country": "IND",
+    "city": "std:0124",
+    "action": "update",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_uri": "https://api.greenreceipt.in/ondc",
+    "transaction_id": "3b505f52-9f97-44a0-80e2-51ac2c3411b8",
+    "message_id": "4f6e5d06-2ae8-4164-9c03-6473bc4604e4",
+    "timestamp": "2024-07-05T10:22:02.130Z",
+    "bpp_id": "api.greenreceipt.in",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "update_target": "item",
+    "order": {
+      "id": "2024-07-05-178086",
+      "fulfillments": [
+        {
+          "type": "Return",
+          "tags": [
+            {
+              "code": "return_request",
+              "list": [
+                {
+                  "code": "id",
+                  "value": "6687c94a51dde107f6751ed2"
+                },
+                {
+                  "code": "item_id",
+                  "value": "24932_2740440"
+                },
+                {
+                  "code": "parent_item_id",
+                  "value": ""
+                },
+                {
+                  "code": "item_quantity",
+                  "value": "1"
+                },
+                {
+                  "code": "reason_id",
+                  "value": "001"
+                },
+                {
+                  "code": "reason_desc",
+                  "value": "detailed description for return"
+                },
+                {
+                  "code": "images",
+                  "value": "https://reference-buyer-app-assets.s3-ap-south-1.amazonaws.com/public-assets/2024-07-05-178086/7fd0e3a4-6abe-482b-a103-2326f3408293.png"
+                },
+                {
+                  "code": "ttl_approval",
+                  "value": "PT24H"
+                },
+                {
+                  "code": "ttl_reverseqc",
+                  "value": "P3D"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow6/update_reverseQC.json
+++ b/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow6/update_reverseQC.json
@@ -1,0 +1,71 @@
+{
+  "context": {
+    "domain": "ONDC:RET14",
+    "country": "IND",
+    "city": "std:0124",
+    "action": "update",
+    "core_version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+    "bpp_uri": "https://api.greenreceipt.in/ondc",
+    "transaction_id": "3b505f52-9f97-44a0-80e2-51ac2c3411b8",
+    "message_id": "19516de9-dcb6-454e-8af6-cd4f79d8a613",
+    "timestamp": "2024-07-05T10:17:22.415Z",
+    "bpp_id": "api.greenreceipt.in",
+    "ttl": "PT30S"
+  },
+  "message": {
+    "update_target": "item",
+    "order": {
+      "id": "2024-07-05-178086",
+      "fulfillments": [
+        {
+          "type": "Return",
+          "tags": [
+            {
+              "code": "return_request",
+              "list": [
+                {
+                  "code": "id",
+                  "value": "6687c83251dde107f6751c41"
+                },
+                {
+                  "code": "item_id",
+                  "value": "24932_2740442"
+                },
+                {
+                  "code": "parent_item_id",
+                  "value": ""
+                },
+                {
+                  "code": "item_quantity",
+                  "value": "1"
+                },
+                {
+                  "code": "reason_id",
+                  "value": "001"
+                },
+                {
+                  "code": "reason_desc",
+                  "value": "detailed description for return"
+                },
+                {
+                  "code": "images",
+                  "value": "https://reference-buyer-app-assets.s3-ap-south-1.amazonaws.com/public-assets/2024-07-05-178086/171ec969-ec7e-4771-9565-67591f9c750f.png"
+                },
+                {
+                  "code": "ttl_approval",
+                  "value": "PT24H"
+                },
+                {
+                  "code": "ttl_reverseqc",
+                  "value": "P3D"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow6_log_utility_resp.json
+++ b/Buynxt_Greenreceipt/RET14_updated_2024_07_11/Flow6_log_utility_resp.json
@@ -1,0 +1,13 @@
+{
+    "success": true,
+    "response": {
+        "message": "Logs were verified successfully",
+        "report": {},
+        "bpp_id": "api.greenreceipt.in",
+        "bap_id": "buyer-app-preprod-v2.ondc.org",
+        "domain": "ONDC:RET14",
+        "reportTimestamp": "2024-07-11T11:41:57.032Z"
+    },
+    "signature": "3lLeoAyjV3QeyN3t3pdDqpH+9ispHT5ye/tu9jnZ64txRa8dqjceqeA60Kx1opQQY3VVmwiBHMsZIi2hZLqXDA==",
+    "signTimestamp": "2024-07-11T11:41:57.033Z"
+}


### PR DESCRIPTION
In our last review of the Electronics (RET:14) logs, you suggested two fixes for Flow 5:

`On_status_rto_delivered`
1 - Items object is provided as an empty array.
2 - RTO_fulfillment.start.time.timestamp is future-dated compared to on_cancel_rto; it should be the same as what's provided in on_cancel. Only RTO_fulfillment.end.time.timestamp will be updated here.

We have addressed these two issues and are now resubmitting the logs for your verification. Added, you will find the log validation utility response files for each flow. We are receiving 200 responses for all flows in the log utility.

Please review and verify them at your earliest convenience.