### PR TITLE
Fix : RSF Compliance Check ( Pirimid Seller App ) Issue #3002

### DIFF
--- a/Pirimid/SellerApp/RSF/FLOW_2/0_settle.json
+++ b/Pirimid/SellerApp/RSF/FLOW_2/0_settle.json
@@ -15,9 +15,9 @@
     "bap_uri": "https://ondc.pirimidtech.com/v2/seller",
     "bpp_id": "rsf-mock-service.ondc.org/seller_protocol_server",
     "bpp_uri": "https://rsf-mock-service.ondc.org/seller_protocol_server_preprod/ondc",
-    "transaction_id": "8bfc7a8c-22d7-4d18-9323-084d02720a35",
-    "message_id": "27c66631-dbcc-40c5-82d1-e0fbfb8027f5",
-    "timestamp": "2024-12-23T13:09:32.376Z",
+    "transaction_id": "c356afb9-7374-44bd-9d74-1ad211bc483a",
+    "message_id": "e088ce4e-d831-476e-b7b6-cb8297bc1ec5",
+    "timestamp": "2025-01-02T10:02:50.204Z",
     "ttl": "P1D"
   },
   "message": {
@@ -25,19 +25,19 @@
     "receiver_app_id": "ondc.pirimidtech.com/v2/seller",
     "settlement": {
       "type": "NP-NP",
-      "id": "f9622368-4aba-4976-9864-9fe1d2d70c12",
+      "id": "96fc9858-6de0-44dd-a8bd-8f22e4595f48",
       "orders": [
         {
-          "id": "a06ddf3c-e4df-4191-b97c-b5f2368bc160",
+          "id": "1ae826ec-9502-4317-a7c1-f7654bc44c7d",
           "inter_participant": {
             "amount": {
-              "value": "641.82"
+              "value": "543.11"
             }
           },
           "collector": {
             "amount": {
               "currency": "INR",
-              "value": "19.85"
+              "value": "16.8"
             }
           },
           "provider": {
@@ -49,7 +49,7 @@
             },
             "amount": {
               "currency": "INR",
-              "value": "591.82"
+              "value": "493.11"
             }
           },
           "self": {

--- a/Pirimid/SellerApp/RSF/FLOW_2/1_on_settle.json
+++ b/Pirimid/SellerApp/RSF/FLOW_2/1_on_settle.json
@@ -12,9 +12,9 @@
         "code": "*"
       }
     },
-    "transaction_id": "a536aab9-0de1-41bb-85e6-775e7ad68770",
-    "message_id": "99a5d2ef-702f-42de-8670-691145a42b32",
-    "timestamp": "2024-12-23T13:12:28.904Z",
+    "transaction_id": "c356afb9-7374-44bd-9d74-1ad211bc483a",
+    "message_id": "e088ce4e-d831-476e-b7b6-cb8297bc1ec5",
+    "timestamp": "2025-01-02T10:03:11.336Z",
     "domain": "ONDC:NTS10",
     "version": "2.0.0",
     "ttl": "PT10M",
@@ -25,25 +25,25 @@
     "receiver_app_id": "ondc.pirimidtech.com/v2/seller",
     "settlement": {
       "type": "NP-NP",
-      "id": "398d93d9-5fd9-46d4-abaf-d4abc4a354f6",
+      "id": "96fc9858-6de0-44dd-a8bd-8f22e4595f48",
       "orders": [
         {
-          "id": "a06ddf3c-e4df-4191-b97c-b5f2368bc160",
+          "id": "1ae826ec-9502-4317-a7c1-f7654bc44c7d",
           "inter_participant": {
             "amount": {
-              "value": "641.82",
+              "value": "543.11",
               "currency": "INR"
             },
             "settled_amount": {
-              "value": "641.82",
+              "value": "543.11",
               "currency": "INR"
             },
-            "status": "SETTLED",
-            "reference_no": "1238683618638"
+            "status": "NOT_SETTLED",
+            "reference_no": "1238683618634"
           },
           "collector": {
             "amount": {
-              "value": "19.85",
+              "value": "16.8",
               "currency": "INR"
             }
           },
@@ -52,13 +52,13 @@
               "value": "50.0",
               "currency": "INR"
             },
-            "status": "SETTLED",
-            "reference_no": "1238683618638"
+            "status": "NOT_SETTLED",
+            "reference_no": "1238683618634"
           },
           "provider": {
             "id": "569cb6de-db0d-408b-8090-e05ac22a0ec8",
             "amount": {
-              "value": "591.82",
+              "value": "493.11",
               "currency": "INR"
             }
           }

--- a/Pirimid/SellerApp/RSF/FLOW_2/2_report.json
+++ b/Pirimid/SellerApp/RSF/FLOW_2/2_report.json
@@ -15,13 +15,13 @@
     "bap_uri": "https://ondc.pirimidtech.com/v2/seller",
     "bpp_id": "rsf-mock-service.ondc.org/seller_protocol_server",
     "bpp_uri": "https://rsf-mock-service.ondc.org/seller_protocol_server_preprod/ondc",
-    "transaction_id": "8bfc7a8c-22d7-4d18-9323-084d02720a35",
-    "message_id": "c23edcff-32b9-422e-95e0-9ba4ef51fdd1",
-    "timestamp": "2024-12-23T13:09:32.376Z",
+    "transaction_id": "c356afb9-7374-44bd-9d74-1ad211bc483a",
+    "message_id": "29780806-5d1c-497c-af53-5af4cd5bbdd4",
+    "timestamp": "2025-01-02T10:02:50.204Z",
     "ttl": "P1D"
   },
   "message": {
-    "ref_transaction_id": "8bfc7a8c-22d7-4d18-9323-084d02720a35",
-    "ref_message_id": "27c66631-dbcc-40c5-82d1-e0fbfb8027f5"
+    "ref_transaction_id": "c356afb9-7374-44bd-9d74-1ad211bc483a",
+    "ref_message_id": "e088ce4e-d831-476e-b7b6-cb8297bc1ec5"
   }
 }

--- a/Pirimid/SellerApp/RSF/FLOW_2/3_on_report.json
+++ b/Pirimid/SellerApp/RSF/FLOW_2/3_on_report.json
@@ -12,9 +12,9 @@
         "code": "*"
       }
     },
-    "transaction_id": "8bfc7a8c-22d7-4d18-9323-084d02720a35",
-    "message_id": "c23edcff-32b9-422e-95e0-9ba4ef51fdd1",
-    "timestamp": "2024-12-23T13:10:18.312Z",
+    "transaction_id": "c356afb9-7374-44bd-9d74-1ad211bc483a",
+    "message_id": "29780806-5d1c-497c-af53-5af4cd5bbdd4",
+    "timestamp": "2025-01-02T10:03:42.479Z",
     "domain": "ONDC:NTS10",
     "version": "2.0.0",
     "ttl": "PT10M",
@@ -25,17 +25,17 @@
     "receiver_app_id": "ondc.pirimidtech.com/v2/seller",
     "settlement": {
       "type": "NP-NP",
-      "id": "f9622368-4aba-4976-9864-9fe1d2d70c12",
+      "id": "96fc9858-6de0-44dd-a8bd-8f22e4595f48",
       "orders": [
         {
-          "id": "a06ddf3c-e4df-4191-b97c-b5f2368bc160",
+          "id": "1ae826ec-9502-4317-a7c1-f7654bc44c7d",
           "inter_participant": {
             "amount": {
-              "value": "641.82",
+              "value": "543.11",
               "currency": "INR"
             },
             "settled_amount": {
-              "value": "641.82",
+              "value": "543.11",
               "currency": "INR"
             },
             "status": "NOT_SETTLED",
@@ -43,7 +43,7 @@
           },
           "collector": {
             "amount": {
-              "value": "19.85",
+              "value": "16.8",
               "currency": "INR"
             }
           },
@@ -58,11 +58,11 @@
           "provider": {
             "id": "569cb6de-db0d-408b-8090-e05ac22a0ec8",
             "amount": {
-              "value": "591.82",
+              "value": "493.11",
               "currency": "INR"
             },
             "status": "NOT_SETTLED",
-            "reference_no": "1238683618635"
+            "reference_no": "1238683618636"
           },
           "error": {
             "code": "70023",

--- a/Pirimid/SellerApp/RSF/FLOW_2/4_recon.json
+++ b/Pirimid/SellerApp/RSF/FLOW_2/4_recon.json
@@ -15,32 +15,31 @@
     "bap_uri": "https://ondc.pirimidtech.com/v2/seller",
     "bpp_id": "ondc.pirimidtech.com/v2/buyer",
     "bpp_uri": "https://rsf-mock-service.ondc.org/seller_protocol_server_preprod/ondc",
-    "transaction_id": "8bfc7a8c-22d7-4d18-9323-084d02720a35",
-    "message_id": "8accb10f-7421-492d-bfbf-be6462952d8e",
-    "timestamp": "2024-12-23T13:10:26.086Z",
+    "transaction_id": "c356afb9-7374-44bd-9d74-1ad211bc483a",
+    "message_id": "5cdbc9bc-8e61-4a3f-b431-faad8c8cb8cb",
+    "timestamp": "2025-01-02T10:03:49.051Z",
     "ttl": "P1D"
   },
   "message": {
     "orders": [
       {
-        "id": "a06ddf3c-e4df-4191-b97c-b5f2368bc160",
+        "id": "1ae826ec-9502-4317-a7c1-f7654bc44c7d",
         "amount": {
           "currency": "INR",
-          "value": "661.67"
+          "value": "559.91"
         },
-        "recon_accord": false,
         "settlements": [
           {
-            "id": "f9622368-4aba-4976-9864-9fe1d2d70c12",
-            "payment_id": "2a106c9f-a4d6-40e4-b659-f1a0c21fda30",
+            "id": "96fc9858-6de0-44dd-a8bd-8f22e4595f48",
+            "payment_id": "2c057f1a-c442-43a8-b7c3-3270577e1085",
             "status": "PENDING",
             "amount": {
               "currency": "INR",
-              "value": "641.82"
+              "value": "543.11"
             },
             "commission": {
               "currency": "INR",
-              "value": "19.85"
+              "value": "16.8"
             },
             "withholding_amount": {
               "currency": "INR",
@@ -54,7 +53,7 @@
               "currency": "INR",
               "value": "0.0"
             },
-            "updated_at": "2024-12-23T13:10:19.445Z",
+            "updated_at": "2025-01-02T10:03:42.592Z",
             "settlement_ref_no": "1238683618634"
           }
         ]

--- a/Pirimid/SellerApp/RSF/FLOW_2/5_on_recon.json
+++ b/Pirimid/SellerApp/RSF/FLOW_2/5_on_recon.json
@@ -12,9 +12,9 @@
         "code": "*"
       }
     },
-    "transaction_id": "8bfc7a8c-22d7-4d18-9323-084d02720a35",
-    "message_id": "8accb10f-7421-492d-bfbf-be6462952d8e",
-    "timestamp": "2024-12-23T13:10:31.545Z",
+    "transaction_id": "c356afb9-7374-44bd-9d74-1ad211bc483a",
+    "message_id": "5cdbc9bc-8e61-4a3f-b431-faad8c8cb8cb",
+    "timestamp": "2025-01-02T10:04:03.240Z",
     "domain": "ONDC:NTS10",
     "version": "2.0.0",
     "ttl": "PT10M",
@@ -23,24 +23,24 @@
   "message": {
     "orders": [
       {
-        "id": "a06ddf3c-e4df-4191-b97c-b5f2368bc160",
+        "id": "1ae826ec-9502-4317-a7c1-f7654bc44c7d",
         "amount": {
-          "value": "661.67",
+          "value": "559.91",
           "currency": "INR"
         },
         "recon_accord": "true",
         "settlements": [
           {
-            "id": "f9622368-4aba-4976-9864-9fe1d2d70c12",
-            "payment_id": "2a106c9f-a4d6-40e4-b659-f1a0c21fda30",
+            "id": "96fc9858-6de0-44dd-a8bd-8f22e4595f48",
+            "payment_id": "2c057f1a-c442-43a8-b7c3-3270577e1085",
             "status": "PENDING",
             "amount": {
-              "value": "641.82",
+              "value": "543.11",
               "currency": "INR",
               "diff_value": "0"
             },
             "commission": {
-              "value": "19.85",
+              "value": "16.8",
               "currency": "INR",
               "diff_value": "0"
             },
@@ -60,7 +60,7 @@
               "diff_value": "0"
             },
             "settlement_ref_no": "1238683618634",
-            "updated_at": "2024-12-23T13:10:19.445Z"
+            "updated_at": "2025-01-02T10:03:42.592Z"
           }
         ]
       }

--- a/Pirimid/SellerApp/RSF/FLOW_2/6_settle.json
+++ b/Pirimid/SellerApp/RSF/FLOW_2/6_settle.json
@@ -15,9 +15,9 @@
     "bap_uri": "https://ondc.pirimidtech.com/v2/seller",
     "bpp_id": "rsf-mock-service.ondc.org/seller_protocol_server",
     "bpp_uri": "https://rsf-mock-service.ondc.org/seller_protocol_server_preprod/ondc",
-    "transaction_id": "a536aab9-0de1-41bb-85e6-775e7ad68770",
-    "message_id": "99a5d2ef-702f-42de-8670-691145a42b32",
-    "timestamp": "2024-12-23T13:12:14.583Z",
+    "transaction_id": "64b1a884-d684-4e8f-aecb-b13f3e302cca",
+    "message_id": "344b9abb-1331-4b7a-ab52-0c7155992c77",
+    "timestamp": "2025-01-02T10:20:02.783Z",
     "ttl": "P1D"
   },
   "message": {
@@ -25,19 +25,19 @@
     "receiver_app_id": "ondc.pirimidtech.com/v2/seller",
     "settlement": {
       "type": "NP-NP",
-      "id": "398d93d9-5fd9-46d4-abaf-d4abc4a354f6",
+      "id": "456f9a43-de00-4e37-b944-6376aec40897",
       "orders": [
         {
-          "id": "a06ddf3c-e4df-4191-b97c-b5f2368bc160",
+          "id": "1ae826ec-9502-4317-a7c1-f7654bc44c7d",
           "inter_participant": {
             "amount": {
-              "value": "641.82"
+              "value": "543.11"
             }
           },
           "collector": {
             "amount": {
               "currency": "INR",
-              "value": "19.85"
+              "value": "16.8"
             }
           },
           "provider": {
@@ -49,7 +49,7 @@
             },
             "amount": {
               "currency": "INR",
-              "value": "591.82"
+              "value": "493.11"
             }
           },
           "self": {

--- a/Pirimid/SellerApp/RSF/FLOW_2/7_on_settle.json
+++ b/Pirimid/SellerApp/RSF/FLOW_2/7_on_settle.json
@@ -12,9 +12,9 @@
         "code": "*"
       }
     },
-    "transaction_id": "8bfc7a8c-22d7-4d18-9323-084d02720a35",
-    "message_id": "27c66631-dbcc-40c5-82d1-e0fbfb8027f5",
-    "timestamp": "2024-12-23T13:09:47.640Z",
+    "transaction_id": "64b1a884-d684-4e8f-aecb-b13f3e302cca",
+    "message_id": "344b9abb-1331-4b7a-ab52-0c7155992c77",
+    "timestamp": "2025-01-02T10:20:25.522Z",
     "domain": "ONDC:NTS10",
     "version": "2.0.0",
     "ttl": "PT10M",
@@ -25,25 +25,25 @@
     "receiver_app_id": "ondc.pirimidtech.com/v2/seller",
     "settlement": {
       "type": "NP-NP",
-      "id": "f9622368-4aba-4976-9864-9fe1d2d70c12",
+      "id": "456f9a43-de00-4e37-b944-6376aec40897",
       "orders": [
         {
-          "id": "a06ddf3c-e4df-4191-b97c-b5f2368bc160",
+          "id": "1ae826ec-9502-4317-a7c1-f7654bc44c7d",
           "inter_participant": {
             "amount": {
-              "value": "641.82",
+              "value": "543.11",
               "currency": "INR"
             },
             "settled_amount": {
-              "value": "641.82",
+              "value": "543.11",
               "currency": "INR"
             },
-            "status": "NOT_SETTLED",
-            "reference_no": "1238683618634"
+            "status": "SETTLED",
+            "reference_no": "1238683618635"
           },
           "collector": {
             "amount": {
-              "value": "19.85",
+              "value": "16.8",
               "currency": "INR"
             }
           },
@@ -52,13 +52,13 @@
               "value": "50.0",
               "currency": "INR"
             },
-            "status": "NOT_SETTLED",
-            "reference_no": "1238683618634"
+            "status": "SETTLED",
+            "reference_no": "1238683618635"
           },
           "provider": {
             "id": "569cb6de-db0d-408b-8090-e05ac22a0ec8",
             "amount": {
-              "value": "591.82",
+              "value": "493.11",
               "currency": "INR"
             }
           }

--- a/Pirimid/SellerApp/RSF/FLOW_3/0_settle.json
+++ b/Pirimid/SellerApp/RSF/FLOW_3/0_settle.json
@@ -15,9 +15,9 @@
     "bap_uri": "https://ondc.pirimidtech.com/v2/seller",
     "bpp_id": "rsf-mock-service.ondc.org/seller_protocol_server",
     "bpp_uri": "https://rsf-mock-service.ondc.org/seller_protocol_server_preprod/ondc",
-    "transaction_id": "9db4e07a-867c-4e7b-9575-9862d8e9d248",
-    "message_id": "e2006cf0-af92-479a-8e9b-9823f588ee4e",
-    "timestamp": "2024-12-23T13:19:10.558Z",
+    "transaction_id": "4905f98a-9773-44e9-88ce-a2b9598c58cf",
+    "message_id": "6628ffbc-89f8-4fb1-9629-2cc810a54c59",
+    "timestamp": "2025-01-02T10:38:39.940Z",
     "ttl": "P1D"
   },
   "message": {
@@ -25,19 +25,19 @@
     "receiver_app_id": "ondc.pirimidtech.com/v2/seller",
     "settlement": {
       "type": "NP-NP",
-      "id": "5f963a78-bd7a-4d55-99ab-03b3e1c1268d",
+      "id": "72dd1b15-b9c6-4a66-81c6-f6de96021595",
       "orders": [
         {
-          "id": "a06ddf3c-e4df-4191-b97c-b5f2368bc160",
+          "id": "1ae826ec-9502-4317-a7c1-f7654bc44c7d",
           "inter_participant": {
             "amount": {
-              "value": "641.82"
+              "value": "630.91"
             }
           },
           "collector": {
             "amount": {
               "currency": "INR",
-              "value": "19.85"
+              "value": "19.51"
             }
           },
           "provider": {
@@ -49,7 +49,7 @@
             },
             "amount": {
               "currency": "INR",
-              "value": "591.82"
+              "value": "580.91"
             }
           },
           "self": {

--- a/Pirimid/SellerApp/RSF/FLOW_3/1_on_settle.json
+++ b/Pirimid/SellerApp/RSF/FLOW_3/1_on_settle.json
@@ -12,9 +12,9 @@
         "code": "*"
       }
     },
-    "transaction_id": "9db4e07a-867c-4e7b-9575-9862d8e9d248",
-    "message_id": "e2006cf0-af92-479a-8e9b-9823f588ee4e",
-    "timestamp": "2024-12-23T13:19:22.983Z",
+    "transaction_id": "4905f98a-9773-44e9-88ce-a2b9598c58cf",
+    "message_id": "6628ffbc-89f8-4fb1-9629-2cc810a54c59",
+    "timestamp": "2025-01-02T10:39:10.875Z",
     "domain": "ONDC:NTS10",
     "version": "2.0.0",
     "ttl": "PT10M",
@@ -25,17 +25,17 @@
     "receiver_app_id": "ondc.pirimidtech.com/v2/seller",
     "settlement": {
       "type": "NP-NP",
-      "id": "5f963a78-bd7a-4d55-99ab-03b3e1c1268d",
+      "id": "72dd1b15-b9c6-4a66-81c6-f6de96021595",
       "orders": [
         {
-          "id": "a06ddf3c-e4df-4191-b97c-b5f2368bc160",
+          "id": "1ae826ec-9502-4317-a7c1-f7654bc44c7d",
           "inter_participant": {
             "amount": {
-              "value": "641.82",
+              "value": "630.91",
               "currency": "INR"
             },
             "settled_amount": {
-              "value": "641.82",
+              "value": "630.91",
               "currency": "INR"
             },
             "status": "NOT_SETTLED",
@@ -43,7 +43,7 @@
           },
           "collector": {
             "amount": {
-              "value": "19.85",
+              "value": "19.51",
               "currency": "INR"
             }
           },
@@ -58,7 +58,7 @@
           "provider": {
             "id": "569cb6de-db0d-408b-8090-e05ac22a0ec8",
             "amount": {
-              "value": "591.82",
+              "value": "580.91",
               "currency": "INR"
             }
           }

--- a/Pirimid/SellerApp/RSF/FLOW_3/2_report.json
+++ b/Pirimid/SellerApp/RSF/FLOW_3/2_report.json
@@ -15,13 +15,13 @@
     "bap_uri": "https://ondc.pirimidtech.com/v2/seller",
     "bpp_id": "rsf-mock-service.ondc.org/seller_protocol_server",
     "bpp_uri": "https://rsf-mock-service.ondc.org/seller_protocol_server_preprod/ondc",
-    "transaction_id": "9db4e07a-867c-4e7b-9575-9862d8e9d248",
-    "message_id": "911e2879-67a4-432a-856d-f8ebdecb6587",
-    "timestamp": "2024-12-23T13:19:10.558Z",
+    "transaction_id": "4905f98a-9773-44e9-88ce-a2b9598c58cf",
+    "message_id": "3b1da96f-7dba-4c53-ba9e-67d2c71a9a5f",
+    "timestamp": "2025-01-02T10:38:39.940Z",
     "ttl": "P1D"
   },
   "message": {
-    "ref_transaction_id": "9db4e07a-867c-4e7b-9575-9862d8e9d248",
-    "ref_message_id": "e2006cf0-af92-479a-8e9b-9823f588ee4e"
+    "ref_transaction_id": "4905f98a-9773-44e9-88ce-a2b9598c58cf",
+    "ref_message_id": "6628ffbc-89f8-4fb1-9629-2cc810a54c59"
   }
 }

--- a/Pirimid/SellerApp/RSF/FLOW_3/3_on_report.json
+++ b/Pirimid/SellerApp/RSF/FLOW_3/3_on_report.json
@@ -12,9 +12,9 @@
         "code": "*"
       }
     },
-    "transaction_id": "9db4e07a-867c-4e7b-9575-9862d8e9d248",
-    "message_id": "911e2879-67a4-432a-856d-f8ebdecb6587",
-    "timestamp": "2024-12-23T13:19:45.864Z",
+    "transaction_id": "4905f98a-9773-44e9-88ce-a2b9598c58cf",
+    "message_id": "3b1da96f-7dba-4c53-ba9e-67d2c71a9a5f",
+    "timestamp": "2025-01-02T10:39:44.861Z",
     "domain": "ONDC:NTS10",
     "version": "2.0.0",
     "ttl": "PT10M",
@@ -25,17 +25,17 @@
     "receiver_app_id": "ondc.pirimidtech.com/v2/seller",
     "settlement": {
       "type": "NP-NP",
-      "id": "5f963a78-bd7a-4d55-99ab-03b3e1c1268d",
+      "id": "72dd1b15-b9c6-4a66-81c6-f6de96021595",
       "orders": [
         {
-          "id": "a06ddf3c-e4df-4191-b97c-b5f2368bc160",
+          "id": "1ae826ec-9502-4317-a7c1-f7654bc44c7d",
           "inter_participant": {
             "amount": {
-              "value": "641.82",
+              "value": "630.91",
               "currency": "INR"
             },
             "settled_amount": {
-              "value": "641.82",
+              "value": "630.91",
               "currency": "INR"
             },
             "status": "NOT_SETTLED",
@@ -43,7 +43,7 @@
           },
           "collector": {
             "amount": {
-              "value": "19.85",
+              "value": "19.51",
               "currency": "INR"
             }
           },
@@ -58,11 +58,11 @@
           "provider": {
             "id": "569cb6de-db0d-408b-8090-e05ac22a0ec8",
             "amount": {
-              "value": "591.82",
+              "value": "580.91",
               "currency": "INR"
             },
             "status": "NOT_SETTLED",
-            "reference_no": "1238683618632"
+            "reference_no": "1238683618635"
           },
           "error": {
             "code": "70023",

--- a/Pirimid/SellerApp/RSF/FLOW_3/4_recon.json
+++ b/Pirimid/SellerApp/RSF/FLOW_3/4_recon.json
@@ -15,32 +15,31 @@
     "bap_uri": "https://ondc.pirimidtech.com/v2/seller",
     "bpp_id": "ondc.pirimidtech.com/v2/buyer",
     "bpp_uri": "https://rsf-mock-service.ondc.org/seller_protocol_server_preprod/ondc",
-    "transaction_id": "9db4e07a-867c-4e7b-9575-9862d8e9d248",
-    "message_id": "4f0853ff-280e-44c4-8a77-10cbc0533748",
-    "timestamp": "2024-12-23T13:20:05.864Z",
+    "transaction_id": "4905f98a-9773-44e9-88ce-a2b9598c58cf",
+    "message_id": "f7316c00-a408-4853-8fd3-7c9812b909e2",
+    "timestamp": "2025-01-02T10:39:50.698Z",
     "ttl": "P1D"
   },
   "message": {
     "orders": [
       {
-        "id": "a06ddf3c-e4df-4191-b97c-b5f2368bc160",
+        "id": "1ae826ec-9502-4317-a7c1-f7654bc44c7d",
         "amount": {
           "currency": "INR",
-          "value": "661.67"
+          "value": "650.42"
         },
-        "recon_accord": false,
         "settlements": [
           {
-            "id": "5f963a78-bd7a-4d55-99ab-03b3e1c1268d",
-            "payment_id": "2a106c9f-a4d6-40e4-b659-f1a0c21fda30",
+            "id": "72dd1b15-b9c6-4a66-81c6-f6de96021595",
+            "payment_id": "2c057f1a-c442-43a8-b7c3-3270577e1085",
             "status": "PENDING",
             "amount": {
               "currency": "INR",
-              "value": "641.82"
+              "value": "630.91"
             },
             "commission": {
               "currency": "INR",
-              "value": "19.85"
+              "value": "19.51"
             },
             "withholding_amount": {
               "currency": "INR",
@@ -54,7 +53,7 @@
               "currency": "INR",
               "value": "0.0"
             },
-            "updated_at": "2024-12-23T13:19:46.997Z",
+            "updated_at": "2025-01-02T10:39:44.952Z",
             "settlement_ref_no": "1238683618634"
           }
         ]

--- a/Pirimid/SellerApp/RSF/FLOW_3/5_on_recon.json
+++ b/Pirimid/SellerApp/RSF/FLOW_3/5_on_recon.json
@@ -12,9 +12,9 @@
         "code": "*"
       }
     },
-    "transaction_id": "9db4e07a-867c-4e7b-9575-9862d8e9d248",
-    "message_id": "4f0853ff-280e-44c4-8a77-10cbc0533748",
-    "timestamp": "2024-12-23T13:20:19.456Z",
+    "transaction_id": "4905f98a-9773-44e9-88ce-a2b9598c58cf",
+    "message_id": "f7316c00-a408-4853-8fd3-7c9812b909e2",
+    "timestamp": "2025-01-02T10:40:29.211Z",
     "domain": "ONDC:NTS10",
     "version": "2.0.0",
     "ttl": "PT10M",
@@ -23,24 +23,24 @@
   "message": {
     "orders": [
       {
-        "id": "a06ddf3c-e4df-4191-b97c-b5f2368bc160",
+        "id": "1ae826ec-9502-4317-a7c1-f7654bc44c7d",
         "amount": {
-          "value": "661.67",
+          "value": "650.42",
           "currency": "INR"
         },
         "recon_accord": "false",
         "settlements": [
           {
-            "id": "5f963a78-bd7a-4d55-99ab-03b3e1c1268d",
-            "payment_id": "2a106c9f-a4d6-40e4-b659-f1a0c21fda30",
+            "id": "72dd1b15-b9c6-4a66-81c6-f6de96021595",
+            "payment_id": "2c057f1a-c442-43a8-b7c3-3270577e1085",
             "status": "PENDING",
             "amount": {
-              "value": "641.82",
+              "value": "630.91",
               "currency": "INR",
               "diff_value": "-5"
             },
             "commission": {
-              "value": "19.85",
+              "value": "19.51",
               "currency": "INR",
               "diff_value": "5"
             },
@@ -60,7 +60,7 @@
               "diff_value": "0"
             },
             "settlement_ref_no": "1238683618634",
-            "updated_at": "2024-12-23T13:19:46.997Z"
+            "updated_at": "2025-01-02T10:39:44.952Z"
           }
         ]
       }


### PR DESCRIPTION
As per the given suggestion in Issue #3002, the recon call of flow-2 and flow-3 contains an extra property recon_accord which is removed.
This PR contains the Resubmission of Flow-2 and Flow-3 Logs.