### PR TITLE
Catalog Rejection Logs Added

### DIFF
--- a/Easy Pay/BuyerApp/Catalog Rejection/RET14.json
+++ b/Easy Pay/BuyerApp/Catalog Rejection/RET14.json
@@ -1,0 +1,31 @@
+{
+  "context": {
+    "domain": "ONDC:RET14",
+    "country": "IND",
+    "city": "std:033",
+    "action": "catalog_rejection",
+    "core_version": "1.2.0",
+    "bap_id": "preprod.easypay.co.in",
+    "bap_uri": "https://preprod.easypay.co.in/ecommerce/ondc/buyer",
+    "transaction_id": "f7507bb8-c6c8-4376-915e-356e5ecfab60",
+    "message_id": "b4954721-f92f-47b6-9ff5-ddbe299865f0",
+    "timestamp": "2024-09-19T06:28:43.545Z",
+    "ttl": "PT30S",
+    "bpp_id": "preprod-ondc.ndh01.com/retail",
+    "bpp_uri": "https://preprod-ondc.ndh01.com/retail/seller"
+  },
+  "errors": [
+    {
+      "code": "90000",
+      "type": "PROVIDER-ERROR",
+      "path": "message.catalog.bpp/providers[?(@.id=='134964')]",
+      "message": "Provider technical/Business error codes"
+    },
+    {
+      "code": "92000",
+      "type": "BPP-ERROR",
+      "path": "message.catalog",
+      "message": "BPP level business error codes"
+    }
+  ]
+}

--- a/Easy Pay/BuyerApp/Catalog Rejection/RET15.json
+++ b/Easy Pay/BuyerApp/Catalog Rejection/RET15.json
@@ -1,0 +1,35 @@
+{
+  "context": {
+    "domain": "ONDC:RET15",
+    "country": "IND",
+    "city": "std:080",
+    "action": "catalog_rejection",
+    "core_version": "1.2.0",
+    "bap_id": "preprod.easypay.co.in",
+    "bap_uri": "https://preprod.easypay.co.in/ecommerce/ondc/buyer",
+    "transaction_id": "0ec54c4e-24e1-4889-9248-02e3cee518a0",
+    "message_id": "e7d6531d-1f18-4060-9572-8a4399cfd808",
+    "timestamp": "2024-09-19T06:58:44.416Z",
+    "ttl": "PT30S",
+    "bpp_id": "preprod-ondc.ndh01.com/retail",
+    "bpp_uri": "https://preprod-ondc.ndh01.com/retail/seller"
+  },
+  "errors": [
+    {
+      "code": "90000",
+      "type": "PROVIDER-ERROR",
+      "path": "message.catalog.bpp/providers[?(@.id=='134965')]",
+      "message": "Provider technical/Business error codes"
+    },
+    {
+      "code": "92000",
+      "type": "BPP-ERROR",
+      "path": "message.catalog",
+      "message": "BPP level business error codes"
+    }
+  ]
+}
+
+
+
+


### PR DESCRIPTION
As Suggested over the email, we have shared catalog rejection logs for RET14 and RET15. This is same catalog rejection on search which we submitted earlier.