### PR TITLE
added logs for RET11

### DIFF
--- a/eComviser/Seller App RET11/Flow-1/flow-1_validate_report.json
+++ b/eComviser/Seller App RET11/Flow-1/flow-1_validate_report.json
@@ -1,0 +1,17 @@
+{
+    "success": false,
+    "response": {
+        "message": "Logs were not verified successfully",
+        "report": {
+            "on_search_full_catalog_refresh": {
+                "message/catalog/bpp/providers0/categories/items": "No items are mapped with the given category_id 844147zabcde in providers0/items"
+            }
+        },
+        "bpp_id": "ondc.ecomviser.com",
+        "bap_id": "buyer-app-preprod-v2.ondc.org",
+        "domain": "ONDC:RET11",
+        "reportTimestamp": "2025-01-08T12:15:49.171Z"
+    },
+    "signature": "NBvGM7VEg5P1QtuvmqsIYBdCcqTXMSRYtoZb5BjQ3Y/eRhD9w707+fTF35Sr41yWwG9ZR8PDlhGUzyqbyB1vCQ==",
+    "signTimestamp": "2025-01-08T12:15:49.171Z"
+}

--- a/eComviser/Seller App RET11/Flow-1/flow-1_validate_request.json
+++ b/eComviser/Seller App RET11/Flow-1/flow-1_validate_request.json
@@ -1,0 +1,825 @@
+{
+    "domain": "ONDC:RET11",
+    "version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bpp_id": "ondc.ecomviser.com",
+    "payload": {
+        "search_full_catalog_refresh": {
+            "context": {
+                "domain": "ONDC:RET11",
+                "action": "search",
+                "country": "IND",
+                "city": "std:0120",
+                "core_version": "1.2.0",
+                "bap_id": "buyer-app-preprod-v2.ondc.org",
+                "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+                "transaction_id": "0646bc94-5d3d-4b2d-6325-a8a33843dbb9",
+                "message_id": "36c56392-f004-4813-ace5-0d40033a8420",
+                "timestamp": "2025-01-06T16:47:42.734Z",
+                "ttl": "PT30S"
+            },
+            "message": {
+                "intent": {
+                    "fulfillment": {
+                        "type": "Delivery"
+                    },
+                    "payment": {
+                        "@ondc/org/buyer_app_finder_fee_type": "percent",
+                        "@ondc/org/buyer_app_finder_fee_amount": "3"
+                    }
+                }
+            }
+        },
+        "on_search_full_catalog_refresh": {
+            "context": {
+                "domain": "ONDC:RET11",
+                "action": "on_search",
+                "country": "IND",
+                "city": "std:0120",
+                "core_version": "1.2.0",
+                "bap_id": "buyer-app-preprod-v2.ondc.org",
+                "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+                "transaction_id": "0646bc94-5d3d-4b2d-6325-a8a33843dbb9",
+                "message_id": "36c56392-f004-4813-ace5-0d40033a8420",
+                "timestamp": "2025-01-06T11:17:49.476Z",
+                "ttl": "PT30S",
+                "bpp_id": "ondc.ecomviser.com",
+                "bpp_uri": "https://ondc.ecomviser.com/api/v1"
+            },
+            "message": {
+                "catalog": {
+                    "bpp/descriptor": {
+                        "name": "Webkul",
+                        "symbol": "https://ondc.ecomviser.com/public/img/webkul_logo.png",
+                        "short_desc": "Enterprise Digital Commerce & Marketplace Solution Experts",
+                        "long_desc": "Helping companies with our industry-leading digital commerce, ERP, and CRM solutions. In the last 13 years, we have served 150K+ clients worldwide to handle complex operations and grow their businesses",
+                        "images": [
+                            "https://ondc.ecomviser.com/public/img/webkul_banner.png",
+                            "https://ondc.ecomviser.com/public/img/webkul_clients.png",
+                            "https://ondc.ecomviser.com/public/img/webkul_awards.png"
+                        ],
+                        "tags": [
+                            {
+                                "code": "bpp_terms",
+                                "list": [
+                                    {
+                                        "code": "np_type",
+                                        "value": "MSN"
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                    "bpp/fulfillments": [
+                        {
+                            "id": "155",
+                            "type": "Delivery"
+                        }
+                    ],
+                    "bpp/providers": [
+                        {
+                            "id": "84",
+                            "time": {
+                                "label": "enable",
+                                "timestamp": "2025-01-06T10:47:48.872Z"
+                            },
+                            "descriptor": {
+                                "name": "Ajeet Food Shop",
+                                "symbol": "https://ondc-prepod-digital-delivery.s3.amazonaws.com/seller_shop_logo/84/39MylDtZVC.jpg",
+                                "short_desc": "short desc",
+                                "long_desc": "store desc",
+                                "images": [
+                                    "https://ondc-prepod-digital-delivery.s3.amazonaws.com/seller_shop_logo/84/39MylDtZVC.jpg"
+                                ]
+                            },
+                            "fulfillments": [
+                                {
+                                    "id": "155",
+                                    "type": "Delivery",
+                                    "contact": {
+                                        "phone": "9812345678",
+                                        "email": "ajeetchauhan.symfony143@webkul.in"
+                                    }
+                                }
+                            ],
+                            "locations": [
+                                {
+                                    "id": "83",
+                                    "gps": "28.62972640,77.37783230",
+                                    "address": {
+                                        "locality": "Noida",
+                                        "street": "H-28",
+                                        "city": "Gautam Buddh Nagar",
+                                        "area_code": "201301",
+                                        "state": "Uttar Pradesh"
+                                    },
+                                    "circle": {
+                                        "gps": "28.62972640,77.37783230",
+                                        "radius": {
+                                            "unit": "km",
+                                            "value": "5"
+                                        }
+                                    },
+                                    "time": {
+                                        "label": "enable",
+                                        "timestamp": "2025-01-06T10:47:48.872Z",
+                                        "days": "1,2,3,4,5,6,7",
+                                        "schedule": {
+                                            "holidays": []
+                                        },
+                                        "range": {
+                                            "start": "0800",
+                                            "end": "1707"
+                                        }
+                                    }
+                                }
+                            ],
+                            "@ondc/org/fssai_license_no": "12345678908898",
+                            "categories": [
+                                {
+                                    "id": "66zabcdefghi",
+                                    "descriptor": {
+                                        "name": "Cheese"
+                                    },
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "custom_group"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "config",
+                                            "list": [
+                                                {
+                                                    "code": "min",
+                                                    "value": "1"
+                                                },
+                                                {
+                                                    "code": "max",
+                                                    "value": "1"
+                                                },
+                                                {
+                                                    "code": "input",
+                                                    "value": "select"
+                                                },
+                                                {
+                                                    "code": "seq",
+                                                    "value": "1"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                {
+                                    "id": "67zabcdefghi",
+                                    "descriptor": {
+                                        "name": "Non-veg toppings"
+                                    },
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "custom_group"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "config",
+                                            "list": [
+                                                {
+                                                    "code": "min",
+                                                    "value": "1"
+                                                },
+                                                {
+                                                    "code": "max",
+                                                    "value": "1"
+                                                },
+                                                {
+                                                    "code": "input",
+                                                    "value": "select"
+                                                },
+                                                {
+                                                    "code": "seq",
+                                                    "value": "2"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                {
+                                    "id": "844147zabcde",
+                                    "parent_category_id": "",
+                                    "descriptor": {
+                                        "name": "Pizza",
+                                        "short_desc": "Pizza",
+                                        "long_desc": "Pizza"
+                                    },
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "custom_menu"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "display",
+                                            "list": [
+                                                {
+                                                    "code": "rank",
+                                                    "value": "1"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "timing",
+                                            "list": [
+                                                {
+                                                    "code": "day_from",
+                                                    "value": "1"
+                                                },
+                                                {
+                                                    "code": "day_to",
+                                                    "value": "5"
+                                                },
+                                                {
+                                                    "code": "time_from",
+                                                    "value": "0800"
+                                                },
+                                                {
+                                                    "code": "time_to",
+                                                    "value": "2200"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ],
+                            "items": [
+                                {
+                                    "id": "451",
+                                    "time": {
+                                        "label": "enable",
+                                        "timestamp": "2025-01-06T10:47:48.872Z"
+                                    },
+                                    "descriptor": {
+                                        "name": "Pizza Mania",
+                                        "symbol": "https://d3bhszwz094mhs.cloudfront.net/product_img/main_img/342/NipTw8cSUY.jpeg",
+                                        "short_desc": "pizza best small",
+                                        "long_desc": "best pizza",
+                                        "images": [
+                                            "https://d3bhszwz094mhs.cloudfront.net/product_img/main_img/342/NipTw8cSUY.jpeg"
+                                        ],
+                                        "code": "1:123456789876"
+                                    },
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "99",
+                                        "maximum_value": "110",
+                                        "tags": [
+                                            {
+                                                "code": "range",
+                                                "list": [
+                                                    {
+                                                        "code": "lower",
+                                                        "value": "99.00"
+                                                    },
+                                                    {
+                                                        "code": "upper",
+                                                        "value": "159"
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                "code": "default_selection",
+                                                "list": [
+                                                    {
+                                                        "code": "value",
+                                                        "value": "99.00"
+                                                    },
+                                                    {
+                                                        "code": "maximum_value",
+                                                        "value": "159"
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "quantity": {
+                                        "available": {
+                                            "count": "99"
+                                        },
+                                        "maximum": {
+                                            "count": "99"
+                                        },
+                                        "unitized": {
+                                            "measure": {
+                                                "unit": "gram",
+                                                "value": "200"
+                                            }
+                                        }
+                                    },
+                                    "location_id": "83",
+                                    "category_id": "F&B",
+                                    "fulfillment_id": "155",
+                                    "@ondc/org/time_to_ship": "PT1H",
+                                    "@ondc/org/cancellable": true,
+                                    "@ondc/org/seller_pickup_return": false,
+                                    "@ondc/org/returnable": false,
+                                    "@ondc/org/return_window": "PT0S",
+                                    "@ondc/org/available_on_cod": false,
+                                    "@ondc/org/contact_details_consumer_care": "ajeet,ajeetchauhan.symfony143@webkul.in,9812345678",
+                                    "tags": [
+                                        {
+                                            "code": "origin",
+                                            "list": [
+                                                {
+                                                    "code": "country",
+                                                    "value": "IND"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "item"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "custom_group",
+                                            "list": [
+                                                {
+                                                    "code": "id",
+                                                    "value": "66zabcdefghi"
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "category_ids": [
+                                        "844147zabcde:1"
+                                    ]
+                                },
+                                {
+                                    "id": "93",
+                                    "descriptor": {
+                                        "name": "Extra"
+                                    },
+                                    "quantity": {
+                                        "available": {
+                                            "count": "99"
+                                        },
+                                        "maximum": {
+                                            "count": "99"
+                                        }
+                                    },
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "5.00",
+                                        "maximum_value": "5.00"
+                                    },
+                                    "category_id": "F&B",
+                                    "related": true,
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "customization"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "parent",
+                                            "list": [
+                                                {
+                                                    "code": "id",
+                                                    "value": "66zabcdefghi"
+                                                },
+                                                {
+                                                    "code": "default",
+                                                    "value": "yes"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "veg_nonveg",
+                                            "list": [
+                                                {
+                                                    "code": "veg",
+                                                    "value": "yes"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "child",
+                                            "list": [
+                                                {
+                                                    "code": "id",
+                                                    "value": "67zabcdefghi"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                {
+                                    "id": "94",
+                                    "descriptor": {
+                                        "name": "Vegan"
+                                    },
+                                    "quantity": {
+                                        "available": {
+                                            "count": "99"
+                                        },
+                                        "maximum": {
+                                            "count": "99"
+                                        }
+                                    },
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "10.00",
+                                        "maximum_value": "10.00"
+                                    },
+                                    "category_id": "F&B",
+                                    "related": true,
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "customization"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "parent",
+                                            "list": [
+                                                {
+                                                    "code": "id",
+                                                    "value": "66zabcdefghi"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "veg_nonveg",
+                                            "list": [
+                                                {
+                                                    "code": "veg",
+                                                    "value": "yes"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "child",
+                                            "list": [
+                                                {
+                                                    "code": "id",
+                                                    "value": "67zabcdefghi"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                {
+                                    "id": "95",
+                                    "descriptor": {
+                                        "name": "Chicken"
+                                    },
+                                    "quantity": {
+                                        "available": {
+                                            "count": "99"
+                                        },
+                                        "maximum": {
+                                            "count": "99"
+                                        }
+                                    },
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "10.00",
+                                        "maximum_value": "10.00"
+                                    },
+                                    "category_id": "F&B",
+                                    "related": true,
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "customization"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "parent",
+                                            "list": [
+                                                {
+                                                    "code": "id",
+                                                    "value": "67zabcdefghi"
+                                                },
+                                                {
+                                                    "code": "default",
+                                                    "value": "yes"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "veg_nonveg",
+                                            "list": [
+                                                {
+                                                    "code": "non_veg",
+                                                    "value": "yes"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                {
+                                    "id": "96",
+                                    "descriptor": {
+                                        "name": "Mutton"
+                                    },
+                                    "quantity": {
+                                        "available": {
+                                            "count": "99"
+                                        },
+                                        "maximum": {
+                                            "count": "99"
+                                        }
+                                    },
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "50.00",
+                                        "maximum_value": "50.00"
+                                    },
+                                    "category_id": "F&B",
+                                    "related": true,
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "customization"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "parent",
+                                            "list": [
+                                                {
+                                                    "code": "id",
+                                                    "value": "67zabcdefghi"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "veg_nonveg",
+                                            "list": [
+                                                {
+                                                    "code": "veg",
+                                                    "value": "yes"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ],
+                            "tags": [
+                                {
+                                    "code": "timing",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "Order"
+                                        },
+                                        {
+                                            "code": "location",
+                                            "value": "83"
+                                        },
+                                        {
+                                            "code": "day_from",
+                                            "value": "1"
+                                        },
+                                        {
+                                            "code": "day_to",
+                                            "value": "7"
+                                        },
+                                        {
+                                            "code": "time_from",
+                                            "value": "0900"
+                                        },
+                                        {
+                                            "code": "time_to",
+                                            "value": "2300"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "timing",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "Delivery"
+                                        },
+                                        {
+                                            "code": "location",
+                                            "value": "83"
+                                        },
+                                        {
+                                            "code": "day_from",
+                                            "value": "1"
+                                        },
+                                        {
+                                            "code": "day_to",
+                                            "value": "7"
+                                        },
+                                        {
+                                            "code": "time_from",
+                                            "value": "1000"
+                                        },
+                                        {
+                                            "code": "time_to",
+                                            "value": "2100"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "serviceability",
+                                    "list": [
+                                        {
+                                            "code": "location",
+                                            "value": "83"
+                                        },
+                                        {
+                                            "code": "category",
+                                            "value": "F&B"
+                                        },
+                                        {
+                                            "code": "type",
+                                            "value": "10"
+                                        },
+                                        {
+                                            "code": "val",
+                                            "value": "5"
+                                        },
+                                        {
+                                            "code": "unit",
+                                            "value": "km"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "ttl": "P1D"
+                        }
+                    ]
+                }
+            }
+        },
+        "search_inc_refresh": {
+            "context": {
+                "domain": "ONDC:RET11",
+                "action": "search",
+                "country": "IND",
+                "city": "*",
+                "core_version": "1.2.0",
+                "bap_id": "buyer-app-preprod-v2.ondc.org",
+                "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+                "transaction_id": "827d011c-4c9c-4f76-90ac-c30c34ce422a",
+                "message_id": "64ef94b9-5c81-4992-b346-0609d50fd109",
+                "timestamp": "2025-01-06T17:28:33.022Z",
+                "ttl": "PT30S",
+                "bpp_id": "ondc.ecomviser.com",
+                "bpp_uri": "https://ondc.ecomviser.com/api/v1"
+            },
+            "message": {
+                "intent": {
+                    "payment": {
+                        "@ondc/org/buyer_app_finder_fee_type": "percent",
+                        "@ondc/org/buyer_app_finder_fee_amount": "3"
+                    },
+                    "tags": [
+                        {
+                            "code": "catalog_inc",
+                            "list": [
+                                {
+                                    "code": "mode",
+                                    "value": "start"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        },
+        "on_search_inc_refresh": {
+            "context": {
+                "ttl": "PT30S",
+                "city": "*",
+                "action": "on_search",
+                "bap_id": "buyer-app-preprod-v2.ondc.org",
+                "bpp_id": "ondc.ecomviser.com",
+                "domain": "ONDC:RET11",
+                "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+                "bpp_uri": "https://ondc.ecomviser.com/api/v1",
+                "country": "IND",
+                "timestamp": "2025-01-06T11:56:44.926Z",
+                "message_id": "677bc4fce220a91f15226-5fa7",
+                "core_version": "1.2.0",
+                "transaction_id": "827d011c-4c9c-4f76-90ac-c30c34ce422a"
+            },
+            "message": {
+                "catalog": {
+                    "bpp/providers": [
+                        {
+                            "id": "84",
+                            "items": [
+                                {
+                                    "id": "451",
+                                    "time": {
+                                        "label": "enable",
+                                        "timestamp": "2025-01-06T11:26:44.926Z"
+                                    },
+                                    "descriptor": {
+                                        "name": "Pizza Mania Updated",
+                                        "symbol": "https://d3bhszwz094mhs.cloudfront.net/product_img/main_img/342/NipTw8cSUY.jpeg",
+                                        "short_desc": "pizza best small",
+                                        "long_desc": "best pizza",
+                                        "images": [
+                                            "https://d3bhszwz094mhs.cloudfront.net/product_img/main_img/342/NipTw8cSUY.jpeg"
+                                        ],
+                                        "code": "1:123456789876"
+                                    },
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "99",
+                                        "maximum_value": "110"
+                                    },
+                                    "quantity": {
+                                        "available": {
+                                            "count": "99"
+                                        },
+                                        "maximum": {
+                                            "count": "99"
+                                        },
+                                        "unitized": {
+                                            "measure": {
+                                                "unit": "gram",
+                                                "value": "200"
+                                            }
+                                        }
+                                    },
+                                    "location_id": "83",
+                                    "category_id": "F&B",
+                                    "fulfillment_id": "155",
+                                    "@ondc/org/time_to_ship": "PT1H",
+                                    "@ondc/org/cancellable": true,
+                                    "@ondc/org/seller_pickup_return": false,
+                                    "@ondc/org/returnable": false,
+                                    "@ondc/org/return_window": "PT0S",
+                                    "@ondc/org/available_on_cod": false,
+                                    "@ondc/org/contact_details_consumer_care": "ajeet,ajeetchauhan.symfony143@webkul.in,9812345678",
+                                    "tags": [
+                                        {
+                                            "code": "origin",
+                                            "list": [
+                                                {
+                                                    "code": "country",
+                                                    "value": "IND"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "item"
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "parent_item_id": "342zabcdefgh",
+                                    "category_ids": []
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        }
+    },
+    "flow": "1"
+}

--- a/eComviser/Seller App RET11/Flow-1/inc_search.json
+++ b/eComviser/Seller App RET11/Flow-1/inc_search.json
@@ -1,0 +1,36 @@
+{
+    "context": {
+        "domain": "ONDC:RET11",
+        "action": "search",
+        "country": "IND",
+        "city": "*",
+        "core_version": "1.2.0",
+        "bap_id": "buyer-app-preprod-v2.ondc.org",
+        "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+        "transaction_id": "827d011c-4c9c-4f76-90ac-c30c34ce422a",
+        "message_id": "64ef94b9-5c81-4992-b346-0609d50fd109",
+        "timestamp": "2025-01-06T17:28:33.022Z",
+        "ttl": "PT30S",
+        "bpp_id": "ondc.ecomviser.com",
+        "bpp_uri": "https://ondc.ecomviser.com/api/v1"
+    },
+    "message": {
+        "intent": {
+            "payment": {
+                "@ondc/org/buyer_app_finder_fee_type": "percent",
+                "@ondc/org/buyer_app_finder_fee_amount": "3"
+            },
+            "tags": [
+                {
+                    "code": "catalog_inc",
+                    "list": [
+                        {
+                            "code": "mode",
+                            "value": "start"
+                        }
+                    ]
+                }
+            ]
+        }
+    }
+}

--- a/eComviser/Seller App RET11/Flow-1/on_inc_search.json
+++ b/eComviser/Seller App RET11/Flow-1/on_inc_search.json
@@ -1,0 +1,96 @@
+{
+    "context": {
+        "ttl": "PT30S",
+        "city": "*",
+        "action": "on_search",
+        "bap_id": "buyer-app-preprod-v2.ondc.org",
+        "bpp_id": "ondc.ecomviser.com",
+        "domain": "ONDC:RET11",
+        "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+        "bpp_uri": "https://ondc.ecomviser.com/api/v1",
+        "country": "IND",
+        "timestamp": "2025-01-06T11:56:44.926Z",
+        "message_id": "677bc4fce220a91f15226-5fa7",
+        "core_version": "1.2.0",
+        "transaction_id": "827d011c-4c9c-4f76-90ac-c30c34ce422a"
+    },
+    "message": {
+        "catalog": {
+            "bpp/providers": [
+                {
+                    "id": "84",
+                    "items": [
+                        {
+                            "id": "451",
+                            "time": {
+                                "label": "enable",
+                                "timestamp": "2025-01-06T11:26:44.926Z"
+                            },
+                            "descriptor": {
+                                "name": "Pizza Mania Updated",
+                                "symbol": "https://d3bhszwz094mhs.cloudfront.net/product_img/main_img/342/NipTw8cSUY.jpeg",
+                                "short_desc": "pizza best small",
+                                "long_desc": "best pizza",
+                                "images": [
+                                    "https://d3bhszwz094mhs.cloudfront.net/product_img/main_img/342/NipTw8cSUY.jpeg"
+                                ],
+                                "code": "1:123456789876"
+                            },
+                            "price": {
+                                "currency": "INR",
+                                "value": "99",
+                                "maximum_value": "110"
+                            },
+                            "quantity": {
+                                "available": {
+                                    "count": "99"
+                                },
+                                "maximum": {
+                                    "count": "99"
+                                },
+                                "unitized": {
+                                    "measure": {
+                                        "unit": "gram",
+                                        "value": "200"
+                                    }
+                                }
+                            },
+                            "location_id": "83",
+                            "category_id": "F&B",
+                            "fulfillment_id": "155",
+                            "@ondc/org/time_to_ship": "PT1H",
+                            "@ondc/org/cancellable": true,
+                            "@ondc/org/seller_pickup_return": false,
+                            "@ondc/org/returnable": false,
+                            "@ondc/org/return_window": "PT0S",
+                            "@ondc/org/available_on_cod": false,
+                            "@ondc/org/contact_details_consumer_care": "ajeet,ajeetchauhan.symfony143@webkul.in,9812345678",
+                            "tags": [
+                                {
+                                    "code": "origin",
+                                    "list": [
+                                        {
+                                            "code": "country",
+                                            "value": "IND"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "item"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "parent_item_id": "342zabcdefgh",
+                            "category_ids": []
+                        }
+                    ]
+                }
+            ]
+        }
+    }
+}

--- a/eComviser/Seller App RET11/Flow-1/on_search.json
+++ b/eComviser/Seller App RET11/Flow-1/on_search.json
@@ -1,0 +1,658 @@
+{
+    "context": {
+        "domain": "ONDC:RET11",
+        "action": "on_search",
+        "country": "IND",
+        "city": "std:0120",
+        "core_version": "1.2.0",
+        "bap_id": "buyer-app-preprod-v2.ondc.org",
+        "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+        "transaction_id": "0646bc94-5d3d-4b2d-6325-a8a33843dbb9",
+        "message_id": "36c56392-f004-4813-ace5-0d40033a8420",
+        "timestamp": "2025-01-06T11:17:49.476Z",
+        "ttl": "PT30S",
+        "bpp_id": "ondc.ecomviser.com",
+        "bpp_uri": "https://ondc.ecomviser.com/api/v1"
+    },
+    "message": {
+        "catalog": {
+            "bpp/descriptor": {
+                "name": "Webkul",
+                "symbol": "https://ondc.ecomviser.com/public/img/webkul_logo.png",
+                "short_desc": "Enterprise Digital Commerce & Marketplace Solution Experts",
+                "long_desc": "Helping companies with our industry-leading digital commerce, ERP, and CRM solutions. In the last 13 years, we have served 150K+ clients worldwide to handle complex operations and grow their businesses",
+                "images": [
+                    "https://ondc.ecomviser.com/public/img/webkul_banner.png",
+                    "https://ondc.ecomviser.com/public/img/webkul_clients.png",
+                    "https://ondc.ecomviser.com/public/img/webkul_awards.png"
+                ],
+                "tags": [
+                    {
+                        "code": "bpp_terms",
+                        "list": [
+                            {
+                                "code": "np_type",
+                                "value": "MSN"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "bpp/fulfillments": [
+                {
+                    "id": "155",
+                    "type": "Delivery"
+                }
+            ],
+            "bpp/providers": [
+                {
+                    "id": "84",
+                    "time": {
+                        "label": "enable",
+                        "timestamp": "2025-01-06T10:47:48.872Z"
+                    },
+                    "descriptor": {
+                        "name": "Ajeet Food Shop",
+                        "symbol": "https://ondc-prepod-digital-delivery.s3.amazonaws.com/seller_shop_logo/84/39MylDtZVC.jpg",
+                        "short_desc": "short desc",
+                        "long_desc": "store desc",
+                        "images": [
+                            "https://ondc-prepod-digital-delivery.s3.amazonaws.com/seller_shop_logo/84/39MylDtZVC.jpg"
+                        ]
+                    },
+                    "fulfillments": [
+                        {
+                            "id": "155",
+                            "type": "Delivery",
+                            "contact": {
+                                "phone": "9812345678",
+                                "email": "ajeetchauhan.symfony143@webkul.in"
+                            }
+                        }
+                    ],
+                    "locations": [
+                        {
+                            "id": "83",
+                            "gps": "28.62972640,77.37783230",
+                            "address": {
+                                "locality": "Noida",
+                                "street": "H-28",
+                                "city": "Gautam Buddh Nagar",
+                                "area_code": "201301",
+                                "state": "Uttar Pradesh"
+                            },
+                            "circle": {
+                                "gps": "28.62972640,77.37783230",
+                                "radius": {
+                                    "unit": "km",
+                                    "value": "5"
+                                }
+                            },
+                            "time": {
+                                "label": "enable",
+                                "timestamp": "2025-01-06T10:47:48.872Z",
+                                "days": "1,2,3,4,5,6,7",
+                                "schedule": {
+                                    "holidays": []
+                                },
+                                "range": {
+                                    "start": "0800",
+                                    "end": "1707"
+                                }
+                            }
+                        }
+                    ],
+                    "@ondc/org/fssai_license_no": "12345678908898",
+                    "categories": [
+                        {
+                            "id": "66zabcdefghi",
+                            "descriptor": {
+                                "name": "Cheese"
+                            },
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "custom_group"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "config",
+                                    "list": [
+                                        {
+                                            "code": "min",
+                                            "value": "1"
+                                        },
+                                        {
+                                            "code": "max",
+                                            "value": "1"
+                                        },
+                                        {
+                                            "code": "input",
+                                            "value": "select"
+                                        },
+                                        {
+                                            "code": "seq",
+                                            "value": "1"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "67zabcdefghi",
+                            "descriptor": {
+                                "name": "Non-veg toppings"
+                            },
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "custom_group"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "config",
+                                    "list": [
+                                        {
+                                            "code": "min",
+                                            "value": "1"
+                                        },
+                                        {
+                                            "code": "max",
+                                            "value": "1"
+                                        },
+                                        {
+                                            "code": "input",
+                                            "value": "select"
+                                        },
+                                        {
+                                            "code": "seq",
+                                            "value": "2"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "844147zabcde",
+                            "parent_category_id": "",
+                            "descriptor": {
+                                "name": "Pizza",
+                                "short_desc": "Pizza",
+                                "long_desc": "Pizza"
+                            },
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "custom_menu"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "display",
+                                    "list": [
+                                        {
+                                            "code": "rank",
+                                            "value": "1"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "timing",
+                                    "list": [
+                                        {
+                                            "code": "day_from",
+                                            "value": "1"
+                                        },
+                                        {
+                                            "code": "day_to",
+                                            "value": "5"
+                                        },
+                                        {
+                                            "code": "time_from",
+                                            "value": "0800"
+                                        },
+                                        {
+                                            "code": "time_to",
+                                            "value": "2200"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ],
+                    "items": [
+                        {
+                            "id": "451",
+                            "time": {
+                                "label": "enable",
+                                "timestamp": "2025-01-06T10:47:48.872Z"
+                            },
+                            "descriptor": {
+                                "name": "Pizza Mania",
+                                "symbol": "https://d3bhszwz094mhs.cloudfront.net/product_img/main_img/342/NipTw8cSUY.jpeg",
+                                "short_desc": "pizza best small",
+                                "long_desc": "best pizza",
+                                "images": [
+                                    "https://d3bhszwz094mhs.cloudfront.net/product_img/main_img/342/NipTw8cSUY.jpeg"
+                                ],
+                                "code": "1:123456789876"
+                            },
+                            "price": {
+                                "currency": "INR",
+                                "value": "99",
+                                "maximum_value": "110",
+                                "tags": [
+                                    {
+                                        "code": "range",
+                                        "list": [
+                                            {
+                                                "code": "lower",
+                                                "value": "99.00"
+                                            },
+                                            {
+                                                "code": "upper",
+                                                "value": "159"
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "code": "default_selection",
+                                        "list": [
+                                            {
+                                                "code": "value",
+                                                "value": "99.00"
+                                            },
+                                            {
+                                                "code": "maximum_value",
+                                                "value": "159"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            "quantity": {
+                                "available": {
+                                    "count": "99"
+                                },
+                                "maximum": {
+                                    "count": "99"
+                                },
+                                "unitized": {
+                                    "measure": {
+                                        "unit": "gram",
+                                        "value": "200"
+                                    }
+                                }
+                            },
+                            "location_id": "83",
+                            "category_id": "F&B",
+                            "fulfillment_id": "155",
+                            "@ondc/org/time_to_ship": "PT1H",
+                            "@ondc/org/cancellable": true,
+                            "@ondc/org/seller_pickup_return": false,
+                            "@ondc/org/returnable": false,
+                            "@ondc/org/return_window": "PT0S",
+                            "@ondc/org/available_on_cod": false,
+                            "@ondc/org/contact_details_consumer_care": "ajeet,ajeetchauhan.symfony143@webkul.in,9812345678",
+                            "tags": [
+                                {
+                                    "code": "origin",
+                                    "list": [
+                                        {
+                                            "code": "country",
+                                            "value": "IND"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "item"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "custom_group",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "66zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "category_ids": [
+                                "844147zabcde:1"
+                            ]
+                        },
+                        {
+                            "id": "93",
+                            "descriptor": {
+                                "name": "Extra"
+                            },
+                            "quantity": {
+                                "available": {
+                                    "count": "99"
+                                },
+                                "maximum": {
+                                    "count": "99"
+                                }
+                            },
+                            "price": {
+                                "currency": "INR",
+                                "value": "5.00",
+                                "maximum_value": "5.00"
+                            },
+                            "category_id": "F&B",
+                            "related": true,
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "66zabcdefghi"
+                                        },
+                                        {
+                                            "code": "default",
+                                            "value": "yes"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "veg_nonveg",
+                                    "list": [
+                                        {
+                                            "code": "veg",
+                                            "value": "yes"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "child",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "67zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "94",
+                            "descriptor": {
+                                "name": "Vegan"
+                            },
+                            "quantity": {
+                                "available": {
+                                    "count": "99"
+                                },
+                                "maximum": {
+                                    "count": "99"
+                                }
+                            },
+                            "price": {
+                                "currency": "INR",
+                                "value": "10.00",
+                                "maximum_value": "10.00"
+                            },
+                            "category_id": "F&B",
+                            "related": true,
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "66zabcdefghi"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "veg_nonveg",
+                                    "list": [
+                                        {
+                                            "code": "veg",
+                                            "value": "yes"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "child",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "67zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "95",
+                            "descriptor": {
+                                "name": "Chicken"
+                            },
+                            "quantity": {
+                                "available": {
+                                    "count": "99"
+                                },
+                                "maximum": {
+                                    "count": "99"
+                                }
+                            },
+                            "price": {
+                                "currency": "INR",
+                                "value": "10.00",
+                                "maximum_value": "10.00"
+                            },
+                            "category_id": "F&B",
+                            "related": true,
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "67zabcdefghi"
+                                        },
+                                        {
+                                            "code": "default",
+                                            "value": "yes"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "veg_nonveg",
+                                    "list": [
+                                        {
+                                            "code": "non_veg",
+                                            "value": "yes"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "96",
+                            "descriptor": {
+                                "name": "Mutton"
+                            },
+                            "quantity": {
+                                "available": {
+                                    "count": "99"
+                                },
+                                "maximum": {
+                                    "count": "99"
+                                }
+                            },
+                            "price": {
+                                "currency": "INR",
+                                "value": "50.00",
+                                "maximum_value": "50.00"
+                            },
+                            "category_id": "F&B",
+                            "related": true,
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "67zabcdefghi"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "veg_nonveg",
+                                    "list": [
+                                        {
+                                            "code": "veg",
+                                            "value": "yes"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ],
+                    "tags": [
+                        {
+                            "code": "timing",
+                            "list": [
+                                {
+                                    "code": "type",
+                                    "value": "Order"
+                                },
+                                {
+                                    "code": "location",
+                                    "value": "83"
+                                },
+                                {
+                                    "code": "day_from",
+                                    "value": "1"
+                                },
+                                {
+                                    "code": "day_to",
+                                    "value": "7"
+                                },
+                                {
+                                    "code": "time_from",
+                                    "value": "0900"
+                                },
+                                {
+                                    "code": "time_to",
+                                    "value": "2300"
+                                }
+                            ]
+                        },
+                        {
+                            "code": "timing",
+                            "list": [
+                                {
+                                    "code": "type",
+                                    "value": "Delivery"
+                                },
+                                {
+                                    "code": "location",
+                                    "value": "83"
+                                },
+                                {
+                                    "code": "day_from",
+                                    "value": "1"
+                                },
+                                {
+                                    "code": "day_to",
+                                    "value": "7"
+                                },
+                                {
+                                    "code": "time_from",
+                                    "value": "1000"
+                                },
+                                {
+                                    "code": "time_to",
+                                    "value": "2100"
+                                }
+                            ]
+                        },
+                        {
+                            "code": "serviceability",
+                            "list": [
+                                {
+                                    "code": "location",
+                                    "value": "83"
+                                },
+                                {
+                                    "code": "category",
+                                    "value": "F&B"
+                                },
+                                {
+                                    "code": "type",
+                                    "value": "10"
+                                },
+                                {
+                                    "code": "val",
+                                    "value": "5"
+                                },
+                                {
+                                    "code": "unit",
+                                    "value": "km"
+                                }
+                            ]
+                        }
+                    ],
+                    "ttl": "P1D"
+                }
+            ]
+        }
+    }
+}

--- a/eComviser/Seller App RET11/Flow-1/search.json
+++ b/eComviser/Seller App RET11/Flow-1/search.json
@@ -1,0 +1,26 @@
+{
+    "context": {
+        "domain": "ONDC:RET11",
+        "action": "search",
+        "country": "IND",
+        "city": "std:0120",
+        "core_version": "1.2.0",
+        "bap_id": "buyer-app-preprod-v2.ondc.org",
+        "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+        "transaction_id": "0646bc94-5d3d-4b2d-6325-a8a33843dbb9",
+        "message_id": "36c56392-f004-4813-ace5-0d40033a8420",
+        "timestamp": "2025-01-06T16:47:42.734Z",
+        "ttl": "PT30S"
+    },
+    "message": {
+        "intent": {
+            "fulfillment": {
+                "type": "Delivery"
+            },
+            "payment": {
+                "@ondc/org/buyer_app_finder_fee_type": "percent",
+                "@ondc/org/buyer_app_finder_fee_amount": "3"
+            }
+        }
+    }
+}

--- a/eComviser/Seller App RET11/Flow-2/confirm.json
+++ b/eComviser/Seller App RET11/Flow-2/confirm.json
@@ -1,0 +1,341 @@
+{
+    "context": {
+        "domain": "ONDC:RET11",
+        "country": "IND",
+        "city": "std:0120",
+        "action": "confirm",
+        "core_version": "1.2.0",
+        "bap_id": "buyer-app-preprod-v2.ondc.org",
+        "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+        "bpp_uri": "https://ondc.ecomviser.com/api/v1",
+        "transaction_id": "bbeea929-e45e-48df-b3b7-d58a4a5301a7",
+        "message_id": "f772812e-326c-400d-920f-c57942de6df9",
+        "timestamp": "2025-01-06T10:32:04.500Z",
+        "bpp_id": "ondc.ecomviser.com",
+        "ttl": "PT30S"
+    },
+    "message": {
+        "order": {
+            "id": "2025-01-06-248869",
+            "state": "Created",
+            "billing": {
+                "address": {
+                    "name": "Ajeet Chauhan",
+                    "building": "ARV Park",
+                    "locality": "Unnamed Road",
+                    "city": "Noida",
+                    "state": "Uttar Pradesh",
+                    "country": "IND",
+                    "area_code": "201301"
+                },
+                "phone": "8574739650",
+                "name": "Ajeet Chauhan",
+                "email": "ajeetchauhan.symfony143@webkul.in",
+                "created_at": "2025-01-06T10:31:29.847Z",
+                "updated_at": "2025-01-06T10:31:29.847Z"
+            },
+            "items": [
+                {
+                    "id": "451",
+                    "quantity": {
+                        "count": 1
+                    },
+                    "fulfillment_id": "155",
+                    "tags": [
+                        {
+                            "code": "type",
+                            "list": [
+                                {
+                                    "code": "type",
+                                    "value": "item"
+                                }
+                            ]
+                        }
+                    ],
+                    "parent_item_id": "xvvxY6eaBE5I"
+                },
+                {
+                    "id": "94",
+                    "quantity": {
+                        "count": 1
+                    },
+                    "fulfillment_id": "155",
+                    "tags": [
+                        {
+                            "code": "type",
+                            "list": [
+                                {
+                                    "code": "type",
+                                    "value": "customization"
+                                }
+                            ]
+                        },
+                        {
+                            "code": "parent",
+                            "list": [
+                                {
+                                    "code": "id",
+                                    "value": "66zabcdefghi"
+                                }
+                            ]
+                        }
+                    ],
+                    "parent_item_id": "xvvxY6eaBE5I"
+                },
+                {
+                    "id": "96",
+                    "quantity": {
+                        "count": 1
+                    },
+                    "fulfillment_id": "155",
+                    "tags": [
+                        {
+                            "code": "type",
+                            "list": [
+                                {
+                                    "code": "type",
+                                    "value": "customization"
+                                }
+                            ]
+                        },
+                        {
+                            "code": "parent",
+                            "list": [
+                                {
+                                    "code": "id",
+                                    "value": "67zabcdefghi"
+                                }
+                            ]
+                        }
+                    ],
+                    "parent_item_id": "xvvxY6eaBE5I"
+                }
+            ],
+            "provider": {
+                "id": "84",
+                "locations": [
+                    {
+                        "id": "83"
+                    }
+                ]
+            },
+            "fulfillments": [
+                {
+                    "@ondc/org/TAT": "PT90M",
+                    "id": "155",
+                    "tracking": true,
+                    "end": {
+                        "contact": {
+                            "email": "ajeetchauhan.symfony143@webkul.in",
+                            "phone": "8574739650"
+                        },
+                        "person": {
+                            "name": "Ajeet Chauhan"
+                        },
+                        "location": {
+                            "gps": "28.629743,77.377795",
+                            "address": {
+                                "name": "Ajeet Chauhan",
+                                "building": "ARV Park",
+                                "locality": "Unnamed Road",
+                                "city": "Noida",
+                                "state": "Uttar Pradesh",
+                                "country": "IND",
+                                "area_code": "201301"
+                            }
+                        }
+                    },
+                    "type": "Delivery"
+                }
+            ],
+            "payment": {
+                "uri": "https://razorpay.com/",
+                "tl_method": "http/get",
+                "params": {
+                    "amount": "164.63",
+                    "currency": "INR",
+                    "transaction_id": "order_Pg7qlLR529ZmhG"
+                },
+                "status": "PAID",
+                "type": "ON-ORDER",
+                "collected_by": "BAP",
+                "@ondc/org/buyer_app_finder_fee_type": "percent",
+                "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+                "@ondc/org/settlement_details": [
+                    {
+                        "settlement_counterparty": "seller-app",
+                        "settlement_phase": "sale-amount",
+                        "settlement_type": "neft",
+                        "beneficiary_name": "fasdf asdfasdf",
+                        "settlement_bank_account_no": "534512341234132",
+                        "settlement_ifsc_code": "HDFC0000088",
+                        "bank_name": "fasdf",
+                        "branch_name": "noida",
+                        "settlement_status": "NOT-PAID"
+                    }
+                ]
+            },
+            "quote": {
+                "price": {
+                    "currency": "INR",
+                    "value": "164.63"
+                },
+                "breakup": [
+                    {
+                        "title": "Pizza Mania",
+                        "price": {
+                            "currency": "INR",
+                            "value": "99"
+                        },
+                        "@ondc/org/title_type": "item",
+                        "@ondc/org/item_id": "451",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
+                        },
+                        "item": {
+                            "price": {
+                                "currency": "INR",
+                                "value": "99"
+                            },
+                            "parent_item_id": "xvvxY6eaBE5I",
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "item"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "title": "Vegan",
+                        "price": {
+                            "currency": "INR",
+                            "value": "10"
+                        },
+                        "@ondc/org/title_type": "item",
+                        "@ondc/org/item_id": "94",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
+                        },
+                        "item": {
+                            "price": {
+                                "currency": "INR",
+                                "value": "10"
+                            },
+                            "parent_item_id": "xvvxY6eaBE5I",
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "66zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "title": "Mutton",
+                        "price": {
+                            "currency": "INR",
+                            "value": "50"
+                        },
+                        "@ondc/org/title_type": "item",
+                        "@ondc/org/item_id": "96",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
+                        },
+                        "item": {
+                            "price": {
+                                "currency": "INR",
+                                "value": "50"
+                            },
+                            "parent_item_id": "xvvxY6eaBE5I",
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "67zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "title": "Convenience fee",
+                        "price": {
+                            "currency": "INR",
+                            "value": "5.63"
+                        },
+                        "@ondc/org/title_type": "misc",
+                        "@ondc/org/item_id": "155"
+                    },
+                    {
+                        "title": "Delivery charges",
+                        "price": {
+                            "currency": "INR",
+                            "value": "0"
+                        },
+                        "@ondc/org/title_type": "delivery",
+                        "@ondc/org/item_id": "155"
+                    }
+                ],
+                "ttl": "PT6H"
+            },
+            "tags": [
+                {
+                    "code": "bpp_terms",
+                    "list": [
+                        {
+                            "code": "tax_number",
+                            "value": "09AABCW0339G3ZD"
+                        },
+                        {
+                            "code": "provider_tax_number",
+                            "value": "DERTC3376R"
+                        }
+                    ]
+                },
+                {
+                    "code": "bap_terms",
+                    "list": [
+                        {
+                            "code": "tax_number",
+                            "value": "GSTIN1234567890"
+                        }
+                    ]
+                }
+            ],
+            "created_at": "2025-01-06T10:32:04.500Z",
+            "updated_at": "2025-01-06T10:32:04.500Z"
+        }
+    }
+}

--- a/eComviser/Seller App RET11/Flow-2/flow-2_validate_report.json
+++ b/eComviser/Seller App RET11/Flow-2/flow-2_validate_report.json
@@ -1,0 +1,17 @@
+{
+    "success": false,
+    "response": {
+        "message": "Logs were not verified successfully",
+        "report": {
+            "on_search_full_catalog_refresh": {
+                "message/catalog/bpp/providers0/categories/items": "No items are mapped with the given category_id 844147zabcde in providers0/items"
+            }
+        },
+        "bpp_id": "ondc.ecomviser.com",
+        "bap_id": "buyer-app-preprod-v2.ondc.org",
+        "domain": "ONDC:RET11",
+        "reportTimestamp": "2025-01-08T12:36:00.620Z"
+    },
+    "signature": "NTbeY+vuO7MkBWtNHAdQOwupgKGhEiL6mqNfPl2Ko2bXVrgif5JZPbU2AJFSIJBSH10eWpUd7PmTmetUJw8RDg==",
+    "signTimestamp": "2025-01-08T12:36:00.620Z"
+}

--- a/eComviser/Seller App RET11/Flow-2/flow-2_validate_request.json
+++ b/eComviser/Seller App RET11/Flow-2/flow-2_validate_request.json
@@ -1,0 +1,4084 @@
+{
+    "domain": "ONDC:RET11",
+    "version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bpp_id": "ondc.ecomviser.com",
+    "flow": "2",
+    "payload": {
+        "search_full_catalog_refresh": {
+            "context": {
+                "domain": "ONDC:RET11",
+                "action": "search",
+                "country": "IND",
+                "city": "std:0120",
+                "core_version": "1.2.0",
+                "bap_id": "buyer-app-preprod-v2.ondc.org",
+                "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+                "transaction_id": "0646bc94-5d3d-4b2d-9852-a8a33843dbb9",
+                "message_id": "36c56392-f004-4813-ace5-0d40033a8420",
+                "timestamp": "2025-01-06T15:40:58.595Z",
+                "ttl": "PT30S"
+            },
+            "message": {
+                "intent": {
+                    "fulfillment": {
+                        "type": "Delivery"
+                    },
+                    "payment": {
+                        "@ondc/org/buyer_app_finder_fee_type": "percent",
+                        "@ondc/org/buyer_app_finder_fee_amount": "3"
+                    }
+                }
+            }
+        },
+        "on_search_full_catalog_refresh": {
+            "context": {
+                "domain": "ONDC:RET11",
+                "action": "on_search",
+                "country": "IND",
+                "city": "std:0120",
+                "core_version": "1.2.0",
+                "bap_id": "buyer-app-preprod-v2.ondc.org",
+                "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+                "transaction_id": "0646bc94-5d3d-4b2d-9852-a8a33843dbb9",
+                "message_id": "36c56392-f004-4813-ace5-0d40033a8420",
+                "timestamp": "2025-01-06T10:11:35.354Z",
+                "ttl": "PT30S",
+                "bpp_id": "ondc.ecomviser.com",
+                "bpp_uri": "https://ondc.ecomviser.com/api/v1"
+            },
+            "message": {
+                "catalog": {
+                    "bpp/descriptor": {
+                        "name": "Webkul",
+                        "symbol": "https://ondc.ecomviser.com/public/img/webkul_logo.png",
+                        "short_desc": "Enterprise Digital Commerce & Marketplace Solution Experts",
+                        "long_desc": "Helping companies with our industry-leading digital commerce, ERP, and CRM solutions. In the last 13 years, we have served 150K+ clients worldwide to handle complex operations and grow their businesses",
+                        "images": [
+                            "https://ondc.ecomviser.com/public/img/webkul_banner.png",
+                            "https://ondc.ecomviser.com/public/img/webkul_clients.png",
+                            "https://ondc.ecomviser.com/public/img/webkul_awards.png"
+                        ],
+                        "tags": [
+                            {
+                                "code": "bpp_terms",
+                                "list": [
+                                    {
+                                        "code": "np_type",
+                                        "value": "MSN"
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                    "bpp/fulfillments": [
+                        {
+                            "id": "155",
+                            "type": "Delivery"
+                        }
+                    ],
+                    "bpp/providers": [
+                        {
+                            "id": "84",
+                            "time": {
+                                "label": "enable",
+                                "timestamp": "2025-01-06T09:41:34.774Z"
+                            },
+                            "descriptor": {
+                                "name": "Ajeet Food Shop",
+                                "symbol": "https://ondc-prepod-digital-delivery.s3.amazonaws.com/seller_shop_logo/84/39MylDtZVC.jpg",
+                                "short_desc": "short desc",
+                                "long_desc": "store desc",
+                                "images": [
+                                    "https://ondc-prepod-digital-delivery.s3.amazonaws.com/seller_shop_logo/84/39MylDtZVC.jpg"
+                                ]
+                            },
+                            "fulfillments": [
+                                {
+                                    "id": "155",
+                                    "type": "Delivery",
+                                    "contact": {
+                                        "phone": "9812345678",
+                                        "email": "ajeetchauhan.symfony143@webkul.in"
+                                    }
+                                }
+                            ],
+                            "locations": [
+                                {
+                                    "id": "83",
+                                    "gps": "28.62972640,77.37783230",
+                                    "address": {
+                                        "locality": "Noida",
+                                        "street": "H-28",
+                                        "city": "Gautam Buddh Nagar",
+                                        "area_code": "201301",
+                                        "state": "Uttar Pradesh"
+                                    },
+                                    "circle": {
+                                        "gps": "28.62972640,77.37783230",
+                                        "radius": {
+                                            "unit": "km",
+                                            "value": "5"
+                                        }
+                                    },
+                                    "time": {
+                                        "label": "enable",
+                                        "timestamp": "2025-01-06T09:41:34.774Z",
+                                        "days": "1,2,3,4,5,6,7",
+                                        "schedule": {
+                                            "holidays": []
+                                        },
+                                        "range": {
+                                            "start": "0800",
+                                            "end": "1707"
+                                        }
+                                    }
+                                }
+                            ],
+                            "@ondc/org/fssai_license_no": "12345678908898",
+                            "categories": [
+                                {
+                                    "id": "66zabcdefghi",
+                                    "descriptor": {
+                                        "name": "Cheese"
+                                    },
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "custom_group"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "config",
+                                            "list": [
+                                                {
+                                                    "code": "min",
+                                                    "value": "1"
+                                                },
+                                                {
+                                                    "code": "max",
+                                                    "value": "1"
+                                                },
+                                                {
+                                                    "code": "input",
+                                                    "value": "select"
+                                                },
+                                                {
+                                                    "code": "seq",
+                                                    "value": "1"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                {
+                                    "id": "67zabcdefghi",
+                                    "descriptor": {
+                                        "name": "Non-veg toppings"
+                                    },
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "custom_group"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "config",
+                                            "list": [
+                                                {
+                                                    "code": "min",
+                                                    "value": "1"
+                                                },
+                                                {
+                                                    "code": "max",
+                                                    "value": "1"
+                                                },
+                                                {
+                                                    "code": "input",
+                                                    "value": "select"
+                                                },
+                                                {
+                                                    "code": "seq",
+                                                    "value": "2"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                {
+                                    "id": "844147zabcde",
+                                    "parent_category_id": "",
+                                    "descriptor": {
+                                        "name": "Pizza",
+                                        "short_desc": "Pizza",
+                                        "long_desc": "Pizza"
+                                    },
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "custom_menu"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "display",
+                                            "list": [
+                                                {
+                                                    "code": "rank",
+                                                    "value": "1"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "timing",
+                                            "list": [
+                                                {
+                                                    "code": "day_from",
+                                                    "value": "1"
+                                                },
+                                                {
+                                                    "code": "day_to",
+                                                    "value": "5"
+                                                },
+                                                {
+                                                    "code": "time_from",
+                                                    "value": "0800"
+                                                },
+                                                {
+                                                    "code": "time_to",
+                                                    "value": "2200"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ],
+                            "items": [
+                                {
+                                    "id": "451",
+                                    "time": {
+                                        "label": "enable",
+                                        "timestamp": "2025-01-06T09:41:34.774Z"
+                                    },
+                                    "descriptor": {
+                                        "name": "Pizza Mania",
+                                        "symbol": "https://d3bhszwz094mhs.cloudfront.net/product_img/main_img/342/NipTw8cSUY.jpeg",
+                                        "short_desc": "pizza best small",
+                                        "long_desc": "best pizza",
+                                        "images": [
+                                            "https://d3bhszwz094mhs.cloudfront.net/product_img/main_img/342/NipTw8cSUY.jpeg"
+                                        ]
+                                    },
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "99",
+                                        "maximum_value": "110",
+                                        "tags": [
+                                            {
+                                                "code": "range",
+                                                "list": [
+                                                    {
+                                                        "code": "lower",
+                                                        "value": "99.00"
+                                                    },
+                                                    {
+                                                        "code": "upper",
+                                                        "value": "159"
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                "code": "default_selection",
+                                                "list": [
+                                                    {
+                                                        "code": "value",
+                                                        "value": "99.00"
+                                                    },
+                                                    {
+                                                        "code": "maximum_value",
+                                                        "value": "159"
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "quantity": {
+                                        "available": {
+                                            "count": "99"
+                                        },
+                                        "maximum": {
+                                            "count": "99"
+                                        },
+                                        "unitized": {
+                                            "measure": {
+                                                "unit": "gram",
+                                                "value": "200"
+                                            }
+                                        }
+                                    },
+                                    "location_id": "83",
+                                    "category_id": "F&B",
+                                    "fulfillment_id": "155",
+                                    "@ondc/org/time_to_ship": "PT1H",
+                                    "@ondc/org/cancellable": true,
+                                    "@ondc/org/seller_pickup_return": false,
+                                    "@ondc/org/returnable": false,
+                                    "@ondc/org/return_window": "PT0S",
+                                    "@ondc/org/available_on_cod": false,
+                                    "@ondc/org/contact_details_consumer_care": "ajeet,ajeetchauhan.symfony143@webkul.in,9812345678",
+                                    "tags": [
+                                        {
+                                            "code": "origin",
+                                            "list": [
+                                                {
+                                                    "code": "country",
+                                                    "value": "IND"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "item"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "custom_group",
+                                            "list": [
+                                                {
+                                                    "code": "id",
+                                                    "value": "66zabcdefghi"
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "category_ids": [
+                                        "844147zabcde:1"
+                                    ]
+                                },
+                                {
+                                    "id": "93",
+                                    "descriptor": {
+                                        "name": "Extra"
+                                    },
+                                    "quantity": {
+                                        "available": {
+                                            "count": "99"
+                                        },
+                                        "maximum": {
+                                            "count": "99"
+                                        }
+                                    },
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "5.00",
+                                        "maximum_value": "5.00"
+                                    },
+                                    "category_id": "F&B",
+                                    "related": true,
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "customization"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "parent",
+                                            "list": [
+                                                {
+                                                    "code": "id",
+                                                    "value": "66zabcdefghi"
+                                                },
+                                                {
+                                                    "code": "default",
+                                                    "value": "yes"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "veg_nonveg",
+                                            "list": [
+                                                {
+                                                    "code": "veg",
+                                                    "value": "yes"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "child",
+                                            "list": [
+                                                {
+                                                    "code": "id",
+                                                    "value": "67zabcdefghi"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                {
+                                    "id": "94",
+                                    "descriptor": {
+                                        "name": "Vegan"
+                                    },
+                                    "quantity": {
+                                        "available": {
+                                            "count": "99"
+                                        },
+                                        "maximum": {
+                                            "count": "99"
+                                        }
+                                    },
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "10.00",
+                                        "maximum_value": "10.00"
+                                    },
+                                    "category_id": "F&B",
+                                    "related": true,
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "customization"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "parent",
+                                            "list": [
+                                                {
+                                                    "code": "id",
+                                                    "value": "66zabcdefghi"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "veg_nonveg",
+                                            "list": [
+                                                {
+                                                    "code": "veg",
+                                                    "value": "yes"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "child",
+                                            "list": [
+                                                {
+                                                    "code": "id",
+                                                    "value": "67zabcdefghi"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                {
+                                    "id": "95",
+                                    "descriptor": {
+                                        "name": "Chicken"
+                                    },
+                                    "quantity": {
+                                        "available": {
+                                            "count": "99"
+                                        },
+                                        "maximum": {
+                                            "count": "99"
+                                        }
+                                    },
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "10.00",
+                                        "maximum_value": "10.00"
+                                    },
+                                    "category_id": "F&B",
+                                    "related": true,
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "customization"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "parent",
+                                            "list": [
+                                                {
+                                                    "code": "id",
+                                                    "value": "67zabcdefghi"
+                                                },
+                                                {
+                                                    "code": "default",
+                                                    "value": "yes"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "veg_nonveg",
+                                            "list": [
+                                                {
+                                                    "code": "non_veg",
+                                                    "value": "yes"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                {
+                                    "id": "96",
+                                    "descriptor": {
+                                        "name": "Mutton"
+                                    },
+                                    "quantity": {
+                                        "available": {
+                                            "count": "99"
+                                        },
+                                        "maximum": {
+                                            "count": "99"
+                                        }
+                                    },
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "50.00",
+                                        "maximum_value": "50.00"
+                                    },
+                                    "category_id": "F&B",
+                                    "related": true,
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "customization"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "parent",
+                                            "list": [
+                                                {
+                                                    "code": "id",
+                                                    "value": "67zabcdefghi"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "veg_nonveg",
+                                            "list": [
+                                                {
+                                                    "code": "veg",
+                                                    "value": "yes"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ],
+                            "tags": [
+                                {
+                                    "code": "timing",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "Order"
+                                        },
+                                        {
+                                            "code": "location",
+                                            "value": "83"
+                                        },
+                                        {
+                                            "code": "day_from",
+                                            "value": "1"
+                                        },
+                                        {
+                                            "code": "day_to",
+                                            "value": "7"
+                                        },
+                                        {
+                                            "code": "time_from",
+                                            "value": "0900"
+                                        },
+                                        {
+                                            "code": "time_to",
+                                            "value": "2300"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "timing",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "Delivery"
+                                        },
+                                        {
+                                            "code": "location",
+                                            "value": "83"
+                                        },
+                                        {
+                                            "code": "day_from",
+                                            "value": "1"
+                                        },
+                                        {
+                                            "code": "day_to",
+                                            "value": "7"
+                                        },
+                                        {
+                                            "code": "time_from",
+                                            "value": "1000"
+                                        },
+                                        {
+                                            "code": "time_to",
+                                            "value": "2100"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "serviceability",
+                                    "list": [
+                                        {
+                                            "code": "location",
+                                            "value": "83"
+                                        },
+                                        {
+                                            "code": "category",
+                                            "value": "F&B"
+                                        },
+                                        {
+                                            "code": "type",
+                                            "value": "10"
+                                        },
+                                        {
+                                            "code": "val",
+                                            "value": "5"
+                                        },
+                                        {
+                                            "code": "unit",
+                                            "value": "km"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "ttl": "P1D"
+                        }
+                    ]
+                }
+            }
+        },
+        "select": {
+            "context": {
+                "domain": "ONDC:RET11",
+                "country": "IND",
+                "city": "std:0120",
+                "action": "select",
+                "core_version": "1.2.0",
+                "bap_id": "buyer-app-preprod-v2.ondc.org",
+                "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+                "bpp_uri": "https://ondc.ecomviser.com/api/v1",
+                "transaction_id": "bbeea929-e45e-48df-b3b7-d58a4a5301a7",
+                "message_id": "3d2694e7-9b62-431e-b44d-4f1725292759",
+                "timestamp": "2025-01-06T10:31:15.135Z",
+                "bpp_id": "ondc.ecomviser.com",
+                "ttl": "PT30S"
+            },
+            "message": {
+                "order": {
+                    "items": [
+                        {
+                            "id": "451",
+                            "quantity": {
+                                "count": 1
+                            },
+                            "location_id": "83",
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "item"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "parent_item_id": "xvvxY6eaBE5I"
+                        },
+                        {
+                            "id": "94",
+                            "quantity": {
+                                "count": 1
+                            },
+                            "location_id": "83",
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "66zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "parent_item_id": "xvvxY6eaBE5I"
+                        },
+                        {
+                            "id": "96",
+                            "quantity": {
+                                "count": 1
+                            },
+                            "location_id": "83",
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "67zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "parent_item_id": "xvvxY6eaBE5I"
+                        }
+                    ],
+                    "provider": {
+                        "id": "84",
+                        "locations": [
+                            {
+                                "id": "83"
+                            }
+                        ]
+                    },
+                    "fulfillments": [
+                        {
+                            "end": {
+                                "location": {
+                                    "gps": "28.629743,77.377795",
+                                    "address": {
+                                        "area_code": "201301"
+                                    }
+                                }
+                            }
+                        }
+                    ]
+                }
+            }
+        },
+        "on_select": {
+            "context": {
+                "domain": "ONDC:RET11",
+                "country": "IND",
+                "city": "std:0120",
+                "action": "on_select",
+                "core_version": "1.2.0",
+                "bap_id": "buyer-app-preprod-v2.ondc.org",
+                "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+                "bpp_uri": "https://ondc.ecomviser.com/api/v1",
+                "transaction_id": "bbeea929-e45e-48df-b3b7-d58a4a5301a7",
+                "message_id": "3d2694e7-9b62-431e-b44d-4f1725292759",
+                "timestamp": "2025-01-06T10:31:16.574Z",
+                "bpp_id": "ondc.ecomviser.com"
+            },
+            "message": {
+                "order": {
+                    "provider": {
+                        "id": "84",
+                        "locations": [
+                            {
+                                "id": "83"
+                            }
+                        ]
+                    },
+                    "items": [
+                        {
+                            "id": "451",
+                            "fulfillment_id": "155",
+                            "parent_item_id": "xvvxY6eaBE5I",
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "item"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "94",
+                            "fulfillment_id": "155",
+                            "parent_item_id": "xvvxY6eaBE5I",
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "66zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "96",
+                            "fulfillment_id": "155",
+                            "parent_item_id": "xvvxY6eaBE5I",
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "67zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ],
+                    "fulfillments": [
+                        {
+                            "id": "155",
+                            "type": "Delivery",
+                            "@ondc/org/provider_name": "ondc.ecomviser.com",
+                            "tracking": true,
+                            "@ondc/org/category": "Immediate Delivery",
+                            "@ondc/org/TAT": "PT90M",
+                            "state": {
+                                "descriptor": {
+                                    "code": "Serviceable"
+                                }
+                            }
+                        }
+                    ],
+                    "quote": {
+                        "price": {
+                            "currency": "INR",
+                            "value": "164.63"
+                        },
+                        "breakup": [
+                            {
+                                "title": "Pizza Mania",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "99"
+                                },
+                                "@ondc/org/title_type": "item",
+                                "@ondc/org/item_id": "451",
+                                "@ondc/org/item_quantity": {
+                                    "count": 1
+                                },
+                                "item": {
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "99"
+                                    },
+                                    "quantity": {
+                                        "available": {
+                                            "count": "99"
+                                        },
+                                        "maximum": {
+                                            "count": "99"
+                                        }
+                                    },
+                                    "parent_item_id": "xvvxY6eaBE5I",
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "item"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "title": "Vegan",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "10"
+                                },
+                                "@ondc/org/title_type": "item",
+                                "@ondc/org/item_id": "94",
+                                "@ondc/org/item_quantity": {
+                                    "count": 1
+                                },
+                                "item": {
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "10"
+                                    },
+                                    "quantity": {
+                                        "available": {
+                                            "count": "99"
+                                        },
+                                        "maximum": {
+                                            "count": "99"
+                                        }
+                                    },
+                                    "parent_item_id": "xvvxY6eaBE5I",
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "customization"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "parent",
+                                            "list": [
+                                                {
+                                                    "code": "id",
+                                                    "value": "66zabcdefghi"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "title": "Mutton",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "50"
+                                },
+                                "@ondc/org/title_type": "item",
+                                "@ondc/org/item_id": "96",
+                                "@ondc/org/item_quantity": {
+                                    "count": 1
+                                },
+                                "item": {
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "50"
+                                    },
+                                    "quantity": {
+                                        "available": {
+                                            "count": "99"
+                                        },
+                                        "maximum": {
+                                            "count": "99"
+                                        }
+                                    },
+                                    "parent_item_id": "xvvxY6eaBE5I",
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "customization"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "parent",
+                                            "list": [
+                                                {
+                                                    "code": "id",
+                                                    "value": "67zabcdefghi"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "title": "Convenience fee",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "5.63"
+                                },
+                                "@ondc/org/title_type": "misc",
+                                "@ondc/org/item_id": "155"
+                            },
+                            {
+                                "title": "Delivery charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "0"
+                                },
+                                "@ondc/org/title_type": "delivery",
+                                "@ondc/org/item_id": "155"
+                            }
+                        ],
+                        "ttl": "PT6H"
+                    }
+                }
+            }
+        },
+        "init": {
+            "context": {
+                "domain": "ONDC:RET11",
+                "country": "IND",
+                "city": "std:0120",
+                "action": "init",
+                "core_version": "1.2.0",
+                "bap_id": "buyer-app-preprod-v2.ondc.org",
+                "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+                "bpp_uri": "https://ondc.ecomviser.com/api/v1",
+                "transaction_id": "bbeea929-e45e-48df-b3b7-d58a4a5301a7",
+                "message_id": "56c3ec3f-daaa-4ebb-a7bc-7c62470d052a",
+                "timestamp": "2025-01-06T10:31:29.847Z",
+                "bpp_id": "ondc.ecomviser.com",
+                "ttl": "PT30S"
+            },
+            "message": {
+                "order": {
+                    "provider": {
+                        "id": "84",
+                        "locations": [
+                            {
+                                "id": "83"
+                            }
+                        ]
+                    },
+                    "items": [
+                        {
+                            "id": "451",
+                            "quantity": {
+                                "count": 1
+                            },
+                            "location_id": "83",
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "item"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "parent_item_id": "xvvxY6eaBE5I",
+                            "fulfillment_id": "155"
+                        },
+                        {
+                            "id": "94",
+                            "quantity": {
+                                "count": 1
+                            },
+                            "location_id": "83",
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "66zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "fulfillment_id": "155",
+                            "parent_item_id": "xvvxY6eaBE5I"
+                        },
+                        {
+                            "id": "96",
+                            "quantity": {
+                                "count": 1
+                            },
+                            "location_id": "83",
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "67zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "fulfillment_id": "155",
+                            "parent_item_id": "xvvxY6eaBE5I"
+                        }
+                    ],
+                    "billing": {
+                        "address": {
+                            "building": "ARV Park",
+                            "city": "Noida",
+                            "state": "Uttar Pradesh",
+                            "country": "IND",
+                            "area_code": "201301",
+                            "locality": "Unnamed Road",
+                            "name": "Ajeet Chauhan"
+                        },
+                        "phone": "8574739650",
+                        "name": "Ajeet Chauhan",
+                        "email": "ajeetchauhan.symfony143@webkul.in",
+                        "created_at": "2025-01-06T10:31:29.847Z",
+                        "updated_at": "2025-01-06T10:31:29.847Z"
+                    },
+                    "fulfillments": [
+                        {
+                            "id": "155",
+                            "type": "Delivery",
+                            "end": {
+                                "contact": {
+                                    "email": "ajeetchauhan.symfony143@webkul.in",
+                                    "phone": "8574739650"
+                                },
+                                "location": {
+                                    "gps": "28.629743,77.377795",
+                                    "address": {
+                                        "building": "ARV Park",
+                                        "city": "Noida",
+                                        "state": "Uttar Pradesh",
+                                        "country": "IND",
+                                        "area_code": "201301",
+                                        "locality": "Unnamed Road",
+                                        "name": "Ajeet Chauhan"
+                                    }
+                                }
+                            }
+                        }
+                    ]
+                }
+            }
+        },
+        "on_init": {
+            "context": {
+                "domain": "ONDC:RET11",
+                "country": "IND",
+                "city": "std:0120",
+                "action": "on_init",
+                "core_version": "1.2.0",
+                "bap_id": "buyer-app-preprod-v2.ondc.org",
+                "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+                "bpp_uri": "https://ondc.ecomviser.com/api/v1",
+                "transaction_id": "bbeea929-e45e-48df-b3b7-d58a4a5301a7",
+                "message_id": "56c3ec3f-daaa-4ebb-a7bc-7c62470d052a",
+                "timestamp": "2025-01-06T10:31:32.428Z",
+                "bpp_id": "ondc.ecomviser.com",
+                "ttl": "PT30S"
+            },
+            "message": {
+                "order": {
+                    "provider": {
+                        "id": "84",
+                        "locations": [
+                            {
+                                "id": "83"
+                            }
+                        ]
+                    },
+                    "items": [
+                        {
+                            "id": "451",
+                            "fulfillment_id": "155",
+                            "quantity": {
+                                "count": 1
+                            },
+                            "parent_item_id": "xvvxY6eaBE5I",
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "item"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "94",
+                            "fulfillment_id": "155",
+                            "quantity": {
+                                "count": 1
+                            },
+                            "parent_item_id": "xvvxY6eaBE5I",
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "66zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "96",
+                            "fulfillment_id": "155",
+                            "quantity": {
+                                "count": 1
+                            },
+                            "parent_item_id": "xvvxY6eaBE5I",
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "67zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ],
+                    "quote": {
+                        "price": {
+                            "currency": "INR",
+                            "value": "164.63"
+                        },
+                        "breakup": [
+                            {
+                                "title": "Pizza Mania",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "99"
+                                },
+                                "@ondc/org/title_type": "item",
+                                "@ondc/org/item_id": "451",
+                                "@ondc/org/item_quantity": {
+                                    "count": 1
+                                },
+                                "item": {
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "99"
+                                    },
+                                    "parent_item_id": "xvvxY6eaBE5I",
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "item"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "title": "Vegan",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "10"
+                                },
+                                "@ondc/org/title_type": "item",
+                                "@ondc/org/item_id": "94",
+                                "@ondc/org/item_quantity": {
+                                    "count": 1
+                                },
+                                "item": {
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "10"
+                                    },
+                                    "parent_item_id": "xvvxY6eaBE5I",
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "customization"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "parent",
+                                            "list": [
+                                                {
+                                                    "code": "id",
+                                                    "value": "66zabcdefghi"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "title": "Mutton",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "50"
+                                },
+                                "@ondc/org/title_type": "item",
+                                "@ondc/org/item_id": "96",
+                                "@ondc/org/item_quantity": {
+                                    "count": 1
+                                },
+                                "item": {
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "50"
+                                    },
+                                    "parent_item_id": "xvvxY6eaBE5I",
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "customization"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "parent",
+                                            "list": [
+                                                {
+                                                    "code": "id",
+                                                    "value": "67zabcdefghi"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "title": "Convenience fee",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "5.63"
+                                },
+                                "@ondc/org/title_type": "misc",
+                                "@ondc/org/item_id": "155"
+                            },
+                            {
+                                "title": "Delivery charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "0"
+                                },
+                                "@ondc/org/title_type": "delivery",
+                                "@ondc/org/item_id": "155"
+                            }
+                        ],
+                        "ttl": "PT6H"
+                    },
+                    "billing": {
+                        "address": {
+                            "building": "ARV Park",
+                            "city": "Noida",
+                            "state": "Uttar Pradesh",
+                            "country": "IND",
+                            "area_code": "201301",
+                            "locality": "Unnamed Road",
+                            "name": "Ajeet Chauhan"
+                        },
+                        "phone": "8574739650",
+                        "name": "Ajeet Chauhan",
+                        "email": "ajeetchauhan.symfony143@webkul.in",
+                        "created_at": "2025-01-06T10:31:29.847Z",
+                        "updated_at": "2025-01-06T10:31:29.847Z"
+                    },
+                    "fulfillments": [
+                        {
+                            "id": "155",
+                            "type": "Delivery",
+                            "end": {
+                                "contact": {
+                                    "email": "ajeetchauhan.symfony143@webkul.in",
+                                    "phone": "8574739650"
+                                },
+                                "location": {
+                                    "gps": "28.629743,77.377795",
+                                    "address": {
+                                        "building": "ARV Park",
+                                        "city": "Noida",
+                                        "state": "Uttar Pradesh",
+                                        "country": "IND",
+                                        "area_code": "201301",
+                                        "locality": "Unnamed Road",
+                                        "name": "Ajeet Chauhan"
+                                    }
+                                }
+                            },
+                            "tracking": true
+                        }
+                    ],
+                    "payment": {
+                        "type": "ON-ORDER",
+                        "collected_by": "BAP",
+                        "@ondc/org/collected_by_status": "Agree",
+                        "@ondc/org/buyer_app_finder_fee_type": "percent",
+                        "@ondc/org/buyer_app_finder_fee_amount": "3",
+                        "@ondc/org/settlement_details": [
+                            {
+                                "settlement_counterparty": "seller-app",
+                                "settlement_phase": "sale-amount",
+                                "settlement_type": "neft",
+                                "beneficiary_name": "fasdf asdfasdf",
+                                "settlement_bank_account_no": "534512341234132",
+                                "settlement_ifsc_code": "HDFC0000088",
+                                "bank_name": "fasdf",
+                                "branch_name": "noida",
+                                "settlement_status": "NOT-PAID"
+                            }
+                        ]
+                    },
+                    "tags": [
+                        {
+                            "code": "bpp_terms",
+                            "list": [
+                                {
+                                    "code": "tax_number",
+                                    "value": "09AABCW0339G3ZD"
+                                },
+                                {
+                                    "code": "provider_tax_number",
+                                    "value": "DERTC3376R"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        },
+        "confirm": {
+            "context": {
+                "domain": "ONDC:RET11",
+                "country": "IND",
+                "city": "std:0120",
+                "action": "confirm",
+                "core_version": "1.2.0",
+                "bap_id": "buyer-app-preprod-v2.ondc.org",
+                "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+                "bpp_uri": "https://ondc.ecomviser.com/api/v1",
+                "transaction_id": "bbeea929-e45e-48df-b3b7-d58a4a5301a7",
+                "message_id": "f772812e-326c-400d-920f-c57942de6df9",
+                "timestamp": "2025-01-06T10:32:04.500Z",
+                "bpp_id": "ondc.ecomviser.com",
+                "ttl": "PT30S"
+            },
+            "message": {
+                "order": {
+                    "id": "2025-01-06-248869",
+                    "state": "Created",
+                    "billing": {
+                        "address": {
+                            "name": "Ajeet Chauhan",
+                            "building": "ARV Park",
+                            "locality": "Unnamed Road",
+                            "city": "Noida",
+                            "state": "Uttar Pradesh",
+                            "country": "IND",
+                            "area_code": "201301"
+                        },
+                        "phone": "8574739650",
+                        "name": "Ajeet Chauhan",
+                        "email": "ajeetchauhan.symfony143@webkul.in",
+                        "created_at": "2025-01-06T10:31:29.847Z",
+                        "updated_at": "2025-01-06T10:31:29.847Z"
+                    },
+                    "items": [
+                        {
+                            "id": "451",
+                            "quantity": {
+                                "count": 1
+                            },
+                            "fulfillment_id": "155",
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "item"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "parent_item_id": "xvvxY6eaBE5I"
+                        },
+                        {
+                            "id": "94",
+                            "quantity": {
+                                "count": 1
+                            },
+                            "fulfillment_id": "155",
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "66zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "parent_item_id": "xvvxY6eaBE5I"
+                        },
+                        {
+                            "id": "96",
+                            "quantity": {
+                                "count": 1
+                            },
+                            "fulfillment_id": "155",
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "67zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "parent_item_id": "xvvxY6eaBE5I"
+                        }
+                    ],
+                    "provider": {
+                        "id": "84",
+                        "locations": [
+                            {
+                                "id": "83"
+                            }
+                        ]
+                    },
+                    "fulfillments": [
+                        {
+                            "@ondc/org/TAT": "PT90M",
+                            "id": "155",
+                            "tracking": true,
+                            "end": {
+                                "contact": {
+                                    "email": "ajeetchauhan.symfony143@webkul.in",
+                                    "phone": "8574739650"
+                                },
+                                "person": {
+                                    "name": "Ajeet Chauhan"
+                                },
+                                "location": {
+                                    "gps": "28.629743,77.377795",
+                                    "address": {
+                                        "name": "Ajeet Chauhan",
+                                        "building": "ARV Park",
+                                        "locality": "Unnamed Road",
+                                        "city": "Noida",
+                                        "state": "Uttar Pradesh",
+                                        "country": "IND",
+                                        "area_code": "201301"
+                                    }
+                                }
+                            },
+                            "type": "Delivery"
+                        }
+                    ],
+                    "payment": {
+                        "uri": "https://razorpay.com/",
+                        "tl_method": "http/get",
+                        "params": {
+                            "amount": "164.63",
+                            "currency": "INR",
+                            "transaction_id": "order_Pg7qlLR529ZmhG"
+                        },
+                        "status": "PAID",
+                        "type": "ON-ORDER",
+                        "collected_by": "BAP",
+                        "@ondc/org/buyer_app_finder_fee_type": "percent",
+                        "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+                        "@ondc/org/settlement_details": [
+                            {
+                                "settlement_counterparty": "seller-app",
+                                "settlement_phase": "sale-amount",
+                                "settlement_type": "neft",
+                                "beneficiary_name": "fasdf asdfasdf",
+                                "settlement_bank_account_no": "534512341234132",
+                                "settlement_ifsc_code": "HDFC0000088",
+                                "bank_name": "fasdf",
+                                "branch_name": "noida",
+                                "settlement_status": "NOT-PAID"
+                            }
+                        ]
+                    },
+                    "quote": {
+                        "price": {
+                            "currency": "INR",
+                            "value": "164.63"
+                        },
+                        "breakup": [
+                            {
+                                "title": "Pizza Mania",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "99"
+                                },
+                                "@ondc/org/title_type": "item",
+                                "@ondc/org/item_id": "451",
+                                "@ondc/org/item_quantity": {
+                                    "count": 1
+                                },
+                                "item": {
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "99"
+                                    },
+                                    "parent_item_id": "xvvxY6eaBE5I",
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "item"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "title": "Vegan",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "10"
+                                },
+                                "@ondc/org/title_type": "item",
+                                "@ondc/org/item_id": "94",
+                                "@ondc/org/item_quantity": {
+                                    "count": 1
+                                },
+                                "item": {
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "10"
+                                    },
+                                    "parent_item_id": "xvvxY6eaBE5I",
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "customization"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "parent",
+                                            "list": [
+                                                {
+                                                    "code": "id",
+                                                    "value": "66zabcdefghi"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "title": "Mutton",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "50"
+                                },
+                                "@ondc/org/title_type": "item",
+                                "@ondc/org/item_id": "96",
+                                "@ondc/org/item_quantity": {
+                                    "count": 1
+                                },
+                                "item": {
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "50"
+                                    },
+                                    "parent_item_id": "xvvxY6eaBE5I",
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "customization"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "parent",
+                                            "list": [
+                                                {
+                                                    "code": "id",
+                                                    "value": "67zabcdefghi"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "title": "Convenience fee",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "5.63"
+                                },
+                                "@ondc/org/title_type": "misc",
+                                "@ondc/org/item_id": "155"
+                            },
+                            {
+                                "title": "Delivery charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "0"
+                                },
+                                "@ondc/org/title_type": "delivery",
+                                "@ondc/org/item_id": "155"
+                            }
+                        ],
+                        "ttl": "PT6H"
+                    },
+                    "tags": [
+                        {
+                            "code": "bpp_terms",
+                            "list": [
+                                {
+                                    "code": "tax_number",
+                                    "value": "09AABCW0339G3ZD"
+                                },
+                                {
+                                    "code": "provider_tax_number",
+                                    "value": "DERTC3376R"
+                                }
+                            ]
+                        },
+                        {
+                            "code": "bap_terms",
+                            "list": [
+                                {
+                                    "code": "tax_number",
+                                    "value": "GSTIN1234567890"
+                                }
+                            ]
+                        }
+                    ],
+                    "created_at": "2025-01-06T10:32:04.500Z",
+                    "updated_at": "2025-01-06T10:32:04.500Z"
+                }
+            }
+        },
+        "on_confirm": {
+            "context": {
+                "domain": "ONDC:RET11",
+                "country": "IND",
+                "city": "std:0120",
+                "action": "on_confirm",
+                "core_version": "1.2.0",
+                "bap_id": "buyer-app-preprod-v2.ondc.org",
+                "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+                "bpp_uri": "https://ondc.ecomviser.com/api/v1",
+                "transaction_id": "bbeea929-e45e-48df-b3b7-d58a4a5301a7",
+                "message_id": "f772812e-326c-400d-920f-c57942de6df9",
+                "timestamp": "2025-01-06T10:32:07.911Z",
+                "bpp_id": "ondc.ecomviser.com"
+            },
+            "message": {
+                "order": {
+                    "id": "2025-01-06-248869",
+                    "state": "Created",
+                    "provider": {
+                        "id": "84",
+                        "locations": [
+                            {
+                                "id": "83"
+                            }
+                        ]
+                    },
+                    "items": [
+                        {
+                            "id": "451",
+                            "quantity": {
+                                "count": 1
+                            },
+                            "fulfillment_id": "155",
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "item"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "parent_item_id": "xvvxY6eaBE5I"
+                        },
+                        {
+                            "id": "94",
+                            "quantity": {
+                                "count": 1
+                            },
+                            "fulfillment_id": "155",
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "66zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "parent_item_id": "xvvxY6eaBE5I"
+                        },
+                        {
+                            "id": "96",
+                            "quantity": {
+                                "count": 1
+                            },
+                            "fulfillment_id": "155",
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "67zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "parent_item_id": "xvvxY6eaBE5I"
+                        }
+                    ],
+                    "billing": {
+                        "address": {
+                            "name": "Ajeet Chauhan",
+                            "building": "ARV Park",
+                            "locality": "Unnamed Road",
+                            "city": "Noida",
+                            "state": "Uttar Pradesh",
+                            "country": "IND",
+                            "area_code": "201301"
+                        },
+                        "phone": "8574739650",
+                        "name": "Ajeet Chauhan",
+                        "email": "ajeetchauhan.symfony143@webkul.in",
+                        "created_at": "2025-01-06T10:31:29.847Z",
+                        "updated_at": "2025-01-06T10:31:29.847Z"
+                    },
+                    "fulfillments": [
+                        {
+                            "@ondc/org/TAT": "PT90M",
+                            "id": "155",
+                            "tracking": true,
+                            "end": {
+                                "contact": {
+                                    "email": "ajeetchauhan.symfony143@webkul.in",
+                                    "phone": "8574739650"
+                                },
+                                "person": {
+                                    "name": "Ajeet Chauhan"
+                                },
+                                "location": {
+                                    "gps": "28.629743,77.377795",
+                                    "address": {
+                                        "name": "Ajeet Chauhan",
+                                        "building": "ARV Park",
+                                        "locality": "Unnamed Road",
+                                        "city": "Noida",
+                                        "state": "Uttar Pradesh",
+                                        "country": "IND",
+                                        "area_code": "201301"
+                                    }
+                                },
+                                "time": {
+                                    "range": {
+                                        "start": "2025-01-06T10:32:09.006Z",
+                                        "end": "2025-01-06T11:32:09.006Z"
+                                    }
+                                }
+                            },
+                            "type": "Delivery",
+                            "@ondc/org/provider_name": "ondc.ecomviser.com",
+                            "state": {
+                                "descriptor": {
+                                    "code": "Pending"
+                                }
+                            },
+                            "start": {
+                                "location": {
+                                    "id": "83",
+                                    "descriptor": {
+                                        "name": "Ajeet Food Shop"
+                                    },
+                                    "gps": "28.62972640,77.37783230",
+                                    "address": {
+                                        "locality": "Noida",
+                                        "city": "Gautam Buddh Nagar",
+                                        "area_code": "201301",
+                                        "state": "Uttar Pradesh"
+                                    }
+                                },
+                                "contact": {
+                                    "phone": "9876543210",
+                                    "email": "support@webkul.in"
+                                },
+                                "time": {
+                                    "range": {
+                                        "start": "2025-01-06T10:32:09.006Z",
+                                        "end": "2025-01-06T11:32:09.006Z"
+                                    }
+                                }
+                            }
+                        }
+                    ],
+                    "quote": {
+                        "price": {
+                            "currency": "INR",
+                            "value": "164.63"
+                        },
+                        "breakup": [
+                            {
+                                "title": "Pizza Mania",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "99"
+                                },
+                                "@ondc/org/title_type": "item",
+                                "@ondc/org/item_id": "451",
+                                "@ondc/org/item_quantity": {
+                                    "count": 1
+                                },
+                                "item": {
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "99"
+                                    },
+                                    "parent_item_id": "xvvxY6eaBE5I",
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "item"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "title": "Vegan",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "10"
+                                },
+                                "@ondc/org/title_type": "item",
+                                "@ondc/org/item_id": "94",
+                                "@ondc/org/item_quantity": {
+                                    "count": 1
+                                },
+                                "item": {
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "10"
+                                    },
+                                    "parent_item_id": "xvvxY6eaBE5I",
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "customization"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "parent",
+                                            "list": [
+                                                {
+                                                    "code": "id",
+                                                    "value": "66zabcdefghi"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "title": "Mutton",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "50"
+                                },
+                                "@ondc/org/title_type": "item",
+                                "@ondc/org/item_id": "96",
+                                "@ondc/org/item_quantity": {
+                                    "count": 1
+                                },
+                                "item": {
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "50"
+                                    },
+                                    "parent_item_id": "xvvxY6eaBE5I",
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "customization"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "parent",
+                                            "list": [
+                                                {
+                                                    "code": "id",
+                                                    "value": "67zabcdefghi"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "title": "Convenience fee",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "5.63"
+                                },
+                                "@ondc/org/title_type": "misc",
+                                "@ondc/org/item_id": "155"
+                            },
+                            {
+                                "title": "Delivery charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "0"
+                                },
+                                "@ondc/org/title_type": "delivery",
+                                "@ondc/org/item_id": "155"
+                            }
+                        ],
+                        "ttl": "PT6H"
+                    },
+                    "payment": {
+                        "uri": "https://razorpay.com/",
+                        "tl_method": "http/get",
+                        "params": {
+                            "amount": "164.63",
+                            "currency": "INR",
+                            "transaction_id": "order_Pg7qlLR529ZmhG"
+                        },
+                        "status": "PAID",
+                        "type": "ON-ORDER",
+                        "collected_by": "BAP",
+                        "@ondc/org/buyer_app_finder_fee_type": "percent",
+                        "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+                        "@ondc/org/settlement_details": [
+                            {
+                                "settlement_counterparty": "seller-app",
+                                "settlement_phase": "sale-amount",
+                                "settlement_type": "neft",
+                                "beneficiary_name": "fasdf asdfasdf",
+                                "settlement_bank_account_no": "534512341234132",
+                                "settlement_ifsc_code": "HDFC0000088",
+                                "bank_name": "fasdf",
+                                "branch_name": "noida",
+                                "settlement_status": "NOT-PAID"
+                            }
+                        ]
+                    },
+                    "tags": [
+                        {
+                            "code": "bpp_terms",
+                            "list": [
+                                {
+                                    "code": "np_type",
+                                    "value": "MSN"
+                                },
+                                {
+                                    "code": "tax_number",
+                                    "value": "09AABCW0339G3ZD"
+                                },
+                                {
+                                    "code": "provider_tax_number",
+                                    "value": "DERTC3376R"
+                                }
+                            ]
+                        },
+                        {
+                            "code": "bap_terms",
+                            "list": [
+                                {
+                                    "code": "tax_number",
+                                    "value": "GSTIN1234567890"
+                                }
+                            ]
+                        }
+                    ],
+                    "created_at": "2025-01-06T10:32:04.500Z",
+                    "updated_at": "2025-01-06T10:32:07.911Z"
+                }
+            }
+        },
+        "on_status_pending": {
+            "context": {
+                "domain": "ONDC:RET11",
+                "country": "IND",
+                "city": "std:0120",
+                "action": "on_status",
+                "core_version": "1.2.0",
+                "bap_id": "buyer-app-preprod-v2.ondc.org",
+                "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+                "bpp_uri": "https://ondc.ecomviser.com/api/v1",
+                "transaction_id": "bbeea929-e45e-48df-b3b7-d58a4a5301a7",
+                "message_id": "677bb1423532b3ed53da8-7c2f",
+                "timestamp": "2025-01-06T10:32:34.218Z",
+                "bpp_id": "ondc.ecomviser.com",
+                "ttl": "PT30S"
+            },
+            "message": {
+                "order": {
+                    "id": "2025-01-06-248869",
+                    "state": "Accepted",
+                    "provider": {
+                        "id": "84",
+                        "locations": [
+                            {
+                                "id": "83"
+                            }
+                        ]
+                    },
+                    "items": [
+                        {
+                            "id": "451",
+                            "fulfillment_id": "155",
+                            "quantity": {
+                                "count": 1
+                            }
+                        }
+                    ],
+                    "fulfillments": [
+                        {
+                            "id": "155",
+                            "end": {
+                                "time": {
+                                    "range": {
+                                        "end": "2025-01-06T11:32:09.006Z",
+                                        "start": "2025-01-06T10:32:09.006Z"
+                                    }
+                                },
+                                "person": {
+                                    "name": "Ajeet Chauhan"
+                                },
+                                "contact": {
+                                    "email": "ajeetchauhan.symfony143@webkul.in",
+                                    "phone": "8574739650"
+                                },
+                                "location": {
+                                    "gps": "28.629743,77.377795",
+                                    "address": {
+                                        "city": "Noida",
+                                        "name": "Ajeet Chauhan",
+                                        "state": "Uttar Pradesh",
+                                        "country": "IND",
+                                        "building": "ARV Park",
+                                        "locality": "Unnamed Road",
+                                        "area_code": "201301"
+                                    }
+                                }
+                            },
+                            "type": "Delivery",
+                            "start": {
+                                "time": {
+                                    "range": {
+                                        "end": "2025-01-06T11:32:09.006Z",
+                                        "start": "2025-01-06T10:32:09.006Z"
+                                    }
+                                },
+                                "contact": {
+                                    "email": "support@webkul.in",
+                                    "phone": "9876543210"
+                                },
+                                "location": {
+                                    "id": "83",
+                                    "gps": "28.62972640,77.37783230",
+                                    "address": {
+                                        "city": "Gautam Buddh Nagar",
+                                        "state": "Uttar Pradesh",
+                                        "locality": "Noida",
+                                        "area_code": "201301"
+                                    },
+                                    "descriptor": {
+                                        "name": "Ajeet Food Shop"
+                                    }
+                                }
+                            },
+                            "state": {
+                                "descriptor": {
+                                    "code": "Pending"
+                                }
+                            },
+                            "tracking": true,
+                            "@ondc/org/TAT": "PT90M",
+                            "@ondc/org/provider_name": "ondc.ecomviser.com"
+                        }
+                    ],
+                    "quote": {
+                        "ttl": "PT6H",
+                        "price": {
+                            "value": "164.63",
+                            "currency": "INR"
+                        },
+                        "breakup": [
+                            {
+                                "item": {
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "item"
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "price": {
+                                        "value": "99",
+                                        "currency": "INR"
+                                    },
+                                    "parent_item_id": "xvvxY6eaBE5I"
+                                },
+                                "price": {
+                                    "value": "99",
+                                    "currency": "INR"
+                                },
+                                "title": "Pizza Mania",
+                                "@ondc/org/item_id": "451",
+                                "@ondc/org/title_type": "item",
+                                "@ondc/org/item_quantity": {
+                                    "count": 1
+                                }
+                            },
+                            {
+                                "item": {
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "customization"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "parent",
+                                            "list": [
+                                                {
+                                                    "code": "id",
+                                                    "value": "66zabcdefghi"
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "price": {
+                                        "value": "10",
+                                        "currency": "INR"
+                                    },
+                                    "parent_item_id": "xvvxY6eaBE5I"
+                                },
+                                "price": {
+                                    "value": "10",
+                                    "currency": "INR"
+                                },
+                                "title": "Vegan",
+                                "@ondc/org/item_id": "94",
+                                "@ondc/org/title_type": "item",
+                                "@ondc/org/item_quantity": {
+                                    "count": 1
+                                }
+                            },
+                            {
+                                "item": {
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "customization"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "parent",
+                                            "list": [
+                                                {
+                                                    "code": "id",
+                                                    "value": "67zabcdefghi"
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "price": {
+                                        "value": "50",
+                                        "currency": "INR"
+                                    },
+                                    "parent_item_id": "xvvxY6eaBE5I"
+                                },
+                                "price": {
+                                    "value": "50",
+                                    "currency": "INR"
+                                },
+                                "title": "Mutton",
+                                "@ondc/org/item_id": "96",
+                                "@ondc/org/title_type": "item",
+                                "@ondc/org/item_quantity": {
+                                    "count": 1
+                                }
+                            },
+                            {
+                                "price": {
+                                    "value": "5.63",
+                                    "currency": "INR"
+                                },
+                                "title": "Convenience fee",
+                                "@ondc/org/item_id": "155",
+                                "@ondc/org/title_type": "misc"
+                            },
+                            {
+                                "price": {
+                                    "value": "0",
+                                    "currency": "INR"
+                                },
+                                "title": "Delivery charges",
+                                "@ondc/org/item_id": "155",
+                                "@ondc/org/title_type": "delivery"
+                            }
+                        ]
+                    },
+                    "billing": {
+                        "name": "Ajeet Chauhan",
+                        "email": "ajeetchauhan.symfony143@webkul.in",
+                        "phone": "8574739650",
+                        "address": {
+                            "city": "Noida",
+                            "name": "Ajeet Chauhan",
+                            "state": "Uttar Pradesh",
+                            "country": "IND",
+                            "building": "ARV Park",
+                            "locality": "Unnamed Road",
+                            "area_code": "201301"
+                        },
+                        "created_at": "2025-01-06T10:31:29.847Z",
+                        "updated_at": "2025-01-06T10:31:29.847Z"
+                    },
+                    "payment": {
+                        "uri": "https://razorpay.com/",
+                        "type": "ON-ORDER",
+                        "params": {
+                            "amount": "164.63",
+                            "currency": "INR",
+                            "transaction_id": "order_Pg7qlLR529ZmhG"
+                        },
+                        "status": "PAID",
+                        "tl_method": "http/get",
+                        "collected_by": "BAP",
+                        "@ondc/org/settlement_details": [
+                            {
+                                "bank_name": "fasdf",
+                                "branch_name": "noida",
+                                "settlement_type": "neft",
+                                "beneficiary_name": "fasdf asdfasdf",
+                                "settlement_phase": "sale-amount",
+                                "settlement_status": "NOT-PAID",
+                                "settlement_ifsc_code": "HDFC0000088",
+                                "settlement_counterparty": "seller-app",
+                                "settlement_bank_account_no": "534512341234132"
+                            }
+                        ],
+                        "@ondc/org/buyer_app_finder_fee_type": "percent",
+                        "@ondc/org/buyer_app_finder_fee_amount": "3.0"
+                    },
+                    "created_at": "2025-01-06T10:32:04.500Z",
+                    "updated_at": "2025-01-06T10:32:34.218Z"
+                }
+            }
+        },
+        "on_status_packed": {
+            "context": {
+                "domain": "ONDC:RET11",
+                "country": "IND",
+                "city": "std:0120",
+                "action": "on_status",
+                "core_version": "1.2.0",
+                "bap_id": "buyer-app-preprod-v2.ondc.org",
+                "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+                "bpp_uri": "https://ondc.ecomviser.com/api/v1",
+                "transaction_id": "bbeea929-e45e-48df-b3b7-d58a4a5301a7",
+                "message_id": "677bb1512596faa9f3a59-2f38",
+                "timestamp": "2025-01-06T10:32:49.154Z",
+                "bpp_id": "ondc.ecomviser.com",
+                "ttl": "PT30S"
+            },
+            "message": {
+                "order": {
+                    "id": "2025-01-06-248869",
+                    "state": "In-progress",
+                    "provider": {
+                        "id": "84",
+                        "locations": [
+                            {
+                                "id": "83"
+                            }
+                        ]
+                    },
+                    "items": [
+                        {
+                            "id": "451",
+                            "fulfillment_id": "155",
+                            "quantity": {
+                                "count": 1
+                            }
+                        }
+                    ],
+                    "fulfillments": [
+                        {
+                            "id": "155",
+                            "end": {
+                                "time": {
+                                    "range": {
+                                        "end": "2025-01-06T11:32:09.006Z",
+                                        "start": "2025-01-06T10:32:09.006Z"
+                                    }
+                                },
+                                "person": {
+                                    "name": "Ajeet Chauhan"
+                                },
+                                "contact": {
+                                    "email": "ajeetchauhan.symfony143@webkul.in",
+                                    "phone": "8574739650"
+                                },
+                                "location": {
+                                    "gps": "28.629743,77.377795",
+                                    "address": {
+                                        "city": "Noida",
+                                        "name": "Ajeet Chauhan",
+                                        "state": "Uttar Pradesh",
+                                        "country": "IND",
+                                        "building": "ARV Park",
+                                        "locality": "Unnamed Road",
+                                        "area_code": "201301"
+                                    }
+                                }
+                            },
+                            "type": "Delivery",
+                            "start": {
+                                "time": {
+                                    "range": {
+                                        "end": "2025-01-06T11:32:09.006Z",
+                                        "start": "2025-01-06T10:32:09.006Z"
+                                    }
+                                },
+                                "contact": {
+                                    "email": "support@webkul.in",
+                                    "phone": "9876543210"
+                                },
+                                "location": {
+                                    "id": "83",
+                                    "gps": "28.62972640,77.37783230",
+                                    "address": {
+                                        "city": "Gautam Buddh Nagar",
+                                        "state": "Uttar Pradesh",
+                                        "locality": "Noida",
+                                        "area_code": "201301"
+                                    },
+                                    "descriptor": {
+                                        "name": "Ajeet Food Shop"
+                                    }
+                                }
+                            },
+                            "state": {
+                                "descriptor": {
+                                    "code": "Packed"
+                                }
+                            },
+                            "tracking": true,
+                            "@ondc/org/TAT": "PT90M",
+                            "@ondc/org/provider_name": "ondc.ecomviser.com"
+                        }
+                    ],
+                    "quote": {
+                        "ttl": "PT6H",
+                        "price": {
+                            "value": "164.63",
+                            "currency": "INR"
+                        },
+                        "breakup": [
+                            {
+                                "item": {
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "item"
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "price": {
+                                        "value": "99",
+                                        "currency": "INR"
+                                    },
+                                    "parent_item_id": "xvvxY6eaBE5I"
+                                },
+                                "price": {
+                                    "value": "99",
+                                    "currency": "INR"
+                                },
+                                "title": "Pizza Mania",
+                                "@ondc/org/item_id": "451",
+                                "@ondc/org/title_type": "item",
+                                "@ondc/org/item_quantity": {
+                                    "count": 1
+                                }
+                            },
+                            {
+                                "item": {
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "customization"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "parent",
+                                            "list": [
+                                                {
+                                                    "code": "id",
+                                                    "value": "66zabcdefghi"
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "price": {
+                                        "value": "10",
+                                        "currency": "INR"
+                                    },
+                                    "parent_item_id": "xvvxY6eaBE5I"
+                                },
+                                "price": {
+                                    "value": "10",
+                                    "currency": "INR"
+                                },
+                                "title": "Vegan",
+                                "@ondc/org/item_id": "94",
+                                "@ondc/org/title_type": "item",
+                                "@ondc/org/item_quantity": {
+                                    "count": 1
+                                }
+                            },
+                            {
+                                "item": {
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "customization"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "parent",
+                                            "list": [
+                                                {
+                                                    "code": "id",
+                                                    "value": "67zabcdefghi"
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "price": {
+                                        "value": "50",
+                                        "currency": "INR"
+                                    },
+                                    "parent_item_id": "xvvxY6eaBE5I"
+                                },
+                                "price": {
+                                    "value": "50",
+                                    "currency": "INR"
+                                },
+                                "title": "Mutton",
+                                "@ondc/org/item_id": "96",
+                                "@ondc/org/title_type": "item",
+                                "@ondc/org/item_quantity": {
+                                    "count": 1
+                                }
+                            },
+                            {
+                                "price": {
+                                    "value": "5.63",
+                                    "currency": "INR"
+                                },
+                                "title": "Convenience fee",
+                                "@ondc/org/item_id": "155",
+                                "@ondc/org/title_type": "misc"
+                            },
+                            {
+                                "price": {
+                                    "value": "0",
+                                    "currency": "INR"
+                                },
+                                "title": "Delivery charges",
+                                "@ondc/org/item_id": "155",
+                                "@ondc/org/title_type": "delivery"
+                            }
+                        ]
+                    },
+                    "billing": {
+                        "name": "Ajeet Chauhan",
+                        "email": "ajeetchauhan.symfony143@webkul.in",
+                        "phone": "8574739650",
+                        "address": {
+                            "city": "Noida",
+                            "name": "Ajeet Chauhan",
+                            "state": "Uttar Pradesh",
+                            "country": "IND",
+                            "building": "ARV Park",
+                            "locality": "Unnamed Road",
+                            "area_code": "201301"
+                        },
+                        "created_at": "2025-01-06T10:31:29.847Z",
+                        "updated_at": "2025-01-06T10:31:29.847Z"
+                    },
+                    "payment": {
+                        "uri": "https://razorpay.com/",
+                        "type": "ON-ORDER",
+                        "params": {
+                            "amount": "164.63",
+                            "currency": "INR",
+                            "transaction_id": "order_Pg7qlLR529ZmhG"
+                        },
+                        "status": "PAID",
+                        "tl_method": "http/get",
+                        "collected_by": "BAP",
+                        "@ondc/org/settlement_details": [
+                            {
+                                "bank_name": "fasdf",
+                                "branch_name": "noida",
+                                "settlement_type": "neft",
+                                "beneficiary_name": "fasdf asdfasdf",
+                                "settlement_phase": "sale-amount",
+                                "settlement_status": "NOT-PAID",
+                                "settlement_ifsc_code": "HDFC0000088",
+                                "settlement_counterparty": "seller-app",
+                                "settlement_bank_account_no": "534512341234132"
+                            }
+                        ],
+                        "@ondc/org/buyer_app_finder_fee_type": "percent",
+                        "@ondc/org/buyer_app_finder_fee_amount": "3.0"
+                    },
+                    "created_at": "2025-01-06T10:32:04.500Z",
+                    "updated_at": "2025-01-06T10:32:49.154Z"
+                }
+            }
+        },
+        "on_status_agent_assigned": {
+            "context": {
+                "domain": "ONDC:RET11",
+                "country": "IND",
+                "city": "std:0120",
+                "action": "on_status",
+                "core_version": "1.2.0",
+                "bap_id": "buyer-app-preprod-v2.ondc.org",
+                "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+                "bpp_uri": "https://ondc.ecomviser.com/api/v1",
+                "transaction_id": "bbeea929-e45e-48df-b3b7-d58a4a5301a7",
+                "message_id": "677bb16388b49f15553e6-e888",
+                "timestamp": "2025-01-06T10:33:07.560Z",
+                "bpp_id": "ondc.ecomviser.com",
+                "ttl": "PT30S"
+            },
+            "message": {
+                "order": {
+                    "id": "2025-01-06-248869",
+                    "state": "In-progress",
+                    "provider": {
+                        "id": "84",
+                        "locations": [
+                            {
+                                "id": "83"
+                            }
+                        ]
+                    },
+                    "items": [
+                        {
+                            "id": "451",
+                            "fulfillment_id": "155",
+                            "quantity": {
+                                "count": 1
+                            }
+                        }
+                    ],
+                    "fulfillments": [
+                        {
+                            "id": "155",
+                            "end": {
+                                "time": {
+                                    "range": {
+                                        "end": "2025-01-06T11:32:09.006Z",
+                                        "start": "2025-01-06T10:32:09.006Z"
+                                    }
+                                },
+                                "person": {
+                                    "name": "Ajeet Chauhan"
+                                },
+                                "contact": {
+                                    "email": "ajeetchauhan.symfony143@webkul.in",
+                                    "phone": "8574739650"
+                                },
+                                "location": {
+                                    "gps": "28.629743,77.377795",
+                                    "address": {
+                                        "city": "Noida",
+                                        "name": "Ajeet Chauhan",
+                                        "state": "Uttar Pradesh",
+                                        "country": "IND",
+                                        "building": "ARV Park",
+                                        "locality": "Unnamed Road",
+                                        "area_code": "201301"
+                                    }
+                                }
+                            },
+                            "type": "Delivery",
+                            "start": {
+                                "time": {
+                                    "range": {
+                                        "end": "2025-01-06T11:32:09.006Z",
+                                        "start": "2025-01-06T10:32:09.006Z"
+                                    }
+                                },
+                                "contact": {
+                                    "email": "support@webkul.in",
+                                    "phone": "9876543210"
+                                },
+                                "location": {
+                                    "id": "83",
+                                    "gps": "28.62972640,77.37783230",
+                                    "address": {
+                                        "city": "Gautam Buddh Nagar",
+                                        "state": "Uttar Pradesh",
+                                        "locality": "Noida",
+                                        "area_code": "201301"
+                                    },
+                                    "descriptor": {
+                                        "name": "Ajeet Food Shop"
+                                    }
+                                }
+                            },
+                            "state": {
+                                "descriptor": {
+                                    "code": "Agent-assigned"
+                                }
+                            },
+                            "tracking": true,
+                            "@ondc/org/TAT": "PT90M",
+                            "@ondc/org/provider_name": "ondc.ecomviser.com"
+                        }
+                    ],
+                    "quote": {
+                        "ttl": "PT6H",
+                        "price": {
+                            "value": "164.63",
+                            "currency": "INR"
+                        },
+                        "breakup": [
+                            {
+                                "item": {
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "item"
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "price": {
+                                        "value": "99",
+                                        "currency": "INR"
+                                    },
+                                    "parent_item_id": "xvvxY6eaBE5I"
+                                },
+                                "price": {
+                                    "value": "99",
+                                    "currency": "INR"
+                                },
+                                "title": "Pizza Mania",
+                                "@ondc/org/item_id": "451",
+                                "@ondc/org/title_type": "item",
+                                "@ondc/org/item_quantity": {
+                                    "count": 1
+                                }
+                            },
+                            {
+                                "item": {
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "customization"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "parent",
+                                            "list": [
+                                                {
+                                                    "code": "id",
+                                                    "value": "66zabcdefghi"
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "price": {
+                                        "value": "10",
+                                        "currency": "INR"
+                                    },
+                                    "parent_item_id": "xvvxY6eaBE5I"
+                                },
+                                "price": {
+                                    "value": "10",
+                                    "currency": "INR"
+                                },
+                                "title": "Vegan",
+                                "@ondc/org/item_id": "94",
+                                "@ondc/org/title_type": "item",
+                                "@ondc/org/item_quantity": {
+                                    "count": 1
+                                }
+                            },
+                            {
+                                "item": {
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "customization"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "parent",
+                                            "list": [
+                                                {
+                                                    "code": "id",
+                                                    "value": "67zabcdefghi"
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "price": {
+                                        "value": "50",
+                                        "currency": "INR"
+                                    },
+                                    "parent_item_id": "xvvxY6eaBE5I"
+                                },
+                                "price": {
+                                    "value": "50",
+                                    "currency": "INR"
+                                },
+                                "title": "Mutton",
+                                "@ondc/org/item_id": "96",
+                                "@ondc/org/title_type": "item",
+                                "@ondc/org/item_quantity": {
+                                    "count": 1
+                                }
+                            },
+                            {
+                                "price": {
+                                    "value": "5.63",
+                                    "currency": "INR"
+                                },
+                                "title": "Convenience fee",
+                                "@ondc/org/item_id": "155",
+                                "@ondc/org/title_type": "misc"
+                            },
+                            {
+                                "price": {
+                                    "value": "0",
+                                    "currency": "INR"
+                                },
+                                "title": "Delivery charges",
+                                "@ondc/org/item_id": "155",
+                                "@ondc/org/title_type": "delivery"
+                            }
+                        ]
+                    },
+                    "billing": {
+                        "name": "Ajeet Chauhan",
+                        "email": "ajeetchauhan.symfony143@webkul.in",
+                        "phone": "8574739650",
+                        "address": {
+                            "city": "Noida",
+                            "name": "Ajeet Chauhan",
+                            "state": "Uttar Pradesh",
+                            "country": "IND",
+                            "building": "ARV Park",
+                            "locality": "Unnamed Road",
+                            "area_code": "201301"
+                        },
+                        "created_at": "2025-01-06T10:31:29.847Z",
+                        "updated_at": "2025-01-06T10:31:29.847Z"
+                    },
+                    "payment": {
+                        "uri": "https://razorpay.com/",
+                        "type": "ON-ORDER",
+                        "params": {
+                            "amount": "164.63",
+                            "currency": "INR",
+                            "transaction_id": "order_Pg7qlLR529ZmhG"
+                        },
+                        "status": "PAID",
+                        "tl_method": "http/get",
+                        "collected_by": "BAP",
+                        "@ondc/org/settlement_details": [
+                            {
+                                "bank_name": "fasdf",
+                                "branch_name": "noida",
+                                "settlement_type": "neft",
+                                "beneficiary_name": "fasdf asdfasdf",
+                                "settlement_phase": "sale-amount",
+                                "settlement_status": "NOT-PAID",
+                                "settlement_ifsc_code": "HDFC0000088",
+                                "settlement_counterparty": "seller-app",
+                                "settlement_bank_account_no": "534512341234132"
+                            }
+                        ],
+                        "@ondc/org/buyer_app_finder_fee_type": "percent",
+                        "@ondc/org/buyer_app_finder_fee_amount": "3.0"
+                    },
+                    "created_at": "2025-01-06T10:32:04.500Z",
+                    "updated_at": "2025-01-06T10:33:07.560Z"
+                }
+            }
+        },
+        "on_status_picked": {
+            "context": {
+                "domain": "ONDC:RET11",
+                "country": "IND",
+                "city": "std:0120",
+                "action": "on_status",
+                "core_version": "1.2.0",
+                "bap_id": "buyer-app-preprod-v2.ondc.org",
+                "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+                "bpp_uri": "https://ondc.ecomviser.com/api/v1",
+                "transaction_id": "bbeea929-e45e-48df-b3b7-d58a4a5301a7",
+                "message_id": "677bb16b4ae6a6c6bd3d8-82a3",
+                "timestamp": "2025-01-06T10:33:15.307Z",
+                "bpp_id": "ondc.ecomviser.com",
+                "ttl": "PT30S"
+            },
+            "message": {
+                "order": {
+                    "id": "2025-01-06-248869",
+                    "state": "In-progress",
+                    "provider": {
+                        "id": "84",
+                        "locations": [
+                            {
+                                "id": "83"
+                            }
+                        ]
+                    },
+                    "items": [
+                        {
+                            "id": "451",
+                            "fulfillment_id": "155",
+                            "quantity": {
+                                "count": 1
+                            }
+                        }
+                    ],
+                    "fulfillments": [
+                        {
+                            "id": "155",
+                            "end": {
+                                "time": {
+                                    "range": {
+                                        "end": "2025-01-06T11:32:09.006Z",
+                                        "start": "2025-01-06T10:32:09.006Z"
+                                    }
+                                },
+                                "person": {
+                                    "name": "Ajeet Chauhan"
+                                },
+                                "contact": {
+                                    "email": "ajeetchauhan.symfony143@webkul.in",
+                                    "phone": "8574739650"
+                                },
+                                "location": {
+                                    "gps": "28.629743,77.377795",
+                                    "address": {
+                                        "city": "Noida",
+                                        "name": "Ajeet Chauhan",
+                                        "state": "Uttar Pradesh",
+                                        "country": "IND",
+                                        "building": "ARV Park",
+                                        "locality": "Unnamed Road",
+                                        "area_code": "201301"
+                                    }
+                                }
+                            },
+                            "type": "Delivery",
+                            "start": {
+                                "time": {
+                                    "range": {
+                                        "end": "2025-01-06T11:32:09.006Z",
+                                        "start": "2025-01-06T10:32:09.006Z"
+                                    },
+                                    "timestamp": "2025-01-06T10:33:14.727Z"
+                                },
+                                "contact": {
+                                    "email": "support@webkul.in",
+                                    "phone": "9876543210"
+                                },
+                                "location": {
+                                    "id": "83",
+                                    "gps": "28.62972640,77.37783230",
+                                    "address": {
+                                        "city": "Gautam Buddh Nagar",
+                                        "state": "Uttar Pradesh",
+                                        "locality": "Noida",
+                                        "area_code": "201301"
+                                    },
+                                    "descriptor": {
+                                        "name": "Ajeet Food Shop"
+                                    }
+                                },
+                                "instructions": {
+                                    "code": "2",
+                                    "name": "ONDC Order",
+                                    "short_desc": "ae34fd",
+                                    "long_desc": "additional instructions for pickup"
+                                }
+                            },
+                            "state": {
+                                "descriptor": {
+                                    "code": "Order-picked-up"
+                                }
+                            },
+                            "tracking": true,
+                            "@ondc/org/TAT": "PT90M",
+                            "@ondc/org/provider_name": "ondc.ecomviser.com",
+                            "tags": [
+                                {
+                                    "code": "routing",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "P2P"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "tracking",
+                                    "list": [
+                                        {
+                                            "code": "gps_enabled",
+                                            "value": "yes"
+                                        },
+                                        {
+                                            "code": "url_enabled",
+                                            "value": "no"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ],
+                    "quote": {
+                        "ttl": "PT6H",
+                        "price": {
+                            "value": "164.63",
+                            "currency": "INR"
+                        },
+                        "breakup": [
+                            {
+                                "item": {
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "item"
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "price": {
+                                        "value": "99",
+                                        "currency": "INR"
+                                    },
+                                    "parent_item_id": "xvvxY6eaBE5I"
+                                },
+                                "price": {
+                                    "value": "99",
+                                    "currency": "INR"
+                                },
+                                "title": "Pizza Mania",
+                                "@ondc/org/item_id": "451",
+                                "@ondc/org/title_type": "item",
+                                "@ondc/org/item_quantity": {
+                                    "count": 1
+                                }
+                            },
+                            {
+                                "item": {
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "customization"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "parent",
+                                            "list": [
+                                                {
+                                                    "code": "id",
+                                                    "value": "66zabcdefghi"
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "price": {
+                                        "value": "10",
+                                        "currency": "INR"
+                                    },
+                                    "parent_item_id": "xvvxY6eaBE5I"
+                                },
+                                "price": {
+                                    "value": "10",
+                                    "currency": "INR"
+                                },
+                                "title": "Vegan",
+                                "@ondc/org/item_id": "94",
+                                "@ondc/org/title_type": "item",
+                                "@ondc/org/item_quantity": {
+                                    "count": 1
+                                }
+                            },
+                            {
+                                "item": {
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "customization"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "parent",
+                                            "list": [
+                                                {
+                                                    "code": "id",
+                                                    "value": "67zabcdefghi"
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "price": {
+                                        "value": "50",
+                                        "currency": "INR"
+                                    },
+                                    "parent_item_id": "xvvxY6eaBE5I"
+                                },
+                                "price": {
+                                    "value": "50",
+                                    "currency": "INR"
+                                },
+                                "title": "Mutton",
+                                "@ondc/org/item_id": "96",
+                                "@ondc/org/title_type": "item",
+                                "@ondc/org/item_quantity": {
+                                    "count": 1
+                                }
+                            },
+                            {
+                                "price": {
+                                    "value": "5.63",
+                                    "currency": "INR"
+                                },
+                                "title": "Convenience fee",
+                                "@ondc/org/item_id": "155",
+                                "@ondc/org/title_type": "misc"
+                            },
+                            {
+                                "price": {
+                                    "value": "0",
+                                    "currency": "INR"
+                                },
+                                "title": "Delivery charges",
+                                "@ondc/org/item_id": "155",
+                                "@ondc/org/title_type": "delivery"
+                            }
+                        ]
+                    },
+                    "billing": {
+                        "name": "Ajeet Chauhan",
+                        "email": "ajeetchauhan.symfony143@webkul.in",
+                        "phone": "8574739650",
+                        "address": {
+                            "city": "Noida",
+                            "name": "Ajeet Chauhan",
+                            "state": "Uttar Pradesh",
+                            "country": "IND",
+                            "building": "ARV Park",
+                            "locality": "Unnamed Road",
+                            "area_code": "201301"
+                        },
+                        "created_at": "2025-01-06T10:31:29.847Z",
+                        "updated_at": "2025-01-06T10:31:29.847Z"
+                    },
+                    "payment": {
+                        "uri": "https://razorpay.com/",
+                        "type": "ON-ORDER",
+                        "params": {
+                            "amount": "164.63",
+                            "currency": "INR",
+                            "transaction_id": "order_Pg7qlLR529ZmhG"
+                        },
+                        "status": "PAID",
+                        "tl_method": "http/get",
+                        "collected_by": "BAP",
+                        "@ondc/org/settlement_details": [
+                            {
+                                "bank_name": "fasdf",
+                                "branch_name": "noida",
+                                "settlement_type": "neft",
+                                "beneficiary_name": "fasdf asdfasdf",
+                                "settlement_phase": "sale-amount",
+                                "settlement_status": "NOT-PAID",
+                                "settlement_ifsc_code": "HDFC0000088",
+                                "settlement_counterparty": "seller-app",
+                                "settlement_bank_account_no": "534512341234132"
+                            }
+                        ],
+                        "@ondc/org/buyer_app_finder_fee_type": "percent",
+                        "@ondc/org/buyer_app_finder_fee_amount": "3.0"
+                    },
+                    "created_at": "2025-01-06T10:32:04.500Z",
+                    "updated_at": "2025-01-06T10:33:15.307Z",
+                    "documents": [
+                        {
+                            "label": "Invoice",
+                            "url": "https://ecomviser-prepod.sp-seller-preprod.ecomviser.com/index.php?p=invoice_download&key=MTczOjg0OmVjb212aXNlcg=="
+                        }
+                    ]
+                }
+            }
+        },
+        "on_status_out_for_delivery": {
+            "context": {
+                "domain": "ONDC:RET11",
+                "country": "IND",
+                "city": "std:0120",
+                "action": "on_status",
+                "core_version": "1.2.0",
+                "bap_id": "buyer-app-preprod-v2.ondc.org",
+                "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+                "bpp_uri": "https://ondc.ecomviser.com/api/v1",
+                "transaction_id": "bbeea929-e45e-48df-b3b7-d58a4a5301a7",
+                "message_id": "677bb1730c138a10240ec-ff2f",
+                "timestamp": "2025-01-06T10:33:23.049Z",
+                "bpp_id": "ondc.ecomviser.com",
+                "ttl": "PT30S"
+            },
+            "message": {
+                "order": {
+                    "id": "2025-01-06-248869",
+                    "state": "In-progress",
+                    "provider": {
+                        "id": "84",
+                        "locations": [
+                            {
+                                "id": "83"
+                            }
+                        ]
+                    },
+                    "items": [
+                        {
+                            "id": "451",
+                            "fulfillment_id": "155",
+                            "quantity": {
+                                "count": 1
+                            }
+                        }
+                    ],
+                    "fulfillments": [
+                        {
+                            "id": "155",
+                            "end": {
+                                "time": {
+                                    "range": {
+                                        "end": "2025-01-06T11:32:09.006Z",
+                                        "start": "2025-01-06T10:32:09.006Z"
+                                    }
+                                },
+                                "person": {
+                                    "name": "Ajeet Chauhan"
+                                },
+                                "contact": {
+                                    "email": "ajeetchauhan.symfony143@webkul.in",
+                                    "phone": "8574739650"
+                                },
+                                "location": {
+                                    "gps": "28.629743,77.377795",
+                                    "address": {
+                                        "city": "Noida",
+                                        "name": "Ajeet Chauhan",
+                                        "state": "Uttar Pradesh",
+                                        "country": "IND",
+                                        "building": "ARV Park",
+                                        "locality": "Unnamed Road",
+                                        "area_code": "201301"
+                                    }
+                                }
+                            },
+                            "type": "Delivery",
+                            "start": {
+                                "time": {
+                                    "range": {
+                                        "end": "2025-01-06T11:32:09.006Z",
+                                        "start": "2025-01-06T10:32:09.006Z"
+                                    },
+                                    "timestamp": "2025-01-06T10:33:14.727Z"
+                                },
+                                "contact": {
+                                    "email": "support@webkul.in",
+                                    "phone": "9876543210"
+                                },
+                                "location": {
+                                    "id": "83",
+                                    "gps": "28.62972640,77.37783230",
+                                    "address": {
+                                        "city": "Gautam Buddh Nagar",
+                                        "state": "Uttar Pradesh",
+                                        "locality": "Noida",
+                                        "area_code": "201301"
+                                    },
+                                    "descriptor": {
+                                        "name": "Ajeet Food Shop"
+                                    }
+                                }
+                            },
+                            "state": {
+                                "descriptor": {
+                                    "code": "Out-for-delivery"
+                                }
+                            },
+                            "tracking": true,
+                            "@ondc/org/TAT": "PT90M",
+                            "@ondc/org/provider_name": "ondc.ecomviser.com",
+                            "tags": [
+                                {
+                                    "code": "routing",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "P2P"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "tracking",
+                                    "list": [
+                                        {
+                                            "code": "gps_enabled",
+                                            "value": "yes"
+                                        },
+                                        {
+                                            "code": "url_enabled",
+                                            "value": "no"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ],
+                    "quote": {
+                        "ttl": "PT6H",
+                        "price": {
+                            "value": "164.63",
+                            "currency": "INR"
+                        },
+                        "breakup": [
+                            {
+                                "item": {
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "item"
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "price": {
+                                        "value": "99",
+                                        "currency": "INR"
+                                    },
+                                    "parent_item_id": "xvvxY6eaBE5I"
+                                },
+                                "price": {
+                                    "value": "99",
+                                    "currency": "INR"
+                                },
+                                "title": "Pizza Mania",
+                                "@ondc/org/item_id": "451",
+                                "@ondc/org/title_type": "item",
+                                "@ondc/org/item_quantity": {
+                                    "count": 1
+                                }
+                            },
+                            {
+                                "item": {
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "customization"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "parent",
+                                            "list": [
+                                                {
+                                                    "code": "id",
+                                                    "value": "66zabcdefghi"
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "price": {
+                                        "value": "10",
+                                        "currency": "INR"
+                                    },
+                                    "parent_item_id": "xvvxY6eaBE5I"
+                                },
+                                "price": {
+                                    "value": "10",
+                                    "currency": "INR"
+                                },
+                                "title": "Vegan",
+                                "@ondc/org/item_id": "94",
+                                "@ondc/org/title_type": "item",
+                                "@ondc/org/item_quantity": {
+                                    "count": 1
+                                }
+                            },
+                            {
+                                "item": {
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "customization"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "parent",
+                                            "list": [
+                                                {
+                                                    "code": "id",
+                                                    "value": "67zabcdefghi"
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "price": {
+                                        "value": "50",
+                                        "currency": "INR"
+                                    },
+                                    "parent_item_id": "xvvxY6eaBE5I"
+                                },
+                                "price": {
+                                    "value": "50",
+                                    "currency": "INR"
+                                },
+                                "title": "Mutton",
+                                "@ondc/org/item_id": "96",
+                                "@ondc/org/title_type": "item",
+                                "@ondc/org/item_quantity": {
+                                    "count": 1
+                                }
+                            },
+                            {
+                                "price": {
+                                    "value": "5.63",
+                                    "currency": "INR"
+                                },
+                                "title": "Convenience fee",
+                                "@ondc/org/item_id": "155",
+                                "@ondc/org/title_type": "misc"
+                            },
+                            {
+                                "price": {
+                                    "value": "0",
+                                    "currency": "INR"
+                                },
+                                "title": "Delivery charges",
+                                "@ondc/org/item_id": "155",
+                                "@ondc/org/title_type": "delivery"
+                            }
+                        ]
+                    },
+                    "billing": {
+                        "name": "Ajeet Chauhan",
+                        "email": "ajeetchauhan.symfony143@webkul.in",
+                        "phone": "8574739650",
+                        "address": {
+                            "city": "Noida",
+                            "name": "Ajeet Chauhan",
+                            "state": "Uttar Pradesh",
+                            "country": "IND",
+                            "building": "ARV Park",
+                            "locality": "Unnamed Road",
+                            "area_code": "201301"
+                        },
+                        "created_at": "2025-01-06T10:31:29.847Z",
+                        "updated_at": "2025-01-06T10:31:29.847Z"
+                    },
+                    "payment": {
+                        "uri": "https://razorpay.com/",
+                        "type": "ON-ORDER",
+                        "params": {
+                            "amount": "164.63",
+                            "currency": "INR",
+                            "transaction_id": "order_Pg7qlLR529ZmhG"
+                        },
+                        "status": "PAID",
+                        "tl_method": "http/get",
+                        "collected_by": "BAP",
+                        "@ondc/org/settlement_details": [
+                            {
+                                "bank_name": "fasdf",
+                                "branch_name": "noida",
+                                "settlement_type": "neft",
+                                "beneficiary_name": "fasdf asdfasdf",
+                                "settlement_phase": "sale-amount",
+                                "settlement_status": "NOT-PAID",
+                                "settlement_ifsc_code": "HDFC0000088",
+                                "settlement_counterparty": "seller-app",
+                                "settlement_bank_account_no": "534512341234132"
+                            }
+                        ],
+                        "@ondc/org/buyer_app_finder_fee_type": "percent",
+                        "@ondc/org/buyer_app_finder_fee_amount": "3.0"
+                    },
+                    "created_at": "2025-01-06T10:32:04.500Z",
+                    "updated_at": "2025-01-06T10:33:23.049Z",
+                    "documents": [
+                        {
+                            "label": "Invoice",
+                            "url": "https://ecomviser-prepod.sp-seller-preprod.ecomviser.com/index.php?p=invoice_download&key=MTczOjg0OmVjb212aXNlcg=="
+                        }
+                    ]
+                }
+            }
+        },
+        "on_status_delivered": {
+            "context": {
+                "domain": "ONDC:RET11",
+                "country": "IND",
+                "city": "std:0120",
+                "action": "on_status",
+                "core_version": "1.2.0",
+                "bap_id": "buyer-app-preprod-v2.ondc.org",
+                "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+                "bpp_uri": "https://ondc.ecomviser.com/api/v1",
+                "transaction_id": "bbeea929-e45e-48df-b3b7-d58a4a5301a7",
+                "message_id": "677bb17aeeb42ad85dc95-a084",
+                "timestamp": "2025-01-06T10:33:30.978Z",
+                "bpp_id": "ondc.ecomviser.com",
+                "ttl": "PT30S"
+            },
+            "message": {
+                "order": {
+                    "id": "2025-01-06-248869",
+                    "state": "Completed",
+                    "provider": {
+                        "id": "84",
+                        "locations": [
+                            {
+                                "id": "83"
+                            }
+                        ]
+                    },
+                    "items": [
+                        {
+                            "id": "451",
+                            "fulfillment_id": "155",
+                            "quantity": {
+                                "count": 1
+                            }
+                        }
+                    ],
+                    "fulfillments": [
+                        {
+                            "id": "155",
+                            "end": {
+                                "time": {
+                                    "range": {
+                                        "end": "2025-01-06T11:32:09.006Z",
+                                        "start": "2025-01-06T10:32:09.006Z"
+                                    },
+                                    "timestamp": "2025-01-06T10:33:30.387Z"
+                                },
+                                "person": {
+                                    "name": "Ajeet Chauhan"
+                                },
+                                "contact": {
+                                    "email": "ajeetchauhan.symfony143@webkul.in",
+                                    "phone": "8574739650"
+                                },
+                                "location": {
+                                    "gps": "28.629743,77.377795",
+                                    "address": {
+                                        "city": "Noida",
+                                        "name": "Ajeet Chauhan",
+                                        "state": "Uttar Pradesh",
+                                        "country": "IND",
+                                        "building": "ARV Park",
+                                        "locality": "Unnamed Road",
+                                        "area_code": "201301"
+                                    }
+                                }
+                            },
+                            "type": "Delivery",
+                            "start": {
+                                "time": {
+                                    "range": {
+                                        "end": "2025-01-06T11:32:09.006Z",
+                                        "start": "2025-01-06T10:32:09.006Z"
+                                    },
+                                    "timestamp": "2025-01-06T10:33:14.727Z"
+                                },
+                                "contact": {
+                                    "email": "support@webkul.in",
+                                    "phone": "9876543210"
+                                },
+                                "location": {
+                                    "id": "83",
+                                    "gps": "28.62972640,77.37783230",
+                                    "address": {
+                                        "city": "Gautam Buddh Nagar",
+                                        "state": "Uttar Pradesh",
+                                        "locality": "Noida",
+                                        "area_code": "201301"
+                                    },
+                                    "descriptor": {
+                                        "name": "Ajeet Food Shop"
+                                    }
+                                }
+                            },
+                            "state": {
+                                "descriptor": {
+                                    "code": "Order-delivered"
+                                }
+                            },
+                            "tracking": true,
+                            "@ondc/org/TAT": "PT90M",
+                            "@ondc/org/provider_name": "ondc.ecomviser.com",
+                            "tags": [
+                                {
+                                    "code": "routing",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "P2P"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "tracking",
+                                    "list": [
+                                        {
+                                            "code": "gps_enabled",
+                                            "value": "yes"
+                                        },
+                                        {
+                                            "code": "url_enabled",
+                                            "value": "no"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ],
+                    "quote": {
+                        "ttl": "PT6H",
+                        "price": {
+                            "value": "164.63",
+                            "currency": "INR"
+                        },
+                        "breakup": [
+                            {
+                                "item": {
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "item"
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "price": {
+                                        "value": "99",
+                                        "currency": "INR"
+                                    },
+                                    "parent_item_id": "xvvxY6eaBE5I"
+                                },
+                                "price": {
+                                    "value": "99",
+                                    "currency": "INR"
+                                },
+                                "title": "Pizza Mania",
+                                "@ondc/org/item_id": "451",
+                                "@ondc/org/title_type": "item",
+                                "@ondc/org/item_quantity": {
+                                    "count": 1
+                                }
+                            },
+                            {
+                                "item": {
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "customization"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "parent",
+                                            "list": [
+                                                {
+                                                    "code": "id",
+                                                    "value": "66zabcdefghi"
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "price": {
+                                        "value": "10",
+                                        "currency": "INR"
+                                    },
+                                    "parent_item_id": "xvvxY6eaBE5I"
+                                },
+                                "price": {
+                                    "value": "10",
+                                    "currency": "INR"
+                                },
+                                "title": "Vegan",
+                                "@ondc/org/item_id": "94",
+                                "@ondc/org/title_type": "item",
+                                "@ondc/org/item_quantity": {
+                                    "count": 1
+                                }
+                            },
+                            {
+                                "item": {
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "customization"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "parent",
+                                            "list": [
+                                                {
+                                                    "code": "id",
+                                                    "value": "67zabcdefghi"
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "price": {
+                                        "value": "50",
+                                        "currency": "INR"
+                                    },
+                                    "parent_item_id": "xvvxY6eaBE5I"
+                                },
+                                "price": {
+                                    "value": "50",
+                                    "currency": "INR"
+                                },
+                                "title": "Mutton",
+                                "@ondc/org/item_id": "96",
+                                "@ondc/org/title_type": "item",
+                                "@ondc/org/item_quantity": {
+                                    "count": 1
+                                }
+                            },
+                            {
+                                "price": {
+                                    "value": "5.63",
+                                    "currency": "INR"
+                                },
+                                "title": "Convenience fee",
+                                "@ondc/org/item_id": "155",
+                                "@ondc/org/title_type": "misc"
+                            },
+                            {
+                                "price": {
+                                    "value": "0",
+                                    "currency": "INR"
+                                },
+                                "title": "Delivery charges",
+                                "@ondc/org/item_id": "155",
+                                "@ondc/org/title_type": "delivery"
+                            }
+                        ]
+                    },
+                    "billing": {
+                        "name": "Ajeet Chauhan",
+                        "email": "ajeetchauhan.symfony143@webkul.in",
+                        "phone": "8574739650",
+                        "address": {
+                            "city": "Noida",
+                            "name": "Ajeet Chauhan",
+                            "state": "Uttar Pradesh",
+                            "country": "IND",
+                            "building": "ARV Park",
+                            "locality": "Unnamed Road",
+                            "area_code": "201301"
+                        },
+                        "created_at": "2025-01-06T10:31:29.847Z",
+                        "updated_at": "2025-01-06T10:31:29.847Z"
+                    },
+                    "payment": {
+                        "uri": "https://razorpay.com/",
+                        "type": "ON-ORDER",
+                        "params": {
+                            "amount": "164.63",
+                            "currency": "INR",
+                            "transaction_id": "order_Pg7qlLR529ZmhG"
+                        },
+                        "status": "PAID",
+                        "tl_method": "http/get",
+                        "collected_by": "BAP",
+                        "@ondc/org/settlement_details": [
+                            {
+                                "bank_name": "fasdf",
+                                "branch_name": "noida",
+                                "settlement_type": "neft",
+                                "beneficiary_name": "fasdf asdfasdf",
+                                "settlement_phase": "sale-amount",
+                                "settlement_status": "NOT-PAID",
+                                "settlement_ifsc_code": "HDFC0000088",
+                                "settlement_counterparty": "seller-app",
+                                "settlement_bank_account_no": "534512341234132"
+                            }
+                        ],
+                        "@ondc/org/buyer_app_finder_fee_type": "percent",
+                        "@ondc/org/buyer_app_finder_fee_amount": "3.0"
+                    },
+                    "created_at": "2025-01-06T10:32:04.500Z",
+                    "updated_at": "2025-01-06T10:33:30.978Z",
+                    "documents": [
+                        {
+                            "label": "Invoice",
+                            "url": "https://ecomviser-prepod.sp-seller-preprod.ecomviser.com/index.php?p=invoice_download&key=MTczOjg0OmVjb212aXNlcg=="
+                        }
+                    ]
+                }
+            }
+        }
+    }
+}

--- a/eComviser/Seller App RET11/Flow-2/init.json
+++ b/eComviser/Seller App RET11/Flow-2/init.json
@@ -1,0 +1,149 @@
+{
+    "context": {
+        "domain": "ONDC:RET11",
+        "country": "IND",
+        "city": "std:0120",
+        "action": "init",
+        "core_version": "1.2.0",
+        "bap_id": "buyer-app-preprod-v2.ondc.org",
+        "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+        "bpp_uri": "https://ondc.ecomviser.com/api/v1",
+        "transaction_id": "bbeea929-e45e-48df-b3b7-d58a4a5301a7",
+        "message_id": "56c3ec3f-daaa-4ebb-a7bc-7c62470d052a",
+        "timestamp": "2025-01-06T10:31:29.847Z",
+        "bpp_id": "ondc.ecomviser.com",
+        "ttl": "PT30S"
+    },
+    "message": {
+        "order": {
+            "provider": {
+                "id": "84",
+                "locations": [
+                    {
+                        "id": "83"
+                    }
+                ]
+            },
+            "items": [
+                {
+                    "id": "451",
+                    "quantity": {
+                        "count": 1
+                    },
+                    "location_id": "83",
+                    "tags": [
+                        {
+                            "code": "type",
+                            "list": [
+                                {
+                                    "code": "type",
+                                    "value": "item"
+                                }
+                            ]
+                        }
+                    ],
+                    "parent_item_id": "xvvxY6eaBE5I",
+                    "fulfillment_id": "155"
+                },
+                {
+                    "id": "94",
+                    "quantity": {
+                        "count": 1
+                    },
+                    "location_id": "83",
+                    "tags": [
+                        {
+                            "code": "type",
+                            "list": [
+                                {
+                                    "code": "type",
+                                    "value": "customization"
+                                }
+                            ]
+                        },
+                        {
+                            "code": "parent",
+                            "list": [
+                                {
+                                    "code": "id",
+                                    "value": "66zabcdefghi"
+                                }
+                            ]
+                        }
+                    ],
+                    "fulfillment_id": "155",
+                    "parent_item_id": "xvvxY6eaBE5I"
+                },
+                {
+                    "id": "96",
+                    "quantity": {
+                        "count": 1
+                    },
+                    "location_id": "83",
+                    "tags": [
+                        {
+                            "code": "type",
+                            "list": [
+                                {
+                                    "code": "type",
+                                    "value": "customization"
+                                }
+                            ]
+                        },
+                        {
+                            "code": "parent",
+                            "list": [
+                                {
+                                    "code": "id",
+                                    "value": "67zabcdefghi"
+                                }
+                            ]
+                        }
+                    ],
+                    "fulfillment_id": "155",
+                    "parent_item_id": "xvvxY6eaBE5I"
+                }
+            ],
+            "billing": {
+                "address": {
+                    "building": "ARV Park",
+                    "city": "Noida",
+                    "state": "Uttar Pradesh",
+                    "country": "IND",
+                    "area_code": "201301",
+                    "locality": "Unnamed Road",
+                    "name": "Ajeet Chauhan"
+                },
+                "phone": "8574739650",
+                "name": "Ajeet Chauhan",
+                "email": "ajeetchauhan.symfony143@webkul.in",
+                "created_at": "2025-01-06T10:31:29.847Z",
+                "updated_at": "2025-01-06T10:31:29.847Z"
+            },
+            "fulfillments": [
+                {
+                    "id": "155",
+                    "type": "Delivery",
+                    "end": {
+                        "contact": {
+                            "email": "ajeetchauhan.symfony143@webkul.in",
+                            "phone": "8574739650"
+                        },
+                        "location": {
+                            "gps": "28.629743,77.377795",
+                            "address": {
+                                "building": "ARV Park",
+                                "city": "Noida",
+                                "state": "Uttar Pradesh",
+                                "country": "IND",
+                                "area_code": "201301",
+                                "locality": "Unnamed Road",
+                                "name": "Ajeet Chauhan"
+                            }
+                        }
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/eComviser/Seller App RET11/Flow-2/on_confirm.json
+++ b/eComviser/Seller App RET11/Flow-2/on_confirm.json
@@ -1,0 +1,381 @@
+{
+    "context": {
+        "domain": "ONDC:RET11",
+        "country": "IND",
+        "city": "std:0120",
+        "action": "on_confirm",
+        "core_version": "1.2.0",
+        "bap_id": "buyer-app-preprod-v2.ondc.org",
+        "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+        "bpp_uri": "https://ondc.ecomviser.com/api/v1",
+        "transaction_id": "bbeea929-e45e-48df-b3b7-d58a4a5301a7",
+        "message_id": "f772812e-326c-400d-920f-c57942de6df9",
+        "timestamp": "2025-01-06T10:32:07.911Z",
+        "bpp_id": "ondc.ecomviser.com"
+    },
+    "message": {
+        "order": {
+            "id": "2025-01-06-248869",
+            "state": "Created",
+            "provider": {
+                "id": "84",
+                "locations": [
+                    {
+                        "id": "83"
+                    }
+                ]
+            },
+            "items": [
+                {
+                    "id": "451",
+                    "quantity": {
+                        "count": 1
+                    },
+                    "fulfillment_id": "155",
+                    "tags": [
+                        {
+                            "code": "type",
+                            "list": [
+                                {
+                                    "code": "type",
+                                    "value": "item"
+                                }
+                            ]
+                        }
+                    ],
+                    "parent_item_id": "xvvxY6eaBE5I"
+                },
+                {
+                    "id": "94",
+                    "quantity": {
+                        "count": 1
+                    },
+                    "fulfillment_id": "155",
+                    "tags": [
+                        {
+                            "code": "type",
+                            "list": [
+                                {
+                                    "code": "type",
+                                    "value": "customization"
+                                }
+                            ]
+                        },
+                        {
+                            "code": "parent",
+                            "list": [
+                                {
+                                    "code": "id",
+                                    "value": "66zabcdefghi"
+                                }
+                            ]
+                        }
+                    ],
+                    "parent_item_id": "xvvxY6eaBE5I"
+                },
+                {
+                    "id": "96",
+                    "quantity": {
+                        "count": 1
+                    },
+                    "fulfillment_id": "155",
+                    "tags": [
+                        {
+                            "code": "type",
+                            "list": [
+                                {
+                                    "code": "type",
+                                    "value": "customization"
+                                }
+                            ]
+                        },
+                        {
+                            "code": "parent",
+                            "list": [
+                                {
+                                    "code": "id",
+                                    "value": "67zabcdefghi"
+                                }
+                            ]
+                        }
+                    ],
+                    "parent_item_id": "xvvxY6eaBE5I"
+                }
+            ],
+            "billing": {
+                "address": {
+                    "name": "Ajeet Chauhan",
+                    "building": "ARV Park",
+                    "locality": "Unnamed Road",
+                    "city": "Noida",
+                    "state": "Uttar Pradesh",
+                    "country": "IND",
+                    "area_code": "201301"
+                },
+                "phone": "8574739650",
+                "name": "Ajeet Chauhan",
+                "email": "ajeetchauhan.symfony143@webkul.in",
+                "created_at": "2025-01-06T10:31:29.847Z",
+                "updated_at": "2025-01-06T10:31:29.847Z"
+            },
+            "fulfillments": [
+                {
+                    "@ondc/org/TAT": "PT90M",
+                    "id": "155",
+                    "tracking": true,
+                    "end": {
+                        "contact": {
+                            "email": "ajeetchauhan.symfony143@webkul.in",
+                            "phone": "8574739650"
+                        },
+                        "person": {
+                            "name": "Ajeet Chauhan"
+                        },
+                        "location": {
+                            "gps": "28.629743,77.377795",
+                            "address": {
+                                "name": "Ajeet Chauhan",
+                                "building": "ARV Park",
+                                "locality": "Unnamed Road",
+                                "city": "Noida",
+                                "state": "Uttar Pradesh",
+                                "country": "IND",
+                                "area_code": "201301"
+                            }
+                        },
+                        "time": {
+                            "range": {
+                                "start": "2025-01-06T10:32:09.006Z",
+                                "end": "2025-01-06T11:32:09.006Z"
+                            }
+                        }
+                    },
+                    "type": "Delivery",
+                    "@ondc/org/provider_name": "ondc.ecomviser.com",
+                    "state": {
+                        "descriptor": {
+                            "code": "Pending"
+                        }
+                    },
+                    "start": {
+                        "location": {
+                            "id": "83",
+                            "descriptor": {
+                                "name": "Ajeet Food Shop"
+                            },
+                            "gps": "28.62972640,77.37783230",
+                            "address": {
+                                "locality": "Noida",
+                                "city": "Gautam Buddh Nagar",
+                                "area_code": "201301",
+                                "state": "Uttar Pradesh"
+                            }
+                        },
+                        "contact": {
+                            "phone": "9876543210",
+                            "email": "support@webkul.in"
+                        },
+                        "time": {
+                            "range": {
+                                "start": "2025-01-06T10:32:09.006Z",
+                                "end": "2025-01-06T11:32:09.006Z"
+                            }
+                        }
+                    }
+                }
+            ],
+            "quote": {
+                "price": {
+                    "currency": "INR",
+                    "value": "164.63"
+                },
+                "breakup": [
+                    {
+                        "title": "Pizza Mania",
+                        "price": {
+                            "currency": "INR",
+                            "value": "99"
+                        },
+                        "@ondc/org/title_type": "item",
+                        "@ondc/org/item_id": "451",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
+                        },
+                        "item": {
+                            "price": {
+                                "currency": "INR",
+                                "value": "99"
+                            },
+                            "parent_item_id": "xvvxY6eaBE5I",
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "item"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "title": "Vegan",
+                        "price": {
+                            "currency": "INR",
+                            "value": "10"
+                        },
+                        "@ondc/org/title_type": "item",
+                        "@ondc/org/item_id": "94",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
+                        },
+                        "item": {
+                            "price": {
+                                "currency": "INR",
+                                "value": "10"
+                            },
+                            "parent_item_id": "xvvxY6eaBE5I",
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "66zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "title": "Mutton",
+                        "price": {
+                            "currency": "INR",
+                            "value": "50"
+                        },
+                        "@ondc/org/title_type": "item",
+                        "@ondc/org/item_id": "96",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
+                        },
+                        "item": {
+                            "price": {
+                                "currency": "INR",
+                                "value": "50"
+                            },
+                            "parent_item_id": "xvvxY6eaBE5I",
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "67zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "title": "Convenience fee",
+                        "price": {
+                            "currency": "INR",
+                            "value": "5.63"
+                        },
+                        "@ondc/org/title_type": "misc",
+                        "@ondc/org/item_id": "155"
+                    },
+                    {
+                        "title": "Delivery charges",
+                        "price": {
+                            "currency": "INR",
+                            "value": "0"
+                        },
+                        "@ondc/org/title_type": "delivery",
+                        "@ondc/org/item_id": "155"
+                    }
+                ],
+                "ttl": "PT6H"
+            },
+            "payment": {
+                "uri": "https://razorpay.com/",
+                "tl_method": "http/get",
+                "params": {
+                    "amount": "164.63",
+                    "currency": "INR",
+                    "transaction_id": "order_Pg7qlLR529ZmhG"
+                },
+                "status": "PAID",
+                "type": "ON-ORDER",
+                "collected_by": "BAP",
+                "@ondc/org/buyer_app_finder_fee_type": "percent",
+                "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+                "@ondc/org/settlement_details": [
+                    {
+                        "settlement_counterparty": "seller-app",
+                        "settlement_phase": "sale-amount",
+                        "settlement_type": "neft",
+                        "beneficiary_name": "fasdf asdfasdf",
+                        "settlement_bank_account_no": "534512341234132",
+                        "settlement_ifsc_code": "HDFC0000088",
+                        "bank_name": "fasdf",
+                        "branch_name": "noida",
+                        "settlement_status": "NOT-PAID"
+                    }
+                ]
+            },
+            "tags": [
+                {
+                    "code": "bpp_terms",
+                    "list": [
+                        {
+                            "code": "np_type",
+                            "value": "MSN"
+                        },
+                        {
+                            "code": "tax_number",
+                            "value": "09AABCW0339G3ZD"
+                        },
+                        {
+                            "code": "provider_tax_number",
+                            "value": "DERTC3376R"
+                        }
+                    ]
+                },
+                {
+                    "code": "bap_terms",
+                    "list": [
+                        {
+                            "code": "tax_number",
+                            "value": "GSTIN1234567890"
+                        }
+                    ]
+                }
+            ],
+            "created_at": "2025-01-06T10:32:04.500Z",
+            "updated_at": "2025-01-06T10:32:07.911Z"
+        }
+    }
+}

--- a/eComviser/Seller App RET11/Flow-2/on_init.json
+++ b/eComviser/Seller App RET11/Flow-2/on_init.json
@@ -1,0 +1,317 @@
+{
+    "context": {
+        "domain": "ONDC:RET11",
+        "country": "IND",
+        "city": "std:0120",
+        "action": "on_init",
+        "core_version": "1.2.0",
+        "bap_id": "buyer-app-preprod-v2.ondc.org",
+        "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+        "bpp_uri": "https://ondc.ecomviser.com/api/v1",
+        "transaction_id": "bbeea929-e45e-48df-b3b7-d58a4a5301a7",
+        "message_id": "56c3ec3f-daaa-4ebb-a7bc-7c62470d052a",
+        "timestamp": "2025-01-06T10:31:32.428Z",
+        "bpp_id": "ondc.ecomviser.com",
+        "ttl": "PT30S"
+    },
+    "message": {
+        "order": {
+            "provider": {
+                "id": "84",
+                "locations": [
+                    {
+                        "id": "83"
+                    }
+                ]
+            },
+            "items": [
+                {
+                    "id": "451",
+                    "fulfillment_id": "155",
+                    "quantity": {
+                        "count": 1
+                    },
+                    "parent_item_id": "xvvxY6eaBE5I",
+                    "tags": [
+                        {
+                            "code": "type",
+                            "list": [
+                                {
+                                    "code": "type",
+                                    "value": "item"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "id": "94",
+                    "fulfillment_id": "155",
+                    "quantity": {
+                        "count": 1
+                    },
+                    "parent_item_id": "xvvxY6eaBE5I",
+                    "tags": [
+                        {
+                            "code": "type",
+                            "list": [
+                                {
+                                    "code": "type",
+                                    "value": "customization"
+                                }
+                            ]
+                        },
+                        {
+                            "code": "parent",
+                            "list": [
+                                {
+                                    "code": "id",
+                                    "value": "66zabcdefghi"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "id": "96",
+                    "fulfillment_id": "155",
+                    "quantity": {
+                        "count": 1
+                    },
+                    "parent_item_id": "xvvxY6eaBE5I",
+                    "tags": [
+                        {
+                            "code": "type",
+                            "list": [
+                                {
+                                    "code": "type",
+                                    "value": "customization"
+                                }
+                            ]
+                        },
+                        {
+                            "code": "parent",
+                            "list": [
+                                {
+                                    "code": "id",
+                                    "value": "67zabcdefghi"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "quote": {
+                "price": {
+                    "currency": "INR",
+                    "value": "164.63"
+                },
+                "breakup": [
+                    {
+                        "title": "Pizza Mania",
+                        "price": {
+                            "currency": "INR",
+                            "value": "99"
+                        },
+                        "@ondc/org/title_type": "item",
+                        "@ondc/org/item_id": "451",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
+                        },
+                        "item": {
+                            "price": {
+                                "currency": "INR",
+                                "value": "99"
+                            },
+                            "parent_item_id": "xvvxY6eaBE5I",
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "item"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "title": "Vegan",
+                        "price": {
+                            "currency": "INR",
+                            "value": "10"
+                        },
+                        "@ondc/org/title_type": "item",
+                        "@ondc/org/item_id": "94",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
+                        },
+                        "item": {
+                            "price": {
+                                "currency": "INR",
+                                "value": "10"
+                            },
+                            "parent_item_id": "xvvxY6eaBE5I",
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "66zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "title": "Mutton",
+                        "price": {
+                            "currency": "INR",
+                            "value": "50"
+                        },
+                        "@ondc/org/title_type": "item",
+                        "@ondc/org/item_id": "96",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
+                        },
+                        "item": {
+                            "price": {
+                                "currency": "INR",
+                                "value": "50"
+                            },
+                            "parent_item_id": "xvvxY6eaBE5I",
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "67zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "title": "Convenience fee",
+                        "price": {
+                            "currency": "INR",
+                            "value": "5.63"
+                        },
+                        "@ondc/org/title_type": "misc",
+                        "@ondc/org/item_id": "155"
+                    },
+                    {
+                        "title": "Delivery charges",
+                        "price": {
+                            "currency": "INR",
+                            "value": "0"
+                        },
+                        "@ondc/org/title_type": "delivery",
+                        "@ondc/org/item_id": "155"
+                    }
+                ],
+                "ttl": "PT6H"
+            },
+            "billing": {
+                "address": {
+                    "building": "ARV Park",
+                    "city": "Noida",
+                    "state": "Uttar Pradesh",
+                    "country": "IND",
+                    "area_code": "201301",
+                    "locality": "Unnamed Road",
+                    "name": "Ajeet Chauhan"
+                },
+                "phone": "8574739650",
+                "name": "Ajeet Chauhan",
+                "email": "ajeetchauhan.symfony143@webkul.in",
+                "created_at": "2025-01-06T10:31:29.847Z",
+                "updated_at": "2025-01-06T10:31:29.847Z"
+            },
+            "fulfillments": [
+                {
+                    "id": "155",
+                    "type": "Delivery",
+                    "end": {
+                        "contact": {
+                            "email": "ajeetchauhan.symfony143@webkul.in",
+                            "phone": "8574739650"
+                        },
+                        "location": {
+                            "gps": "28.629743,77.377795",
+                            "address": {
+                                "building": "ARV Park",
+                                "city": "Noida",
+                                "state": "Uttar Pradesh",
+                                "country": "IND",
+                                "area_code": "201301",
+                                "locality": "Unnamed Road",
+                                "name": "Ajeet Chauhan"
+                            }
+                        }
+                    },
+                    "tracking": true
+                }
+            ],
+            "payment": {
+                "type": "ON-ORDER",
+                "collected_by": "BAP",
+                "@ondc/org/collected_by_status": "Agree",
+                "@ondc/org/buyer_app_finder_fee_type": "percent",
+                "@ondc/org/buyer_app_finder_fee_amount": "3",
+                "@ondc/org/settlement_details": [
+                    {
+                        "settlement_counterparty": "seller-app",
+                        "settlement_phase": "sale-amount",
+                        "settlement_type": "neft",
+                        "beneficiary_name": "fasdf asdfasdf",
+                        "settlement_bank_account_no": "534512341234132",
+                        "settlement_ifsc_code": "HDFC0000088",
+                        "bank_name": "fasdf",
+                        "branch_name": "noida",
+                        "settlement_status": "NOT-PAID"
+                    }
+                ]
+            },
+            "tags": [
+                {
+                    "code": "bpp_terms",
+                    "list": [
+                        {
+                            "code": "tax_number",
+                            "value": "09AABCW0339G3ZD"
+                        },
+                        {
+                            "code": "provider_tax_number",
+                            "value": "DERTC3376R"
+                        }
+                    ]
+                }
+            ]
+        }
+    }
+}

--- a/eComviser/Seller App RET11/Flow-2/on_search.json
+++ b/eComviser/Seller App RET11/Flow-2/on_search.json
@@ -1,0 +1,657 @@
+{
+    "context": {
+        "domain": "ONDC:RET11",
+        "action": "on_search",
+        "country": "IND",
+        "city": "std:0120",
+        "core_version": "1.2.0",
+        "bap_id": "buyer-app-preprod-v2.ondc.org",
+        "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+        "transaction_id": "0646bc94-5d3d-4b2d-9852-a8a33843dbb9",
+        "message_id": "36c56392-f004-4813-ace5-0d40033a8420",
+        "timestamp": "2025-01-06T10:11:35.354Z",
+        "ttl": "PT30S",
+        "bpp_id": "ondc.ecomviser.com",
+        "bpp_uri": "https://ondc.ecomviser.com/api/v1"
+    },
+    "message": {
+        "catalog": {
+            "bpp/descriptor": {
+                "name": "Webkul",
+                "symbol": "https://ondc.ecomviser.com/public/img/webkul_logo.png",
+                "short_desc": "Enterprise Digital Commerce & Marketplace Solution Experts",
+                "long_desc": "Helping companies with our industry-leading digital commerce, ERP, and CRM solutions. In the last 13 years, we have served 150K+ clients worldwide to handle complex operations and grow their businesses",
+                "images": [
+                    "https://ondc.ecomviser.com/public/img/webkul_banner.png",
+                    "https://ondc.ecomviser.com/public/img/webkul_clients.png",
+                    "https://ondc.ecomviser.com/public/img/webkul_awards.png"
+                ],
+                "tags": [
+                    {
+                        "code": "bpp_terms",
+                        "list": [
+                            {
+                                "code": "np_type",
+                                "value": "MSN"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "bpp/fulfillments": [
+                {
+                    "id": "155",
+                    "type": "Delivery"
+                }
+            ],
+            "bpp/providers": [
+                {
+                    "id": "84",
+                    "time": {
+                        "label": "enable",
+                        "timestamp": "2025-01-06T09:41:34.774Z"
+                    },
+                    "descriptor": {
+                        "name": "Ajeet Food Shop",
+                        "symbol": "https://ondc-prepod-digital-delivery.s3.amazonaws.com/seller_shop_logo/84/39MylDtZVC.jpg",
+                        "short_desc": "short desc",
+                        "long_desc": "store desc",
+                        "images": [
+                            "https://ondc-prepod-digital-delivery.s3.amazonaws.com/seller_shop_logo/84/39MylDtZVC.jpg"
+                        ]
+                    },
+                    "fulfillments": [
+                        {
+                            "id": "155",
+                            "type": "Delivery",
+                            "contact": {
+                                "phone": "9812345678",
+                                "email": "ajeetchauhan.symfony143@webkul.in"
+                            }
+                        }
+                    ],
+                    "locations": [
+                        {
+                            "id": "83",
+                            "gps": "28.62972640,77.37783230",
+                            "address": {
+                                "locality": "Noida",
+                                "street": "H-28",
+                                "city": "Gautam Buddh Nagar",
+                                "area_code": "201301",
+                                "state": "Uttar Pradesh"
+                            },
+                            "circle": {
+                                "gps": "28.62972640,77.37783230",
+                                "radius": {
+                                    "unit": "km",
+                                    "value": "5"
+                                }
+                            },
+                            "time": {
+                                "label": "enable",
+                                "timestamp": "2025-01-06T09:41:34.774Z",
+                                "days": "1,2,3,4,5,6,7",
+                                "schedule": {
+                                    "holidays": []
+                                },
+                                "range": {
+                                    "start": "0800",
+                                    "end": "1707"
+                                }
+                            }
+                        }
+                    ],
+                    "@ondc/org/fssai_license_no": "12345678908898",
+                    "categories": [
+                        {
+                            "id": "66zabcdefghi",
+                            "descriptor": {
+                                "name": "Cheese"
+                            },
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "custom_group"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "config",
+                                    "list": [
+                                        {
+                                            "code": "min",
+                                            "value": "1"
+                                        },
+                                        {
+                                            "code": "max",
+                                            "value": "1"
+                                        },
+                                        {
+                                            "code": "input",
+                                            "value": "select"
+                                        },
+                                        {
+                                            "code": "seq",
+                                            "value": "1"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "67zabcdefghi",
+                            "descriptor": {
+                                "name": "Non-veg toppings"
+                            },
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "custom_group"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "config",
+                                    "list": [
+                                        {
+                                            "code": "min",
+                                            "value": "1"
+                                        },
+                                        {
+                                            "code": "max",
+                                            "value": "1"
+                                        },
+                                        {
+                                            "code": "input",
+                                            "value": "select"
+                                        },
+                                        {
+                                            "code": "seq",
+                                            "value": "2"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "844147zabcde",
+                            "parent_category_id": "",
+                            "descriptor": {
+                                "name": "Pizza",
+                                "short_desc": "Pizza",
+                                "long_desc": "Pizza"
+                            },
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "custom_menu"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "display",
+                                    "list": [
+                                        {
+                                            "code": "rank",
+                                            "value": "1"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "timing",
+                                    "list": [
+                                        {
+                                            "code": "day_from",
+                                            "value": "1"
+                                        },
+                                        {
+                                            "code": "day_to",
+                                            "value": "5"
+                                        },
+                                        {
+                                            "code": "time_from",
+                                            "value": "0800"
+                                        },
+                                        {
+                                            "code": "time_to",
+                                            "value": "2200"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ],
+                    "items": [
+                        {
+                            "id": "451",
+                            "time": {
+                                "label": "enable",
+                                "timestamp": "2025-01-06T09:41:34.774Z"
+                            },
+                            "descriptor": {
+                                "name": "Pizza Mania",
+                                "symbol": "https://d3bhszwz094mhs.cloudfront.net/product_img/main_img/342/NipTw8cSUY.jpeg",
+                                "short_desc": "pizza best small",
+                                "long_desc": "best pizza",
+                                "images": [
+                                    "https://d3bhszwz094mhs.cloudfront.net/product_img/main_img/342/NipTw8cSUY.jpeg"
+                                ]
+                            },
+                            "price": {
+                                "currency": "INR",
+                                "value": "99",
+                                "maximum_value": "110",
+                                "tags": [
+                                    {
+                                        "code": "range",
+                                        "list": [
+                                            {
+                                                "code": "lower",
+                                                "value": "99.00"
+                                            },
+                                            {
+                                                "code": "upper",
+                                                "value": "159"
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "code": "default_selection",
+                                        "list": [
+                                            {
+                                                "code": "value",
+                                                "value": "99.00"
+                                            },
+                                            {
+                                                "code": "maximum_value",
+                                                "value": "159"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            "quantity": {
+                                "available": {
+                                    "count": "99"
+                                },
+                                "maximum": {
+                                    "count": "99"
+                                },
+                                "unitized": {
+                                    "measure": {
+                                        "unit": "gram",
+                                        "value": "200"
+                                    }
+                                }
+                            },
+                            "location_id": "83",
+                            "category_id": "F&B",
+                            "fulfillment_id": "155",
+                            "@ondc/org/time_to_ship": "PT1H",
+                            "@ondc/org/cancellable": true,
+                            "@ondc/org/seller_pickup_return": false,
+                            "@ondc/org/returnable": false,
+                            "@ondc/org/return_window": "PT0S",
+                            "@ondc/org/available_on_cod": false,
+                            "@ondc/org/contact_details_consumer_care": "ajeet,ajeetchauhan.symfony143@webkul.in,9812345678",
+                            "tags": [
+                                {
+                                    "code": "origin",
+                                    "list": [
+                                        {
+                                            "code": "country",
+                                            "value": "IND"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "item"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "custom_group",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "66zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "category_ids": [
+                                "844147zabcde:1"
+                            ]
+                        },
+                        {
+                            "id": "93",
+                            "descriptor": {
+                                "name": "Extra"
+                            },
+                            "quantity": {
+                                "available": {
+                                    "count": "99"
+                                },
+                                "maximum": {
+                                    "count": "99"
+                                }
+                            },
+                            "price": {
+                                "currency": "INR",
+                                "value": "5.00",
+                                "maximum_value": "5.00"
+                            },
+                            "category_id": "F&B",
+                            "related": true,
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "66zabcdefghi"
+                                        },
+                                        {
+                                            "code": "default",
+                                            "value": "yes"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "veg_nonveg",
+                                    "list": [
+                                        {
+                                            "code": "veg",
+                                            "value": "yes"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "child",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "67zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "94",
+                            "descriptor": {
+                                "name": "Vegan"
+                            },
+                            "quantity": {
+                                "available": {
+                                    "count": "99"
+                                },
+                                "maximum": {
+                                    "count": "99"
+                                }
+                            },
+                            "price": {
+                                "currency": "INR",
+                                "value": "10.00",
+                                "maximum_value": "10.00"
+                            },
+                            "category_id": "F&B",
+                            "related": true,
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "66zabcdefghi"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "veg_nonveg",
+                                    "list": [
+                                        {
+                                            "code": "veg",
+                                            "value": "yes"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "child",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "67zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "95",
+                            "descriptor": {
+                                "name": "Chicken"
+                            },
+                            "quantity": {
+                                "available": {
+                                    "count": "99"
+                                },
+                                "maximum": {
+                                    "count": "99"
+                                }
+                            },
+                            "price": {
+                                "currency": "INR",
+                                "value": "10.00",
+                                "maximum_value": "10.00"
+                            },
+                            "category_id": "F&B",
+                            "related": true,
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "67zabcdefghi"
+                                        },
+                                        {
+                                            "code": "default",
+                                            "value": "yes"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "veg_nonveg",
+                                    "list": [
+                                        {
+                                            "code": "non_veg",
+                                            "value": "yes"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "96",
+                            "descriptor": {
+                                "name": "Mutton"
+                            },
+                            "quantity": {
+                                "available": {
+                                    "count": "99"
+                                },
+                                "maximum": {
+                                    "count": "99"
+                                }
+                            },
+                            "price": {
+                                "currency": "INR",
+                                "value": "50.00",
+                                "maximum_value": "50.00"
+                            },
+                            "category_id": "F&B",
+                            "related": true,
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "67zabcdefghi"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "veg_nonveg",
+                                    "list": [
+                                        {
+                                            "code": "veg",
+                                            "value": "yes"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ],
+                    "tags": [
+                        {
+                            "code": "timing",
+                            "list": [
+                                {
+                                    "code": "type",
+                                    "value": "Order"
+                                },
+                                {
+                                    "code": "location",
+                                    "value": "83"
+                                },
+                                {
+                                    "code": "day_from",
+                                    "value": "1"
+                                },
+                                {
+                                    "code": "day_to",
+                                    "value": "7"
+                                },
+                                {
+                                    "code": "time_from",
+                                    "value": "0900"
+                                },
+                                {
+                                    "code": "time_to",
+                                    "value": "2300"
+                                }
+                            ]
+                        },
+                        {
+                            "code": "timing",
+                            "list": [
+                                {
+                                    "code": "type",
+                                    "value": "Delivery"
+                                },
+                                {
+                                    "code": "location",
+                                    "value": "83"
+                                },
+                                {
+                                    "code": "day_from",
+                                    "value": "1"
+                                },
+                                {
+                                    "code": "day_to",
+                                    "value": "7"
+                                },
+                                {
+                                    "code": "time_from",
+                                    "value": "1000"
+                                },
+                                {
+                                    "code": "time_to",
+                                    "value": "2100"
+                                }
+                            ]
+                        },
+                        {
+                            "code": "serviceability",
+                            "list": [
+                                {
+                                    "code": "location",
+                                    "value": "83"
+                                },
+                                {
+                                    "code": "category",
+                                    "value": "F&B"
+                                },
+                                {
+                                    "code": "type",
+                                    "value": "10"
+                                },
+                                {
+                                    "code": "val",
+                                    "value": "5"
+                                },
+                                {
+                                    "code": "unit",
+                                    "value": "km"
+                                }
+                            ]
+                        }
+                    ],
+                    "ttl": "P1D"
+                }
+            ]
+        }
+    }
+}

--- a/eComviser/Seller App RET11/Flow-2/on_select.json
+++ b/eComviser/Seller App RET11/Flow-2/on_select.json
@@ -1,0 +1,270 @@
+{
+    "context": {
+        "domain": "ONDC:RET11",
+        "country": "IND",
+        "city": "std:0120",
+        "action": "on_select",
+        "core_version": "1.2.0",
+        "bap_id": "buyer-app-preprod-v2.ondc.org",
+        "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+        "bpp_uri": "https://ondc.ecomviser.com/api/v1",
+        "transaction_id": "bbeea929-e45e-48df-b3b7-d58a4a5301a7",
+        "message_id": "3d2694e7-9b62-431e-b44d-4f1725292759",
+        "timestamp": "2025-01-06T10:31:16.574Z",
+        "bpp_id": "ondc.ecomviser.com"
+    },
+    "message": {
+        "order": {
+            "provider": {
+                "id": "84",
+                "locations": [
+                    {
+                        "id": "83"
+                    }
+                ]
+            },
+            "items": [
+                {
+                    "id": "451",
+                    "fulfillment_id": "155",
+                    "parent_item_id": "xvvxY6eaBE5I",
+                    "tags": [
+                        {
+                            "code": "type",
+                            "list": [
+                                {
+                                    "code": "type",
+                                    "value": "item"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "id": "94",
+                    "fulfillment_id": "155",
+                    "parent_item_id": "xvvxY6eaBE5I",
+                    "tags": [
+                        {
+                            "code": "type",
+                            "list": [
+                                {
+                                    "code": "type",
+                                    "value": "customization"
+                                }
+                            ]
+                        },
+                        {
+                            "code": "parent",
+                            "list": [
+                                {
+                                    "code": "id",
+                                    "value": "66zabcdefghi"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "id": "96",
+                    "fulfillment_id": "155",
+                    "parent_item_id": "xvvxY6eaBE5I",
+                    "tags": [
+                        {
+                            "code": "type",
+                            "list": [
+                                {
+                                    "code": "type",
+                                    "value": "customization"
+                                }
+                            ]
+                        },
+                        {
+                            "code": "parent",
+                            "list": [
+                                {
+                                    "code": "id",
+                                    "value": "67zabcdefghi"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "fulfillments": [
+                {
+                    "id": "155",
+                    "type": "Delivery",
+                    "@ondc/org/provider_name": "ondc.ecomviser.com",
+                    "tracking": true,
+                    "@ondc/org/category": "Immediate Delivery",
+                    "@ondc/org/TAT": "PT90M",
+                    "state": {
+                        "descriptor": {
+                            "code": "Serviceable"
+                        }
+                    }
+                }
+            ],
+            "quote": {
+                "price": {
+                    "currency": "INR",
+                    "value": "164.63"
+                },
+                "breakup": [
+                    {
+                        "title": "Pizza Mania",
+                        "price": {
+                            "currency": "INR",
+                            "value": "99"
+                        },
+                        "@ondc/org/title_type": "item",
+                        "@ondc/org/item_id": "451",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
+                        },
+                        "item": {
+                            "price": {
+                                "currency": "INR",
+                                "value": "99"
+                            },
+                            "quantity": {
+                                "available": {
+                                    "count": "99"
+                                },
+                                "maximum": {
+                                    "count": "99"
+                                }
+                            },
+                            "parent_item_id": "xvvxY6eaBE5I",
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "item"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "title": "Vegan",
+                        "price": {
+                            "currency": "INR",
+                            "value": "10"
+                        },
+                        "@ondc/org/title_type": "item",
+                        "@ondc/org/item_id": "94",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
+                        },
+                        "item": {
+                            "price": {
+                                "currency": "INR",
+                                "value": "10"
+                            },
+                            "quantity": {
+                                "available": {
+                                    "count": "99"
+                                },
+                                "maximum": {
+                                    "count": "99"
+                                }
+                            },
+                            "parent_item_id": "xvvxY6eaBE5I",
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "66zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "title": "Mutton",
+                        "price": {
+                            "currency": "INR",
+                            "value": "50"
+                        },
+                        "@ondc/org/title_type": "item",
+                        "@ondc/org/item_id": "96",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
+                        },
+                        "item": {
+                            "price": {
+                                "currency": "INR",
+                                "value": "50"
+                            },
+                            "quantity": {
+                                "available": {
+                                    "count": "99"
+                                },
+                                "maximum": {
+                                    "count": "99"
+                                }
+                            },
+                            "parent_item_id": "xvvxY6eaBE5I",
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "67zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "title": "Convenience fee",
+                        "price": {
+                            "currency": "INR",
+                            "value": "5.63"
+                        },
+                        "@ondc/org/title_type": "misc",
+                        "@ondc/org/item_id": "155"
+                    },
+                    {
+                        "title": "Delivery charges",
+                        "price": {
+                            "currency": "INR",
+                            "value": "0"
+                        },
+                        "@ondc/org/title_type": "delivery",
+                        "@ondc/org/item_id": "155"
+                    }
+                ],
+                "ttl": "PT6H"
+            }
+        }
+    }
+}

--- a/eComviser/Seller App RET11/Flow-2/on_status_agent_assigned.json
+++ b/eComviser/Seller App RET11/Flow-2/on_status_agent_assigned.json
@@ -1,0 +1,286 @@
+{
+    "context": {
+        "domain": "ONDC:RET11",
+        "country": "IND",
+        "city": "std:0120",
+        "action": "on_status",
+        "core_version": "1.2.0",
+        "bap_id": "buyer-app-preprod-v2.ondc.org",
+        "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+        "bpp_uri": "https://ondc.ecomviser.com/api/v1",
+        "transaction_id": "bbeea929-e45e-48df-b3b7-d58a4a5301a7",
+        "message_id": "677bb16388b49f15553e6-e888",
+        "timestamp": "2025-01-06T10:33:07.560Z",
+        "bpp_id": "ondc.ecomviser.com",
+        "ttl": "PT30S"
+    },
+    "message": {
+        "order": {
+            "id": "2025-01-06-248869",
+            "state": "In-progress",
+            "provider": {
+                "id": "84",
+                "locations": [
+                    {
+                        "id": "83"
+                    }
+                ]
+            },
+            "items": [
+                {
+                    "id": "451",
+                    "fulfillment_id": "155",
+                    "quantity": {
+                        "count": 1
+                    }
+                }
+            ],
+            "fulfillments": [
+                {
+                    "id": "155",
+                    "end": {
+                        "time": {
+                            "range": {
+                                "end": "2025-01-06T11:32:09.006Z",
+                                "start": "2025-01-06T10:32:09.006Z"
+                            }
+                        },
+                        "person": {
+                            "name": "Ajeet Chauhan"
+                        },
+                        "contact": {
+                            "email": "ajeetchauhan.symfony143@webkul.in",
+                            "phone": "8574739650"
+                        },
+                        "location": {
+                            "gps": "28.629743,77.377795",
+                            "address": {
+                                "city": "Noida",
+                                "name": "Ajeet Chauhan",
+                                "state": "Uttar Pradesh",
+                                "country": "IND",
+                                "building": "ARV Park",
+                                "locality": "Unnamed Road",
+                                "area_code": "201301"
+                            }
+                        }
+                    },
+                    "type": "Delivery",
+                    "start": {
+                        "time": {
+                            "range": {
+                                "end": "2025-01-06T11:32:09.006Z",
+                                "start": "2025-01-06T10:32:09.006Z"
+                            }
+                        },
+                        "contact": {
+                            "email": "support@webkul.in",
+                            "phone": "9876543210"
+                        },
+                        "location": {
+                            "id": "83",
+                            "gps": "28.62972640,77.37783230",
+                            "address": {
+                                "city": "Gautam Buddh Nagar",
+                                "state": "Uttar Pradesh",
+                                "locality": "Noida",
+                                "area_code": "201301"
+                            },
+                            "descriptor": {
+                                "name": "Ajeet Food Shop"
+                            }
+                        }
+                    },
+                    "state": {
+                        "descriptor": {
+                            "code": "Agent-assigned"
+                        }
+                    },
+                    "tracking": true,
+                    "@ondc/org/TAT": "PT90M",
+                    "@ondc/org/provider_name": "ondc.ecomviser.com"
+                }
+            ],
+            "quote": {
+                "ttl": "PT6H",
+                "price": {
+                    "value": "164.63",
+                    "currency": "INR"
+                },
+                "breakup": [
+                    {
+                        "item": {
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "item"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "price": {
+                                "value": "99",
+                                "currency": "INR"
+                            },
+                            "parent_item_id": "xvvxY6eaBE5I"
+                        },
+                        "price": {
+                            "value": "99",
+                            "currency": "INR"
+                        },
+                        "title": "Pizza Mania",
+                        "@ondc/org/item_id": "451",
+                        "@ondc/org/title_type": "item",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
+                        }
+                    },
+                    {
+                        "item": {
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "66zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "price": {
+                                "value": "10",
+                                "currency": "INR"
+                            },
+                            "parent_item_id": "xvvxY6eaBE5I"
+                        },
+                        "price": {
+                            "value": "10",
+                            "currency": "INR"
+                        },
+                        "title": "Vegan",
+                        "@ondc/org/item_id": "94",
+                        "@ondc/org/title_type": "item",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
+                        }
+                    },
+                    {
+                        "item": {
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "67zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "price": {
+                                "value": "50",
+                                "currency": "INR"
+                            },
+                            "parent_item_id": "xvvxY6eaBE5I"
+                        },
+                        "price": {
+                            "value": "50",
+                            "currency": "INR"
+                        },
+                        "title": "Mutton",
+                        "@ondc/org/item_id": "96",
+                        "@ondc/org/title_type": "item",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
+                        }
+                    },
+                    {
+                        "price": {
+                            "value": "5.63",
+                            "currency": "INR"
+                        },
+                        "title": "Convenience fee",
+                        "@ondc/org/item_id": "155",
+                        "@ondc/org/title_type": "misc"
+                    },
+                    {
+                        "price": {
+                            "value": "0",
+                            "currency": "INR"
+                        },
+                        "title": "Delivery charges",
+                        "@ondc/org/item_id": "155",
+                        "@ondc/org/title_type": "delivery"
+                    }
+                ]
+            },
+            "billing": {
+                "name": "Ajeet Chauhan",
+                "email": "ajeetchauhan.symfony143@webkul.in",
+                "phone": "8574739650",
+                "address": {
+                    "city": "Noida",
+                    "name": "Ajeet Chauhan",
+                    "state": "Uttar Pradesh",
+                    "country": "IND",
+                    "building": "ARV Park",
+                    "locality": "Unnamed Road",
+                    "area_code": "201301"
+                },
+                "created_at": "2025-01-06T10:31:29.847Z",
+                "updated_at": "2025-01-06T10:31:29.847Z"
+            },
+            "payment": {
+                "uri": "https://razorpay.com/",
+                "type": "ON-ORDER",
+                "params": {
+                    "amount": "164.63",
+                    "currency": "INR",
+                    "transaction_id": "order_Pg7qlLR529ZmhG"
+                },
+                "status": "PAID",
+                "tl_method": "http/get",
+                "collected_by": "BAP",
+                "@ondc/org/settlement_details": [
+                    {
+                        "bank_name": "fasdf",
+                        "branch_name": "noida",
+                        "settlement_type": "neft",
+                        "beneficiary_name": "fasdf asdfasdf",
+                        "settlement_phase": "sale-amount",
+                        "settlement_status": "NOT-PAID",
+                        "settlement_ifsc_code": "HDFC0000088",
+                        "settlement_counterparty": "seller-app",
+                        "settlement_bank_account_no": "534512341234132"
+                    }
+                ],
+                "@ondc/org/buyer_app_finder_fee_type": "percent",
+                "@ondc/org/buyer_app_finder_fee_amount": "3.0"
+            },
+            "created_at": "2025-01-06T10:32:04.500Z",
+            "updated_at": "2025-01-06T10:33:07.560Z"
+        }
+    }
+}

--- a/eComviser/Seller App RET11/Flow-2/on_status_delivered.json
+++ b/eComviser/Seller App RET11/Flow-2/on_status_delivered.json
@@ -1,0 +1,318 @@
+{
+    "context": {
+        "domain": "ONDC:RET11",
+        "country": "IND",
+        "city": "std:0120",
+        "action": "on_status",
+        "core_version": "1.2.0",
+        "bap_id": "buyer-app-preprod-v2.ondc.org",
+        "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+        "bpp_uri": "https://ondc.ecomviser.com/api/v1",
+        "transaction_id": "bbeea929-e45e-48df-b3b7-d58a4a5301a7",
+        "message_id": "677bb17aeeb42ad85dc95-a084",
+        "timestamp": "2025-01-06T10:33:30.978Z",
+        "bpp_id": "ondc.ecomviser.com",
+        "ttl": "PT30S"
+    },
+    "message": {
+        "order": {
+            "id": "2025-01-06-248869",
+            "state": "Completed",
+            "provider": {
+                "id": "84",
+                "locations": [
+                    {
+                        "id": "83"
+                    }
+                ]
+            },
+            "items": [
+                {
+                    "id": "451",
+                    "fulfillment_id": "155",
+                    "quantity": {
+                        "count": 1
+                    }
+                }
+            ],
+            "fulfillments": [
+                {
+                    "id": "155",
+                    "end": {
+                        "time": {
+                            "range": {
+                                "end": "2025-01-06T11:32:09.006Z",
+                                "start": "2025-01-06T10:32:09.006Z"
+                            },
+                            "timestamp": "2025-01-06T10:33:30.387Z"
+                        },
+                        "person": {
+                            "name": "Ajeet Chauhan"
+                        },
+                        "contact": {
+                            "email": "ajeetchauhan.symfony143@webkul.in",
+                            "phone": "8574739650"
+                        },
+                        "location": {
+                            "gps": "28.629743,77.377795",
+                            "address": {
+                                "city": "Noida",
+                                "name": "Ajeet Chauhan",
+                                "state": "Uttar Pradesh",
+                                "country": "IND",
+                                "building": "ARV Park",
+                                "locality": "Unnamed Road",
+                                "area_code": "201301"
+                            }
+                        }
+                    },
+                    "type": "Delivery",
+                    "start": {
+                        "time": {
+                            "range": {
+                                "end": "2025-01-06T11:32:09.006Z",
+                                "start": "2025-01-06T10:32:09.006Z"
+                            },
+                            "timestamp": "2025-01-06T10:33:14.727Z"
+                        },
+                        "contact": {
+                            "email": "support@webkul.in",
+                            "phone": "9876543210"
+                        },
+                        "location": {
+                            "id": "83",
+                            "gps": "28.62972640,77.37783230",
+                            "address": {
+                                "city": "Gautam Buddh Nagar",
+                                "state": "Uttar Pradesh",
+                                "locality": "Noida",
+                                "area_code": "201301"
+                            },
+                            "descriptor": {
+                                "name": "Ajeet Food Shop"
+                            }
+                        }
+                    },
+                    "state": {
+                        "descriptor": {
+                            "code": "Order-delivered"
+                        }
+                    },
+                    "tracking": true,
+                    "@ondc/org/TAT": "PT90M",
+                    "@ondc/org/provider_name": "ondc.ecomviser.com",
+                    "tags": [
+                        {
+                            "code": "routing",
+                            "list": [
+                                {
+                                    "code": "type",
+                                    "value": "P2P"
+                                }
+                            ]
+                        },
+                        {
+                            "code": "tracking",
+                            "list": [
+                                {
+                                    "code": "gps_enabled",
+                                    "value": "yes"
+                                },
+                                {
+                                    "code": "url_enabled",
+                                    "value": "no"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "quote": {
+                "ttl": "PT6H",
+                "price": {
+                    "value": "164.63",
+                    "currency": "INR"
+                },
+                "breakup": [
+                    {
+                        "item": {
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "item"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "price": {
+                                "value": "99",
+                                "currency": "INR"
+                            },
+                            "parent_item_id": "xvvxY6eaBE5I"
+                        },
+                        "price": {
+                            "value": "99",
+                            "currency": "INR"
+                        },
+                        "title": "Pizza Mania",
+                        "@ondc/org/item_id": "451",
+                        "@ondc/org/title_type": "item",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
+                        }
+                    },
+                    {
+                        "item": {
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "66zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "price": {
+                                "value": "10",
+                                "currency": "INR"
+                            },
+                            "parent_item_id": "xvvxY6eaBE5I"
+                        },
+                        "price": {
+                            "value": "10",
+                            "currency": "INR"
+                        },
+                        "title": "Vegan",
+                        "@ondc/org/item_id": "94",
+                        "@ondc/org/title_type": "item",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
+                        }
+                    },
+                    {
+                        "item": {
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "67zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "price": {
+                                "value": "50",
+                                "currency": "INR"
+                            },
+                            "parent_item_id": "xvvxY6eaBE5I"
+                        },
+                        "price": {
+                            "value": "50",
+                            "currency": "INR"
+                        },
+                        "title": "Mutton",
+                        "@ondc/org/item_id": "96",
+                        "@ondc/org/title_type": "item",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
+                        }
+                    },
+                    {
+                        "price": {
+                            "value": "5.63",
+                            "currency": "INR"
+                        },
+                        "title": "Convenience fee",
+                        "@ondc/org/item_id": "155",
+                        "@ondc/org/title_type": "misc"
+                    },
+                    {
+                        "price": {
+                            "value": "0",
+                            "currency": "INR"
+                        },
+                        "title": "Delivery charges",
+                        "@ondc/org/item_id": "155",
+                        "@ondc/org/title_type": "delivery"
+                    }
+                ]
+            },
+            "billing": {
+                "name": "Ajeet Chauhan",
+                "email": "ajeetchauhan.symfony143@webkul.in",
+                "phone": "8574739650",
+                "address": {
+                    "city": "Noida",
+                    "name": "Ajeet Chauhan",
+                    "state": "Uttar Pradesh",
+                    "country": "IND",
+                    "building": "ARV Park",
+                    "locality": "Unnamed Road",
+                    "area_code": "201301"
+                },
+                "created_at": "2025-01-06T10:31:29.847Z",
+                "updated_at": "2025-01-06T10:31:29.847Z"
+            },
+            "payment": {
+                "uri": "https://razorpay.com/",
+                "type": "ON-ORDER",
+                "params": {
+                    "amount": "164.63",
+                    "currency": "INR",
+                    "transaction_id": "order_Pg7qlLR529ZmhG"
+                },
+                "status": "PAID",
+                "tl_method": "http/get",
+                "collected_by": "BAP",
+                "@ondc/org/settlement_details": [
+                    {
+                        "bank_name": "fasdf",
+                        "branch_name": "noida",
+                        "settlement_type": "neft",
+                        "beneficiary_name": "fasdf asdfasdf",
+                        "settlement_phase": "sale-amount",
+                        "settlement_status": "NOT-PAID",
+                        "settlement_ifsc_code": "HDFC0000088",
+                        "settlement_counterparty": "seller-app",
+                        "settlement_bank_account_no": "534512341234132"
+                    }
+                ],
+                "@ondc/org/buyer_app_finder_fee_type": "percent",
+                "@ondc/org/buyer_app_finder_fee_amount": "3.0"
+            },
+            "created_at": "2025-01-06T10:32:04.500Z",
+            "updated_at": "2025-01-06T10:33:30.978Z",
+            "documents": [
+                {
+                    "label": "Invoice",
+                    "url": "https://ecomviser-prepod.sp-seller-preprod.ecomviser.com/index.php?p=invoice_download&key=MTczOjg0OmVjb212aXNlcg=="
+                }
+            ]
+        }
+    }
+}

--- a/eComviser/Seller App RET11/Flow-2/on_status_out_for_delivery.json
+++ b/eComviser/Seller App RET11/Flow-2/on_status_out_for_delivery.json
@@ -1,0 +1,317 @@
+{
+    "context": {
+        "domain": "ONDC:RET11",
+        "country": "IND",
+        "city": "std:0120",
+        "action": "on_status",
+        "core_version": "1.2.0",
+        "bap_id": "buyer-app-preprod-v2.ondc.org",
+        "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+        "bpp_uri": "https://ondc.ecomviser.com/api/v1",
+        "transaction_id": "bbeea929-e45e-48df-b3b7-d58a4a5301a7",
+        "message_id": "677bb1730c138a10240ec-ff2f",
+        "timestamp": "2025-01-06T10:33:23.049Z",
+        "bpp_id": "ondc.ecomviser.com",
+        "ttl": "PT30S"
+    },
+    "message": {
+        "order": {
+            "id": "2025-01-06-248869",
+            "state": "In-progress",
+            "provider": {
+                "id": "84",
+                "locations": [
+                    {
+                        "id": "83"
+                    }
+                ]
+            },
+            "items": [
+                {
+                    "id": "451",
+                    "fulfillment_id": "155",
+                    "quantity": {
+                        "count": 1
+                    }
+                }
+            ],
+            "fulfillments": [
+                {
+                    "id": "155",
+                    "end": {
+                        "time": {
+                            "range": {
+                                "end": "2025-01-06T11:32:09.006Z",
+                                "start": "2025-01-06T10:32:09.006Z"
+                            }
+                        },
+                        "person": {
+                            "name": "Ajeet Chauhan"
+                        },
+                        "contact": {
+                            "email": "ajeetchauhan.symfony143@webkul.in",
+                            "phone": "8574739650"
+                        },
+                        "location": {
+                            "gps": "28.629743,77.377795",
+                            "address": {
+                                "city": "Noida",
+                                "name": "Ajeet Chauhan",
+                                "state": "Uttar Pradesh",
+                                "country": "IND",
+                                "building": "ARV Park",
+                                "locality": "Unnamed Road",
+                                "area_code": "201301"
+                            }
+                        }
+                    },
+                    "type": "Delivery",
+                    "start": {
+                        "time": {
+                            "range": {
+                                "end": "2025-01-06T11:32:09.006Z",
+                                "start": "2025-01-06T10:32:09.006Z"
+                            },
+                            "timestamp": "2025-01-06T10:33:14.727Z"
+                        },
+                        "contact": {
+                            "email": "support@webkul.in",
+                            "phone": "9876543210"
+                        },
+                        "location": {
+                            "id": "83",
+                            "gps": "28.62972640,77.37783230",
+                            "address": {
+                                "city": "Gautam Buddh Nagar",
+                                "state": "Uttar Pradesh",
+                                "locality": "Noida",
+                                "area_code": "201301"
+                            },
+                            "descriptor": {
+                                "name": "Ajeet Food Shop"
+                            }
+                        }
+                    },
+                    "state": {
+                        "descriptor": {
+                            "code": "Out-for-delivery"
+                        }
+                    },
+                    "tracking": true,
+                    "@ondc/org/TAT": "PT90M",
+                    "@ondc/org/provider_name": "ondc.ecomviser.com",
+                    "tags": [
+                        {
+                            "code": "routing",
+                            "list": [
+                                {
+                                    "code": "type",
+                                    "value": "P2P"
+                                }
+                            ]
+                        },
+                        {
+                            "code": "tracking",
+                            "list": [
+                                {
+                                    "code": "gps_enabled",
+                                    "value": "yes"
+                                },
+                                {
+                                    "code": "url_enabled",
+                                    "value": "no"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "quote": {
+                "ttl": "PT6H",
+                "price": {
+                    "value": "164.63",
+                    "currency": "INR"
+                },
+                "breakup": [
+                    {
+                        "item": {
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "item"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "price": {
+                                "value": "99",
+                                "currency": "INR"
+                            },
+                            "parent_item_id": "xvvxY6eaBE5I"
+                        },
+                        "price": {
+                            "value": "99",
+                            "currency": "INR"
+                        },
+                        "title": "Pizza Mania",
+                        "@ondc/org/item_id": "451",
+                        "@ondc/org/title_type": "item",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
+                        }
+                    },
+                    {
+                        "item": {
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "66zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "price": {
+                                "value": "10",
+                                "currency": "INR"
+                            },
+                            "parent_item_id": "xvvxY6eaBE5I"
+                        },
+                        "price": {
+                            "value": "10",
+                            "currency": "INR"
+                        },
+                        "title": "Vegan",
+                        "@ondc/org/item_id": "94",
+                        "@ondc/org/title_type": "item",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
+                        }
+                    },
+                    {
+                        "item": {
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "67zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "price": {
+                                "value": "50",
+                                "currency": "INR"
+                            },
+                            "parent_item_id": "xvvxY6eaBE5I"
+                        },
+                        "price": {
+                            "value": "50",
+                            "currency": "INR"
+                        },
+                        "title": "Mutton",
+                        "@ondc/org/item_id": "96",
+                        "@ondc/org/title_type": "item",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
+                        }
+                    },
+                    {
+                        "price": {
+                            "value": "5.63",
+                            "currency": "INR"
+                        },
+                        "title": "Convenience fee",
+                        "@ondc/org/item_id": "155",
+                        "@ondc/org/title_type": "misc"
+                    },
+                    {
+                        "price": {
+                            "value": "0",
+                            "currency": "INR"
+                        },
+                        "title": "Delivery charges",
+                        "@ondc/org/item_id": "155",
+                        "@ondc/org/title_type": "delivery"
+                    }
+                ]
+            },
+            "billing": {
+                "name": "Ajeet Chauhan",
+                "email": "ajeetchauhan.symfony143@webkul.in",
+                "phone": "8574739650",
+                "address": {
+                    "city": "Noida",
+                    "name": "Ajeet Chauhan",
+                    "state": "Uttar Pradesh",
+                    "country": "IND",
+                    "building": "ARV Park",
+                    "locality": "Unnamed Road",
+                    "area_code": "201301"
+                },
+                "created_at": "2025-01-06T10:31:29.847Z",
+                "updated_at": "2025-01-06T10:31:29.847Z"
+            },
+            "payment": {
+                "uri": "https://razorpay.com/",
+                "type": "ON-ORDER",
+                "params": {
+                    "amount": "164.63",
+                    "currency": "INR",
+                    "transaction_id": "order_Pg7qlLR529ZmhG"
+                },
+                "status": "PAID",
+                "tl_method": "http/get",
+                "collected_by": "BAP",
+                "@ondc/org/settlement_details": [
+                    {
+                        "bank_name": "fasdf",
+                        "branch_name": "noida",
+                        "settlement_type": "neft",
+                        "beneficiary_name": "fasdf asdfasdf",
+                        "settlement_phase": "sale-amount",
+                        "settlement_status": "NOT-PAID",
+                        "settlement_ifsc_code": "HDFC0000088",
+                        "settlement_counterparty": "seller-app",
+                        "settlement_bank_account_no": "534512341234132"
+                    }
+                ],
+                "@ondc/org/buyer_app_finder_fee_type": "percent",
+                "@ondc/org/buyer_app_finder_fee_amount": "3.0"
+            },
+            "created_at": "2025-01-06T10:32:04.500Z",
+            "updated_at": "2025-01-06T10:33:23.049Z",
+            "documents": [
+                {
+                    "label": "Invoice",
+                    "url": "https://ecomviser-prepod.sp-seller-preprod.ecomviser.com/index.php?p=invoice_download&key=MTczOjg0OmVjb212aXNlcg=="
+                }
+            ]
+        }
+    }
+}

--- a/eComviser/Seller App RET11/Flow-2/on_status_packed.json
+++ b/eComviser/Seller App RET11/Flow-2/on_status_packed.json
@@ -1,0 +1,286 @@
+{
+    "context": {
+        "domain": "ONDC:RET11",
+        "country": "IND",
+        "city": "std:0120",
+        "action": "on_status",
+        "core_version": "1.2.0",
+        "bap_id": "buyer-app-preprod-v2.ondc.org",
+        "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+        "bpp_uri": "https://ondc.ecomviser.com/api/v1",
+        "transaction_id": "bbeea929-e45e-48df-b3b7-d58a4a5301a7",
+        "message_id": "677bb1512596faa9f3a59-2f38",
+        "timestamp": "2025-01-06T10:32:49.154Z",
+        "bpp_id": "ondc.ecomviser.com",
+        "ttl": "PT30S"
+    },
+    "message": {
+        "order": {
+            "id": "2025-01-06-248869",
+            "state": "In-progress",
+            "provider": {
+                "id": "84",
+                "locations": [
+                    {
+                        "id": "83"
+                    }
+                ]
+            },
+            "items": [
+                {
+                    "id": "451",
+                    "fulfillment_id": "155",
+                    "quantity": {
+                        "count": 1
+                    }
+                }
+            ],
+            "fulfillments": [
+                {
+                    "id": "155",
+                    "end": {
+                        "time": {
+                            "range": {
+                                "end": "2025-01-06T11:32:09.006Z",
+                                "start": "2025-01-06T10:32:09.006Z"
+                            }
+                        },
+                        "person": {
+                            "name": "Ajeet Chauhan"
+                        },
+                        "contact": {
+                            "email": "ajeetchauhan.symfony143@webkul.in",
+                            "phone": "8574739650"
+                        },
+                        "location": {
+                            "gps": "28.629743,77.377795",
+                            "address": {
+                                "city": "Noida",
+                                "name": "Ajeet Chauhan",
+                                "state": "Uttar Pradesh",
+                                "country": "IND",
+                                "building": "ARV Park",
+                                "locality": "Unnamed Road",
+                                "area_code": "201301"
+                            }
+                        }
+                    },
+                    "type": "Delivery",
+                    "start": {
+                        "time": {
+                            "range": {
+                                "end": "2025-01-06T11:32:09.006Z",
+                                "start": "2025-01-06T10:32:09.006Z"
+                            }
+                        },
+                        "contact": {
+                            "email": "support@webkul.in",
+                            "phone": "9876543210"
+                        },
+                        "location": {
+                            "id": "83",
+                            "gps": "28.62972640,77.37783230",
+                            "address": {
+                                "city": "Gautam Buddh Nagar",
+                                "state": "Uttar Pradesh",
+                                "locality": "Noida",
+                                "area_code": "201301"
+                            },
+                            "descriptor": {
+                                "name": "Ajeet Food Shop"
+                            }
+                        }
+                    },
+                    "state": {
+                        "descriptor": {
+                            "code": "Packed"
+                        }
+                    },
+                    "tracking": true,
+                    "@ondc/org/TAT": "PT90M",
+                    "@ondc/org/provider_name": "ondc.ecomviser.com"
+                }
+            ],
+            "quote": {
+                "ttl": "PT6H",
+                "price": {
+                    "value": "164.63",
+                    "currency": "INR"
+                },
+                "breakup": [
+                    {
+                        "item": {
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "item"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "price": {
+                                "value": "99",
+                                "currency": "INR"
+                            },
+                            "parent_item_id": "xvvxY6eaBE5I"
+                        },
+                        "price": {
+                            "value": "99",
+                            "currency": "INR"
+                        },
+                        "title": "Pizza Mania",
+                        "@ondc/org/item_id": "451",
+                        "@ondc/org/title_type": "item",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
+                        }
+                    },
+                    {
+                        "item": {
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "66zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "price": {
+                                "value": "10",
+                                "currency": "INR"
+                            },
+                            "parent_item_id": "xvvxY6eaBE5I"
+                        },
+                        "price": {
+                            "value": "10",
+                            "currency": "INR"
+                        },
+                        "title": "Vegan",
+                        "@ondc/org/item_id": "94",
+                        "@ondc/org/title_type": "item",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
+                        }
+                    },
+                    {
+                        "item": {
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "67zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "price": {
+                                "value": "50",
+                                "currency": "INR"
+                            },
+                            "parent_item_id": "xvvxY6eaBE5I"
+                        },
+                        "price": {
+                            "value": "50",
+                            "currency": "INR"
+                        },
+                        "title": "Mutton",
+                        "@ondc/org/item_id": "96",
+                        "@ondc/org/title_type": "item",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
+                        }
+                    },
+                    {
+                        "price": {
+                            "value": "5.63",
+                            "currency": "INR"
+                        },
+                        "title": "Convenience fee",
+                        "@ondc/org/item_id": "155",
+                        "@ondc/org/title_type": "misc"
+                    },
+                    {
+                        "price": {
+                            "value": "0",
+                            "currency": "INR"
+                        },
+                        "title": "Delivery charges",
+                        "@ondc/org/item_id": "155",
+                        "@ondc/org/title_type": "delivery"
+                    }
+                ]
+            },
+            "billing": {
+                "name": "Ajeet Chauhan",
+                "email": "ajeetchauhan.symfony143@webkul.in",
+                "phone": "8574739650",
+                "address": {
+                    "city": "Noida",
+                    "name": "Ajeet Chauhan",
+                    "state": "Uttar Pradesh",
+                    "country": "IND",
+                    "building": "ARV Park",
+                    "locality": "Unnamed Road",
+                    "area_code": "201301"
+                },
+                "created_at": "2025-01-06T10:31:29.847Z",
+                "updated_at": "2025-01-06T10:31:29.847Z"
+            },
+            "payment": {
+                "uri": "https://razorpay.com/",
+                "type": "ON-ORDER",
+                "params": {
+                    "amount": "164.63",
+                    "currency": "INR",
+                    "transaction_id": "order_Pg7qlLR529ZmhG"
+                },
+                "status": "PAID",
+                "tl_method": "http/get",
+                "collected_by": "BAP",
+                "@ondc/org/settlement_details": [
+                    {
+                        "bank_name": "fasdf",
+                        "branch_name": "noida",
+                        "settlement_type": "neft",
+                        "beneficiary_name": "fasdf asdfasdf",
+                        "settlement_phase": "sale-amount",
+                        "settlement_status": "NOT-PAID",
+                        "settlement_ifsc_code": "HDFC0000088",
+                        "settlement_counterparty": "seller-app",
+                        "settlement_bank_account_no": "534512341234132"
+                    }
+                ],
+                "@ondc/org/buyer_app_finder_fee_type": "percent",
+                "@ondc/org/buyer_app_finder_fee_amount": "3.0"
+            },
+            "created_at": "2025-01-06T10:32:04.500Z",
+            "updated_at": "2025-01-06T10:32:49.154Z"
+        }
+    }
+}

--- a/eComviser/Seller App RET11/Flow-2/on_status_pending.json
+++ b/eComviser/Seller App RET11/Flow-2/on_status_pending.json
@@ -1,0 +1,286 @@
+{
+    "context": {
+        "domain": "ONDC:RET11",
+        "country": "IND",
+        "city": "std:0120",
+        "action": "on_status",
+        "core_version": "1.2.0",
+        "bap_id": "buyer-app-preprod-v2.ondc.org",
+        "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+        "bpp_uri": "https://ondc.ecomviser.com/api/v1",
+        "transaction_id": "bbeea929-e45e-48df-b3b7-d58a4a5301a7",
+        "message_id": "677bb1423532b3ed53da8-7c2f",
+        "timestamp": "2025-01-06T10:32:34.218Z",
+        "bpp_id": "ondc.ecomviser.com",
+        "ttl": "PT30S"
+    },
+    "message": {
+        "order": {
+            "id": "2025-01-06-248869",
+            "state": "Accepted",
+            "provider": {
+                "id": "84",
+                "locations": [
+                    {
+                        "id": "83"
+                    }
+                ]
+            },
+            "items": [
+                {
+                    "id": "451",
+                    "fulfillment_id": "155",
+                    "quantity": {
+                        "count": 1
+                    }
+                }
+            ],
+            "fulfillments": [
+                {
+                    "id": "155",
+                    "end": {
+                        "time": {
+                            "range": {
+                                "end": "2025-01-06T11:32:09.006Z",
+                                "start": "2025-01-06T10:32:09.006Z"
+                            }
+                        },
+                        "person": {
+                            "name": "Ajeet Chauhan"
+                        },
+                        "contact": {
+                            "email": "ajeetchauhan.symfony143@webkul.in",
+                            "phone": "8574739650"
+                        },
+                        "location": {
+                            "gps": "28.629743,77.377795",
+                            "address": {
+                                "city": "Noida",
+                                "name": "Ajeet Chauhan",
+                                "state": "Uttar Pradesh",
+                                "country": "IND",
+                                "building": "ARV Park",
+                                "locality": "Unnamed Road",
+                                "area_code": "201301"
+                            }
+                        }
+                    },
+                    "type": "Delivery",
+                    "start": {
+                        "time": {
+                            "range": {
+                                "end": "2025-01-06T11:32:09.006Z",
+                                "start": "2025-01-06T10:32:09.006Z"
+                            }
+                        },
+                        "contact": {
+                            "email": "support@webkul.in",
+                            "phone": "9876543210"
+                        },
+                        "location": {
+                            "id": "83",
+                            "gps": "28.62972640,77.37783230",
+                            "address": {
+                                "city": "Gautam Buddh Nagar",
+                                "state": "Uttar Pradesh",
+                                "locality": "Noida",
+                                "area_code": "201301"
+                            },
+                            "descriptor": {
+                                "name": "Ajeet Food Shop"
+                            }
+                        }
+                    },
+                    "state": {
+                        "descriptor": {
+                            "code": "Pending"
+                        }
+                    },
+                    "tracking": true,
+                    "@ondc/org/TAT": "PT90M",
+                    "@ondc/org/provider_name": "ondc.ecomviser.com"
+                }
+            ],
+            "quote": {
+                "ttl": "PT6H",
+                "price": {
+                    "value": "164.63",
+                    "currency": "INR"
+                },
+                "breakup": [
+                    {
+                        "item": {
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "item"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "price": {
+                                "value": "99",
+                                "currency": "INR"
+                            },
+                            "parent_item_id": "xvvxY6eaBE5I"
+                        },
+                        "price": {
+                            "value": "99",
+                            "currency": "INR"
+                        },
+                        "title": "Pizza Mania",
+                        "@ondc/org/item_id": "451",
+                        "@ondc/org/title_type": "item",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
+                        }
+                    },
+                    {
+                        "item": {
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "66zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "price": {
+                                "value": "10",
+                                "currency": "INR"
+                            },
+                            "parent_item_id": "xvvxY6eaBE5I"
+                        },
+                        "price": {
+                            "value": "10",
+                            "currency": "INR"
+                        },
+                        "title": "Vegan",
+                        "@ondc/org/item_id": "94",
+                        "@ondc/org/title_type": "item",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
+                        }
+                    },
+                    {
+                        "item": {
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "67zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "price": {
+                                "value": "50",
+                                "currency": "INR"
+                            },
+                            "parent_item_id": "xvvxY6eaBE5I"
+                        },
+                        "price": {
+                            "value": "50",
+                            "currency": "INR"
+                        },
+                        "title": "Mutton",
+                        "@ondc/org/item_id": "96",
+                        "@ondc/org/title_type": "item",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
+                        }
+                    },
+                    {
+                        "price": {
+                            "value": "5.63",
+                            "currency": "INR"
+                        },
+                        "title": "Convenience fee",
+                        "@ondc/org/item_id": "155",
+                        "@ondc/org/title_type": "misc"
+                    },
+                    {
+                        "price": {
+                            "value": "0",
+                            "currency": "INR"
+                        },
+                        "title": "Delivery charges",
+                        "@ondc/org/item_id": "155",
+                        "@ondc/org/title_type": "delivery"
+                    }
+                ]
+            },
+            "billing": {
+                "name": "Ajeet Chauhan",
+                "email": "ajeetchauhan.symfony143@webkul.in",
+                "phone": "8574739650",
+                "address": {
+                    "city": "Noida",
+                    "name": "Ajeet Chauhan",
+                    "state": "Uttar Pradesh",
+                    "country": "IND",
+                    "building": "ARV Park",
+                    "locality": "Unnamed Road",
+                    "area_code": "201301"
+                },
+                "created_at": "2025-01-06T10:31:29.847Z",
+                "updated_at": "2025-01-06T10:31:29.847Z"
+            },
+            "payment": {
+                "uri": "https://razorpay.com/",
+                "type": "ON-ORDER",
+                "params": {
+                    "amount": "164.63",
+                    "currency": "INR",
+                    "transaction_id": "order_Pg7qlLR529ZmhG"
+                },
+                "status": "PAID",
+                "tl_method": "http/get",
+                "collected_by": "BAP",
+                "@ondc/org/settlement_details": [
+                    {
+                        "bank_name": "fasdf",
+                        "branch_name": "noida",
+                        "settlement_type": "neft",
+                        "beneficiary_name": "fasdf asdfasdf",
+                        "settlement_phase": "sale-amount",
+                        "settlement_status": "NOT-PAID",
+                        "settlement_ifsc_code": "HDFC0000088",
+                        "settlement_counterparty": "seller-app",
+                        "settlement_bank_account_no": "534512341234132"
+                    }
+                ],
+                "@ondc/org/buyer_app_finder_fee_type": "percent",
+                "@ondc/org/buyer_app_finder_fee_amount": "3.0"
+            },
+            "created_at": "2025-01-06T10:32:04.500Z",
+            "updated_at": "2025-01-06T10:32:34.218Z"
+        }
+    }
+}

--- a/eComviser/Seller App RET11/Flow-2/on_status_picked.json
+++ b/eComviser/Seller App RET11/Flow-2/on_status_picked.json
@@ -1,0 +1,323 @@
+{
+    "context": {
+        "domain": "ONDC:RET11",
+        "country": "IND",
+        "city": "std:0120",
+        "action": "on_status",
+        "core_version": "1.2.0",
+        "bap_id": "buyer-app-preprod-v2.ondc.org",
+        "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+        "bpp_uri": "https://ondc.ecomviser.com/api/v1",
+        "transaction_id": "bbeea929-e45e-48df-b3b7-d58a4a5301a7",
+        "message_id": "677bb16b4ae6a6c6bd3d8-82a3",
+        "timestamp": "2025-01-06T10:33:15.307Z",
+        "bpp_id": "ondc.ecomviser.com",
+        "ttl": "PT30S"
+    },
+    "message": {
+        "order": {
+            "id": "2025-01-06-248869",
+            "state": "In-progress",
+            "provider": {
+                "id": "84",
+                "locations": [
+                    {
+                        "id": "83"
+                    }
+                ]
+            },
+            "items": [
+                {
+                    "id": "451",
+                    "fulfillment_id": "155",
+                    "quantity": {
+                        "count": 1
+                    }
+                }
+            ],
+            "fulfillments": [
+                {
+                    "id": "155",
+                    "end": {
+                        "time": {
+                            "range": {
+                                "end": "2025-01-06T11:32:09.006Z",
+                                "start": "2025-01-06T10:32:09.006Z"
+                            }
+                        },
+                        "person": {
+                            "name": "Ajeet Chauhan"
+                        },
+                        "contact": {
+                            "email": "ajeetchauhan.symfony143@webkul.in",
+                            "phone": "8574739650"
+                        },
+                        "location": {
+                            "gps": "28.629743,77.377795",
+                            "address": {
+                                "city": "Noida",
+                                "name": "Ajeet Chauhan",
+                                "state": "Uttar Pradesh",
+                                "country": "IND",
+                                "building": "ARV Park",
+                                "locality": "Unnamed Road",
+                                "area_code": "201301"
+                            }
+                        }
+                    },
+                    "type": "Delivery",
+                    "start": {
+                        "time": {
+                            "range": {
+                                "end": "2025-01-06T11:32:09.006Z",
+                                "start": "2025-01-06T10:32:09.006Z"
+                            },
+                            "timestamp": "2025-01-06T10:33:14.727Z"
+                        },
+                        "contact": {
+                            "email": "support@webkul.in",
+                            "phone": "9876543210"
+                        },
+                        "location": {
+                            "id": "83",
+                            "gps": "28.62972640,77.37783230",
+                            "address": {
+                                "city": "Gautam Buddh Nagar",
+                                "state": "Uttar Pradesh",
+                                "locality": "Noida",
+                                "area_code": "201301"
+                            },
+                            "descriptor": {
+                                "name": "Ajeet Food Shop"
+                            }
+                        },
+                        "instructions": {
+                            "code": "2",
+                            "name": "ONDC Order",
+                            "short_desc": "ae34fd",
+                            "long_desc": "additional instructions for pickup"
+                        }
+                    },
+                    "state": {
+                        "descriptor": {
+                            "code": "Order-picked-up"
+                        }
+                    },
+                    "tracking": true,
+                    "@ondc/org/TAT": "PT90M",
+                    "@ondc/org/provider_name": "ondc.ecomviser.com",
+                    "tags": [
+                        {
+                            "code": "routing",
+                            "list": [
+                                {
+                                    "code": "type",
+                                    "value": "P2P"
+                                }
+                            ]
+                        },
+                        {
+                            "code": "tracking",
+                            "list": [
+                                {
+                                    "code": "gps_enabled",
+                                    "value": "yes"
+                                },
+                                {
+                                    "code": "url_enabled",
+                                    "value": "no"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "quote": {
+                "ttl": "PT6H",
+                "price": {
+                    "value": "164.63",
+                    "currency": "INR"
+                },
+                "breakup": [
+                    {
+                        "item": {
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "item"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "price": {
+                                "value": "99",
+                                "currency": "INR"
+                            },
+                            "parent_item_id": "xvvxY6eaBE5I"
+                        },
+                        "price": {
+                            "value": "99",
+                            "currency": "INR"
+                        },
+                        "title": "Pizza Mania",
+                        "@ondc/org/item_id": "451",
+                        "@ondc/org/title_type": "item",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
+                        }
+                    },
+                    {
+                        "item": {
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "66zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "price": {
+                                "value": "10",
+                                "currency": "INR"
+                            },
+                            "parent_item_id": "xvvxY6eaBE5I"
+                        },
+                        "price": {
+                            "value": "10",
+                            "currency": "INR"
+                        },
+                        "title": "Vegan",
+                        "@ondc/org/item_id": "94",
+                        "@ondc/org/title_type": "item",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
+                        }
+                    },
+                    {
+                        "item": {
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "67zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "price": {
+                                "value": "50",
+                                "currency": "INR"
+                            },
+                            "parent_item_id": "xvvxY6eaBE5I"
+                        },
+                        "price": {
+                            "value": "50",
+                            "currency": "INR"
+                        },
+                        "title": "Mutton",
+                        "@ondc/org/item_id": "96",
+                        "@ondc/org/title_type": "item",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
+                        }
+                    },
+                    {
+                        "price": {
+                            "value": "5.63",
+                            "currency": "INR"
+                        },
+                        "title": "Convenience fee",
+                        "@ondc/org/item_id": "155",
+                        "@ondc/org/title_type": "misc"
+                    },
+                    {
+                        "price": {
+                            "value": "0",
+                            "currency": "INR"
+                        },
+                        "title": "Delivery charges",
+                        "@ondc/org/item_id": "155",
+                        "@ondc/org/title_type": "delivery"
+                    }
+                ]
+            },
+            "billing": {
+                "name": "Ajeet Chauhan",
+                "email": "ajeetchauhan.symfony143@webkul.in",
+                "phone": "8574739650",
+                "address": {
+                    "city": "Noida",
+                    "name": "Ajeet Chauhan",
+                    "state": "Uttar Pradesh",
+                    "country": "IND",
+                    "building": "ARV Park",
+                    "locality": "Unnamed Road",
+                    "area_code": "201301"
+                },
+                "created_at": "2025-01-06T10:31:29.847Z",
+                "updated_at": "2025-01-06T10:31:29.847Z"
+            },
+            "payment": {
+                "uri": "https://razorpay.com/",
+                "type": "ON-ORDER",
+                "params": {
+                    "amount": "164.63",
+                    "currency": "INR",
+                    "transaction_id": "order_Pg7qlLR529ZmhG"
+                },
+                "status": "PAID",
+                "tl_method": "http/get",
+                "collected_by": "BAP",
+                "@ondc/org/settlement_details": [
+                    {
+                        "bank_name": "fasdf",
+                        "branch_name": "noida",
+                        "settlement_type": "neft",
+                        "beneficiary_name": "fasdf asdfasdf",
+                        "settlement_phase": "sale-amount",
+                        "settlement_status": "NOT-PAID",
+                        "settlement_ifsc_code": "HDFC0000088",
+                        "settlement_counterparty": "seller-app",
+                        "settlement_bank_account_no": "534512341234132"
+                    }
+                ],
+                "@ondc/org/buyer_app_finder_fee_type": "percent",
+                "@ondc/org/buyer_app_finder_fee_amount": "3.0"
+            },
+            "created_at": "2025-01-06T10:32:04.500Z",
+            "updated_at": "2025-01-06T10:33:15.307Z",
+            "documents": [
+                {
+                    "label": "Invoice",
+                    "url": "https://ecomviser-prepod.sp-seller-preprod.ecomviser.com/index.php?p=invoice_download&key=MTczOjg0OmVjb212aXNlcg=="
+                }
+            ]
+        }
+    }
+}

--- a/eComviser/Seller App RET11/Flow-2/search.json
+++ b/eComviser/Seller App RET11/Flow-2/search.json
@@ -1,0 +1,26 @@
+{
+    "context": {
+        "domain": "ONDC:RET11",
+        "action": "search",
+        "country": "IND",
+        "city": "std:0120",
+        "core_version": "1.2.0",
+        "bap_id": "buyer-app-preprod-v2.ondc.org",
+        "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+        "transaction_id": "0646bc94-5d3d-4b2d-9852-a8a33843dbb9",
+        "message_id": "36c56392-f004-4813-ace5-0d40033a8420",
+        "timestamp": "2025-01-06T15:40:58.595Z",
+        "ttl": "PT30S"
+    },
+    "message": {
+        "intent": {
+            "fulfillment": {
+                "type": "Delivery"
+            },
+            "payment": {
+                "@ondc/org/buyer_app_finder_fee_type": "percent",
+                "@ondc/org/buyer_app_finder_fee_amount": "3"
+            }
+        }
+    }
+}

--- a/eComviser/Seller App RET11/Flow-2/select.json
+++ b/eComviser/Seller App RET11/Flow-2/select.json
@@ -1,0 +1,118 @@
+{
+    "context": {
+        "domain": "ONDC:RET11",
+        "country": "IND",
+        "city": "std:0120",
+        "action": "select",
+        "core_version": "1.2.0",
+        "bap_id": "buyer-app-preprod-v2.ondc.org",
+        "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+        "bpp_uri": "https://ondc.ecomviser.com/api/v1",
+        "transaction_id": "bbeea929-e45e-48df-b3b7-d58a4a5301a7",
+        "message_id": "3d2694e7-9b62-431e-b44d-4f1725292759",
+        "timestamp": "2025-01-06T10:31:15.135Z",
+        "bpp_id": "ondc.ecomviser.com",
+        "ttl": "PT30S"
+    },
+    "message": {
+        "order": {
+            "items": [
+                {
+                    "id": "451",
+                    "quantity": {
+                        "count": 1
+                    },
+                    "location_id": "83",
+                    "tags": [
+                        {
+                            "code": "type",
+                            "list": [
+                                {
+                                    "code": "type",
+                                    "value": "item"
+                                }
+                            ]
+                        }
+                    ],
+                    "parent_item_id": "xvvxY6eaBE5I"
+                },
+                {
+                    "id": "94",
+                    "quantity": {
+                        "count": 1
+                    },
+                    "location_id": "83",
+                    "tags": [
+                        {
+                            "code": "type",
+                            "list": [
+                                {
+                                    "code": "type",
+                                    "value": "customization"
+                                }
+                            ]
+                        },
+                        {
+                            "code": "parent",
+                            "list": [
+                                {
+                                    "code": "id",
+                                    "value": "66zabcdefghi"
+                                }
+                            ]
+                        }
+                    ],
+                    "parent_item_id": "xvvxY6eaBE5I"
+                },
+                {
+                    "id": "96",
+                    "quantity": {
+                        "count": 1
+                    },
+                    "location_id": "83",
+                    "tags": [
+                        {
+                            "code": "type",
+                            "list": [
+                                {
+                                    "code": "type",
+                                    "value": "customization"
+                                }
+                            ]
+                        },
+                        {
+                            "code": "parent",
+                            "list": [
+                                {
+                                    "code": "id",
+                                    "value": "67zabcdefghi"
+                                }
+                            ]
+                        }
+                    ],
+                    "parent_item_id": "xvvxY6eaBE5I"
+                }
+            ],
+            "provider": {
+                "id": "84",
+                "locations": [
+                    {
+                        "id": "83"
+                    }
+                ]
+            },
+            "fulfillments": [
+                {
+                    "end": {
+                        "location": {
+                            "gps": "28.629743,77.377795",
+                            "address": {
+                                "area_code": "201301"
+                            }
+                        }
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/eComviser/Seller App RET11/Flow-3/confirm.json
+++ b/eComviser/Seller App RET11/Flow-3/confirm.json
@@ -1,0 +1,341 @@
+{
+    "context": {
+        "domain": "ONDC:RET11",
+        "country": "IND",
+        "city": "std:0120",
+        "action": "confirm",
+        "core_version": "1.2.0",
+        "bap_id": "buyer-app-preprod-v2.ondc.org",
+        "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+        "bpp_uri": "https://ondc.ecomviser.com/api/v1",
+        "transaction_id": "5a913b62-e66f-4a6b-bf2a-8072714506d6",
+        "message_id": "ec786fd7-8fe6-4bef-860c-30588f73b0a9",
+        "timestamp": "2025-01-06T10:58:33.520Z",
+        "bpp_id": "ondc.ecomviser.com",
+        "ttl": "PT30S"
+    },
+    "message": {
+        "order": {
+            "id": "2025-01-06-333398",
+            "state": "Created",
+            "billing": {
+                "address": {
+                    "name": "Ajeet Chauhan",
+                    "building": "ARV Park",
+                    "locality": "Unnamed Road",
+                    "city": "Noida",
+                    "state": "Uttar Pradesh",
+                    "country": "IND",
+                    "area_code": "201301"
+                },
+                "phone": "8574739650",
+                "name": "Ajeet Chauhan",
+                "email": "ajeetchauhan.symfony143@webkul.in",
+                "created_at": "2025-01-06T10:58:02.529Z",
+                "updated_at": "2025-01-06T10:58:02.529Z"
+            },
+            "items": [
+                {
+                    "id": "451",
+                    "quantity": {
+                        "count": 1
+                    },
+                    "fulfillment_id": "155",
+                    "tags": [
+                        {
+                            "code": "type",
+                            "list": [
+                                {
+                                    "code": "type",
+                                    "value": "item"
+                                }
+                            ]
+                        }
+                    ],
+                    "parent_item_id": "xXUeYhqy/JJR"
+                },
+                {
+                    "id": "93",
+                    "quantity": {
+                        "count": 1
+                    },
+                    "fulfillment_id": "155",
+                    "tags": [
+                        {
+                            "code": "type",
+                            "list": [
+                                {
+                                    "code": "type",
+                                    "value": "customization"
+                                }
+                            ]
+                        },
+                        {
+                            "code": "parent",
+                            "list": [
+                                {
+                                    "code": "id",
+                                    "value": "66zabcdefghi"
+                                }
+                            ]
+                        }
+                    ],
+                    "parent_item_id": "xXUeYhqy/JJR"
+                },
+                {
+                    "id": "95",
+                    "quantity": {
+                        "count": 1
+                    },
+                    "fulfillment_id": "155",
+                    "tags": [
+                        {
+                            "code": "type",
+                            "list": [
+                                {
+                                    "code": "type",
+                                    "value": "customization"
+                                }
+                            ]
+                        },
+                        {
+                            "code": "parent",
+                            "list": [
+                                {
+                                    "code": "id",
+                                    "value": "67zabcdefghi"
+                                }
+                            ]
+                        }
+                    ],
+                    "parent_item_id": "xXUeYhqy/JJR"
+                }
+            ],
+            "provider": {
+                "id": "84",
+                "locations": [
+                    {
+                        "id": "83"
+                    }
+                ]
+            },
+            "fulfillments": [
+                {
+                    "@ondc/org/TAT": "PT90M",
+                    "id": "155",
+                    "tracking": true,
+                    "end": {
+                        "contact": {
+                            "email": "ajeetchauhan.symfony143@webkul.in",
+                            "phone": "8574739650"
+                        },
+                        "person": {
+                            "name": "Ajeet Chauhan"
+                        },
+                        "location": {
+                            "gps": "28.629743,77.377795",
+                            "address": {
+                                "name": "Ajeet Chauhan",
+                                "building": "ARV Park",
+                                "locality": "Unnamed Road",
+                                "city": "Noida",
+                                "state": "Uttar Pradesh",
+                                "country": "IND",
+                                "area_code": "201301"
+                            }
+                        }
+                    },
+                    "type": "Delivery"
+                }
+            ],
+            "payment": {
+                "uri": "https://razorpay.com/",
+                "tl_method": "http/get",
+                "params": {
+                    "amount": "118.04",
+                    "currency": "INR",
+                    "transaction_id": "order_Pg8IoytiBpf9W3"
+                },
+                "status": "PAID",
+                "type": "ON-ORDER",
+                "collected_by": "BAP",
+                "@ondc/org/buyer_app_finder_fee_type": "percent",
+                "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+                "@ondc/org/settlement_details": [
+                    {
+                        "settlement_counterparty": "seller-app",
+                        "settlement_phase": "sale-amount",
+                        "settlement_type": "neft",
+                        "beneficiary_name": "fasdf asdfasdf",
+                        "settlement_bank_account_no": "534512341234132",
+                        "settlement_ifsc_code": "HDFC0000088",
+                        "bank_name": "fasdf",
+                        "branch_name": "noida",
+                        "settlement_status": "NOT-PAID"
+                    }
+                ]
+            },
+            "quote": {
+                "price": {
+                    "currency": "INR",
+                    "value": "118.04"
+                },
+                "breakup": [
+                    {
+                        "title": "Pizza Mania",
+                        "price": {
+                            "currency": "INR",
+                            "value": "99"
+                        },
+                        "@ondc/org/title_type": "item",
+                        "@ondc/org/item_id": "451",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
+                        },
+                        "item": {
+                            "price": {
+                                "currency": "INR",
+                                "value": "99"
+                            },
+                            "parent_item_id": "xXUeYhqy/JJR",
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "item"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "title": "Extra",
+                        "price": {
+                            "currency": "INR",
+                            "value": "5"
+                        },
+                        "@ondc/org/title_type": "item",
+                        "@ondc/org/item_id": "93",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
+                        },
+                        "item": {
+                            "price": {
+                                "currency": "INR",
+                                "value": "5"
+                            },
+                            "parent_item_id": "xXUeYhqy/JJR",
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "66zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "title": "Chicken",
+                        "price": {
+                            "currency": "INR",
+                            "value": "10"
+                        },
+                        "@ondc/org/title_type": "item",
+                        "@ondc/org/item_id": "95",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
+                        },
+                        "item": {
+                            "price": {
+                                "currency": "INR",
+                                "value": "10"
+                            },
+                            "parent_item_id": "xXUeYhqy/JJR",
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "67zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "title": "Convenience fee",
+                        "price": {
+                            "currency": "INR",
+                            "value": "4.04"
+                        },
+                        "@ondc/org/title_type": "misc",
+                        "@ondc/org/item_id": "155"
+                    },
+                    {
+                        "title": "Delivery charges",
+                        "price": {
+                            "currency": "INR",
+                            "value": "0"
+                        },
+                        "@ondc/org/title_type": "delivery",
+                        "@ondc/org/item_id": "155"
+                    }
+                ],
+                "ttl": "PT6H"
+            },
+            "tags": [
+                {
+                    "code": "bpp_terms",
+                    "list": [
+                        {
+                            "code": "tax_number",
+                            "value": "09AABCW0339G3ZD"
+                        },
+                        {
+                            "code": "provider_tax_number",
+                            "value": "DERTC3376R"
+                        }
+                    ]
+                },
+                {
+                    "code": "bap_terms",
+                    "list": [
+                        {
+                            "code": "tax_number",
+                            "value": "GSTIN1234567890"
+                        }
+                    ]
+                }
+            ],
+            "created_at": "2025-01-06T10:58:33.520Z",
+            "updated_at": "2025-01-06T10:58:33.520Z"
+        }
+    }
+}

--- a/eComviser/Seller App RET11/Flow-3/flow-3_validate_report.json
+++ b/eComviser/Seller App RET11/Flow-3/flow-3_validate_report.json
@@ -1,0 +1,17 @@
+{
+    "success": false,
+    "response": {
+        "message": "Logs were not verified successfully",
+        "report": {
+            "on_search_full_catalog_refresh": {
+                "message/catalog/bpp/providers0/categories/items": "No items are mapped with the given category_id 844147zabcde in providers0/items"
+            }
+        },
+        "bpp_id": "ondc.ecomviser.com",
+        "bap_id": "buyer-app-preprod-v2.ondc.org",
+        "domain": "ONDC:RET11",
+        "reportTimestamp": "2025-01-08T13:21:12.629Z"
+    },
+    "signature": "Z0hHh2g2rNfb0dEu52aShw8Zj+rCYt+Nm9EkinKwjfxFTJ5m76UOqInEMiFLeEcup+4hzZaXRuaB55BLLwL3Dg==",
+    "signTimestamp": "2025-01-08T13:21:12.629Z"
+}

--- a/eComviser/Seller App RET11/Flow-3/flow-3_validate_request.json
+++ b/eComviser/Seller App RET11/Flow-3/flow-3_validate_request.json
@@ -1,0 +1,4478 @@
+{
+    "domain": "ONDC:RET11",
+    "version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bpp_id": "ondc.ecomviser.com",
+    "payload": {
+        "search_full_catalog_refresh": {
+            "context": {
+                "domain": "ONDC:RET11",
+                "action": "search",
+                "country": "IND",
+                "city": "std:0120",
+                "core_version": "1.2.0",
+                "bap_id": "buyer-app-preprod-v2.ondc.org",
+                "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+                "transaction_id": "0646bc94-5d3d-4b2d-6325-a8a33843dbb9",
+                "message_id": "36c56392-f004-4813-ace5-0d40033a8420",
+                "timestamp": "2025-01-06T16:25:29.988Z",
+                "ttl": "PT30S"
+            },
+            "message": {
+                "intent": {
+                    "fulfillment": {
+                        "type": "Delivery"
+                    },
+                    "payment": {
+                        "@ondc/org/buyer_app_finder_fee_type": "percent",
+                        "@ondc/org/buyer_app_finder_fee_amount": "3"
+                    }
+                }
+            }
+        },
+        "on_search_full_catalog_refresh": {
+            "context": {
+                "domain": "ONDC:RET11",
+                "action": "on_search",
+                "country": "IND",
+                "city": "std:0120",
+                "core_version": "1.2.0",
+                "bap_id": "buyer-app-preprod-v2.ondc.org",
+                "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+                "transaction_id": "0646bc94-5d3d-4b2d-6325-a8a33843dbb9",
+                "message_id": "36c56392-f004-4813-ace5-0d40033a8420",
+                "timestamp": "2025-01-06T10:55:38.946Z",
+                "ttl": "PT30S",
+                "bpp_id": "ondc.ecomviser.com",
+                "bpp_uri": "https://ondc.ecomviser.com/api/v1"
+            },
+            "message": {
+                "catalog": {
+                    "bpp/descriptor": {
+                        "name": "Webkul",
+                        "symbol": "https://ondc.ecomviser.com/public/img/webkul_logo.png",
+                        "short_desc": "Enterprise Digital Commerce & Marketplace Solution Experts",
+                        "long_desc": "Helping companies with our industry-leading digital commerce, ERP, and CRM solutions. In the last 13 years, we have served 150K+ clients worldwide to handle complex operations and grow their businesses",
+                        "images": [
+                            "https://ondc.ecomviser.com/public/img/webkul_banner.png",
+                            "https://ondc.ecomviser.com/public/img/webkul_clients.png",
+                            "https://ondc.ecomviser.com/public/img/webkul_awards.png"
+                        ],
+                        "tags": [
+                            {
+                                "code": "bpp_terms",
+                                "list": [
+                                    {
+                                        "code": "np_type",
+                                        "value": "MSN"
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                    "bpp/fulfillments": [
+                        {
+                            "id": "155",
+                            "type": "Delivery"
+                        }
+                    ],
+                    "bpp/providers": [
+                        {
+                            "id": "84",
+                            "time": {
+                                "label": "enable",
+                                "timestamp": "2025-01-06T10:25:38.328Z"
+                            },
+                            "descriptor": {
+                                "name": "Ajeet Food Shop",
+                                "symbol": "https://ondc-prepod-digital-delivery.s3.amazonaws.com/seller_shop_logo/84/39MylDtZVC.jpg",
+                                "short_desc": "short desc",
+                                "long_desc": "store desc",
+                                "images": [
+                                    "https://ondc-prepod-digital-delivery.s3.amazonaws.com/seller_shop_logo/84/39MylDtZVC.jpg"
+                                ]
+                            },
+                            "fulfillments": [
+                                {
+                                    "id": "155",
+                                    "type": "Delivery",
+                                    "contact": {
+                                        "phone": "9812345678",
+                                        "email": "ajeetchauhan.symfony143@webkul.in"
+                                    }
+                                }
+                            ],
+                            "locations": [
+                                {
+                                    "id": "83",
+                                    "gps": "28.62972640,77.37783230",
+                                    "address": {
+                                        "locality": "Noida",
+                                        "street": "H-28",
+                                        "city": "Gautam Buddh Nagar",
+                                        "area_code": "201301",
+                                        "state": "Uttar Pradesh"
+                                    },
+                                    "circle": {
+                                        "gps": "28.62972640,77.37783230",
+                                        "radius": {
+                                            "unit": "km",
+                                            "value": "5"
+                                        }
+                                    },
+                                    "time": {
+                                        "label": "enable",
+                                        "timestamp": "2025-01-06T10:25:38.328Z",
+                                        "days": "1,2,3,4,5,6,7",
+                                        "schedule": {
+                                            "holidays": []
+                                        },
+                                        "range": {
+                                            "start": "0800",
+                                            "end": "1707"
+                                        }
+                                    }
+                                }
+                            ],
+                            "@ondc/org/fssai_license_no": "12345678908898",
+                            "categories": [
+                                {
+                                    "id": "66zabcdefghi",
+                                    "descriptor": {
+                                        "name": "Cheese"
+                                    },
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "custom_group"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "config",
+                                            "list": [
+                                                {
+                                                    "code": "min",
+                                                    "value": "1"
+                                                },
+                                                {
+                                                    "code": "max",
+                                                    "value": "1"
+                                                },
+                                                {
+                                                    "code": "input",
+                                                    "value": "select"
+                                                },
+                                                {
+                                                    "code": "seq",
+                                                    "value": "1"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                {
+                                    "id": "67zabcdefghi",
+                                    "descriptor": {
+                                        "name": "Non-veg toppings"
+                                    },
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "custom_group"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "config",
+                                            "list": [
+                                                {
+                                                    "code": "min",
+                                                    "value": "1"
+                                                },
+                                                {
+                                                    "code": "max",
+                                                    "value": "1"
+                                                },
+                                                {
+                                                    "code": "input",
+                                                    "value": "select"
+                                                },
+                                                {
+                                                    "code": "seq",
+                                                    "value": "2"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                {
+                                    "id": "844147zabcde",
+                                    "parent_category_id": "",
+                                    "descriptor": {
+                                        "name": "Pizza",
+                                        "short_desc": "Pizza",
+                                        "long_desc": "Pizza"
+                                    },
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "custom_menu"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "display",
+                                            "list": [
+                                                {
+                                                    "code": "rank",
+                                                    "value": "1"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "timing",
+                                            "list": [
+                                                {
+                                                    "code": "day_from",
+                                                    "value": "1"
+                                                },
+                                                {
+                                                    "code": "day_to",
+                                                    "value": "5"
+                                                },
+                                                {
+                                                    "code": "time_from",
+                                                    "value": "0800"
+                                                },
+                                                {
+                                                    "code": "time_to",
+                                                    "value": "2200"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ],
+                            "items": [
+                                {
+                                    "id": "451",
+                                    "time": {
+                                        "label": "enable",
+                                        "timestamp": "2025-01-06T10:25:38.328Z"
+                                    },
+                                    "descriptor": {
+                                        "name": "Pizza Mania",
+                                        "symbol": "https://d3bhszwz094mhs.cloudfront.net/product_img/main_img/342/NipTw8cSUY.jpeg",
+                                        "short_desc": "pizza best small",
+                                        "long_desc": "best pizza",
+                                        "images": [
+                                            "https://d3bhszwz094mhs.cloudfront.net/product_img/main_img/342/NipTw8cSUY.jpeg"
+                                        ],
+                                        "code": "1:123456789876"
+                                    },
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "99",
+                                        "maximum_value": "110",
+                                        "tags": [
+                                            {
+                                                "code": "range",
+                                                "list": [
+                                                    {
+                                                        "code": "lower",
+                                                        "value": "99.00"
+                                                    },
+                                                    {
+                                                        "code": "upper",
+                                                        "value": "159"
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                "code": "default_selection",
+                                                "list": [
+                                                    {
+                                                        "code": "value",
+                                                        "value": "99.00"
+                                                    },
+                                                    {
+                                                        "code": "maximum_value",
+                                                        "value": "159"
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "quantity": {
+                                        "available": {
+                                            "count": "99"
+                                        },
+                                        "maximum": {
+                                            "count": "99"
+                                        },
+                                        "unitized": {
+                                            "measure": {
+                                                "unit": "gram",
+                                                "value": "200"
+                                            }
+                                        }
+                                    },
+                                    "location_id": "83",
+                                    "category_id": "F&B",
+                                    "fulfillment_id": "155",
+                                    "@ondc/org/time_to_ship": "PT1H",
+                                    "@ondc/org/cancellable": true,
+                                    "@ondc/org/seller_pickup_return": false,
+                                    "@ondc/org/returnable": false,
+                                    "@ondc/org/return_window": "PT0S",
+                                    "@ondc/org/available_on_cod": false,
+                                    "@ondc/org/contact_details_consumer_care": "ajeet,ajeetchauhan.symfony143@webkul.in,9812345678",
+                                    "tags": [
+                                        {
+                                            "code": "origin",
+                                            "list": [
+                                                {
+                                                    "code": "country",
+                                                    "value": "IND"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "item"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "custom_group",
+                                            "list": [
+                                                {
+                                                    "code": "id",
+                                                    "value": "66zabcdefghi"
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "category_ids": [
+                                        "844147zabcde:1"
+                                    ]
+                                },
+                                {
+                                    "id": "93",
+                                    "descriptor": {
+                                        "name": "Extra"
+                                    },
+                                    "quantity": {
+                                        "available": {
+                                            "count": "99"
+                                        },
+                                        "maximum": {
+                                            "count": "99"
+                                        }
+                                    },
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "5.00",
+                                        "maximum_value": "5.00"
+                                    },
+                                    "category_id": "F&B",
+                                    "related": true,
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "customization"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "parent",
+                                            "list": [
+                                                {
+                                                    "code": "id",
+                                                    "value": "66zabcdefghi"
+                                                },
+                                                {
+                                                    "code": "default",
+                                                    "value": "yes"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "veg_nonveg",
+                                            "list": [
+                                                {
+                                                    "code": "veg",
+                                                    "value": "yes"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "child",
+                                            "list": [
+                                                {
+                                                    "code": "id",
+                                                    "value": "67zabcdefghi"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                {
+                                    "id": "94",
+                                    "descriptor": {
+                                        "name": "Vegan"
+                                    },
+                                    "quantity": {
+                                        "available": {
+                                            "count": "99"
+                                        },
+                                        "maximum": {
+                                            "count": "99"
+                                        }
+                                    },
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "10.00",
+                                        "maximum_value": "10.00"
+                                    },
+                                    "category_id": "F&B",
+                                    "related": true,
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "customization"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "parent",
+                                            "list": [
+                                                {
+                                                    "code": "id",
+                                                    "value": "66zabcdefghi"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "veg_nonveg",
+                                            "list": [
+                                                {
+                                                    "code": "veg",
+                                                    "value": "yes"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "child",
+                                            "list": [
+                                                {
+                                                    "code": "id",
+                                                    "value": "67zabcdefghi"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                {
+                                    "id": "95",
+                                    "descriptor": {
+                                        "name": "Chicken"
+                                    },
+                                    "quantity": {
+                                        "available": {
+                                            "count": "99"
+                                        },
+                                        "maximum": {
+                                            "count": "99"
+                                        }
+                                    },
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "10.00",
+                                        "maximum_value": "10.00"
+                                    },
+                                    "category_id": "F&B",
+                                    "related": true,
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "customization"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "parent",
+                                            "list": [
+                                                {
+                                                    "code": "id",
+                                                    "value": "67zabcdefghi"
+                                                },
+                                                {
+                                                    "code": "default",
+                                                    "value": "yes"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "veg_nonveg",
+                                            "list": [
+                                                {
+                                                    "code": "non_veg",
+                                                    "value": "yes"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                {
+                                    "id": "96",
+                                    "descriptor": {
+                                        "name": "Mutton"
+                                    },
+                                    "quantity": {
+                                        "available": {
+                                            "count": "99"
+                                        },
+                                        "maximum": {
+                                            "count": "99"
+                                        }
+                                    },
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "50.00",
+                                        "maximum_value": "50.00"
+                                    },
+                                    "category_id": "F&B",
+                                    "related": true,
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "customization"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "parent",
+                                            "list": [
+                                                {
+                                                    "code": "id",
+                                                    "value": "67zabcdefghi"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "veg_nonveg",
+                                            "list": [
+                                                {
+                                                    "code": "veg",
+                                                    "value": "yes"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ],
+                            "tags": [
+                                {
+                                    "code": "timing",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "Order"
+                                        },
+                                        {
+                                            "code": "location",
+                                            "value": "83"
+                                        },
+                                        {
+                                            "code": "day_from",
+                                            "value": "1"
+                                        },
+                                        {
+                                            "code": "day_to",
+                                            "value": "7"
+                                        },
+                                        {
+                                            "code": "time_from",
+                                            "value": "0900"
+                                        },
+                                        {
+                                            "code": "time_to",
+                                            "value": "2300"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "timing",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "Delivery"
+                                        },
+                                        {
+                                            "code": "location",
+                                            "value": "83"
+                                        },
+                                        {
+                                            "code": "day_from",
+                                            "value": "1"
+                                        },
+                                        {
+                                            "code": "day_to",
+                                            "value": "7"
+                                        },
+                                        {
+                                            "code": "time_from",
+                                            "value": "1000"
+                                        },
+                                        {
+                                            "code": "time_to",
+                                            "value": "2100"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "serviceability",
+                                    "list": [
+                                        {
+                                            "code": "location",
+                                            "value": "83"
+                                        },
+                                        {
+                                            "code": "category",
+                                            "value": "F&B"
+                                        },
+                                        {
+                                            "code": "type",
+                                            "value": "10"
+                                        },
+                                        {
+                                            "code": "val",
+                                            "value": "5"
+                                        },
+                                        {
+                                            "code": "unit",
+                                            "value": "km"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "ttl": "P1D"
+                        }
+                    ]
+                }
+            }
+        },
+        "select_out_of_stock": {
+            "context": {
+                "domain": "ONDC:RET11",
+                "country": "IND",
+                "city": "std:0120",
+                "action": "select",
+                "core_version": "1.2.0",
+                "bap_id": "buyer-app-preprod-v2.ondc.org",
+                "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+                "bpp_uri": "https://ondc.ecomviser.com/api/v1",
+                "transaction_id": "5a913b62-e66f-4a6b-bf2a-8072714506d6",
+                "message_id": "c80df604-33bf-4987-b515-60d21be332bd",
+                "timestamp": "2025-01-06T10:56:58.721Z",
+                "bpp_id": "ondc.ecomviser.com",
+                "ttl": "PT30S"
+            },
+            "message": {
+                "order": {
+                    "items": [
+                        {
+                            "id": "451",
+                            "quantity": {
+                                "count": 1
+                            },
+                            "location_id": "83",
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "item"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "parent_item_id": "xXUeYhqy/JJR"
+                        },
+                        {
+                            "id": "93",
+                            "quantity": {
+                                "count": 1
+                            },
+                            "location_id": "83",
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "66zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "parent_item_id": "xXUeYhqy/JJR"
+                        },
+                        {
+                            "id": "95",
+                            "quantity": {
+                                "count": 1
+                            },
+                            "location_id": "83",
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "67zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "parent_item_id": "xXUeYhqy/JJR"
+                        }
+                    ],
+                    "provider": {
+                        "id": "84",
+                        "locations": [
+                            {
+                                "id": "83"
+                            }
+                        ]
+                    },
+                    "fulfillments": [
+                        {
+                            "end": {
+                                "location": {
+                                    "gps": "28.629743,77.377795",
+                                    "address": {
+                                        "area_code": "201301"
+                                    }
+                                }
+                            }
+                        }
+                    ]
+                }
+            }
+        },
+        "on_select_out_of_stock": {
+            "context": {
+                "domain": "ONDC:RET11",
+                "country": "IND",
+                "city": "std:0120",
+                "action": "on_select",
+                "core_version": "1.2.0",
+                "bap_id": "buyer-app-preprod-v2.ondc.org",
+                "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+                "bpp_uri": "https://ondc.ecomviser.com/api/v1",
+                "transaction_id": "5a913b62-e66f-4a6b-bf2a-8072714506d6",
+                "message_id": "c80df604-33bf-4987-b515-60d21be332bd",
+                "timestamp": "2025-01-06T10:57:00.846Z",
+                "bpp_id": "ondc.ecomviser.com"
+            },
+            "message": {
+                "order": {
+                    "provider": {
+                        "id": "84",
+                        "locations": [
+                            {
+                                "id": "83"
+                            }
+                        ]
+                    },
+                    "items": [
+                        {
+                            "id": "451",
+                            "fulfillment_id": "155",
+                            "parent_item_id": "xXUeYhqy/JJR",
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "item"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "93",
+                            "fulfillment_id": "155",
+                            "parent_item_id": "xXUeYhqy/JJR",
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "66zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "95",
+                            "fulfillment_id": "155",
+                            "parent_item_id": "xXUeYhqy/JJR",
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "67zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ],
+                    "fulfillments": [
+                        {
+                            "id": "155",
+                            "type": "Delivery",
+                            "@ondc/org/provider_name": "ondc.ecomviser.com",
+                            "tracking": true,
+                            "@ondc/org/category": "Immediate Delivery",
+                            "@ondc/org/TAT": "PT90M",
+                            "state": {
+                                "descriptor": {
+                                    "code": "Serviceable"
+                                }
+                            }
+                        }
+                    ],
+                    "quote": {
+                        "price": {
+                            "currency": "INR",
+                            "value": "15.53"
+                        },
+                        "breakup": [
+                            {
+                                "title": "Pizza Mania",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "0"
+                                },
+                                "@ondc/org/title_type": "item",
+                                "@ondc/org/item_id": "451",
+                                "@ondc/org/item_quantity": {
+                                    "count": 0
+                                },
+                                "item": {
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "99"
+                                    },
+                                    "quantity": {
+                                        "available": {
+                                            "count": "0"
+                                        },
+                                        "maximum": {
+                                            "count": "0"
+                                        }
+                                    },
+                                    "parent_item_id": "xXUeYhqy/JJR",
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "item"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "title": "Extra",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "5"
+                                },
+                                "@ondc/org/title_type": "item",
+                                "@ondc/org/item_id": "93",
+                                "@ondc/org/item_quantity": {
+                                    "count": 1
+                                },
+                                "item": {
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "5"
+                                    },
+                                    "quantity": {
+                                        "available": {
+                                            "count": "99"
+                                        },
+                                        "maximum": {
+                                            "count": "99"
+                                        }
+                                    },
+                                    "parent_item_id": "xXUeYhqy/JJR",
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "customization"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "parent",
+                                            "list": [
+                                                {
+                                                    "code": "id",
+                                                    "value": "66zabcdefghi"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "title": "Chicken",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "10"
+                                },
+                                "@ondc/org/title_type": "item",
+                                "@ondc/org/item_id": "95",
+                                "@ondc/org/item_quantity": {
+                                    "count": 1
+                                },
+                                "item": {
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "10"
+                                    },
+                                    "quantity": {
+                                        "available": {
+                                            "count": "99"
+                                        },
+                                        "maximum": {
+                                            "count": "99"
+                                        }
+                                    },
+                                    "parent_item_id": "xXUeYhqy/JJR",
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "customization"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "parent",
+                                            "list": [
+                                                {
+                                                    "code": "id",
+                                                    "value": "67zabcdefghi"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "title": "Convenience fee",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "0.53"
+                                },
+                                "@ondc/org/title_type": "misc",
+                                "@ondc/org/item_id": "155"
+                            },
+                            {
+                                "title": "Delivery charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "0"
+                                },
+                                "@ondc/org/title_type": "delivery",
+                                "@ondc/org/item_id": "155"
+                            }
+                        ],
+                        "ttl": "PT6H"
+                    }
+                }
+            },
+            "error": {
+                "type": "DOMAIN-ERROR",
+                "code": "40002",
+                "message": "[{\"item_id\":\"451\",\"error\":\"40002\",\"dynamic_item_id\":\"xXUeYhqy\\/JJR\"}]"
+            }
+        },
+        "select": {
+            "context": {
+                "domain": "ONDC:RET11",
+                "country": "IND",
+                "city": "std:0120",
+                "action": "select",
+                "core_version": "1.2.0",
+                "bap_id": "buyer-app-preprod-v2.ondc.org",
+                "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+                "bpp_uri": "https://ondc.ecomviser.com/api/v1",
+                "transaction_id": "5a913b62-e66f-4a6b-bf2a-8072714506d6",
+                "message_id": "f42ce0d2-71d7-4b6f-bd9c-312c97f1fd81",
+                "timestamp": "2025-01-06T10:57:52.838Z",
+                "bpp_id": "ondc.ecomviser.com",
+                "ttl": "PT30S"
+            },
+            "message": {
+                "order": {
+                    "items": [
+                        {
+                            "id": "451",
+                            "quantity": {
+                                "count": 1
+                            },
+                            "location_id": "83",
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "item"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "parent_item_id": "xXUeYhqy/JJR"
+                        },
+                        {
+                            "id": "93",
+                            "quantity": {
+                                "count": 1
+                            },
+                            "location_id": "83",
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "66zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "parent_item_id": "xXUeYhqy/JJR"
+                        },
+                        {
+                            "id": "95",
+                            "quantity": {
+                                "count": 1
+                            },
+                            "location_id": "83",
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "67zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "parent_item_id": "xXUeYhqy/JJR"
+                        }
+                    ],
+                    "provider": {
+                        "id": "84",
+                        "locations": [
+                            {
+                                "id": "83"
+                            }
+                        ]
+                    },
+                    "fulfillments": [
+                        {
+                            "end": {
+                                "location": {
+                                    "gps": "28.629743,77.377795",
+                                    "address": {
+                                        "area_code": "201301"
+                                    }
+                                }
+                            }
+                        }
+                    ]
+                }
+            }
+        },
+        "on_select": {
+            "context": {
+                "domain": "ONDC:RET11",
+                "country": "IND",
+                "city": "std:0120",
+                "action": "on_select",
+                "core_version": "1.2.0",
+                "bap_id": "buyer-app-preprod-v2.ondc.org",
+                "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+                "bpp_uri": "https://ondc.ecomviser.com/api/v1",
+                "transaction_id": "5a913b62-e66f-4a6b-bf2a-8072714506d6",
+                "message_id": "f42ce0d2-71d7-4b6f-bd9c-312c97f1fd81",
+                "timestamp": "2025-01-06T10:57:54.812Z",
+                "bpp_id": "ondc.ecomviser.com"
+            },
+            "message": {
+                "order": {
+                    "provider": {
+                        "id": "84",
+                        "locations": [
+                            {
+                                "id": "83"
+                            }
+                        ]
+                    },
+                    "items": [
+                        {
+                            "id": "451",
+                            "fulfillment_id": "155",
+                            "parent_item_id": "xXUeYhqy/JJR",
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "item"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "93",
+                            "fulfillment_id": "155",
+                            "parent_item_id": "xXUeYhqy/JJR",
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "66zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "95",
+                            "fulfillment_id": "155",
+                            "parent_item_id": "xXUeYhqy/JJR",
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "67zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ],
+                    "fulfillments": [
+                        {
+                            "id": "155",
+                            "type": "Delivery",
+                            "@ondc/org/provider_name": "ondc.ecomviser.com",
+                            "tracking": true,
+                            "@ondc/org/category": "Immediate Delivery",
+                            "@ondc/org/TAT": "PT90M",
+                            "state": {
+                                "descriptor": {
+                                    "code": "Serviceable"
+                                }
+                            }
+                        }
+                    ],
+                    "quote": {
+                        "price": {
+                            "currency": "INR",
+                            "value": "118.04"
+                        },
+                        "breakup": [
+                            {
+                                "title": "Pizza Mania",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "99"
+                                },
+                                "@ondc/org/title_type": "item",
+                                "@ondc/org/item_id": "451",
+                                "@ondc/org/item_quantity": {
+                                    "count": 1
+                                },
+                                "item": {
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "99"
+                                    },
+                                    "quantity": {
+                                        "available": {
+                                            "count": "99"
+                                        },
+                                        "maximum": {
+                                            "count": "99"
+                                        }
+                                    },
+                                    "parent_item_id": "xXUeYhqy/JJR",
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "item"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "title": "Extra",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "5"
+                                },
+                                "@ondc/org/title_type": "item",
+                                "@ondc/org/item_id": "93",
+                                "@ondc/org/item_quantity": {
+                                    "count": 1
+                                },
+                                "item": {
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "5"
+                                    },
+                                    "quantity": {
+                                        "available": {
+                                            "count": "99"
+                                        },
+                                        "maximum": {
+                                            "count": "99"
+                                        }
+                                    },
+                                    "parent_item_id": "xXUeYhqy/JJR",
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "customization"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "parent",
+                                            "list": [
+                                                {
+                                                    "code": "id",
+                                                    "value": "66zabcdefghi"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "title": "Chicken",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "10"
+                                },
+                                "@ondc/org/title_type": "item",
+                                "@ondc/org/item_id": "95",
+                                "@ondc/org/item_quantity": {
+                                    "count": 1
+                                },
+                                "item": {
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "10"
+                                    },
+                                    "quantity": {
+                                        "available": {
+                                            "count": "99"
+                                        },
+                                        "maximum": {
+                                            "count": "99"
+                                        }
+                                    },
+                                    "parent_item_id": "xXUeYhqy/JJR",
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "customization"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "parent",
+                                            "list": [
+                                                {
+                                                    "code": "id",
+                                                    "value": "67zabcdefghi"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "title": "Convenience fee",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "4.04"
+                                },
+                                "@ondc/org/title_type": "misc",
+                                "@ondc/org/item_id": "155"
+                            },
+                            {
+                                "title": "Delivery charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "0"
+                                },
+                                "@ondc/org/title_type": "delivery",
+                                "@ondc/org/item_id": "155"
+                            }
+                        ],
+                        "ttl": "PT6H"
+                    }
+                }
+            }
+        },
+        "init": {
+            "context": {
+                "domain": "ONDC:RET11",
+                "country": "IND",
+                "city": "std:0120",
+                "action": "init",
+                "core_version": "1.2.0",
+                "bap_id": "buyer-app-preprod-v2.ondc.org",
+                "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+                "bpp_uri": "https://ondc.ecomviser.com/api/v1",
+                "transaction_id": "5a913b62-e66f-4a6b-bf2a-8072714506d6",
+                "message_id": "57d47b27-6f2c-48ba-b25c-187db6d119d3",
+                "timestamp": "2025-01-06T10:58:02.529Z",
+                "bpp_id": "ondc.ecomviser.com",
+                "ttl": "PT30S"
+            },
+            "message": {
+                "order": {
+                    "provider": {
+                        "id": "84",
+                        "locations": [
+                            {
+                                "id": "83"
+                            }
+                        ]
+                    },
+                    "items": [
+                        {
+                            "id": "451",
+                            "quantity": {
+                                "count": 1
+                            },
+                            "location_id": "83",
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "item"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "parent_item_id": "xXUeYhqy/JJR",
+                            "fulfillment_id": "155"
+                        },
+                        {
+                            "id": "93",
+                            "quantity": {
+                                "count": 1
+                            },
+                            "location_id": "83",
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "66zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "fulfillment_id": "155",
+                            "parent_item_id": "xXUeYhqy/JJR"
+                        },
+                        {
+                            "id": "95",
+                            "quantity": {
+                                "count": 1
+                            },
+                            "location_id": "83",
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "67zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "fulfillment_id": "155",
+                            "parent_item_id": "xXUeYhqy/JJR"
+                        }
+                    ],
+                    "billing": {
+                        "address": {
+                            "building": "ARV Park",
+                            "city": "Noida",
+                            "state": "Uttar Pradesh",
+                            "country": "IND",
+                            "area_code": "201301",
+                            "locality": "Unnamed Road",
+                            "name": "Ajeet Chauhan"
+                        },
+                        "phone": "8574739650",
+                        "name": "Ajeet Chauhan",
+                        "email": "ajeetchauhan.symfony143@webkul.in",
+                        "created_at": "2025-01-06T10:58:02.529Z",
+                        "updated_at": "2025-01-06T10:58:02.529Z"
+                    },
+                    "fulfillments": [
+                        {
+                            "id": "155",
+                            "type": "Delivery",
+                            "end": {
+                                "contact": {
+                                    "email": "ajeetchauhan.symfony143@webkul.in",
+                                    "phone": "8574739650"
+                                },
+                                "location": {
+                                    "gps": "28.629743,77.377795",
+                                    "address": {
+                                        "building": "ARV Park",
+                                        "city": "Noida",
+                                        "state": "Uttar Pradesh",
+                                        "country": "IND",
+                                        "area_code": "201301",
+                                        "locality": "Unnamed Road",
+                                        "name": "Ajeet Chauhan"
+                                    }
+                                }
+                            }
+                        }
+                    ]
+                }
+            }
+        },
+        "on_init": {
+            "context": {
+                "domain": "ONDC:RET11",
+                "country": "IND",
+                "city": "std:0120",
+                "action": "on_init",
+                "core_version": "1.2.0",
+                "bap_id": "buyer-app-preprod-v2.ondc.org",
+                "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+                "bpp_uri": "https://ondc.ecomviser.com/api/v1",
+                "transaction_id": "5a913b62-e66f-4a6b-bf2a-8072714506d6",
+                "message_id": "57d47b27-6f2c-48ba-b25c-187db6d119d3",
+                "timestamp": "2025-01-06T10:58:06.344Z",
+                "bpp_id": "ondc.ecomviser.com",
+                "ttl": "PT30S"
+            },
+            "message": {
+                "order": {
+                    "provider": {
+                        "id": "84",
+                        "locations": [
+                            {
+                                "id": "83"
+                            }
+                        ]
+                    },
+                    "items": [
+                        {
+                            "id": "451",
+                            "fulfillment_id": "155",
+                            "quantity": {
+                                "count": 1
+                            },
+                            "parent_item_id": "xXUeYhqy/JJR",
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "item"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "93",
+                            "fulfillment_id": "155",
+                            "quantity": {
+                                "count": 1
+                            },
+                            "parent_item_id": "xXUeYhqy/JJR",
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "66zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "95",
+                            "fulfillment_id": "155",
+                            "quantity": {
+                                "count": 1
+                            },
+                            "parent_item_id": "xXUeYhqy/JJR",
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "67zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ],
+                    "quote": {
+                        "price": {
+                            "currency": "INR",
+                            "value": "118.04"
+                        },
+                        "breakup": [
+                            {
+                                "title": "Pizza Mania",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "99"
+                                },
+                                "@ondc/org/title_type": "item",
+                                "@ondc/org/item_id": "451",
+                                "@ondc/org/item_quantity": {
+                                    "count": 1
+                                },
+                                "item": {
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "99"
+                                    },
+                                    "parent_item_id": "xXUeYhqy/JJR",
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "item"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "title": "Extra",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "5"
+                                },
+                                "@ondc/org/title_type": "item",
+                                "@ondc/org/item_id": "93",
+                                "@ondc/org/item_quantity": {
+                                    "count": 1
+                                },
+                                "item": {
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "5"
+                                    },
+                                    "parent_item_id": "xXUeYhqy/JJR",
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "customization"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "parent",
+                                            "list": [
+                                                {
+                                                    "code": "id",
+                                                    "value": "66zabcdefghi"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "title": "Chicken",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "10"
+                                },
+                                "@ondc/org/title_type": "item",
+                                "@ondc/org/item_id": "95",
+                                "@ondc/org/item_quantity": {
+                                    "count": 1
+                                },
+                                "item": {
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "10"
+                                    },
+                                    "parent_item_id": "xXUeYhqy/JJR",
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "customization"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "parent",
+                                            "list": [
+                                                {
+                                                    "code": "id",
+                                                    "value": "67zabcdefghi"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "title": "Convenience fee",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "4.04"
+                                },
+                                "@ondc/org/title_type": "misc",
+                                "@ondc/org/item_id": "155"
+                            },
+                            {
+                                "title": "Delivery charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "0"
+                                },
+                                "@ondc/org/title_type": "delivery",
+                                "@ondc/org/item_id": "155"
+                            }
+                        ],
+                        "ttl": "PT6H"
+                    },
+                    "billing": {
+                        "address": {
+                            "building": "ARV Park",
+                            "city": "Noida",
+                            "state": "Uttar Pradesh",
+                            "country": "IND",
+                            "area_code": "201301",
+                            "locality": "Unnamed Road",
+                            "name": "Ajeet Chauhan"
+                        },
+                        "phone": "8574739650",
+                        "name": "Ajeet Chauhan",
+                        "email": "ajeetchauhan.symfony143@webkul.in",
+                        "created_at": "2025-01-06T10:58:02.529Z",
+                        "updated_at": "2025-01-06T10:58:02.529Z"
+                    },
+                    "fulfillments": [
+                        {
+                            "id": "155",
+                            "type": "Delivery",
+                            "end": {
+                                "contact": {
+                                    "email": "ajeetchauhan.symfony143@webkul.in",
+                                    "phone": "8574739650"
+                                },
+                                "location": {
+                                    "gps": "28.629743,77.377795",
+                                    "address": {
+                                        "building": "ARV Park",
+                                        "city": "Noida",
+                                        "state": "Uttar Pradesh",
+                                        "country": "IND",
+                                        "area_code": "201301",
+                                        "locality": "Unnamed Road",
+                                        "name": "Ajeet Chauhan"
+                                    }
+                                }
+                            },
+                            "tracking": true
+                        }
+                    ],
+                    "payment": {
+                        "type": "ON-ORDER",
+                        "collected_by": "BAP",
+                        "@ondc/org/collected_by_status": "Agree",
+                        "@ondc/org/buyer_app_finder_fee_type": "percent",
+                        "@ondc/org/buyer_app_finder_fee_amount": "3",
+                        "@ondc/org/settlement_details": [
+                            {
+                                "settlement_counterparty": "seller-app",
+                                "settlement_phase": "sale-amount",
+                                "settlement_type": "neft",
+                                "beneficiary_name": "fasdf asdfasdf",
+                                "settlement_bank_account_no": "534512341234132",
+                                "settlement_ifsc_code": "HDFC0000088",
+                                "bank_name": "fasdf",
+                                "branch_name": "noida",
+                                "settlement_status": "NOT-PAID"
+                            }
+                        ]
+                    },
+                    "tags": [
+                        {
+                            "code": "bpp_terms",
+                            "list": [
+                                {
+                                    "code": "tax_number",
+                                    "value": "09AABCW0339G3ZD"
+                                },
+                                {
+                                    "code": "provider_tax_number",
+                                    "value": "DERTC3376R"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        },
+        "confirm": {
+            "context": {
+                "domain": "ONDC:RET11",
+                "country": "IND",
+                "city": "std:0120",
+                "action": "confirm",
+                "core_version": "1.2.0",
+                "bap_id": "buyer-app-preprod-v2.ondc.org",
+                "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+                "bpp_uri": "https://ondc.ecomviser.com/api/v1",
+                "transaction_id": "5a913b62-e66f-4a6b-bf2a-8072714506d6",
+                "message_id": "ec786fd7-8fe6-4bef-860c-30588f73b0a9",
+                "timestamp": "2025-01-06T10:58:33.520Z",
+                "bpp_id": "ondc.ecomviser.com",
+                "ttl": "PT30S"
+            },
+            "message": {
+                "order": {
+                    "id": "2025-01-06-333398",
+                    "state": "Created",
+                    "billing": {
+                        "address": {
+                            "name": "Ajeet Chauhan",
+                            "building": "ARV Park",
+                            "locality": "Unnamed Road",
+                            "city": "Noida",
+                            "state": "Uttar Pradesh",
+                            "country": "IND",
+                            "area_code": "201301"
+                        },
+                        "phone": "8574739650",
+                        "name": "Ajeet Chauhan",
+                        "email": "ajeetchauhan.symfony143@webkul.in",
+                        "created_at": "2025-01-06T10:58:02.529Z",
+                        "updated_at": "2025-01-06T10:58:02.529Z"
+                    },
+                    "items": [
+                        {
+                            "id": "451",
+                            "quantity": {
+                                "count": 1
+                            },
+                            "fulfillment_id": "155",
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "item"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "parent_item_id": "xXUeYhqy/JJR"
+                        },
+                        {
+                            "id": "93",
+                            "quantity": {
+                                "count": 1
+                            },
+                            "fulfillment_id": "155",
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "66zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "parent_item_id": "xXUeYhqy/JJR"
+                        },
+                        {
+                            "id": "95",
+                            "quantity": {
+                                "count": 1
+                            },
+                            "fulfillment_id": "155",
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "67zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "parent_item_id": "xXUeYhqy/JJR"
+                        }
+                    ],
+                    "provider": {
+                        "id": "84",
+                        "locations": [
+                            {
+                                "id": "83"
+                            }
+                        ]
+                    },
+                    "fulfillments": [
+                        {
+                            "@ondc/org/TAT": "PT90M",
+                            "id": "155",
+                            "tracking": true,
+                            "end": {
+                                "contact": {
+                                    "email": "ajeetchauhan.symfony143@webkul.in",
+                                    "phone": "8574739650"
+                                },
+                                "person": {
+                                    "name": "Ajeet Chauhan"
+                                },
+                                "location": {
+                                    "gps": "28.629743,77.377795",
+                                    "address": {
+                                        "name": "Ajeet Chauhan",
+                                        "building": "ARV Park",
+                                        "locality": "Unnamed Road",
+                                        "city": "Noida",
+                                        "state": "Uttar Pradesh",
+                                        "country": "IND",
+                                        "area_code": "201301"
+                                    }
+                                }
+                            },
+                            "type": "Delivery"
+                        }
+                    ],
+                    "payment": {
+                        "uri": "https://razorpay.com/",
+                        "tl_method": "http/get",
+                        "params": {
+                            "amount": "118.04",
+                            "currency": "INR",
+                            "transaction_id": "order_Pg8IoytiBpf9W3"
+                        },
+                        "status": "PAID",
+                        "type": "ON-ORDER",
+                        "collected_by": "BAP",
+                        "@ondc/org/buyer_app_finder_fee_type": "percent",
+                        "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+                        "@ondc/org/settlement_details": [
+                            {
+                                "settlement_counterparty": "seller-app",
+                                "settlement_phase": "sale-amount",
+                                "settlement_type": "neft",
+                                "beneficiary_name": "fasdf asdfasdf",
+                                "settlement_bank_account_no": "534512341234132",
+                                "settlement_ifsc_code": "HDFC0000088",
+                                "bank_name": "fasdf",
+                                "branch_name": "noida",
+                                "settlement_status": "NOT-PAID"
+                            }
+                        ]
+                    },
+                    "quote": {
+                        "price": {
+                            "currency": "INR",
+                            "value": "118.04"
+                        },
+                        "breakup": [
+                            {
+                                "title": "Pizza Mania",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "99"
+                                },
+                                "@ondc/org/title_type": "item",
+                                "@ondc/org/item_id": "451",
+                                "@ondc/org/item_quantity": {
+                                    "count": 1
+                                },
+                                "item": {
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "99"
+                                    },
+                                    "parent_item_id": "xXUeYhqy/JJR",
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "item"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "title": "Extra",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "5"
+                                },
+                                "@ondc/org/title_type": "item",
+                                "@ondc/org/item_id": "93",
+                                "@ondc/org/item_quantity": {
+                                    "count": 1
+                                },
+                                "item": {
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "5"
+                                    },
+                                    "parent_item_id": "xXUeYhqy/JJR",
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "customization"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "parent",
+                                            "list": [
+                                                {
+                                                    "code": "id",
+                                                    "value": "66zabcdefghi"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "title": "Chicken",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "10"
+                                },
+                                "@ondc/org/title_type": "item",
+                                "@ondc/org/item_id": "95",
+                                "@ondc/org/item_quantity": {
+                                    "count": 1
+                                },
+                                "item": {
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "10"
+                                    },
+                                    "parent_item_id": "xXUeYhqy/JJR",
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "customization"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "parent",
+                                            "list": [
+                                                {
+                                                    "code": "id",
+                                                    "value": "67zabcdefghi"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "title": "Convenience fee",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "4.04"
+                                },
+                                "@ondc/org/title_type": "misc",
+                                "@ondc/org/item_id": "155"
+                            },
+                            {
+                                "title": "Delivery charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "0"
+                                },
+                                "@ondc/org/title_type": "delivery",
+                                "@ondc/org/item_id": "155"
+                            }
+                        ],
+                        "ttl": "PT6H"
+                    },
+                    "tags": [
+                        {
+                            "code": "bpp_terms",
+                            "list": [
+                                {
+                                    "code": "tax_number",
+                                    "value": "09AABCW0339G3ZD"
+                                },
+                                {
+                                    "code": "provider_tax_number",
+                                    "value": "DERTC3376R"
+                                }
+                            ]
+                        },
+                        {
+                            "code": "bap_terms",
+                            "list": [
+                                {
+                                    "code": "tax_number",
+                                    "value": "GSTIN1234567890"
+                                }
+                            ]
+                        }
+                    ],
+                    "created_at": "2025-01-06T10:58:33.520Z",
+                    "updated_at": "2025-01-06T10:58:33.520Z"
+                }
+            }
+        },
+        "on_confirm": {
+            "context": {
+                "domain": "ONDC:RET11",
+                "country": "IND",
+                "city": "std:0120",
+                "action": "on_confirm",
+                "core_version": "1.2.0",
+                "bap_id": "buyer-app-preprod-v2.ondc.org",
+                "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+                "bpp_uri": "https://ondc.ecomviser.com/api/v1",
+                "transaction_id": "5a913b62-e66f-4a6b-bf2a-8072714506d6",
+                "message_id": "ec786fd7-8fe6-4bef-860c-30588f73b0a9",
+                "timestamp": "2025-01-06T10:58:37.431Z",
+                "bpp_id": "ondc.ecomviser.com"
+            },
+            "message": {
+                "order": {
+                    "id": "2025-01-06-333398",
+                    "state": "Created",
+                    "provider": {
+                        "id": "84",
+                        "locations": [
+                            {
+                                "id": "83"
+                            }
+                        ]
+                    },
+                    "items": [
+                        {
+                            "id": "451",
+                            "quantity": {
+                                "count": 1
+                            },
+                            "fulfillment_id": "155",
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "item"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "parent_item_id": "xXUeYhqy/JJR"
+                        },
+                        {
+                            "id": "93",
+                            "quantity": {
+                                "count": 1
+                            },
+                            "fulfillment_id": "155",
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "66zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "parent_item_id": "xXUeYhqy/JJR"
+                        },
+                        {
+                            "id": "95",
+                            "quantity": {
+                                "count": 1
+                            },
+                            "fulfillment_id": "155",
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "67zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "parent_item_id": "xXUeYhqy/JJR"
+                        }
+                    ],
+                    "billing": {
+                        "address": {
+                            "name": "Ajeet Chauhan",
+                            "building": "ARV Park",
+                            "locality": "Unnamed Road",
+                            "city": "Noida",
+                            "state": "Uttar Pradesh",
+                            "country": "IND",
+                            "area_code": "201301"
+                        },
+                        "phone": "8574739650",
+                        "name": "Ajeet Chauhan",
+                        "email": "ajeetchauhan.symfony143@webkul.in",
+                        "created_at": "2025-01-06T10:58:02.529Z",
+                        "updated_at": "2025-01-06T10:58:02.529Z"
+                    },
+                    "fulfillments": [
+                        {
+                            "@ondc/org/TAT": "PT90M",
+                            "id": "155",
+                            "tracking": true,
+                            "end": {
+                                "contact": {
+                                    "email": "ajeetchauhan.symfony143@webkul.in",
+                                    "phone": "8574739650"
+                                },
+                                "person": {
+                                    "name": "Ajeet Chauhan"
+                                },
+                                "location": {
+                                    "gps": "28.629743,77.377795",
+                                    "address": {
+                                        "name": "Ajeet Chauhan",
+                                        "building": "ARV Park",
+                                        "locality": "Unnamed Road",
+                                        "city": "Noida",
+                                        "state": "Uttar Pradesh",
+                                        "country": "IND",
+                                        "area_code": "201301"
+                                    }
+                                },
+                                "time": {
+                                    "range": {
+                                        "start": "2025-01-06T10:58:40.518Z",
+                                        "end": "2025-01-06T11:58:40.518Z"
+                                    }
+                                }
+                            },
+                            "type": "Delivery",
+                            "@ondc/org/provider_name": "ondc.ecomviser.com",
+                            "state": {
+                                "descriptor": {
+                                    "code": "Pending"
+                                }
+                            },
+                            "start": {
+                                "location": {
+                                    "id": "83",
+                                    "descriptor": {
+                                        "name": "Ajeet Food Shop"
+                                    },
+                                    "gps": "28.62972640,77.37783230",
+                                    "address": {
+                                        "locality": "Noida",
+                                        "city": "Gautam Buddh Nagar",
+                                        "area_code": "201301",
+                                        "state": "Uttar Pradesh"
+                                    }
+                                },
+                                "contact": {
+                                    "phone": "9876543210",
+                                    "email": "support@webkul.in"
+                                },
+                                "time": {
+                                    "range": {
+                                        "start": "2025-01-06T10:58:40.518Z",
+                                        "end": "2025-01-06T11:58:40.518Z"
+                                    }
+                                }
+                            }
+                        }
+                    ],
+                    "quote": {
+                        "price": {
+                            "currency": "INR",
+                            "value": "118.04"
+                        },
+                        "breakup": [
+                            {
+                                "title": "Pizza Mania",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "99"
+                                },
+                                "@ondc/org/title_type": "item",
+                                "@ondc/org/item_id": "451",
+                                "@ondc/org/item_quantity": {
+                                    "count": 1
+                                },
+                                "item": {
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "99"
+                                    },
+                                    "parent_item_id": "xXUeYhqy/JJR",
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "item"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "title": "Extra",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "5"
+                                },
+                                "@ondc/org/title_type": "item",
+                                "@ondc/org/item_id": "93",
+                                "@ondc/org/item_quantity": {
+                                    "count": 1
+                                },
+                                "item": {
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "5"
+                                    },
+                                    "parent_item_id": "xXUeYhqy/JJR",
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "customization"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "parent",
+                                            "list": [
+                                                {
+                                                    "code": "id",
+                                                    "value": "66zabcdefghi"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "title": "Chicken",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "10"
+                                },
+                                "@ondc/org/title_type": "item",
+                                "@ondc/org/item_id": "95",
+                                "@ondc/org/item_quantity": {
+                                    "count": 1
+                                },
+                                "item": {
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "10"
+                                    },
+                                    "parent_item_id": "xXUeYhqy/JJR",
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "customization"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "parent",
+                                            "list": [
+                                                {
+                                                    "code": "id",
+                                                    "value": "67zabcdefghi"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "title": "Convenience fee",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "4.04"
+                                },
+                                "@ondc/org/title_type": "misc",
+                                "@ondc/org/item_id": "155"
+                            },
+                            {
+                                "title": "Delivery charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "0"
+                                },
+                                "@ondc/org/title_type": "delivery",
+                                "@ondc/org/item_id": "155"
+                            }
+                        ],
+                        "ttl": "PT6H"
+                    },
+                    "payment": {
+                        "uri": "https://razorpay.com/",
+                        "tl_method": "http/get",
+                        "params": {
+                            "amount": "118.04",
+                            "currency": "INR",
+                            "transaction_id": "order_Pg8IoytiBpf9W3"
+                        },
+                        "status": "PAID",
+                        "type": "ON-ORDER",
+                        "collected_by": "BAP",
+                        "@ondc/org/buyer_app_finder_fee_type": "percent",
+                        "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+                        "@ondc/org/settlement_details": [
+                            {
+                                "settlement_counterparty": "seller-app",
+                                "settlement_phase": "sale-amount",
+                                "settlement_type": "neft",
+                                "beneficiary_name": "fasdf asdfasdf",
+                                "settlement_bank_account_no": "534512341234132",
+                                "settlement_ifsc_code": "HDFC0000088",
+                                "bank_name": "fasdf",
+                                "branch_name": "noida",
+                                "settlement_status": "NOT-PAID"
+                            }
+                        ]
+                    },
+                    "tags": [
+                        {
+                            "code": "bpp_terms",
+                            "list": [
+                                {
+                                    "code": "np_type",
+                                    "value": "MSN"
+                                },
+                                {
+                                    "code": "tax_number",
+                                    "value": "09AABCW0339G3ZD"
+                                },
+                                {
+                                    "code": "provider_tax_number",
+                                    "value": "DERTC3376R"
+                                }
+                            ]
+                        },
+                        {
+                            "code": "bap_terms",
+                            "list": [
+                                {
+                                    "code": "tax_number",
+                                    "value": "GSTIN1234567890"
+                                }
+                            ]
+                        }
+                    ],
+                    "created_at": "2025-01-06T10:58:33.520Z",
+                    "updated_at": "2025-01-06T10:58:37.431Z"
+                }
+            }
+        },
+        "on_status_pending": {
+            "context": {
+                "domain": "ONDC:RET11",
+                "country": "IND",
+                "city": "std:0120",
+                "action": "on_status",
+                "core_version": "1.2.0",
+                "bap_id": "buyer-app-preprod-v2.ondc.org",
+                "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+                "bpp_uri": "https://ondc.ecomviser.com/api/v1",
+                "transaction_id": "5a913b62-e66f-4a6b-bf2a-8072714506d6",
+                "message_id": "677bb7aca7a48f0d3be09-c0f1",
+                "timestamp": "2025-01-06T10:59:56.687Z",
+                "bpp_id": "ondc.ecomviser.com",
+                "ttl": "PT30S"
+            },
+            "message": {
+                "order": {
+                    "id": "2025-01-06-333398",
+                    "state": "Accepted",
+                    "provider": {
+                        "id": "84",
+                        "locations": [
+                            {
+                                "id": "83"
+                            }
+                        ]
+                    },
+                    "items": [
+                        {
+                            "id": "451",
+                            "fulfillment_id": "155",
+                            "quantity": {
+                                "count": 1
+                            }
+                        }
+                    ],
+                    "fulfillments": [
+                        {
+                            "id": "155",
+                            "end": {
+                                "time": {
+                                    "range": {
+                                        "end": "2025-01-06T11:58:40.518Z",
+                                        "start": "2025-01-06T10:58:40.518Z"
+                                    }
+                                },
+                                "person": {
+                                    "name": "Ajeet Chauhan"
+                                },
+                                "contact": {
+                                    "email": "ajeetchauhan.symfony143@webkul.in",
+                                    "phone": "8574739650"
+                                },
+                                "location": {
+                                    "gps": "28.629743,77.377795",
+                                    "address": {
+                                        "city": "Noida",
+                                        "name": "Ajeet Chauhan",
+                                        "state": "Uttar Pradesh",
+                                        "country": "IND",
+                                        "building": "ARV Park",
+                                        "locality": "Unnamed Road",
+                                        "area_code": "201301"
+                                    }
+                                }
+                            },
+                            "type": "Delivery",
+                            "start": {
+                                "time": {
+                                    "range": {
+                                        "end": "2025-01-06T11:58:40.518Z",
+                                        "start": "2025-01-06T10:58:40.518Z"
+                                    }
+                                },
+                                "contact": {
+                                    "email": "support@webkul.in",
+                                    "phone": "9876543210"
+                                },
+                                "location": {
+                                    "id": "83",
+                                    "gps": "28.62972640,77.37783230",
+                                    "address": {
+                                        "city": "Gautam Buddh Nagar",
+                                        "state": "Uttar Pradesh",
+                                        "locality": "Noida",
+                                        "area_code": "201301"
+                                    },
+                                    "descriptor": {
+                                        "name": "Ajeet Food Shop"
+                                    }
+                                }
+                            },
+                            "state": {
+                                "descriptor": {
+                                    "code": "Pending"
+                                }
+                            },
+                            "tracking": true,
+                            "@ondc/org/TAT": "PT90M",
+                            "@ondc/org/provider_name": "ondc.ecomviser.com"
+                        }
+                    ],
+                    "quote": {
+                        "ttl": "PT6H",
+                        "price": {
+                            "value": "118.04",
+                            "currency": "INR"
+                        },
+                        "breakup": [
+                            {
+                                "item": {
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "item"
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "price": {
+                                        "value": "99",
+                                        "currency": "INR"
+                                    },
+                                    "parent_item_id": "xXUeYhqy/JJR"
+                                },
+                                "price": {
+                                    "value": "99",
+                                    "currency": "INR"
+                                },
+                                "title": "Pizza Mania",
+                                "@ondc/org/item_id": "451",
+                                "@ondc/org/title_type": "item",
+                                "@ondc/org/item_quantity": {
+                                    "count": 1
+                                }
+                            },
+                            {
+                                "item": {
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "customization"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "parent",
+                                            "list": [
+                                                {
+                                                    "code": "id",
+                                                    "value": "66zabcdefghi"
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "price": {
+                                        "value": "5",
+                                        "currency": "INR"
+                                    },
+                                    "parent_item_id": "xXUeYhqy/JJR"
+                                },
+                                "price": {
+                                    "value": "5",
+                                    "currency": "INR"
+                                },
+                                "title": "Extra",
+                                "@ondc/org/item_id": "93",
+                                "@ondc/org/title_type": "item",
+                                "@ondc/org/item_quantity": {
+                                    "count": 1
+                                }
+                            },
+                            {
+                                "item": {
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "customization"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "parent",
+                                            "list": [
+                                                {
+                                                    "code": "id",
+                                                    "value": "67zabcdefghi"
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "price": {
+                                        "value": "10",
+                                        "currency": "INR"
+                                    },
+                                    "parent_item_id": "xXUeYhqy/JJR"
+                                },
+                                "price": {
+                                    "value": "10",
+                                    "currency": "INR"
+                                },
+                                "title": "Chicken",
+                                "@ondc/org/item_id": "95",
+                                "@ondc/org/title_type": "item",
+                                "@ondc/org/item_quantity": {
+                                    "count": 1
+                                }
+                            },
+                            {
+                                "price": {
+                                    "value": "4.04",
+                                    "currency": "INR"
+                                },
+                                "title": "Convenience fee",
+                                "@ondc/org/item_id": "155",
+                                "@ondc/org/title_type": "misc"
+                            },
+                            {
+                                "price": {
+                                    "value": "0",
+                                    "currency": "INR"
+                                },
+                                "title": "Delivery charges",
+                                "@ondc/org/item_id": "155",
+                                "@ondc/org/title_type": "delivery"
+                            }
+                        ]
+                    },
+                    "billing": {
+                        "name": "Ajeet Chauhan",
+                        "email": "ajeetchauhan.symfony143@webkul.in",
+                        "phone": "8574739650",
+                        "address": {
+                            "city": "Noida",
+                            "name": "Ajeet Chauhan",
+                            "state": "Uttar Pradesh",
+                            "country": "IND",
+                            "building": "ARV Park",
+                            "locality": "Unnamed Road",
+                            "area_code": "201301"
+                        },
+                        "created_at": "2025-01-06T10:58:02.529Z",
+                        "updated_at": "2025-01-06T10:58:02.529Z"
+                    },
+                    "payment": {
+                        "uri": "https://razorpay.com/",
+                        "type": "ON-ORDER",
+                        "params": {
+                            "amount": "118.04",
+                            "currency": "INR",
+                            "transaction_id": "order_Pg8IoytiBpf9W3"
+                        },
+                        "status": "PAID",
+                        "tl_method": "http/get",
+                        "collected_by": "BAP",
+                        "@ondc/org/settlement_details": [
+                            {
+                                "bank_name": "fasdf",
+                                "branch_name": "noida",
+                                "settlement_type": "neft",
+                                "beneficiary_name": "fasdf asdfasdf",
+                                "settlement_phase": "sale-amount",
+                                "settlement_status": "NOT-PAID",
+                                "settlement_ifsc_code": "HDFC0000088",
+                                "settlement_counterparty": "seller-app",
+                                "settlement_bank_account_no": "534512341234132"
+                            }
+                        ],
+                        "@ondc/org/buyer_app_finder_fee_type": "percent",
+                        "@ondc/org/buyer_app_finder_fee_amount": "3.0"
+                    },
+                    "created_at": "2025-01-06T10:58:33.520Z",
+                    "updated_at": "2025-01-06T10:59:56.687Z"
+                }
+            }
+        },
+        "on_status_packed": {
+            "context": {
+                "domain": "ONDC:RET11",
+                "country": "IND",
+                "city": "std:0120",
+                "action": "on_status",
+                "core_version": "1.2.0",
+                "bap_id": "buyer-app-preprod-v2.ondc.org",
+                "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+                "bpp_uri": "https://ondc.ecomviser.com/api/v1",
+                "transaction_id": "5a913b62-e66f-4a6b-bf2a-8072714506d6",
+                "message_id": "677bb7c1e1a860cef9bfe-bacd",
+                "timestamp": "2025-01-06T11:00:17.924Z",
+                "bpp_id": "ondc.ecomviser.com",
+                "ttl": "PT30S"
+            },
+            "message": {
+                "order": {
+                    "id": "2025-01-06-333398",
+                    "state": "In-progress",
+                    "provider": {
+                        "id": "84",
+                        "locations": [
+                            {
+                                "id": "83"
+                            }
+                        ]
+                    },
+                    "items": [
+                        {
+                            "id": "451",
+                            "fulfillment_id": "155",
+                            "quantity": {
+                                "count": 1
+                            }
+                        }
+                    ],
+                    "fulfillments": [
+                        {
+                            "id": "155",
+                            "end": {
+                                "time": {
+                                    "range": {
+                                        "end": "2025-01-06T11:58:40.518Z",
+                                        "start": "2025-01-06T10:58:40.518Z"
+                                    }
+                                },
+                                "person": {
+                                    "name": "Ajeet Chauhan"
+                                },
+                                "contact": {
+                                    "email": "ajeetchauhan.symfony143@webkul.in",
+                                    "phone": "8574739650"
+                                },
+                                "location": {
+                                    "gps": "28.629743,77.377795",
+                                    "address": {
+                                        "city": "Noida",
+                                        "name": "Ajeet Chauhan",
+                                        "state": "Uttar Pradesh",
+                                        "country": "IND",
+                                        "building": "ARV Park",
+                                        "locality": "Unnamed Road",
+                                        "area_code": "201301"
+                                    }
+                                }
+                            },
+                            "type": "Delivery",
+                            "start": {
+                                "time": {
+                                    "range": {
+                                        "end": "2025-01-06T11:58:40.518Z",
+                                        "start": "2025-01-06T10:58:40.518Z"
+                                    }
+                                },
+                                "contact": {
+                                    "email": "support@webkul.in",
+                                    "phone": "9876543210"
+                                },
+                                "location": {
+                                    "id": "83",
+                                    "gps": "28.62972640,77.37783230",
+                                    "address": {
+                                        "city": "Gautam Buddh Nagar",
+                                        "state": "Uttar Pradesh",
+                                        "locality": "Noida",
+                                        "area_code": "201301"
+                                    },
+                                    "descriptor": {
+                                        "name": "Ajeet Food Shop"
+                                    }
+                                }
+                            },
+                            "state": {
+                                "descriptor": {
+                                    "code": "Packed"
+                                }
+                            },
+                            "tracking": true,
+                            "@ondc/org/TAT": "PT90M",
+                            "@ondc/org/provider_name": "ondc.ecomviser.com"
+                        }
+                    ],
+                    "quote": {
+                        "ttl": "PT6H",
+                        "price": {
+                            "value": "118.04",
+                            "currency": "INR"
+                        },
+                        "breakup": [
+                            {
+                                "item": {
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "item"
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "price": {
+                                        "value": "99",
+                                        "currency": "INR"
+                                    },
+                                    "parent_item_id": "xXUeYhqy/JJR"
+                                },
+                                "price": {
+                                    "value": "99",
+                                    "currency": "INR"
+                                },
+                                "title": "Pizza Mania",
+                                "@ondc/org/item_id": "451",
+                                "@ondc/org/title_type": "item",
+                                "@ondc/org/item_quantity": {
+                                    "count": 1
+                                }
+                            },
+                            {
+                                "item": {
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "customization"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "parent",
+                                            "list": [
+                                                {
+                                                    "code": "id",
+                                                    "value": "66zabcdefghi"
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "price": {
+                                        "value": "5",
+                                        "currency": "INR"
+                                    },
+                                    "parent_item_id": "xXUeYhqy/JJR"
+                                },
+                                "price": {
+                                    "value": "5",
+                                    "currency": "INR"
+                                },
+                                "title": "Extra",
+                                "@ondc/org/item_id": "93",
+                                "@ondc/org/title_type": "item",
+                                "@ondc/org/item_quantity": {
+                                    "count": 1
+                                }
+                            },
+                            {
+                                "item": {
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "customization"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "parent",
+                                            "list": [
+                                                {
+                                                    "code": "id",
+                                                    "value": "67zabcdefghi"
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "price": {
+                                        "value": "10",
+                                        "currency": "INR"
+                                    },
+                                    "parent_item_id": "xXUeYhqy/JJR"
+                                },
+                                "price": {
+                                    "value": "10",
+                                    "currency": "INR"
+                                },
+                                "title": "Chicken",
+                                "@ondc/org/item_id": "95",
+                                "@ondc/org/title_type": "item",
+                                "@ondc/org/item_quantity": {
+                                    "count": 1
+                                }
+                            },
+                            {
+                                "price": {
+                                    "value": "4.04",
+                                    "currency": "INR"
+                                },
+                                "title": "Convenience fee",
+                                "@ondc/org/item_id": "155",
+                                "@ondc/org/title_type": "misc"
+                            },
+                            {
+                                "price": {
+                                    "value": "0",
+                                    "currency": "INR"
+                                },
+                                "title": "Delivery charges",
+                                "@ondc/org/item_id": "155",
+                                "@ondc/org/title_type": "delivery"
+                            }
+                        ]
+                    },
+                    "billing": {
+                        "name": "Ajeet Chauhan",
+                        "email": "ajeetchauhan.symfony143@webkul.in",
+                        "phone": "8574739650",
+                        "address": {
+                            "city": "Noida",
+                            "name": "Ajeet Chauhan",
+                            "state": "Uttar Pradesh",
+                            "country": "IND",
+                            "building": "ARV Park",
+                            "locality": "Unnamed Road",
+                            "area_code": "201301"
+                        },
+                        "created_at": "2025-01-06T10:58:02.529Z",
+                        "updated_at": "2025-01-06T10:58:02.529Z"
+                    },
+                    "payment": {
+                        "uri": "https://razorpay.com/",
+                        "type": "ON-ORDER",
+                        "params": {
+                            "amount": "118.04",
+                            "currency": "INR",
+                            "transaction_id": "order_Pg8IoytiBpf9W3"
+                        },
+                        "status": "PAID",
+                        "tl_method": "http/get",
+                        "collected_by": "BAP",
+                        "@ondc/org/settlement_details": [
+                            {
+                                "bank_name": "fasdf",
+                                "branch_name": "noida",
+                                "settlement_type": "neft",
+                                "beneficiary_name": "fasdf asdfasdf",
+                                "settlement_phase": "sale-amount",
+                                "settlement_status": "NOT-PAID",
+                                "settlement_ifsc_code": "HDFC0000088",
+                                "settlement_counterparty": "seller-app",
+                                "settlement_bank_account_no": "534512341234132"
+                            }
+                        ],
+                        "@ondc/org/buyer_app_finder_fee_type": "percent",
+                        "@ondc/org/buyer_app_finder_fee_amount": "3.0"
+                    },
+                    "created_at": "2025-01-06T10:58:33.520Z",
+                    "updated_at": "2025-01-06T11:00:17.924Z"
+                }
+            }
+        },
+        "on_status_agent_assigned": {
+            "context": {
+                "domain": "ONDC:RET11",
+                "country": "IND",
+                "city": "std:0120",
+                "action": "on_status",
+                "core_version": "1.2.0",
+                "bap_id": "buyer-app-preprod-v2.ondc.org",
+                "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+                "bpp_uri": "https://ondc.ecomviser.com/api/v1",
+                "transaction_id": "5a913b62-e66f-4a6b-bf2a-8072714506d6",
+                "message_id": "677bb7c98cab7ec55af9c-9111",
+                "timestamp": "2025-01-06T11:00:25.576Z",
+                "bpp_id": "ondc.ecomviser.com",
+                "ttl": "PT30S"
+            },
+            "message": {
+                "order": {
+                    "id": "2025-01-06-333398",
+                    "state": "In-progress",
+                    "provider": {
+                        "id": "84",
+                        "locations": [
+                            {
+                                "id": "83"
+                            }
+                        ]
+                    },
+                    "items": [
+                        {
+                            "id": "451",
+                            "fulfillment_id": "155",
+                            "quantity": {
+                                "count": 1
+                            }
+                        }
+                    ],
+                    "fulfillments": [
+                        {
+                            "id": "155",
+                            "end": {
+                                "time": {
+                                    "range": {
+                                        "end": "2025-01-06T11:58:40.518Z",
+                                        "start": "2025-01-06T10:58:40.518Z"
+                                    }
+                                },
+                                "person": {
+                                    "name": "Ajeet Chauhan"
+                                },
+                                "contact": {
+                                    "email": "ajeetchauhan.symfony143@webkul.in",
+                                    "phone": "8574739650"
+                                },
+                                "location": {
+                                    "gps": "28.629743,77.377795",
+                                    "address": {
+                                        "city": "Noida",
+                                        "name": "Ajeet Chauhan",
+                                        "state": "Uttar Pradesh",
+                                        "country": "IND",
+                                        "building": "ARV Park",
+                                        "locality": "Unnamed Road",
+                                        "area_code": "201301"
+                                    }
+                                }
+                            },
+                            "type": "Delivery",
+                            "start": {
+                                "time": {
+                                    "range": {
+                                        "end": "2025-01-06T11:58:40.518Z",
+                                        "start": "2025-01-06T10:58:40.518Z"
+                                    }
+                                },
+                                "contact": {
+                                    "email": "support@webkul.in",
+                                    "phone": "9876543210"
+                                },
+                                "location": {
+                                    "id": "83",
+                                    "gps": "28.62972640,77.37783230",
+                                    "address": {
+                                        "city": "Gautam Buddh Nagar",
+                                        "state": "Uttar Pradesh",
+                                        "locality": "Noida",
+                                        "area_code": "201301"
+                                    },
+                                    "descriptor": {
+                                        "name": "Ajeet Food Shop"
+                                    }
+                                }
+                            },
+                            "state": {
+                                "descriptor": {
+                                    "code": "Agent-assigned"
+                                }
+                            },
+                            "tracking": true,
+                            "@ondc/org/TAT": "PT90M",
+                            "@ondc/org/provider_name": "ondc.ecomviser.com"
+                        }
+                    ],
+                    "quote": {
+                        "ttl": "PT6H",
+                        "price": {
+                            "value": "118.04",
+                            "currency": "INR"
+                        },
+                        "breakup": [
+                            {
+                                "item": {
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "item"
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "price": {
+                                        "value": "99",
+                                        "currency": "INR"
+                                    },
+                                    "parent_item_id": "xXUeYhqy/JJR"
+                                },
+                                "price": {
+                                    "value": "99",
+                                    "currency": "INR"
+                                },
+                                "title": "Pizza Mania",
+                                "@ondc/org/item_id": "451",
+                                "@ondc/org/title_type": "item",
+                                "@ondc/org/item_quantity": {
+                                    "count": 1
+                                }
+                            },
+                            {
+                                "item": {
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "customization"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "parent",
+                                            "list": [
+                                                {
+                                                    "code": "id",
+                                                    "value": "66zabcdefghi"
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "price": {
+                                        "value": "5",
+                                        "currency": "INR"
+                                    },
+                                    "parent_item_id": "xXUeYhqy/JJR"
+                                },
+                                "price": {
+                                    "value": "5",
+                                    "currency": "INR"
+                                },
+                                "title": "Extra",
+                                "@ondc/org/item_id": "93",
+                                "@ondc/org/title_type": "item",
+                                "@ondc/org/item_quantity": {
+                                    "count": 1
+                                }
+                            },
+                            {
+                                "item": {
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "customization"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "parent",
+                                            "list": [
+                                                {
+                                                    "code": "id",
+                                                    "value": "67zabcdefghi"
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "price": {
+                                        "value": "10",
+                                        "currency": "INR"
+                                    },
+                                    "parent_item_id": "xXUeYhqy/JJR"
+                                },
+                                "price": {
+                                    "value": "10",
+                                    "currency": "INR"
+                                },
+                                "title": "Chicken",
+                                "@ondc/org/item_id": "95",
+                                "@ondc/org/title_type": "item",
+                                "@ondc/org/item_quantity": {
+                                    "count": 1
+                                }
+                            },
+                            {
+                                "price": {
+                                    "value": "4.04",
+                                    "currency": "INR"
+                                },
+                                "title": "Convenience fee",
+                                "@ondc/org/item_id": "155",
+                                "@ondc/org/title_type": "misc"
+                            },
+                            {
+                                "price": {
+                                    "value": "0",
+                                    "currency": "INR"
+                                },
+                                "title": "Delivery charges",
+                                "@ondc/org/item_id": "155",
+                                "@ondc/org/title_type": "delivery"
+                            }
+                        ]
+                    },
+                    "billing": {
+                        "name": "Ajeet Chauhan",
+                        "email": "ajeetchauhan.symfony143@webkul.in",
+                        "phone": "8574739650",
+                        "address": {
+                            "city": "Noida",
+                            "name": "Ajeet Chauhan",
+                            "state": "Uttar Pradesh",
+                            "country": "IND",
+                            "building": "ARV Park",
+                            "locality": "Unnamed Road",
+                            "area_code": "201301"
+                        },
+                        "created_at": "2025-01-06T10:58:02.529Z",
+                        "updated_at": "2025-01-06T10:58:02.529Z"
+                    },
+                    "payment": {
+                        "uri": "https://razorpay.com/",
+                        "type": "ON-ORDER",
+                        "params": {
+                            "amount": "118.04",
+                            "currency": "INR",
+                            "transaction_id": "order_Pg8IoytiBpf9W3"
+                        },
+                        "status": "PAID",
+                        "tl_method": "http/get",
+                        "collected_by": "BAP",
+                        "@ondc/org/settlement_details": [
+                            {
+                                "bank_name": "fasdf",
+                                "branch_name": "noida",
+                                "settlement_type": "neft",
+                                "beneficiary_name": "fasdf asdfasdf",
+                                "settlement_phase": "sale-amount",
+                                "settlement_status": "NOT-PAID",
+                                "settlement_ifsc_code": "HDFC0000088",
+                                "settlement_counterparty": "seller-app",
+                                "settlement_bank_account_no": "534512341234132"
+                            }
+                        ],
+                        "@ondc/org/buyer_app_finder_fee_type": "percent",
+                        "@ondc/org/buyer_app_finder_fee_amount": "3.0"
+                    },
+                    "created_at": "2025-01-06T10:58:33.520Z",
+                    "updated_at": "2025-01-06T11:00:25.576Z"
+                }
+            }
+        },
+        "on_status_picked": {
+            "context": {
+                "domain": "ONDC:RET11",
+                "country": "IND",
+                "city": "std:0120",
+                "action": "on_status",
+                "core_version": "1.2.0",
+                "bap_id": "buyer-app-preprod-v2.ondc.org",
+                "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+                "bpp_uri": "https://ondc.ecomviser.com/api/v1",
+                "transaction_id": "5a913b62-e66f-4a6b-bf2a-8072714506d6",
+                "message_id": "677bb7d23482b300f39be-3f61",
+                "timestamp": "2025-01-06T11:00:34.215Z",
+                "bpp_id": "ondc.ecomviser.com",
+                "ttl": "PT30S"
+            },
+            "message": {
+                "order": {
+                    "id": "2025-01-06-333398",
+                    "state": "In-progress",
+                    "provider": {
+                        "id": "84",
+                        "locations": [
+                            {
+                                "id": "83"
+                            }
+                        ]
+                    },
+                    "items": [
+                        {
+                            "id": "451",
+                            "fulfillment_id": "155",
+                            "quantity": {
+                                "count": 1
+                            }
+                        }
+                    ],
+                    "fulfillments": [
+                        {
+                            "id": "155",
+                            "end": {
+                                "time": {
+                                    "range": {
+                                        "end": "2025-01-06T11:58:40.518Z",
+                                        "start": "2025-01-06T10:58:40.518Z"
+                                    }
+                                },
+                                "person": {
+                                    "name": "Ajeet Chauhan"
+                                },
+                                "contact": {
+                                    "email": "ajeetchauhan.symfony143@webkul.in",
+                                    "phone": "8574739650"
+                                },
+                                "location": {
+                                    "gps": "28.629743,77.377795",
+                                    "address": {
+                                        "city": "Noida",
+                                        "name": "Ajeet Chauhan",
+                                        "state": "Uttar Pradesh",
+                                        "country": "IND",
+                                        "building": "ARV Park",
+                                        "locality": "Unnamed Road",
+                                        "area_code": "201301"
+                                    }
+                                }
+                            },
+                            "type": "Delivery",
+                            "start": {
+                                "time": {
+                                    "range": {
+                                        "end": "2025-01-06T11:58:40.518Z",
+                                        "start": "2025-01-06T10:58:40.518Z"
+                                    },
+                                    "timestamp": "2025-01-06T11:00:33.631Z"
+                                },
+                                "contact": {
+                                    "email": "support@webkul.in",
+                                    "phone": "9876543210"
+                                },
+                                "location": {
+                                    "id": "83",
+                                    "gps": "28.62972640,77.37783230",
+                                    "address": {
+                                        "city": "Gautam Buddh Nagar",
+                                        "state": "Uttar Pradesh",
+                                        "locality": "Noida",
+                                        "area_code": "201301"
+                                    },
+                                    "descriptor": {
+                                        "name": "Ajeet Food Shop"
+                                    }
+                                },
+                                "instructions": {
+                                    "code": "2",
+                                    "name": "ONDC Order",
+                                    "short_desc": "ae34fd",
+                                    "long_desc": "additional instructions for pickup"
+                                }
+                            },
+                            "state": {
+                                "descriptor": {
+                                    "code": "Order-picked-up"
+                                }
+                            },
+                            "tracking": true,
+                            "@ondc/org/TAT": "PT90M",
+                            "@ondc/org/provider_name": "ondc.ecomviser.com",
+                            "tags": [
+                                {
+                                    "code": "routing",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "P2P"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "tracking",
+                                    "list": [
+                                        {
+                                            "code": "gps_enabled",
+                                            "value": "yes"
+                                        },
+                                        {
+                                            "code": "url_enabled",
+                                            "value": "no"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ],
+                    "quote": {
+                        "ttl": "PT6H",
+                        "price": {
+                            "value": "118.04",
+                            "currency": "INR"
+                        },
+                        "breakup": [
+                            {
+                                "item": {
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "item"
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "price": {
+                                        "value": "99",
+                                        "currency": "INR"
+                                    },
+                                    "parent_item_id": "xXUeYhqy/JJR"
+                                },
+                                "price": {
+                                    "value": "99",
+                                    "currency": "INR"
+                                },
+                                "title": "Pizza Mania",
+                                "@ondc/org/item_id": "451",
+                                "@ondc/org/title_type": "item",
+                                "@ondc/org/item_quantity": {
+                                    "count": 1
+                                }
+                            },
+                            {
+                                "item": {
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "customization"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "parent",
+                                            "list": [
+                                                {
+                                                    "code": "id",
+                                                    "value": "66zabcdefghi"
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "price": {
+                                        "value": "5",
+                                        "currency": "INR"
+                                    },
+                                    "parent_item_id": "xXUeYhqy/JJR"
+                                },
+                                "price": {
+                                    "value": "5",
+                                    "currency": "INR"
+                                },
+                                "title": "Extra",
+                                "@ondc/org/item_id": "93",
+                                "@ondc/org/title_type": "item",
+                                "@ondc/org/item_quantity": {
+                                    "count": 1
+                                }
+                            },
+                            {
+                                "item": {
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "customization"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "parent",
+                                            "list": [
+                                                {
+                                                    "code": "id",
+                                                    "value": "67zabcdefghi"
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "price": {
+                                        "value": "10",
+                                        "currency": "INR"
+                                    },
+                                    "parent_item_id": "xXUeYhqy/JJR"
+                                },
+                                "price": {
+                                    "value": "10",
+                                    "currency": "INR"
+                                },
+                                "title": "Chicken",
+                                "@ondc/org/item_id": "95",
+                                "@ondc/org/title_type": "item",
+                                "@ondc/org/item_quantity": {
+                                    "count": 1
+                                }
+                            },
+                            {
+                                "price": {
+                                    "value": "4.04",
+                                    "currency": "INR"
+                                },
+                                "title": "Convenience fee",
+                                "@ondc/org/item_id": "155",
+                                "@ondc/org/title_type": "misc"
+                            },
+                            {
+                                "price": {
+                                    "value": "0",
+                                    "currency": "INR"
+                                },
+                                "title": "Delivery charges",
+                                "@ondc/org/item_id": "155",
+                                "@ondc/org/title_type": "delivery"
+                            }
+                        ]
+                    },
+                    "billing": {
+                        "name": "Ajeet Chauhan",
+                        "email": "ajeetchauhan.symfony143@webkul.in",
+                        "phone": "8574739650",
+                        "address": {
+                            "city": "Noida",
+                            "name": "Ajeet Chauhan",
+                            "state": "Uttar Pradesh",
+                            "country": "IND",
+                            "building": "ARV Park",
+                            "locality": "Unnamed Road",
+                            "area_code": "201301"
+                        },
+                        "created_at": "2025-01-06T10:58:02.529Z",
+                        "updated_at": "2025-01-06T10:58:02.529Z"
+                    },
+                    "payment": {
+                        "uri": "https://razorpay.com/",
+                        "type": "ON-ORDER",
+                        "params": {
+                            "amount": "118.04",
+                            "currency": "INR",
+                            "transaction_id": "order_Pg8IoytiBpf9W3"
+                        },
+                        "status": "PAID",
+                        "tl_method": "http/get",
+                        "collected_by": "BAP",
+                        "@ondc/org/settlement_details": [
+                            {
+                                "bank_name": "fasdf",
+                                "branch_name": "noida",
+                                "settlement_type": "neft",
+                                "beneficiary_name": "fasdf asdfasdf",
+                                "settlement_phase": "sale-amount",
+                                "settlement_status": "NOT-PAID",
+                                "settlement_ifsc_code": "HDFC0000088",
+                                "settlement_counterparty": "seller-app",
+                                "settlement_bank_account_no": "534512341234132"
+                            }
+                        ],
+                        "@ondc/org/buyer_app_finder_fee_type": "percent",
+                        "@ondc/org/buyer_app_finder_fee_amount": "3.0"
+                    },
+                    "created_at": "2025-01-06T10:58:33.520Z",
+                    "updated_at": "2025-01-06T11:00:34.215Z",
+                    "documents": [
+                        {
+                            "label": "Invoice",
+                            "url": "https://ecomviser-prepod.sp-seller-preprod.ecomviser.com/index.php?p=invoice_download&key=MTc0Ojg0OmVjb212aXNlcg=="
+                        }
+                    ]
+                }
+            }
+        },
+        "on_status_out_for_delivery": {
+            "context": {
+                "domain": "ONDC:RET11",
+                "country": "IND",
+                "city": "std:0120",
+                "action": "on_status",
+                "core_version": "1.2.0",
+                "bap_id": "buyer-app-preprod-v2.ondc.org",
+                "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+                "bpp_uri": "https://ondc.ecomviser.com/api/v1",
+                "transaction_id": "5a913b62-e66f-4a6b-bf2a-8072714506d6",
+                "message_id": "677bb7dfbe21401014d05-44e1",
+                "timestamp": "2025-01-06T11:00:47.779Z",
+                "bpp_id": "ondc.ecomviser.com",
+                "ttl": "PT30S"
+            },
+            "message": {
+                "order": {
+                    "id": "2025-01-06-333398",
+                    "state": "In-progress",
+                    "provider": {
+                        "id": "84",
+                        "locations": [
+                            {
+                                "id": "83"
+                            }
+                        ]
+                    },
+                    "items": [
+                        {
+                            "id": "451",
+                            "fulfillment_id": "155",
+                            "quantity": {
+                                "count": 1
+                            }
+                        }
+                    ],
+                    "fulfillments": [
+                        {
+                            "id": "155",
+                            "end": {
+                                "time": {
+                                    "range": {
+                                        "end": "2025-01-06T11:58:40.518Z",
+                                        "start": "2025-01-06T10:58:40.518Z"
+                                    }
+                                },
+                                "person": {
+                                    "name": "Ajeet Chauhan"
+                                },
+                                "contact": {
+                                    "email": "ajeetchauhan.symfony143@webkul.in",
+                                    "phone": "8574739650"
+                                },
+                                "location": {
+                                    "gps": "28.629743,77.377795",
+                                    "address": {
+                                        "city": "Noida",
+                                        "name": "Ajeet Chauhan",
+                                        "state": "Uttar Pradesh",
+                                        "country": "IND",
+                                        "building": "ARV Park",
+                                        "locality": "Unnamed Road",
+                                        "area_code": "201301"
+                                    }
+                                }
+                            },
+                            "type": "Delivery",
+                            "start": {
+                                "time": {
+                                    "range": {
+                                        "end": "2025-01-06T11:58:40.518Z",
+                                        "start": "2025-01-06T10:58:40.518Z"
+                                    },
+                                    "timestamp": "2025-01-06T11:00:33.631Z"
+                                },
+                                "contact": {
+                                    "email": "support@webkul.in",
+                                    "phone": "9876543210"
+                                },
+                                "location": {
+                                    "id": "83",
+                                    "gps": "28.62972640,77.37783230",
+                                    "address": {
+                                        "city": "Gautam Buddh Nagar",
+                                        "state": "Uttar Pradesh",
+                                        "locality": "Noida",
+                                        "area_code": "201301"
+                                    },
+                                    "descriptor": {
+                                        "name": "Ajeet Food Shop"
+                                    }
+                                }
+                            },
+                            "state": {
+                                "descriptor": {
+                                    "code": "Out-for-delivery"
+                                }
+                            },
+                            "tracking": true,
+                            "@ondc/org/TAT": "PT90M",
+                            "@ondc/org/provider_name": "ondc.ecomviser.com",
+                            "tags": [
+                                {
+                                    "code": "routing",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "P2P"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "tracking",
+                                    "list": [
+                                        {
+                                            "code": "gps_enabled",
+                                            "value": "yes"
+                                        },
+                                        {
+                                            "code": "url_enabled",
+                                            "value": "no"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ],
+                    "quote": {
+                        "ttl": "PT6H",
+                        "price": {
+                            "value": "118.04",
+                            "currency": "INR"
+                        },
+                        "breakup": [
+                            {
+                                "item": {
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "item"
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "price": {
+                                        "value": "99",
+                                        "currency": "INR"
+                                    },
+                                    "parent_item_id": "xXUeYhqy/JJR"
+                                },
+                                "price": {
+                                    "value": "99",
+                                    "currency": "INR"
+                                },
+                                "title": "Pizza Mania",
+                                "@ondc/org/item_id": "451",
+                                "@ondc/org/title_type": "item",
+                                "@ondc/org/item_quantity": {
+                                    "count": 1
+                                }
+                            },
+                            {
+                                "item": {
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "customization"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "parent",
+                                            "list": [
+                                                {
+                                                    "code": "id",
+                                                    "value": "66zabcdefghi"
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "price": {
+                                        "value": "5",
+                                        "currency": "INR"
+                                    },
+                                    "parent_item_id": "xXUeYhqy/JJR"
+                                },
+                                "price": {
+                                    "value": "5",
+                                    "currency": "INR"
+                                },
+                                "title": "Extra",
+                                "@ondc/org/item_id": "93",
+                                "@ondc/org/title_type": "item",
+                                "@ondc/org/item_quantity": {
+                                    "count": 1
+                                }
+                            },
+                            {
+                                "item": {
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "customization"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "parent",
+                                            "list": [
+                                                {
+                                                    "code": "id",
+                                                    "value": "67zabcdefghi"
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "price": {
+                                        "value": "10",
+                                        "currency": "INR"
+                                    },
+                                    "parent_item_id": "xXUeYhqy/JJR"
+                                },
+                                "price": {
+                                    "value": "10",
+                                    "currency": "INR"
+                                },
+                                "title": "Chicken",
+                                "@ondc/org/item_id": "95",
+                                "@ondc/org/title_type": "item",
+                                "@ondc/org/item_quantity": {
+                                    "count": 1
+                                }
+                            },
+                            {
+                                "price": {
+                                    "value": "4.04",
+                                    "currency": "INR"
+                                },
+                                "title": "Convenience fee",
+                                "@ondc/org/item_id": "155",
+                                "@ondc/org/title_type": "misc"
+                            },
+                            {
+                                "price": {
+                                    "value": "0",
+                                    "currency": "INR"
+                                },
+                                "title": "Delivery charges",
+                                "@ondc/org/item_id": "155",
+                                "@ondc/org/title_type": "delivery"
+                            }
+                        ]
+                    },
+                    "billing": {
+                        "name": "Ajeet Chauhan",
+                        "email": "ajeetchauhan.symfony143@webkul.in",
+                        "phone": "8574739650",
+                        "address": {
+                            "city": "Noida",
+                            "name": "Ajeet Chauhan",
+                            "state": "Uttar Pradesh",
+                            "country": "IND",
+                            "building": "ARV Park",
+                            "locality": "Unnamed Road",
+                            "area_code": "201301"
+                        },
+                        "created_at": "2025-01-06T10:58:02.529Z",
+                        "updated_at": "2025-01-06T10:58:02.529Z"
+                    },
+                    "payment": {
+                        "uri": "https://razorpay.com/",
+                        "type": "ON-ORDER",
+                        "params": {
+                            "amount": "118.04",
+                            "currency": "INR",
+                            "transaction_id": "order_Pg8IoytiBpf9W3"
+                        },
+                        "status": "PAID",
+                        "tl_method": "http/get",
+                        "collected_by": "BAP",
+                        "@ondc/org/settlement_details": [
+                            {
+                                "bank_name": "fasdf",
+                                "branch_name": "noida",
+                                "settlement_type": "neft",
+                                "beneficiary_name": "fasdf asdfasdf",
+                                "settlement_phase": "sale-amount",
+                                "settlement_status": "NOT-PAID",
+                                "settlement_ifsc_code": "HDFC0000088",
+                                "settlement_counterparty": "seller-app",
+                                "settlement_bank_account_no": "534512341234132"
+                            }
+                        ],
+                        "@ondc/org/buyer_app_finder_fee_type": "percent",
+                        "@ondc/org/buyer_app_finder_fee_amount": "3.0"
+                    },
+                    "created_at": "2025-01-06T10:58:33.520Z",
+                    "updated_at": "2025-01-06T11:00:47.779Z",
+                    "documents": [
+                        {
+                            "label": "Invoice",
+                            "url": "https://ecomviser-prepod.sp-seller-preprod.ecomviser.com/index.php?p=invoice_download&key=MTc0Ojg0OmVjb212aXNlcg=="
+                        }
+                    ]
+                }
+            }
+        },
+        "on_status_delivered": {
+            "context": {
+                "domain": "ONDC:RET11",
+                "country": "IND",
+                "city": "std:0120",
+                "action": "on_status",
+                "core_version": "1.2.0",
+                "bap_id": "buyer-app-preprod-v2.ondc.org",
+                "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+                "bpp_uri": "https://ondc.ecomviser.com/api/v1",
+                "transaction_id": "5a913b62-e66f-4a6b-bf2a-8072714506d6",
+                "message_id": "677bb7ec87f3ad3d4b6f7-a6e0",
+                "timestamp": "2025-01-06T11:01:00.557Z",
+                "bpp_id": "ondc.ecomviser.com",
+                "ttl": "PT30S"
+            },
+            "message": {
+                "order": {
+                    "id": "2025-01-06-333398",
+                    "state": "Completed",
+                    "provider": {
+                        "id": "84",
+                        "locations": [
+                            {
+                                "id": "83"
+                            }
+                        ]
+                    },
+                    "items": [
+                        {
+                            "id": "451",
+                            "fulfillment_id": "155",
+                            "quantity": {
+                                "count": 1
+                            }
+                        }
+                    ],
+                    "fulfillments": [
+                        {
+                            "id": "155",
+                            "end": {
+                                "time": {
+                                    "range": {
+                                        "end": "2025-01-06T11:58:40.518Z",
+                                        "start": "2025-01-06T10:58:40.518Z"
+                                    },
+                                    "timestamp": "2025-01-06T11:00:59.947Z"
+                                },
+                                "person": {
+                                    "name": "Ajeet Chauhan"
+                                },
+                                "contact": {
+                                    "email": "ajeetchauhan.symfony143@webkul.in",
+                                    "phone": "8574739650"
+                                },
+                                "location": {
+                                    "gps": "28.629743,77.377795",
+                                    "address": {
+                                        "city": "Noida",
+                                        "name": "Ajeet Chauhan",
+                                        "state": "Uttar Pradesh",
+                                        "country": "IND",
+                                        "building": "ARV Park",
+                                        "locality": "Unnamed Road",
+                                        "area_code": "201301"
+                                    }
+                                }
+                            },
+                            "type": "Delivery",
+                            "start": {
+                                "time": {
+                                    "range": {
+                                        "end": "2025-01-06T11:58:40.518Z",
+                                        "start": "2025-01-06T10:58:40.518Z"
+                                    },
+                                    "timestamp": "2025-01-06T11:00:33.631Z"
+                                },
+                                "contact": {
+                                    "email": "support@webkul.in",
+                                    "phone": "9876543210"
+                                },
+                                "location": {
+                                    "id": "83",
+                                    "gps": "28.62972640,77.37783230",
+                                    "address": {
+                                        "city": "Gautam Buddh Nagar",
+                                        "state": "Uttar Pradesh",
+                                        "locality": "Noida",
+                                        "area_code": "201301"
+                                    },
+                                    "descriptor": {
+                                        "name": "Ajeet Food Shop"
+                                    }
+                                }
+                            },
+                            "state": {
+                                "descriptor": {
+                                    "code": "Order-delivered"
+                                }
+                            },
+                            "tracking": true,
+                            "@ondc/org/TAT": "PT90M",
+                            "@ondc/org/provider_name": "ondc.ecomviser.com",
+                            "tags": [
+                                {
+                                    "code": "routing",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "P2P"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "tracking",
+                                    "list": [
+                                        {
+                                            "code": "gps_enabled",
+                                            "value": "yes"
+                                        },
+                                        {
+                                            "code": "url_enabled",
+                                            "value": "no"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ],
+                    "quote": {
+                        "ttl": "PT6H",
+                        "price": {
+                            "value": "118.04",
+                            "currency": "INR"
+                        },
+                        "breakup": [
+                            {
+                                "item": {
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "item"
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "price": {
+                                        "value": "99",
+                                        "currency": "INR"
+                                    },
+                                    "parent_item_id": "xXUeYhqy/JJR"
+                                },
+                                "price": {
+                                    "value": "99",
+                                    "currency": "INR"
+                                },
+                                "title": "Pizza Mania",
+                                "@ondc/org/item_id": "451",
+                                "@ondc/org/title_type": "item",
+                                "@ondc/org/item_quantity": {
+                                    "count": 1
+                                }
+                            },
+                            {
+                                "item": {
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "customization"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "parent",
+                                            "list": [
+                                                {
+                                                    "code": "id",
+                                                    "value": "66zabcdefghi"
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "price": {
+                                        "value": "5",
+                                        "currency": "INR"
+                                    },
+                                    "parent_item_id": "xXUeYhqy/JJR"
+                                },
+                                "price": {
+                                    "value": "5",
+                                    "currency": "INR"
+                                },
+                                "title": "Extra",
+                                "@ondc/org/item_id": "93",
+                                "@ondc/org/title_type": "item",
+                                "@ondc/org/item_quantity": {
+                                    "count": 1
+                                }
+                            },
+                            {
+                                "item": {
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "customization"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "parent",
+                                            "list": [
+                                                {
+                                                    "code": "id",
+                                                    "value": "67zabcdefghi"
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "price": {
+                                        "value": "10",
+                                        "currency": "INR"
+                                    },
+                                    "parent_item_id": "xXUeYhqy/JJR"
+                                },
+                                "price": {
+                                    "value": "10",
+                                    "currency": "INR"
+                                },
+                                "title": "Chicken",
+                                "@ondc/org/item_id": "95",
+                                "@ondc/org/title_type": "item",
+                                "@ondc/org/item_quantity": {
+                                    "count": 1
+                                }
+                            },
+                            {
+                                "price": {
+                                    "value": "4.04",
+                                    "currency": "INR"
+                                },
+                                "title": "Convenience fee",
+                                "@ondc/org/item_id": "155",
+                                "@ondc/org/title_type": "misc"
+                            },
+                            {
+                                "price": {
+                                    "value": "0",
+                                    "currency": "INR"
+                                },
+                                "title": "Delivery charges",
+                                "@ondc/org/item_id": "155",
+                                "@ondc/org/title_type": "delivery"
+                            }
+                        ]
+                    },
+                    "billing": {
+                        "name": "Ajeet Chauhan",
+                        "email": "ajeetchauhan.symfony143@webkul.in",
+                        "phone": "8574739650",
+                        "address": {
+                            "city": "Noida",
+                            "name": "Ajeet Chauhan",
+                            "state": "Uttar Pradesh",
+                            "country": "IND",
+                            "building": "ARV Park",
+                            "locality": "Unnamed Road",
+                            "area_code": "201301"
+                        },
+                        "created_at": "2025-01-06T10:58:02.529Z",
+                        "updated_at": "2025-01-06T10:58:02.529Z"
+                    },
+                    "payment": {
+                        "uri": "https://razorpay.com/",
+                        "type": "ON-ORDER",
+                        "params": {
+                            "amount": "118.04",
+                            "currency": "INR",
+                            "transaction_id": "order_Pg8IoytiBpf9W3"
+                        },
+                        "status": "PAID",
+                        "tl_method": "http/get",
+                        "collected_by": "BAP",
+                        "@ondc/org/settlement_details": [
+                            {
+                                "bank_name": "fasdf",
+                                "branch_name": "noida",
+                                "settlement_type": "neft",
+                                "beneficiary_name": "fasdf asdfasdf",
+                                "settlement_phase": "sale-amount",
+                                "settlement_status": "NOT-PAID",
+                                "settlement_ifsc_code": "HDFC0000088",
+                                "settlement_counterparty": "seller-app",
+                                "settlement_bank_account_no": "534512341234132"
+                            }
+                        ],
+                        "@ondc/org/buyer_app_finder_fee_type": "percent",
+                        "@ondc/org/buyer_app_finder_fee_amount": "3.0"
+                    },
+                    "created_at": "2025-01-06T10:58:33.520Z",
+                    "updated_at": "2025-01-06T11:01:00.557Z",
+                    "documents": [
+                        {
+                            "label": "Invoice",
+                            "url": "https://ecomviser-prepod.sp-seller-preprod.ecomviser.com/index.php?p=invoice_download&key=MTc0Ojg0OmVjb212aXNlcg=="
+                        }
+                    ]
+                }
+            }
+        }
+    },
+    "flow": "3"
+}

--- a/eComviser/Seller App RET11/Flow-3/init.json
+++ b/eComviser/Seller App RET11/Flow-3/init.json
@@ -1,0 +1,149 @@
+{
+    "context": {
+        "domain": "ONDC:RET11",
+        "country": "IND",
+        "city": "std:0120",
+        "action": "init",
+        "core_version": "1.2.0",
+        "bap_id": "buyer-app-preprod-v2.ondc.org",
+        "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+        "bpp_uri": "https://ondc.ecomviser.com/api/v1",
+        "transaction_id": "5a913b62-e66f-4a6b-bf2a-8072714506d6",
+        "message_id": "57d47b27-6f2c-48ba-b25c-187db6d119d3",
+        "timestamp": "2025-01-06T10:58:02.529Z",
+        "bpp_id": "ondc.ecomviser.com",
+        "ttl": "PT30S"
+    },
+    "message": {
+        "order": {
+            "provider": {
+                "id": "84",
+                "locations": [
+                    {
+                        "id": "83"
+                    }
+                ]
+            },
+            "items": [
+                {
+                    "id": "451",
+                    "quantity": {
+                        "count": 1
+                    },
+                    "location_id": "83",
+                    "tags": [
+                        {
+                            "code": "type",
+                            "list": [
+                                {
+                                    "code": "type",
+                                    "value": "item"
+                                }
+                            ]
+                        }
+                    ],
+                    "parent_item_id": "xXUeYhqy/JJR",
+                    "fulfillment_id": "155"
+                },
+                {
+                    "id": "93",
+                    "quantity": {
+                        "count": 1
+                    },
+                    "location_id": "83",
+                    "tags": [
+                        {
+                            "code": "type",
+                            "list": [
+                                {
+                                    "code": "type",
+                                    "value": "customization"
+                                }
+                            ]
+                        },
+                        {
+                            "code": "parent",
+                            "list": [
+                                {
+                                    "code": "id",
+                                    "value": "66zabcdefghi"
+                                }
+                            ]
+                        }
+                    ],
+                    "fulfillment_id": "155",
+                    "parent_item_id": "xXUeYhqy/JJR"
+                },
+                {
+                    "id": "95",
+                    "quantity": {
+                        "count": 1
+                    },
+                    "location_id": "83",
+                    "tags": [
+                        {
+                            "code": "type",
+                            "list": [
+                                {
+                                    "code": "type",
+                                    "value": "customization"
+                                }
+                            ]
+                        },
+                        {
+                            "code": "parent",
+                            "list": [
+                                {
+                                    "code": "id",
+                                    "value": "67zabcdefghi"
+                                }
+                            ]
+                        }
+                    ],
+                    "fulfillment_id": "155",
+                    "parent_item_id": "xXUeYhqy/JJR"
+                }
+            ],
+            "billing": {
+                "address": {
+                    "building": "ARV Park",
+                    "city": "Noida",
+                    "state": "Uttar Pradesh",
+                    "country": "IND",
+                    "area_code": "201301",
+                    "locality": "Unnamed Road",
+                    "name": "Ajeet Chauhan"
+                },
+                "phone": "8574739650",
+                "name": "Ajeet Chauhan",
+                "email": "ajeetchauhan.symfony143@webkul.in",
+                "created_at": "2025-01-06T10:58:02.529Z",
+                "updated_at": "2025-01-06T10:58:02.529Z"
+            },
+            "fulfillments": [
+                {
+                    "id": "155",
+                    "type": "Delivery",
+                    "end": {
+                        "contact": {
+                            "email": "ajeetchauhan.symfony143@webkul.in",
+                            "phone": "8574739650"
+                        },
+                        "location": {
+                            "gps": "28.629743,77.377795",
+                            "address": {
+                                "building": "ARV Park",
+                                "city": "Noida",
+                                "state": "Uttar Pradesh",
+                                "country": "IND",
+                                "area_code": "201301",
+                                "locality": "Unnamed Road",
+                                "name": "Ajeet Chauhan"
+                            }
+                        }
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/eComviser/Seller App RET11/Flow-3/on_confirm.json
+++ b/eComviser/Seller App RET11/Flow-3/on_confirm.json
@@ -1,0 +1,381 @@
+{
+    "context": {
+        "domain": "ONDC:RET11",
+        "country": "IND",
+        "city": "std:0120",
+        "action": "on_confirm",
+        "core_version": "1.2.0",
+        "bap_id": "buyer-app-preprod-v2.ondc.org",
+        "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+        "bpp_uri": "https://ondc.ecomviser.com/api/v1",
+        "transaction_id": "5a913b62-e66f-4a6b-bf2a-8072714506d6",
+        "message_id": "ec786fd7-8fe6-4bef-860c-30588f73b0a9",
+        "timestamp": "2025-01-06T10:58:37.431Z",
+        "bpp_id": "ondc.ecomviser.com"
+    },
+    "message": {
+        "order": {
+            "id": "2025-01-06-333398",
+            "state": "Created",
+            "provider": {
+                "id": "84",
+                "locations": [
+                    {
+                        "id": "83"
+                    }
+                ]
+            },
+            "items": [
+                {
+                    "id": "451",
+                    "quantity": {
+                        "count": 1
+                    },
+                    "fulfillment_id": "155",
+                    "tags": [
+                        {
+                            "code": "type",
+                            "list": [
+                                {
+                                    "code": "type",
+                                    "value": "item"
+                                }
+                            ]
+                        }
+                    ],
+                    "parent_item_id": "xXUeYhqy/JJR"
+                },
+                {
+                    "id": "93",
+                    "quantity": {
+                        "count": 1
+                    },
+                    "fulfillment_id": "155",
+                    "tags": [
+                        {
+                            "code": "type",
+                            "list": [
+                                {
+                                    "code": "type",
+                                    "value": "customization"
+                                }
+                            ]
+                        },
+                        {
+                            "code": "parent",
+                            "list": [
+                                {
+                                    "code": "id",
+                                    "value": "66zabcdefghi"
+                                }
+                            ]
+                        }
+                    ],
+                    "parent_item_id": "xXUeYhqy/JJR"
+                },
+                {
+                    "id": "95",
+                    "quantity": {
+                        "count": 1
+                    },
+                    "fulfillment_id": "155",
+                    "tags": [
+                        {
+                            "code": "type",
+                            "list": [
+                                {
+                                    "code": "type",
+                                    "value": "customization"
+                                }
+                            ]
+                        },
+                        {
+                            "code": "parent",
+                            "list": [
+                                {
+                                    "code": "id",
+                                    "value": "67zabcdefghi"
+                                }
+                            ]
+                        }
+                    ],
+                    "parent_item_id": "xXUeYhqy/JJR"
+                }
+            ],
+            "billing": {
+                "address": {
+                    "name": "Ajeet Chauhan",
+                    "building": "ARV Park",
+                    "locality": "Unnamed Road",
+                    "city": "Noida",
+                    "state": "Uttar Pradesh",
+                    "country": "IND",
+                    "area_code": "201301"
+                },
+                "phone": "8574739650",
+                "name": "Ajeet Chauhan",
+                "email": "ajeetchauhan.symfony143@webkul.in",
+                "created_at": "2025-01-06T10:58:02.529Z",
+                "updated_at": "2025-01-06T10:58:02.529Z"
+            },
+            "fulfillments": [
+                {
+                    "@ondc/org/TAT": "PT90M",
+                    "id": "155",
+                    "tracking": true,
+                    "end": {
+                        "contact": {
+                            "email": "ajeetchauhan.symfony143@webkul.in",
+                            "phone": "8574739650"
+                        },
+                        "person": {
+                            "name": "Ajeet Chauhan"
+                        },
+                        "location": {
+                            "gps": "28.629743,77.377795",
+                            "address": {
+                                "name": "Ajeet Chauhan",
+                                "building": "ARV Park",
+                                "locality": "Unnamed Road",
+                                "city": "Noida",
+                                "state": "Uttar Pradesh",
+                                "country": "IND",
+                                "area_code": "201301"
+                            }
+                        },
+                        "time": {
+                            "range": {
+                                "start": "2025-01-06T10:58:40.518Z",
+                                "end": "2025-01-06T11:58:40.518Z"
+                            }
+                        }
+                    },
+                    "type": "Delivery",
+                    "@ondc/org/provider_name": "ondc.ecomviser.com",
+                    "state": {
+                        "descriptor": {
+                            "code": "Pending"
+                        }
+                    },
+                    "start": {
+                        "location": {
+                            "id": "83",
+                            "descriptor": {
+                                "name": "Ajeet Food Shop"
+                            },
+                            "gps": "28.62972640,77.37783230",
+                            "address": {
+                                "locality": "Noida",
+                                "city": "Gautam Buddh Nagar",
+                                "area_code": "201301",
+                                "state": "Uttar Pradesh"
+                            }
+                        },
+                        "contact": {
+                            "phone": "9876543210",
+                            "email": "support@webkul.in"
+                        },
+                        "time": {
+                            "range": {
+                                "start": "2025-01-06T10:58:40.518Z",
+                                "end": "2025-01-06T11:58:40.518Z"
+                            }
+                        }
+                    }
+                }
+            ],
+            "quote": {
+                "price": {
+                    "currency": "INR",
+                    "value": "118.04"
+                },
+                "breakup": [
+                    {
+                        "title": "Pizza Mania",
+                        "price": {
+                            "currency": "INR",
+                            "value": "99"
+                        },
+                        "@ondc/org/title_type": "item",
+                        "@ondc/org/item_id": "451",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
+                        },
+                        "item": {
+                            "price": {
+                                "currency": "INR",
+                                "value": "99"
+                            },
+                            "parent_item_id": "xXUeYhqy/JJR",
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "item"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "title": "Extra",
+                        "price": {
+                            "currency": "INR",
+                            "value": "5"
+                        },
+                        "@ondc/org/title_type": "item",
+                        "@ondc/org/item_id": "93",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
+                        },
+                        "item": {
+                            "price": {
+                                "currency": "INR",
+                                "value": "5"
+                            },
+                            "parent_item_id": "xXUeYhqy/JJR",
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "66zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "title": "Chicken",
+                        "price": {
+                            "currency": "INR",
+                            "value": "10"
+                        },
+                        "@ondc/org/title_type": "item",
+                        "@ondc/org/item_id": "95",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
+                        },
+                        "item": {
+                            "price": {
+                                "currency": "INR",
+                                "value": "10"
+                            },
+                            "parent_item_id": "xXUeYhqy/JJR",
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "67zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "title": "Convenience fee",
+                        "price": {
+                            "currency": "INR",
+                            "value": "4.04"
+                        },
+                        "@ondc/org/title_type": "misc",
+                        "@ondc/org/item_id": "155"
+                    },
+                    {
+                        "title": "Delivery charges",
+                        "price": {
+                            "currency": "INR",
+                            "value": "0"
+                        },
+                        "@ondc/org/title_type": "delivery",
+                        "@ondc/org/item_id": "155"
+                    }
+                ],
+                "ttl": "PT6H"
+            },
+            "payment": {
+                "uri": "https://razorpay.com/",
+                "tl_method": "http/get",
+                "params": {
+                    "amount": "118.04",
+                    "currency": "INR",
+                    "transaction_id": "order_Pg8IoytiBpf9W3"
+                },
+                "status": "PAID",
+                "type": "ON-ORDER",
+                "collected_by": "BAP",
+                "@ondc/org/buyer_app_finder_fee_type": "percent",
+                "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+                "@ondc/org/settlement_details": [
+                    {
+                        "settlement_counterparty": "seller-app",
+                        "settlement_phase": "sale-amount",
+                        "settlement_type": "neft",
+                        "beneficiary_name": "fasdf asdfasdf",
+                        "settlement_bank_account_no": "534512341234132",
+                        "settlement_ifsc_code": "HDFC0000088",
+                        "bank_name": "fasdf",
+                        "branch_name": "noida",
+                        "settlement_status": "NOT-PAID"
+                    }
+                ]
+            },
+            "tags": [
+                {
+                    "code": "bpp_terms",
+                    "list": [
+                        {
+                            "code": "np_type",
+                            "value": "MSN"
+                        },
+                        {
+                            "code": "tax_number",
+                            "value": "09AABCW0339G3ZD"
+                        },
+                        {
+                            "code": "provider_tax_number",
+                            "value": "DERTC3376R"
+                        }
+                    ]
+                },
+                {
+                    "code": "bap_terms",
+                    "list": [
+                        {
+                            "code": "tax_number",
+                            "value": "GSTIN1234567890"
+                        }
+                    ]
+                }
+            ],
+            "created_at": "2025-01-06T10:58:33.520Z",
+            "updated_at": "2025-01-06T10:58:37.431Z"
+        }
+    }
+}

--- a/eComviser/Seller App RET11/Flow-3/on_init.json
+++ b/eComviser/Seller App RET11/Flow-3/on_init.json
@@ -1,0 +1,317 @@
+{
+    "context": {
+        "domain": "ONDC:RET11",
+        "country": "IND",
+        "city": "std:0120",
+        "action": "on_init",
+        "core_version": "1.2.0",
+        "bap_id": "buyer-app-preprod-v2.ondc.org",
+        "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+        "bpp_uri": "https://ondc.ecomviser.com/api/v1",
+        "transaction_id": "5a913b62-e66f-4a6b-bf2a-8072714506d6",
+        "message_id": "57d47b27-6f2c-48ba-b25c-187db6d119d3",
+        "timestamp": "2025-01-06T10:58:06.344Z",
+        "bpp_id": "ondc.ecomviser.com",
+        "ttl": "PT30S"
+    },
+    "message": {
+        "order": {
+            "provider": {
+                "id": "84",
+                "locations": [
+                    {
+                        "id": "83"
+                    }
+                ]
+            },
+            "items": [
+                {
+                    "id": "451",
+                    "fulfillment_id": "155",
+                    "quantity": {
+                        "count": 1
+                    },
+                    "parent_item_id": "xXUeYhqy/JJR",
+                    "tags": [
+                        {
+                            "code": "type",
+                            "list": [
+                                {
+                                    "code": "type",
+                                    "value": "item"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "id": "93",
+                    "fulfillment_id": "155",
+                    "quantity": {
+                        "count": 1
+                    },
+                    "parent_item_id": "xXUeYhqy/JJR",
+                    "tags": [
+                        {
+                            "code": "type",
+                            "list": [
+                                {
+                                    "code": "type",
+                                    "value": "customization"
+                                }
+                            ]
+                        },
+                        {
+                            "code": "parent",
+                            "list": [
+                                {
+                                    "code": "id",
+                                    "value": "66zabcdefghi"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "id": "95",
+                    "fulfillment_id": "155",
+                    "quantity": {
+                        "count": 1
+                    },
+                    "parent_item_id": "xXUeYhqy/JJR",
+                    "tags": [
+                        {
+                            "code": "type",
+                            "list": [
+                                {
+                                    "code": "type",
+                                    "value": "customization"
+                                }
+                            ]
+                        },
+                        {
+                            "code": "parent",
+                            "list": [
+                                {
+                                    "code": "id",
+                                    "value": "67zabcdefghi"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "quote": {
+                "price": {
+                    "currency": "INR",
+                    "value": "118.04"
+                },
+                "breakup": [
+                    {
+                        "title": "Pizza Mania",
+                        "price": {
+                            "currency": "INR",
+                            "value": "99"
+                        },
+                        "@ondc/org/title_type": "item",
+                        "@ondc/org/item_id": "451",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
+                        },
+                        "item": {
+                            "price": {
+                                "currency": "INR",
+                                "value": "99"
+                            },
+                            "parent_item_id": "xXUeYhqy/JJR",
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "item"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "title": "Extra",
+                        "price": {
+                            "currency": "INR",
+                            "value": "5"
+                        },
+                        "@ondc/org/title_type": "item",
+                        "@ondc/org/item_id": "93",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
+                        },
+                        "item": {
+                            "price": {
+                                "currency": "INR",
+                                "value": "5"
+                            },
+                            "parent_item_id": "xXUeYhqy/JJR",
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "66zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "title": "Chicken",
+                        "price": {
+                            "currency": "INR",
+                            "value": "10"
+                        },
+                        "@ondc/org/title_type": "item",
+                        "@ondc/org/item_id": "95",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
+                        },
+                        "item": {
+                            "price": {
+                                "currency": "INR",
+                                "value": "10"
+                            },
+                            "parent_item_id": "xXUeYhqy/JJR",
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "67zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "title": "Convenience fee",
+                        "price": {
+                            "currency": "INR",
+                            "value": "4.04"
+                        },
+                        "@ondc/org/title_type": "misc",
+                        "@ondc/org/item_id": "155"
+                    },
+                    {
+                        "title": "Delivery charges",
+                        "price": {
+                            "currency": "INR",
+                            "value": "0"
+                        },
+                        "@ondc/org/title_type": "delivery",
+                        "@ondc/org/item_id": "155"
+                    }
+                ],
+                "ttl": "PT6H"
+            },
+            "billing": {
+                "address": {
+                    "building": "ARV Park",
+                    "city": "Noida",
+                    "state": "Uttar Pradesh",
+                    "country": "IND",
+                    "area_code": "201301",
+                    "locality": "Unnamed Road",
+                    "name": "Ajeet Chauhan"
+                },
+                "phone": "8574739650",
+                "name": "Ajeet Chauhan",
+                "email": "ajeetchauhan.symfony143@webkul.in",
+                "created_at": "2025-01-06T10:58:02.529Z",
+                "updated_at": "2025-01-06T10:58:02.529Z"
+            },
+            "fulfillments": [
+                {
+                    "id": "155",
+                    "type": "Delivery",
+                    "end": {
+                        "contact": {
+                            "email": "ajeetchauhan.symfony143@webkul.in",
+                            "phone": "8574739650"
+                        },
+                        "location": {
+                            "gps": "28.629743,77.377795",
+                            "address": {
+                                "building": "ARV Park",
+                                "city": "Noida",
+                                "state": "Uttar Pradesh",
+                                "country": "IND",
+                                "area_code": "201301",
+                                "locality": "Unnamed Road",
+                                "name": "Ajeet Chauhan"
+                            }
+                        }
+                    },
+                    "tracking": true
+                }
+            ],
+            "payment": {
+                "type": "ON-ORDER",
+                "collected_by": "BAP",
+                "@ondc/org/collected_by_status": "Agree",
+                "@ondc/org/buyer_app_finder_fee_type": "percent",
+                "@ondc/org/buyer_app_finder_fee_amount": "3",
+                "@ondc/org/settlement_details": [
+                    {
+                        "settlement_counterparty": "seller-app",
+                        "settlement_phase": "sale-amount",
+                        "settlement_type": "neft",
+                        "beneficiary_name": "fasdf asdfasdf",
+                        "settlement_bank_account_no": "534512341234132",
+                        "settlement_ifsc_code": "HDFC0000088",
+                        "bank_name": "fasdf",
+                        "branch_name": "noida",
+                        "settlement_status": "NOT-PAID"
+                    }
+                ]
+            },
+            "tags": [
+                {
+                    "code": "bpp_terms",
+                    "list": [
+                        {
+                            "code": "tax_number",
+                            "value": "09AABCW0339G3ZD"
+                        },
+                        {
+                            "code": "provider_tax_number",
+                            "value": "DERTC3376R"
+                        }
+                    ]
+                }
+            ]
+        }
+    }
+}

--- a/eComviser/Seller App RET11/Flow-3/on_search.json
+++ b/eComviser/Seller App RET11/Flow-3/on_search.json
@@ -1,0 +1,658 @@
+{
+    "context": {
+        "domain": "ONDC:RET11",
+        "action": "on_search",
+        "country": "IND",
+        "city": "std:0120",
+        "core_version": "1.2.0",
+        "bap_id": "buyer-app-preprod-v2.ondc.org",
+        "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+        "transaction_id": "0646bc94-5d3d-4b2d-6325-a8a33843dbb9",
+        "message_id": "36c56392-f004-4813-ace5-0d40033a8420",
+        "timestamp": "2025-01-06T10:55:38.946Z",
+        "ttl": "PT30S",
+        "bpp_id": "ondc.ecomviser.com",
+        "bpp_uri": "https://ondc.ecomviser.com/api/v1"
+    },
+    "message": {
+        "catalog": {
+            "bpp/descriptor": {
+                "name": "Webkul",
+                "symbol": "https://ondc.ecomviser.com/public/img/webkul_logo.png",
+                "short_desc": "Enterprise Digital Commerce & Marketplace Solution Experts",
+                "long_desc": "Helping companies with our industry-leading digital commerce, ERP, and CRM solutions. In the last 13 years, we have served 150K+ clients worldwide to handle complex operations and grow their businesses",
+                "images": [
+                    "https://ondc.ecomviser.com/public/img/webkul_banner.png",
+                    "https://ondc.ecomviser.com/public/img/webkul_clients.png",
+                    "https://ondc.ecomviser.com/public/img/webkul_awards.png"
+                ],
+                "tags": [
+                    {
+                        "code": "bpp_terms",
+                        "list": [
+                            {
+                                "code": "np_type",
+                                "value": "MSN"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "bpp/fulfillments": [
+                {
+                    "id": "155",
+                    "type": "Delivery"
+                }
+            ],
+            "bpp/providers": [
+                {
+                    "id": "84",
+                    "time": {
+                        "label": "enable",
+                        "timestamp": "2025-01-06T10:25:38.328Z"
+                    },
+                    "descriptor": {
+                        "name": "Ajeet Food Shop",
+                        "symbol": "https://ondc-prepod-digital-delivery.s3.amazonaws.com/seller_shop_logo/84/39MylDtZVC.jpg",
+                        "short_desc": "short desc",
+                        "long_desc": "store desc",
+                        "images": [
+                            "https://ondc-prepod-digital-delivery.s3.amazonaws.com/seller_shop_logo/84/39MylDtZVC.jpg"
+                        ]
+                    },
+                    "fulfillments": [
+                        {
+                            "id": "155",
+                            "type": "Delivery",
+                            "contact": {
+                                "phone": "9812345678",
+                                "email": "ajeetchauhan.symfony143@webkul.in"
+                            }
+                        }
+                    ],
+                    "locations": [
+                        {
+                            "id": "83",
+                            "gps": "28.62972640,77.37783230",
+                            "address": {
+                                "locality": "Noida",
+                                "street": "H-28",
+                                "city": "Gautam Buddh Nagar",
+                                "area_code": "201301",
+                                "state": "Uttar Pradesh"
+                            },
+                            "circle": {
+                                "gps": "28.62972640,77.37783230",
+                                "radius": {
+                                    "unit": "km",
+                                    "value": "5"
+                                }
+                            },
+                            "time": {
+                                "label": "enable",
+                                "timestamp": "2025-01-06T10:25:38.328Z",
+                                "days": "1,2,3,4,5,6,7",
+                                "schedule": {
+                                    "holidays": []
+                                },
+                                "range": {
+                                    "start": "0800",
+                                    "end": "1707"
+                                }
+                            }
+                        }
+                    ],
+                    "@ondc/org/fssai_license_no": "12345678908898",
+                    "categories": [
+                        {
+                            "id": "66zabcdefghi",
+                            "descriptor": {
+                                "name": "Cheese"
+                            },
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "custom_group"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "config",
+                                    "list": [
+                                        {
+                                            "code": "min",
+                                            "value": "1"
+                                        },
+                                        {
+                                            "code": "max",
+                                            "value": "1"
+                                        },
+                                        {
+                                            "code": "input",
+                                            "value": "select"
+                                        },
+                                        {
+                                            "code": "seq",
+                                            "value": "1"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "67zabcdefghi",
+                            "descriptor": {
+                                "name": "Non-veg toppings"
+                            },
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "custom_group"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "config",
+                                    "list": [
+                                        {
+                                            "code": "min",
+                                            "value": "1"
+                                        },
+                                        {
+                                            "code": "max",
+                                            "value": "1"
+                                        },
+                                        {
+                                            "code": "input",
+                                            "value": "select"
+                                        },
+                                        {
+                                            "code": "seq",
+                                            "value": "2"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "844147zabcde",
+                            "parent_category_id": "",
+                            "descriptor": {
+                                "name": "Pizza",
+                                "short_desc": "Pizza",
+                                "long_desc": "Pizza"
+                            },
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "custom_menu"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "display",
+                                    "list": [
+                                        {
+                                            "code": "rank",
+                                            "value": "1"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "timing",
+                                    "list": [
+                                        {
+                                            "code": "day_from",
+                                            "value": "1"
+                                        },
+                                        {
+                                            "code": "day_to",
+                                            "value": "5"
+                                        },
+                                        {
+                                            "code": "time_from",
+                                            "value": "0800"
+                                        },
+                                        {
+                                            "code": "time_to",
+                                            "value": "2200"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ],
+                    "items": [
+                        {
+                            "id": "451",
+                            "time": {
+                                "label": "enable",
+                                "timestamp": "2025-01-06T10:25:38.328Z"
+                            },
+                            "descriptor": {
+                                "name": "Pizza Mania",
+                                "symbol": "https://d3bhszwz094mhs.cloudfront.net/product_img/main_img/342/NipTw8cSUY.jpeg",
+                                "short_desc": "pizza best small",
+                                "long_desc": "best pizza",
+                                "images": [
+                                    "https://d3bhszwz094mhs.cloudfront.net/product_img/main_img/342/NipTw8cSUY.jpeg"
+                                ],
+                                "code": "1:123456789876"
+                            },
+                            "price": {
+                                "currency": "INR",
+                                "value": "99",
+                                "maximum_value": "110",
+                                "tags": [
+                                    {
+                                        "code": "range",
+                                        "list": [
+                                            {
+                                                "code": "lower",
+                                                "value": "99.00"
+                                            },
+                                            {
+                                                "code": "upper",
+                                                "value": "159"
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "code": "default_selection",
+                                        "list": [
+                                            {
+                                                "code": "value",
+                                                "value": "99.00"
+                                            },
+                                            {
+                                                "code": "maximum_value",
+                                                "value": "159"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            "quantity": {
+                                "available": {
+                                    "count": "99"
+                                },
+                                "maximum": {
+                                    "count": "99"
+                                },
+                                "unitized": {
+                                    "measure": {
+                                        "unit": "gram",
+                                        "value": "200"
+                                    }
+                                }
+                            },
+                            "location_id": "83",
+                            "category_id": "F&B",
+                            "fulfillment_id": "155",
+                            "@ondc/org/time_to_ship": "PT1H",
+                            "@ondc/org/cancellable": true,
+                            "@ondc/org/seller_pickup_return": false,
+                            "@ondc/org/returnable": false,
+                            "@ondc/org/return_window": "PT0S",
+                            "@ondc/org/available_on_cod": false,
+                            "@ondc/org/contact_details_consumer_care": "ajeet,ajeetchauhan.symfony143@webkul.in,9812345678",
+                            "tags": [
+                                {
+                                    "code": "origin",
+                                    "list": [
+                                        {
+                                            "code": "country",
+                                            "value": "IND"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "item"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "custom_group",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "66zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "category_ids": [
+                                "844147zabcde:1"
+                            ]
+                        },
+                        {
+                            "id": "93",
+                            "descriptor": {
+                                "name": "Extra"
+                            },
+                            "quantity": {
+                                "available": {
+                                    "count": "99"
+                                },
+                                "maximum": {
+                                    "count": "99"
+                                }
+                            },
+                            "price": {
+                                "currency": "INR",
+                                "value": "5.00",
+                                "maximum_value": "5.00"
+                            },
+                            "category_id": "F&B",
+                            "related": true,
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "66zabcdefghi"
+                                        },
+                                        {
+                                            "code": "default",
+                                            "value": "yes"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "veg_nonveg",
+                                    "list": [
+                                        {
+                                            "code": "veg",
+                                            "value": "yes"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "child",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "67zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "94",
+                            "descriptor": {
+                                "name": "Vegan"
+                            },
+                            "quantity": {
+                                "available": {
+                                    "count": "99"
+                                },
+                                "maximum": {
+                                    "count": "99"
+                                }
+                            },
+                            "price": {
+                                "currency": "INR",
+                                "value": "10.00",
+                                "maximum_value": "10.00"
+                            },
+                            "category_id": "F&B",
+                            "related": true,
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "66zabcdefghi"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "veg_nonveg",
+                                    "list": [
+                                        {
+                                            "code": "veg",
+                                            "value": "yes"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "child",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "67zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "95",
+                            "descriptor": {
+                                "name": "Chicken"
+                            },
+                            "quantity": {
+                                "available": {
+                                    "count": "99"
+                                },
+                                "maximum": {
+                                    "count": "99"
+                                }
+                            },
+                            "price": {
+                                "currency": "INR",
+                                "value": "10.00",
+                                "maximum_value": "10.00"
+                            },
+                            "category_id": "F&B",
+                            "related": true,
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "67zabcdefghi"
+                                        },
+                                        {
+                                            "code": "default",
+                                            "value": "yes"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "veg_nonveg",
+                                    "list": [
+                                        {
+                                            "code": "non_veg",
+                                            "value": "yes"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "96",
+                            "descriptor": {
+                                "name": "Mutton"
+                            },
+                            "quantity": {
+                                "available": {
+                                    "count": "99"
+                                },
+                                "maximum": {
+                                    "count": "99"
+                                }
+                            },
+                            "price": {
+                                "currency": "INR",
+                                "value": "50.00",
+                                "maximum_value": "50.00"
+                            },
+                            "category_id": "F&B",
+                            "related": true,
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "67zabcdefghi"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "veg_nonveg",
+                                    "list": [
+                                        {
+                                            "code": "veg",
+                                            "value": "yes"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ],
+                    "tags": [
+                        {
+                            "code": "timing",
+                            "list": [
+                                {
+                                    "code": "type",
+                                    "value": "Order"
+                                },
+                                {
+                                    "code": "location",
+                                    "value": "83"
+                                },
+                                {
+                                    "code": "day_from",
+                                    "value": "1"
+                                },
+                                {
+                                    "code": "day_to",
+                                    "value": "7"
+                                },
+                                {
+                                    "code": "time_from",
+                                    "value": "0900"
+                                },
+                                {
+                                    "code": "time_to",
+                                    "value": "2300"
+                                }
+                            ]
+                        },
+                        {
+                            "code": "timing",
+                            "list": [
+                                {
+                                    "code": "type",
+                                    "value": "Delivery"
+                                },
+                                {
+                                    "code": "location",
+                                    "value": "83"
+                                },
+                                {
+                                    "code": "day_from",
+                                    "value": "1"
+                                },
+                                {
+                                    "code": "day_to",
+                                    "value": "7"
+                                },
+                                {
+                                    "code": "time_from",
+                                    "value": "1000"
+                                },
+                                {
+                                    "code": "time_to",
+                                    "value": "2100"
+                                }
+                            ]
+                        },
+                        {
+                            "code": "serviceability",
+                            "list": [
+                                {
+                                    "code": "location",
+                                    "value": "83"
+                                },
+                                {
+                                    "code": "category",
+                                    "value": "F&B"
+                                },
+                                {
+                                    "code": "type",
+                                    "value": "10"
+                                },
+                                {
+                                    "code": "val",
+                                    "value": "5"
+                                },
+                                {
+                                    "code": "unit",
+                                    "value": "km"
+                                }
+                            ]
+                        }
+                    ],
+                    "ttl": "P1D"
+                }
+            ]
+        }
+    }
+}

--- a/eComviser/Seller App RET11/Flow-3/on_select.json
+++ b/eComviser/Seller App RET11/Flow-3/on_select.json
@@ -1,0 +1,270 @@
+{
+    "context": {
+        "domain": "ONDC:RET11",
+        "country": "IND",
+        "city": "std:0120",
+        "action": "on_select",
+        "core_version": "1.2.0",
+        "bap_id": "buyer-app-preprod-v2.ondc.org",
+        "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+        "bpp_uri": "https://ondc.ecomviser.com/api/v1",
+        "transaction_id": "5a913b62-e66f-4a6b-bf2a-8072714506d6",
+        "message_id": "f42ce0d2-71d7-4b6f-bd9c-312c97f1fd81",
+        "timestamp": "2025-01-06T10:57:54.812Z",
+        "bpp_id": "ondc.ecomviser.com"
+    },
+    "message": {
+        "order": {
+            "provider": {
+                "id": "84",
+                "locations": [
+                    {
+                        "id": "83"
+                    }
+                ]
+            },
+            "items": [
+                {
+                    "id": "451",
+                    "fulfillment_id": "155",
+                    "parent_item_id": "xXUeYhqy/JJR",
+                    "tags": [
+                        {
+                            "code": "type",
+                            "list": [
+                                {
+                                    "code": "type",
+                                    "value": "item"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "id": "93",
+                    "fulfillment_id": "155",
+                    "parent_item_id": "xXUeYhqy/JJR",
+                    "tags": [
+                        {
+                            "code": "type",
+                            "list": [
+                                {
+                                    "code": "type",
+                                    "value": "customization"
+                                }
+                            ]
+                        },
+                        {
+                            "code": "parent",
+                            "list": [
+                                {
+                                    "code": "id",
+                                    "value": "66zabcdefghi"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "id": "95",
+                    "fulfillment_id": "155",
+                    "parent_item_id": "xXUeYhqy/JJR",
+                    "tags": [
+                        {
+                            "code": "type",
+                            "list": [
+                                {
+                                    "code": "type",
+                                    "value": "customization"
+                                }
+                            ]
+                        },
+                        {
+                            "code": "parent",
+                            "list": [
+                                {
+                                    "code": "id",
+                                    "value": "67zabcdefghi"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "fulfillments": [
+                {
+                    "id": "155",
+                    "type": "Delivery",
+                    "@ondc/org/provider_name": "ondc.ecomviser.com",
+                    "tracking": true,
+                    "@ondc/org/category": "Immediate Delivery",
+                    "@ondc/org/TAT": "PT90M",
+                    "state": {
+                        "descriptor": {
+                            "code": "Serviceable"
+                        }
+                    }
+                }
+            ],
+            "quote": {
+                "price": {
+                    "currency": "INR",
+                    "value": "118.04"
+                },
+                "breakup": [
+                    {
+                        "title": "Pizza Mania",
+                        "price": {
+                            "currency": "INR",
+                            "value": "99"
+                        },
+                        "@ondc/org/title_type": "item",
+                        "@ondc/org/item_id": "451",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
+                        },
+                        "item": {
+                            "price": {
+                                "currency": "INR",
+                                "value": "99"
+                            },
+                            "quantity": {
+                                "available": {
+                                    "count": "99"
+                                },
+                                "maximum": {
+                                    "count": "99"
+                                }
+                            },
+                            "parent_item_id": "xXUeYhqy/JJR",
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "item"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "title": "Extra",
+                        "price": {
+                            "currency": "INR",
+                            "value": "5"
+                        },
+                        "@ondc/org/title_type": "item",
+                        "@ondc/org/item_id": "93",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
+                        },
+                        "item": {
+                            "price": {
+                                "currency": "INR",
+                                "value": "5"
+                            },
+                            "quantity": {
+                                "available": {
+                                    "count": "99"
+                                },
+                                "maximum": {
+                                    "count": "99"
+                                }
+                            },
+                            "parent_item_id": "xXUeYhqy/JJR",
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "66zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "title": "Chicken",
+                        "price": {
+                            "currency": "INR",
+                            "value": "10"
+                        },
+                        "@ondc/org/title_type": "item",
+                        "@ondc/org/item_id": "95",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
+                        },
+                        "item": {
+                            "price": {
+                                "currency": "INR",
+                                "value": "10"
+                            },
+                            "quantity": {
+                                "available": {
+                                    "count": "99"
+                                },
+                                "maximum": {
+                                    "count": "99"
+                                }
+                            },
+                            "parent_item_id": "xXUeYhqy/JJR",
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "67zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "title": "Convenience fee",
+                        "price": {
+                            "currency": "INR",
+                            "value": "4.04"
+                        },
+                        "@ondc/org/title_type": "misc",
+                        "@ondc/org/item_id": "155"
+                    },
+                    {
+                        "title": "Delivery charges",
+                        "price": {
+                            "currency": "INR",
+                            "value": "0"
+                        },
+                        "@ondc/org/title_type": "delivery",
+                        "@ondc/org/item_id": "155"
+                    }
+                ],
+                "ttl": "PT6H"
+            }
+        }
+    }
+}

--- a/eComviser/Seller App RET11/Flow-3/on_status_agent_assigned.json
+++ b/eComviser/Seller App RET11/Flow-3/on_status_agent_assigned.json
@@ -1,0 +1,286 @@
+{
+    "context": {
+        "domain": "ONDC:RET11",
+        "country": "IND",
+        "city": "std:0120",
+        "action": "on_status",
+        "core_version": "1.2.0",
+        "bap_id": "buyer-app-preprod-v2.ondc.org",
+        "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+        "bpp_uri": "https://ondc.ecomviser.com/api/v1",
+        "transaction_id": "5a913b62-e66f-4a6b-bf2a-8072714506d6",
+        "message_id": "677bb7c98cab7ec55af9c-9111",
+        "timestamp": "2025-01-06T11:00:25.576Z",
+        "bpp_id": "ondc.ecomviser.com",
+        "ttl": "PT30S"
+    },
+    "message": {
+        "order": {
+            "id": "2025-01-06-333398",
+            "state": "In-progress",
+            "provider": {
+                "id": "84",
+                "locations": [
+                    {
+                        "id": "83"
+                    }
+                ]
+            },
+            "items": [
+                {
+                    "id": "451",
+                    "fulfillment_id": "155",
+                    "quantity": {
+                        "count": 1
+                    }
+                }
+            ],
+            "fulfillments": [
+                {
+                    "id": "155",
+                    "end": {
+                        "time": {
+                            "range": {
+                                "end": "2025-01-06T11:58:40.518Z",
+                                "start": "2025-01-06T10:58:40.518Z"
+                            }
+                        },
+                        "person": {
+                            "name": "Ajeet Chauhan"
+                        },
+                        "contact": {
+                            "email": "ajeetchauhan.symfony143@webkul.in",
+                            "phone": "8574739650"
+                        },
+                        "location": {
+                            "gps": "28.629743,77.377795",
+                            "address": {
+                                "city": "Noida",
+                                "name": "Ajeet Chauhan",
+                                "state": "Uttar Pradesh",
+                                "country": "IND",
+                                "building": "ARV Park",
+                                "locality": "Unnamed Road",
+                                "area_code": "201301"
+                            }
+                        }
+                    },
+                    "type": "Delivery",
+                    "start": {
+                        "time": {
+                            "range": {
+                                "end": "2025-01-06T11:58:40.518Z",
+                                "start": "2025-01-06T10:58:40.518Z"
+                            }
+                        },
+                        "contact": {
+                            "email": "support@webkul.in",
+                            "phone": "9876543210"
+                        },
+                        "location": {
+                            "id": "83",
+                            "gps": "28.62972640,77.37783230",
+                            "address": {
+                                "city": "Gautam Buddh Nagar",
+                                "state": "Uttar Pradesh",
+                                "locality": "Noida",
+                                "area_code": "201301"
+                            },
+                            "descriptor": {
+                                "name": "Ajeet Food Shop"
+                            }
+                        }
+                    },
+                    "state": {
+                        "descriptor": {
+                            "code": "Agent-assigned"
+                        }
+                    },
+                    "tracking": true,
+                    "@ondc/org/TAT": "PT90M",
+                    "@ondc/org/provider_name": "ondc.ecomviser.com"
+                }
+            ],
+            "quote": {
+                "ttl": "PT6H",
+                "price": {
+                    "value": "118.04",
+                    "currency": "INR"
+                },
+                "breakup": [
+                    {
+                        "item": {
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "item"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "price": {
+                                "value": "99",
+                                "currency": "INR"
+                            },
+                            "parent_item_id": "xXUeYhqy/JJR"
+                        },
+                        "price": {
+                            "value": "99",
+                            "currency": "INR"
+                        },
+                        "title": "Pizza Mania",
+                        "@ondc/org/item_id": "451",
+                        "@ondc/org/title_type": "item",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
+                        }
+                    },
+                    {
+                        "item": {
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "66zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "price": {
+                                "value": "5",
+                                "currency": "INR"
+                            },
+                            "parent_item_id": "xXUeYhqy/JJR"
+                        },
+                        "price": {
+                            "value": "5",
+                            "currency": "INR"
+                        },
+                        "title": "Extra",
+                        "@ondc/org/item_id": "93",
+                        "@ondc/org/title_type": "item",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
+                        }
+                    },
+                    {
+                        "item": {
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "67zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "price": {
+                                "value": "10",
+                                "currency": "INR"
+                            },
+                            "parent_item_id": "xXUeYhqy/JJR"
+                        },
+                        "price": {
+                            "value": "10",
+                            "currency": "INR"
+                        },
+                        "title": "Chicken",
+                        "@ondc/org/item_id": "95",
+                        "@ondc/org/title_type": "item",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
+                        }
+                    },
+                    {
+                        "price": {
+                            "value": "4.04",
+                            "currency": "INR"
+                        },
+                        "title": "Convenience fee",
+                        "@ondc/org/item_id": "155",
+                        "@ondc/org/title_type": "misc"
+                    },
+                    {
+                        "price": {
+                            "value": "0",
+                            "currency": "INR"
+                        },
+                        "title": "Delivery charges",
+                        "@ondc/org/item_id": "155",
+                        "@ondc/org/title_type": "delivery"
+                    }
+                ]
+            },
+            "billing": {
+                "name": "Ajeet Chauhan",
+                "email": "ajeetchauhan.symfony143@webkul.in",
+                "phone": "8574739650",
+                "address": {
+                    "city": "Noida",
+                    "name": "Ajeet Chauhan",
+                    "state": "Uttar Pradesh",
+                    "country": "IND",
+                    "building": "ARV Park",
+                    "locality": "Unnamed Road",
+                    "area_code": "201301"
+                },
+                "created_at": "2025-01-06T10:58:02.529Z",
+                "updated_at": "2025-01-06T10:58:02.529Z"
+            },
+            "payment": {
+                "uri": "https://razorpay.com/",
+                "type": "ON-ORDER",
+                "params": {
+                    "amount": "118.04",
+                    "currency": "INR",
+                    "transaction_id": "order_Pg8IoytiBpf9W3"
+                },
+                "status": "PAID",
+                "tl_method": "http/get",
+                "collected_by": "BAP",
+                "@ondc/org/settlement_details": [
+                    {
+                        "bank_name": "fasdf",
+                        "branch_name": "noida",
+                        "settlement_type": "neft",
+                        "beneficiary_name": "fasdf asdfasdf",
+                        "settlement_phase": "sale-amount",
+                        "settlement_status": "NOT-PAID",
+                        "settlement_ifsc_code": "HDFC0000088",
+                        "settlement_counterparty": "seller-app",
+                        "settlement_bank_account_no": "534512341234132"
+                    }
+                ],
+                "@ondc/org/buyer_app_finder_fee_type": "percent",
+                "@ondc/org/buyer_app_finder_fee_amount": "3.0"
+            },
+            "created_at": "2025-01-06T10:58:33.520Z",
+            "updated_at": "2025-01-06T11:00:25.576Z"
+        }
+    }
+}

--- a/eComviser/Seller App RET11/Flow-3/on_status_delivered.json
+++ b/eComviser/Seller App RET11/Flow-3/on_status_delivered.json
@@ -1,0 +1,318 @@
+{
+    "context": {
+        "domain": "ONDC:RET11",
+        "country": "IND",
+        "city": "std:0120",
+        "action": "on_status",
+        "core_version": "1.2.0",
+        "bap_id": "buyer-app-preprod-v2.ondc.org",
+        "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+        "bpp_uri": "https://ondc.ecomviser.com/api/v1",
+        "transaction_id": "5a913b62-e66f-4a6b-bf2a-8072714506d6",
+        "message_id": "677bb7ec87f3ad3d4b6f7-a6e0",
+        "timestamp": "2025-01-06T11:01:00.557Z",
+        "bpp_id": "ondc.ecomviser.com",
+        "ttl": "PT30S"
+    },
+    "message": {
+        "order": {
+            "id": "2025-01-06-333398",
+            "state": "Completed",
+            "provider": {
+                "id": "84",
+                "locations": [
+                    {
+                        "id": "83"
+                    }
+                ]
+            },
+            "items": [
+                {
+                    "id": "451",
+                    "fulfillment_id": "155",
+                    "quantity": {
+                        "count": 1
+                    }
+                }
+            ],
+            "fulfillments": [
+                {
+                    "id": "155",
+                    "end": {
+                        "time": {
+                            "range": {
+                                "end": "2025-01-06T11:58:40.518Z",
+                                "start": "2025-01-06T10:58:40.518Z"
+                            },
+                            "timestamp": "2025-01-06T11:00:59.947Z"
+                        },
+                        "person": {
+                            "name": "Ajeet Chauhan"
+                        },
+                        "contact": {
+                            "email": "ajeetchauhan.symfony143@webkul.in",
+                            "phone": "8574739650"
+                        },
+                        "location": {
+                            "gps": "28.629743,77.377795",
+                            "address": {
+                                "city": "Noida",
+                                "name": "Ajeet Chauhan",
+                                "state": "Uttar Pradesh",
+                                "country": "IND",
+                                "building": "ARV Park",
+                                "locality": "Unnamed Road",
+                                "area_code": "201301"
+                            }
+                        }
+                    },
+                    "type": "Delivery",
+                    "start": {
+                        "time": {
+                            "range": {
+                                "end": "2025-01-06T11:58:40.518Z",
+                                "start": "2025-01-06T10:58:40.518Z"
+                            },
+                            "timestamp": "2025-01-06T11:00:33.631Z"
+                        },
+                        "contact": {
+                            "email": "support@webkul.in",
+                            "phone": "9876543210"
+                        },
+                        "location": {
+                            "id": "83",
+                            "gps": "28.62972640,77.37783230",
+                            "address": {
+                                "city": "Gautam Buddh Nagar",
+                                "state": "Uttar Pradesh",
+                                "locality": "Noida",
+                                "area_code": "201301"
+                            },
+                            "descriptor": {
+                                "name": "Ajeet Food Shop"
+                            }
+                        }
+                    },
+                    "state": {
+                        "descriptor": {
+                            "code": "Order-delivered"
+                        }
+                    },
+                    "tracking": true,
+                    "@ondc/org/TAT": "PT90M",
+                    "@ondc/org/provider_name": "ondc.ecomviser.com",
+                    "tags": [
+                        {
+                            "code": "routing",
+                            "list": [
+                                {
+                                    "code": "type",
+                                    "value": "P2P"
+                                }
+                            ]
+                        },
+                        {
+                            "code": "tracking",
+                            "list": [
+                                {
+                                    "code": "gps_enabled",
+                                    "value": "yes"
+                                },
+                                {
+                                    "code": "url_enabled",
+                                    "value": "no"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "quote": {
+                "ttl": "PT6H",
+                "price": {
+                    "value": "118.04",
+                    "currency": "INR"
+                },
+                "breakup": [
+                    {
+                        "item": {
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "item"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "price": {
+                                "value": "99",
+                                "currency": "INR"
+                            },
+                            "parent_item_id": "xXUeYhqy/JJR"
+                        },
+                        "price": {
+                            "value": "99",
+                            "currency": "INR"
+                        },
+                        "title": "Pizza Mania",
+                        "@ondc/org/item_id": "451",
+                        "@ondc/org/title_type": "item",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
+                        }
+                    },
+                    {
+                        "item": {
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "66zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "price": {
+                                "value": "5",
+                                "currency": "INR"
+                            },
+                            "parent_item_id": "xXUeYhqy/JJR"
+                        },
+                        "price": {
+                            "value": "5",
+                            "currency": "INR"
+                        },
+                        "title": "Extra",
+                        "@ondc/org/item_id": "93",
+                        "@ondc/org/title_type": "item",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
+                        }
+                    },
+                    {
+                        "item": {
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "67zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "price": {
+                                "value": "10",
+                                "currency": "INR"
+                            },
+                            "parent_item_id": "xXUeYhqy/JJR"
+                        },
+                        "price": {
+                            "value": "10",
+                            "currency": "INR"
+                        },
+                        "title": "Chicken",
+                        "@ondc/org/item_id": "95",
+                        "@ondc/org/title_type": "item",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
+                        }
+                    },
+                    {
+                        "price": {
+                            "value": "4.04",
+                            "currency": "INR"
+                        },
+                        "title": "Convenience fee",
+                        "@ondc/org/item_id": "155",
+                        "@ondc/org/title_type": "misc"
+                    },
+                    {
+                        "price": {
+                            "value": "0",
+                            "currency": "INR"
+                        },
+                        "title": "Delivery charges",
+                        "@ondc/org/item_id": "155",
+                        "@ondc/org/title_type": "delivery"
+                    }
+                ]
+            },
+            "billing": {
+                "name": "Ajeet Chauhan",
+                "email": "ajeetchauhan.symfony143@webkul.in",
+                "phone": "8574739650",
+                "address": {
+                    "city": "Noida",
+                    "name": "Ajeet Chauhan",
+                    "state": "Uttar Pradesh",
+                    "country": "IND",
+                    "building": "ARV Park",
+                    "locality": "Unnamed Road",
+                    "area_code": "201301"
+                },
+                "created_at": "2025-01-06T10:58:02.529Z",
+                "updated_at": "2025-01-06T10:58:02.529Z"
+            },
+            "payment": {
+                "uri": "https://razorpay.com/",
+                "type": "ON-ORDER",
+                "params": {
+                    "amount": "118.04",
+                    "currency": "INR",
+                    "transaction_id": "order_Pg8IoytiBpf9W3"
+                },
+                "status": "PAID",
+                "tl_method": "http/get",
+                "collected_by": "BAP",
+                "@ondc/org/settlement_details": [
+                    {
+                        "bank_name": "fasdf",
+                        "branch_name": "noida",
+                        "settlement_type": "neft",
+                        "beneficiary_name": "fasdf asdfasdf",
+                        "settlement_phase": "sale-amount",
+                        "settlement_status": "NOT-PAID",
+                        "settlement_ifsc_code": "HDFC0000088",
+                        "settlement_counterparty": "seller-app",
+                        "settlement_bank_account_no": "534512341234132"
+                    }
+                ],
+                "@ondc/org/buyer_app_finder_fee_type": "percent",
+                "@ondc/org/buyer_app_finder_fee_amount": "3.0"
+            },
+            "created_at": "2025-01-06T10:58:33.520Z",
+            "updated_at": "2025-01-06T11:01:00.557Z",
+            "documents": [
+                {
+                    "label": "Invoice",
+                    "url": "https://ecomviser-prepod.sp-seller-preprod.ecomviser.com/index.php?p=invoice_download&key=MTc0Ojg0OmVjb212aXNlcg=="
+                }
+            ]
+        }
+    }
+}

--- a/eComviser/Seller App RET11/Flow-3/on_status_out_for_delivery.json
+++ b/eComviser/Seller App RET11/Flow-3/on_status_out_for_delivery.json
@@ -1,0 +1,317 @@
+{
+    "context": {
+        "domain": "ONDC:RET11",
+        "country": "IND",
+        "city": "std:0120",
+        "action": "on_status",
+        "core_version": "1.2.0",
+        "bap_id": "buyer-app-preprod-v2.ondc.org",
+        "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+        "bpp_uri": "https://ondc.ecomviser.com/api/v1",
+        "transaction_id": "5a913b62-e66f-4a6b-bf2a-8072714506d6",
+        "message_id": "677bb7dfbe21401014d05-44e1",
+        "timestamp": "2025-01-06T11:00:47.779Z",
+        "bpp_id": "ondc.ecomviser.com",
+        "ttl": "PT30S"
+    },
+    "message": {
+        "order": {
+            "id": "2025-01-06-333398",
+            "state": "In-progress",
+            "provider": {
+                "id": "84",
+                "locations": [
+                    {
+                        "id": "83"
+                    }
+                ]
+            },
+            "items": [
+                {
+                    "id": "451",
+                    "fulfillment_id": "155",
+                    "quantity": {
+                        "count": 1
+                    }
+                }
+            ],
+            "fulfillments": [
+                {
+                    "id": "155",
+                    "end": {
+                        "time": {
+                            "range": {
+                                "end": "2025-01-06T11:58:40.518Z",
+                                "start": "2025-01-06T10:58:40.518Z"
+                            }
+                        },
+                        "person": {
+                            "name": "Ajeet Chauhan"
+                        },
+                        "contact": {
+                            "email": "ajeetchauhan.symfony143@webkul.in",
+                            "phone": "8574739650"
+                        },
+                        "location": {
+                            "gps": "28.629743,77.377795",
+                            "address": {
+                                "city": "Noida",
+                                "name": "Ajeet Chauhan",
+                                "state": "Uttar Pradesh",
+                                "country": "IND",
+                                "building": "ARV Park",
+                                "locality": "Unnamed Road",
+                                "area_code": "201301"
+                            }
+                        }
+                    },
+                    "type": "Delivery",
+                    "start": {
+                        "time": {
+                            "range": {
+                                "end": "2025-01-06T11:58:40.518Z",
+                                "start": "2025-01-06T10:58:40.518Z"
+                            },
+                            "timestamp": "2025-01-06T11:00:33.631Z"
+                        },
+                        "contact": {
+                            "email": "support@webkul.in",
+                            "phone": "9876543210"
+                        },
+                        "location": {
+                            "id": "83",
+                            "gps": "28.62972640,77.37783230",
+                            "address": {
+                                "city": "Gautam Buddh Nagar",
+                                "state": "Uttar Pradesh",
+                                "locality": "Noida",
+                                "area_code": "201301"
+                            },
+                            "descriptor": {
+                                "name": "Ajeet Food Shop"
+                            }
+                        }
+                    },
+                    "state": {
+                        "descriptor": {
+                            "code": "Out-for-delivery"
+                        }
+                    },
+                    "tracking": true,
+                    "@ondc/org/TAT": "PT90M",
+                    "@ondc/org/provider_name": "ondc.ecomviser.com",
+                    "tags": [
+                        {
+                            "code": "routing",
+                            "list": [
+                                {
+                                    "code": "type",
+                                    "value": "P2P"
+                                }
+                            ]
+                        },
+                        {
+                            "code": "tracking",
+                            "list": [
+                                {
+                                    "code": "gps_enabled",
+                                    "value": "yes"
+                                },
+                                {
+                                    "code": "url_enabled",
+                                    "value": "no"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "quote": {
+                "ttl": "PT6H",
+                "price": {
+                    "value": "118.04",
+                    "currency": "INR"
+                },
+                "breakup": [
+                    {
+                        "item": {
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "item"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "price": {
+                                "value": "99",
+                                "currency": "INR"
+                            },
+                            "parent_item_id": "xXUeYhqy/JJR"
+                        },
+                        "price": {
+                            "value": "99",
+                            "currency": "INR"
+                        },
+                        "title": "Pizza Mania",
+                        "@ondc/org/item_id": "451",
+                        "@ondc/org/title_type": "item",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
+                        }
+                    },
+                    {
+                        "item": {
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "66zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "price": {
+                                "value": "5",
+                                "currency": "INR"
+                            },
+                            "parent_item_id": "xXUeYhqy/JJR"
+                        },
+                        "price": {
+                            "value": "5",
+                            "currency": "INR"
+                        },
+                        "title": "Extra",
+                        "@ondc/org/item_id": "93",
+                        "@ondc/org/title_type": "item",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
+                        }
+                    },
+                    {
+                        "item": {
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "67zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "price": {
+                                "value": "10",
+                                "currency": "INR"
+                            },
+                            "parent_item_id": "xXUeYhqy/JJR"
+                        },
+                        "price": {
+                            "value": "10",
+                            "currency": "INR"
+                        },
+                        "title": "Chicken",
+                        "@ondc/org/item_id": "95",
+                        "@ondc/org/title_type": "item",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
+                        }
+                    },
+                    {
+                        "price": {
+                            "value": "4.04",
+                            "currency": "INR"
+                        },
+                        "title": "Convenience fee",
+                        "@ondc/org/item_id": "155",
+                        "@ondc/org/title_type": "misc"
+                    },
+                    {
+                        "price": {
+                            "value": "0",
+                            "currency": "INR"
+                        },
+                        "title": "Delivery charges",
+                        "@ondc/org/item_id": "155",
+                        "@ondc/org/title_type": "delivery"
+                    }
+                ]
+            },
+            "billing": {
+                "name": "Ajeet Chauhan",
+                "email": "ajeetchauhan.symfony143@webkul.in",
+                "phone": "8574739650",
+                "address": {
+                    "city": "Noida",
+                    "name": "Ajeet Chauhan",
+                    "state": "Uttar Pradesh",
+                    "country": "IND",
+                    "building": "ARV Park",
+                    "locality": "Unnamed Road",
+                    "area_code": "201301"
+                },
+                "created_at": "2025-01-06T10:58:02.529Z",
+                "updated_at": "2025-01-06T10:58:02.529Z"
+            },
+            "payment": {
+                "uri": "https://razorpay.com/",
+                "type": "ON-ORDER",
+                "params": {
+                    "amount": "118.04",
+                    "currency": "INR",
+                    "transaction_id": "order_Pg8IoytiBpf9W3"
+                },
+                "status": "PAID",
+                "tl_method": "http/get",
+                "collected_by": "BAP",
+                "@ondc/org/settlement_details": [
+                    {
+                        "bank_name": "fasdf",
+                        "branch_name": "noida",
+                        "settlement_type": "neft",
+                        "beneficiary_name": "fasdf asdfasdf",
+                        "settlement_phase": "sale-amount",
+                        "settlement_status": "NOT-PAID",
+                        "settlement_ifsc_code": "HDFC0000088",
+                        "settlement_counterparty": "seller-app",
+                        "settlement_bank_account_no": "534512341234132"
+                    }
+                ],
+                "@ondc/org/buyer_app_finder_fee_type": "percent",
+                "@ondc/org/buyer_app_finder_fee_amount": "3.0"
+            },
+            "created_at": "2025-01-06T10:58:33.520Z",
+            "updated_at": "2025-01-06T11:00:47.779Z",
+            "documents": [
+                {
+                    "label": "Invoice",
+                    "url": "https://ecomviser-prepod.sp-seller-preprod.ecomviser.com/index.php?p=invoice_download&key=MTc0Ojg0OmVjb212aXNlcg=="
+                }
+            ]
+        }
+    }
+}

--- a/eComviser/Seller App RET11/Flow-3/on_status_packed.json
+++ b/eComviser/Seller App RET11/Flow-3/on_status_packed.json
@@ -1,0 +1,286 @@
+{
+    "context": {
+        "domain": "ONDC:RET11",
+        "country": "IND",
+        "city": "std:0120",
+        "action": "on_status",
+        "core_version": "1.2.0",
+        "bap_id": "buyer-app-preprod-v2.ondc.org",
+        "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+        "bpp_uri": "https://ondc.ecomviser.com/api/v1",
+        "transaction_id": "5a913b62-e66f-4a6b-bf2a-8072714506d6",
+        "message_id": "677bb7c1e1a860cef9bfe-bacd",
+        "timestamp": "2025-01-06T11:00:17.924Z",
+        "bpp_id": "ondc.ecomviser.com",
+        "ttl": "PT30S"
+    },
+    "message": {
+        "order": {
+            "id": "2025-01-06-333398",
+            "state": "In-progress",
+            "provider": {
+                "id": "84",
+                "locations": [
+                    {
+                        "id": "83"
+                    }
+                ]
+            },
+            "items": [
+                {
+                    "id": "451",
+                    "fulfillment_id": "155",
+                    "quantity": {
+                        "count": 1
+                    }
+                }
+            ],
+            "fulfillments": [
+                {
+                    "id": "155",
+                    "end": {
+                        "time": {
+                            "range": {
+                                "end": "2025-01-06T11:58:40.518Z",
+                                "start": "2025-01-06T10:58:40.518Z"
+                            }
+                        },
+                        "person": {
+                            "name": "Ajeet Chauhan"
+                        },
+                        "contact": {
+                            "email": "ajeetchauhan.symfony143@webkul.in",
+                            "phone": "8574739650"
+                        },
+                        "location": {
+                            "gps": "28.629743,77.377795",
+                            "address": {
+                                "city": "Noida",
+                                "name": "Ajeet Chauhan",
+                                "state": "Uttar Pradesh",
+                                "country": "IND",
+                                "building": "ARV Park",
+                                "locality": "Unnamed Road",
+                                "area_code": "201301"
+                            }
+                        }
+                    },
+                    "type": "Delivery",
+                    "start": {
+                        "time": {
+                            "range": {
+                                "end": "2025-01-06T11:58:40.518Z",
+                                "start": "2025-01-06T10:58:40.518Z"
+                            }
+                        },
+                        "contact": {
+                            "email": "support@webkul.in",
+                            "phone": "9876543210"
+                        },
+                        "location": {
+                            "id": "83",
+                            "gps": "28.62972640,77.37783230",
+                            "address": {
+                                "city": "Gautam Buddh Nagar",
+                                "state": "Uttar Pradesh",
+                                "locality": "Noida",
+                                "area_code": "201301"
+                            },
+                            "descriptor": {
+                                "name": "Ajeet Food Shop"
+                            }
+                        }
+                    },
+                    "state": {
+                        "descriptor": {
+                            "code": "Packed"
+                        }
+                    },
+                    "tracking": true,
+                    "@ondc/org/TAT": "PT90M",
+                    "@ondc/org/provider_name": "ondc.ecomviser.com"
+                }
+            ],
+            "quote": {
+                "ttl": "PT6H",
+                "price": {
+                    "value": "118.04",
+                    "currency": "INR"
+                },
+                "breakup": [
+                    {
+                        "item": {
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "item"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "price": {
+                                "value": "99",
+                                "currency": "INR"
+                            },
+                            "parent_item_id": "xXUeYhqy/JJR"
+                        },
+                        "price": {
+                            "value": "99",
+                            "currency": "INR"
+                        },
+                        "title": "Pizza Mania",
+                        "@ondc/org/item_id": "451",
+                        "@ondc/org/title_type": "item",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
+                        }
+                    },
+                    {
+                        "item": {
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "66zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "price": {
+                                "value": "5",
+                                "currency": "INR"
+                            },
+                            "parent_item_id": "xXUeYhqy/JJR"
+                        },
+                        "price": {
+                            "value": "5",
+                            "currency": "INR"
+                        },
+                        "title": "Extra",
+                        "@ondc/org/item_id": "93",
+                        "@ondc/org/title_type": "item",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
+                        }
+                    },
+                    {
+                        "item": {
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "67zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "price": {
+                                "value": "10",
+                                "currency": "INR"
+                            },
+                            "parent_item_id": "xXUeYhqy/JJR"
+                        },
+                        "price": {
+                            "value": "10",
+                            "currency": "INR"
+                        },
+                        "title": "Chicken",
+                        "@ondc/org/item_id": "95",
+                        "@ondc/org/title_type": "item",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
+                        }
+                    },
+                    {
+                        "price": {
+                            "value": "4.04",
+                            "currency": "INR"
+                        },
+                        "title": "Convenience fee",
+                        "@ondc/org/item_id": "155",
+                        "@ondc/org/title_type": "misc"
+                    },
+                    {
+                        "price": {
+                            "value": "0",
+                            "currency": "INR"
+                        },
+                        "title": "Delivery charges",
+                        "@ondc/org/item_id": "155",
+                        "@ondc/org/title_type": "delivery"
+                    }
+                ]
+            },
+            "billing": {
+                "name": "Ajeet Chauhan",
+                "email": "ajeetchauhan.symfony143@webkul.in",
+                "phone": "8574739650",
+                "address": {
+                    "city": "Noida",
+                    "name": "Ajeet Chauhan",
+                    "state": "Uttar Pradesh",
+                    "country": "IND",
+                    "building": "ARV Park",
+                    "locality": "Unnamed Road",
+                    "area_code": "201301"
+                },
+                "created_at": "2025-01-06T10:58:02.529Z",
+                "updated_at": "2025-01-06T10:58:02.529Z"
+            },
+            "payment": {
+                "uri": "https://razorpay.com/",
+                "type": "ON-ORDER",
+                "params": {
+                    "amount": "118.04",
+                    "currency": "INR",
+                    "transaction_id": "order_Pg8IoytiBpf9W3"
+                },
+                "status": "PAID",
+                "tl_method": "http/get",
+                "collected_by": "BAP",
+                "@ondc/org/settlement_details": [
+                    {
+                        "bank_name": "fasdf",
+                        "branch_name": "noida",
+                        "settlement_type": "neft",
+                        "beneficiary_name": "fasdf asdfasdf",
+                        "settlement_phase": "sale-amount",
+                        "settlement_status": "NOT-PAID",
+                        "settlement_ifsc_code": "HDFC0000088",
+                        "settlement_counterparty": "seller-app",
+                        "settlement_bank_account_no": "534512341234132"
+                    }
+                ],
+                "@ondc/org/buyer_app_finder_fee_type": "percent",
+                "@ondc/org/buyer_app_finder_fee_amount": "3.0"
+            },
+            "created_at": "2025-01-06T10:58:33.520Z",
+            "updated_at": "2025-01-06T11:00:17.924Z"
+        }
+    }
+}

--- a/eComviser/Seller App RET11/Flow-3/on_status_pending.json
+++ b/eComviser/Seller App RET11/Flow-3/on_status_pending.json
@@ -1,0 +1,286 @@
+{
+    "context": {
+        "domain": "ONDC:RET11",
+        "country": "IND",
+        "city": "std:0120",
+        "action": "on_status",
+        "core_version": "1.2.0",
+        "bap_id": "buyer-app-preprod-v2.ondc.org",
+        "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+        "bpp_uri": "https://ondc.ecomviser.com/api/v1",
+        "transaction_id": "5a913b62-e66f-4a6b-bf2a-8072714506d6",
+        "message_id": "677bb7aca7a48f0d3be09-c0f1",
+        "timestamp": "2025-01-06T10:59:56.687Z",
+        "bpp_id": "ondc.ecomviser.com",
+        "ttl": "PT30S"
+    },
+    "message": {
+        "order": {
+            "id": "2025-01-06-333398",
+            "state": "Accepted",
+            "provider": {
+                "id": "84",
+                "locations": [
+                    {
+                        "id": "83"
+                    }
+                ]
+            },
+            "items": [
+                {
+                    "id": "451",
+                    "fulfillment_id": "155",
+                    "quantity": {
+                        "count": 1
+                    }
+                }
+            ],
+            "fulfillments": [
+                {
+                    "id": "155",
+                    "end": {
+                        "time": {
+                            "range": {
+                                "end": "2025-01-06T11:58:40.518Z",
+                                "start": "2025-01-06T10:58:40.518Z"
+                            }
+                        },
+                        "person": {
+                            "name": "Ajeet Chauhan"
+                        },
+                        "contact": {
+                            "email": "ajeetchauhan.symfony143@webkul.in",
+                            "phone": "8574739650"
+                        },
+                        "location": {
+                            "gps": "28.629743,77.377795",
+                            "address": {
+                                "city": "Noida",
+                                "name": "Ajeet Chauhan",
+                                "state": "Uttar Pradesh",
+                                "country": "IND",
+                                "building": "ARV Park",
+                                "locality": "Unnamed Road",
+                                "area_code": "201301"
+                            }
+                        }
+                    },
+                    "type": "Delivery",
+                    "start": {
+                        "time": {
+                            "range": {
+                                "end": "2025-01-06T11:58:40.518Z",
+                                "start": "2025-01-06T10:58:40.518Z"
+                            }
+                        },
+                        "contact": {
+                            "email": "support@webkul.in",
+                            "phone": "9876543210"
+                        },
+                        "location": {
+                            "id": "83",
+                            "gps": "28.62972640,77.37783230",
+                            "address": {
+                                "city": "Gautam Buddh Nagar",
+                                "state": "Uttar Pradesh",
+                                "locality": "Noida",
+                                "area_code": "201301"
+                            },
+                            "descriptor": {
+                                "name": "Ajeet Food Shop"
+                            }
+                        }
+                    },
+                    "state": {
+                        "descriptor": {
+                            "code": "Pending"
+                        }
+                    },
+                    "tracking": true,
+                    "@ondc/org/TAT": "PT90M",
+                    "@ondc/org/provider_name": "ondc.ecomviser.com"
+                }
+            ],
+            "quote": {
+                "ttl": "PT6H",
+                "price": {
+                    "value": "118.04",
+                    "currency": "INR"
+                },
+                "breakup": [
+                    {
+                        "item": {
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "item"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "price": {
+                                "value": "99",
+                                "currency": "INR"
+                            },
+                            "parent_item_id": "xXUeYhqy/JJR"
+                        },
+                        "price": {
+                            "value": "99",
+                            "currency": "INR"
+                        },
+                        "title": "Pizza Mania",
+                        "@ondc/org/item_id": "451",
+                        "@ondc/org/title_type": "item",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
+                        }
+                    },
+                    {
+                        "item": {
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "66zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "price": {
+                                "value": "5",
+                                "currency": "INR"
+                            },
+                            "parent_item_id": "xXUeYhqy/JJR"
+                        },
+                        "price": {
+                            "value": "5",
+                            "currency": "INR"
+                        },
+                        "title": "Extra",
+                        "@ondc/org/item_id": "93",
+                        "@ondc/org/title_type": "item",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
+                        }
+                    },
+                    {
+                        "item": {
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "67zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "price": {
+                                "value": "10",
+                                "currency": "INR"
+                            },
+                            "parent_item_id": "xXUeYhqy/JJR"
+                        },
+                        "price": {
+                            "value": "10",
+                            "currency": "INR"
+                        },
+                        "title": "Chicken",
+                        "@ondc/org/item_id": "95",
+                        "@ondc/org/title_type": "item",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
+                        }
+                    },
+                    {
+                        "price": {
+                            "value": "4.04",
+                            "currency": "INR"
+                        },
+                        "title": "Convenience fee",
+                        "@ondc/org/item_id": "155",
+                        "@ondc/org/title_type": "misc"
+                    },
+                    {
+                        "price": {
+                            "value": "0",
+                            "currency": "INR"
+                        },
+                        "title": "Delivery charges",
+                        "@ondc/org/item_id": "155",
+                        "@ondc/org/title_type": "delivery"
+                    }
+                ]
+            },
+            "billing": {
+                "name": "Ajeet Chauhan",
+                "email": "ajeetchauhan.symfony143@webkul.in",
+                "phone": "8574739650",
+                "address": {
+                    "city": "Noida",
+                    "name": "Ajeet Chauhan",
+                    "state": "Uttar Pradesh",
+                    "country": "IND",
+                    "building": "ARV Park",
+                    "locality": "Unnamed Road",
+                    "area_code": "201301"
+                },
+                "created_at": "2025-01-06T10:58:02.529Z",
+                "updated_at": "2025-01-06T10:58:02.529Z"
+            },
+            "payment": {
+                "uri": "https://razorpay.com/",
+                "type": "ON-ORDER",
+                "params": {
+                    "amount": "118.04",
+                    "currency": "INR",
+                    "transaction_id": "order_Pg8IoytiBpf9W3"
+                },
+                "status": "PAID",
+                "tl_method": "http/get",
+                "collected_by": "BAP",
+                "@ondc/org/settlement_details": [
+                    {
+                        "bank_name": "fasdf",
+                        "branch_name": "noida",
+                        "settlement_type": "neft",
+                        "beneficiary_name": "fasdf asdfasdf",
+                        "settlement_phase": "sale-amount",
+                        "settlement_status": "NOT-PAID",
+                        "settlement_ifsc_code": "HDFC0000088",
+                        "settlement_counterparty": "seller-app",
+                        "settlement_bank_account_no": "534512341234132"
+                    }
+                ],
+                "@ondc/org/buyer_app_finder_fee_type": "percent",
+                "@ondc/org/buyer_app_finder_fee_amount": "3.0"
+            },
+            "created_at": "2025-01-06T10:58:33.520Z",
+            "updated_at": "2025-01-06T10:59:56.687Z"
+        }
+    }
+}

--- a/eComviser/Seller App RET11/Flow-3/on_status_picked.json
+++ b/eComviser/Seller App RET11/Flow-3/on_status_picked.json
@@ -1,0 +1,323 @@
+{
+    "context": {
+        "domain": "ONDC:RET11",
+        "country": "IND",
+        "city": "std:0120",
+        "action": "on_status",
+        "core_version": "1.2.0",
+        "bap_id": "buyer-app-preprod-v2.ondc.org",
+        "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+        "bpp_uri": "https://ondc.ecomviser.com/api/v1",
+        "transaction_id": "5a913b62-e66f-4a6b-bf2a-8072714506d6",
+        "message_id": "677bb7d23482b300f39be-3f61",
+        "timestamp": "2025-01-06T11:00:34.215Z",
+        "bpp_id": "ondc.ecomviser.com",
+        "ttl": "PT30S"
+    },
+    "message": {
+        "order": {
+            "id": "2025-01-06-333398",
+            "state": "In-progress",
+            "provider": {
+                "id": "84",
+                "locations": [
+                    {
+                        "id": "83"
+                    }
+                ]
+            },
+            "items": [
+                {
+                    "id": "451",
+                    "fulfillment_id": "155",
+                    "quantity": {
+                        "count": 1
+                    }
+                }
+            ],
+            "fulfillments": [
+                {
+                    "id": "155",
+                    "end": {
+                        "time": {
+                            "range": {
+                                "end": "2025-01-06T11:58:40.518Z",
+                                "start": "2025-01-06T10:58:40.518Z"
+                            }
+                        },
+                        "person": {
+                            "name": "Ajeet Chauhan"
+                        },
+                        "contact": {
+                            "email": "ajeetchauhan.symfony143@webkul.in",
+                            "phone": "8574739650"
+                        },
+                        "location": {
+                            "gps": "28.629743,77.377795",
+                            "address": {
+                                "city": "Noida",
+                                "name": "Ajeet Chauhan",
+                                "state": "Uttar Pradesh",
+                                "country": "IND",
+                                "building": "ARV Park",
+                                "locality": "Unnamed Road",
+                                "area_code": "201301"
+                            }
+                        }
+                    },
+                    "type": "Delivery",
+                    "start": {
+                        "time": {
+                            "range": {
+                                "end": "2025-01-06T11:58:40.518Z",
+                                "start": "2025-01-06T10:58:40.518Z"
+                            },
+                            "timestamp": "2025-01-06T11:00:33.631Z"
+                        },
+                        "contact": {
+                            "email": "support@webkul.in",
+                            "phone": "9876543210"
+                        },
+                        "location": {
+                            "id": "83",
+                            "gps": "28.62972640,77.37783230",
+                            "address": {
+                                "city": "Gautam Buddh Nagar",
+                                "state": "Uttar Pradesh",
+                                "locality": "Noida",
+                                "area_code": "201301"
+                            },
+                            "descriptor": {
+                                "name": "Ajeet Food Shop"
+                            }
+                        },
+                        "instructions": {
+                            "code": "2",
+                            "name": "ONDC Order",
+                            "short_desc": "ae34fd",
+                            "long_desc": "additional instructions for pickup"
+                        }
+                    },
+                    "state": {
+                        "descriptor": {
+                            "code": "Order-picked-up"
+                        }
+                    },
+                    "tracking": true,
+                    "@ondc/org/TAT": "PT90M",
+                    "@ondc/org/provider_name": "ondc.ecomviser.com",
+                    "tags": [
+                        {
+                            "code": "routing",
+                            "list": [
+                                {
+                                    "code": "type",
+                                    "value": "P2P"
+                                }
+                            ]
+                        },
+                        {
+                            "code": "tracking",
+                            "list": [
+                                {
+                                    "code": "gps_enabled",
+                                    "value": "yes"
+                                },
+                                {
+                                    "code": "url_enabled",
+                                    "value": "no"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "quote": {
+                "ttl": "PT6H",
+                "price": {
+                    "value": "118.04",
+                    "currency": "INR"
+                },
+                "breakup": [
+                    {
+                        "item": {
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "item"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "price": {
+                                "value": "99",
+                                "currency": "INR"
+                            },
+                            "parent_item_id": "xXUeYhqy/JJR"
+                        },
+                        "price": {
+                            "value": "99",
+                            "currency": "INR"
+                        },
+                        "title": "Pizza Mania",
+                        "@ondc/org/item_id": "451",
+                        "@ondc/org/title_type": "item",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
+                        }
+                    },
+                    {
+                        "item": {
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "66zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "price": {
+                                "value": "5",
+                                "currency": "INR"
+                            },
+                            "parent_item_id": "xXUeYhqy/JJR"
+                        },
+                        "price": {
+                            "value": "5",
+                            "currency": "INR"
+                        },
+                        "title": "Extra",
+                        "@ondc/org/item_id": "93",
+                        "@ondc/org/title_type": "item",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
+                        }
+                    },
+                    {
+                        "item": {
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "67zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "price": {
+                                "value": "10",
+                                "currency": "INR"
+                            },
+                            "parent_item_id": "xXUeYhqy/JJR"
+                        },
+                        "price": {
+                            "value": "10",
+                            "currency": "INR"
+                        },
+                        "title": "Chicken",
+                        "@ondc/org/item_id": "95",
+                        "@ondc/org/title_type": "item",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
+                        }
+                    },
+                    {
+                        "price": {
+                            "value": "4.04",
+                            "currency": "INR"
+                        },
+                        "title": "Convenience fee",
+                        "@ondc/org/item_id": "155",
+                        "@ondc/org/title_type": "misc"
+                    },
+                    {
+                        "price": {
+                            "value": "0",
+                            "currency": "INR"
+                        },
+                        "title": "Delivery charges",
+                        "@ondc/org/item_id": "155",
+                        "@ondc/org/title_type": "delivery"
+                    }
+                ]
+            },
+            "billing": {
+                "name": "Ajeet Chauhan",
+                "email": "ajeetchauhan.symfony143@webkul.in",
+                "phone": "8574739650",
+                "address": {
+                    "city": "Noida",
+                    "name": "Ajeet Chauhan",
+                    "state": "Uttar Pradesh",
+                    "country": "IND",
+                    "building": "ARV Park",
+                    "locality": "Unnamed Road",
+                    "area_code": "201301"
+                },
+                "created_at": "2025-01-06T10:58:02.529Z",
+                "updated_at": "2025-01-06T10:58:02.529Z"
+            },
+            "payment": {
+                "uri": "https://razorpay.com/",
+                "type": "ON-ORDER",
+                "params": {
+                    "amount": "118.04",
+                    "currency": "INR",
+                    "transaction_id": "order_Pg8IoytiBpf9W3"
+                },
+                "status": "PAID",
+                "tl_method": "http/get",
+                "collected_by": "BAP",
+                "@ondc/org/settlement_details": [
+                    {
+                        "bank_name": "fasdf",
+                        "branch_name": "noida",
+                        "settlement_type": "neft",
+                        "beneficiary_name": "fasdf asdfasdf",
+                        "settlement_phase": "sale-amount",
+                        "settlement_status": "NOT-PAID",
+                        "settlement_ifsc_code": "HDFC0000088",
+                        "settlement_counterparty": "seller-app",
+                        "settlement_bank_account_no": "534512341234132"
+                    }
+                ],
+                "@ondc/org/buyer_app_finder_fee_type": "percent",
+                "@ondc/org/buyer_app_finder_fee_amount": "3.0"
+            },
+            "created_at": "2025-01-06T10:58:33.520Z",
+            "updated_at": "2025-01-06T11:00:34.215Z",
+            "documents": [
+                {
+                    "label": "Invoice",
+                    "url": "https://ecomviser-prepod.sp-seller-preprod.ecomviser.com/index.php?p=invoice_download&key=MTc0Ojg0OmVjb212aXNlcg=="
+                }
+            ]
+        }
+    }
+}

--- a/eComviser/Seller App RET11/Flow-3/search.json
+++ b/eComviser/Seller App RET11/Flow-3/search.json
@@ -1,0 +1,26 @@
+{
+    "context": {
+        "domain": "ONDC:RET11",
+        "action": "search",
+        "country": "IND",
+        "city": "std:0120",
+        "core_version": "1.2.0",
+        "bap_id": "buyer-app-preprod-v2.ondc.org",
+        "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+        "transaction_id": "0646bc94-5d3d-4b2d-6325-a8a33843dbb9",
+        "message_id": "36c56392-f004-4813-ace5-0d40033a8420",
+        "timestamp": "2025-01-06T16:25:29.988Z",
+        "ttl": "PT30S"
+    },
+    "message": {
+        "intent": {
+            "fulfillment": {
+                "type": "Delivery"
+            },
+            "payment": {
+                "@ondc/org/buyer_app_finder_fee_type": "percent",
+                "@ondc/org/buyer_app_finder_fee_amount": "3"
+            }
+        }
+    }
+}

--- a/eComviser/Seller App RET11/Flow-3/select.json
+++ b/eComviser/Seller App RET11/Flow-3/select.json
@@ -1,0 +1,118 @@
+{
+    "context": {
+        "domain": "ONDC:RET11",
+        "country": "IND",
+        "city": "std:0120",
+        "action": "select",
+        "core_version": "1.2.0",
+        "bap_id": "buyer-app-preprod-v2.ondc.org",
+        "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+        "bpp_uri": "https://ondc.ecomviser.com/api/v1",
+        "transaction_id": "5a913b62-e66f-4a6b-bf2a-8072714506d6",
+        "message_id": "f42ce0d2-71d7-4b6f-bd9c-312c97f1fd81",
+        "timestamp": "2025-01-06T10:57:52.838Z",
+        "bpp_id": "ondc.ecomviser.com",
+        "ttl": "PT30S"
+    },
+    "message": {
+        "order": {
+            "items": [
+                {
+                    "id": "451",
+                    "quantity": {
+                        "count": 1
+                    },
+                    "location_id": "83",
+                    "tags": [
+                        {
+                            "code": "type",
+                            "list": [
+                                {
+                                    "code": "type",
+                                    "value": "item"
+                                }
+                            ]
+                        }
+                    ],
+                    "parent_item_id": "xXUeYhqy/JJR"
+                },
+                {
+                    "id": "93",
+                    "quantity": {
+                        "count": 1
+                    },
+                    "location_id": "83",
+                    "tags": [
+                        {
+                            "code": "type",
+                            "list": [
+                                {
+                                    "code": "type",
+                                    "value": "customization"
+                                }
+                            ]
+                        },
+                        {
+                            "code": "parent",
+                            "list": [
+                                {
+                                    "code": "id",
+                                    "value": "66zabcdefghi"
+                                }
+                            ]
+                        }
+                    ],
+                    "parent_item_id": "xXUeYhqy/JJR"
+                },
+                {
+                    "id": "95",
+                    "quantity": {
+                        "count": 1
+                    },
+                    "location_id": "83",
+                    "tags": [
+                        {
+                            "code": "type",
+                            "list": [
+                                {
+                                    "code": "type",
+                                    "value": "customization"
+                                }
+                            ]
+                        },
+                        {
+                            "code": "parent",
+                            "list": [
+                                {
+                                    "code": "id",
+                                    "value": "67zabcdefghi"
+                                }
+                            ]
+                        }
+                    ],
+                    "parent_item_id": "xXUeYhqy/JJR"
+                }
+            ],
+            "provider": {
+                "id": "84",
+                "locations": [
+                    {
+                        "id": "83"
+                    }
+                ]
+            },
+            "fulfillments": [
+                {
+                    "end": {
+                        "location": {
+                            "gps": "28.629743,77.377795",
+                            "address": {
+                                "area_code": "201301"
+                            }
+                        }
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/eComviser/Seller App RET11/Flow-4/cancel.json
+++ b/eComviser/Seller App RET11/Flow-4/cancel.json
@@ -1,0 +1,21 @@
+{
+    "context": {
+        "domain": "ONDC:RET11",
+        "country": "IND",
+        "city": "std:0120",
+        "action": "cancel",
+        "core_version": "1.2.0",
+        "bap_id": "buyer-app-preprod-v2.ondc.org",
+        "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+        "bpp_uri": "https://ondc.ecomviser.com/api/v1",
+        "transaction_id": "0d4b4422-4561-4a23-89fd-6c98c823219b",
+        "message_id": "09053c59-c21d-4361-98ea-ea0b25954f22",
+        "timestamp": "2025-01-06T11:48:56.252Z",
+        "bpp_id": "ondc.ecomviser.com",
+        "ttl": "PT30S"
+    },
+    "message": {
+        "order_id": "2025-01-06-197962",
+        "cancellation_reason_id": "003"
+    }
+}

--- a/eComviser/Seller App RET11/Flow-4/confirm.json
+++ b/eComviser/Seller App RET11/Flow-4/confirm.json
@@ -1,0 +1,341 @@
+{
+    "context": {
+        "domain": "ONDC:RET11",
+        "country": "IND",
+        "city": "std:0120",
+        "action": "confirm",
+        "core_version": "1.2.0",
+        "bap_id": "buyer-app-preprod-v2.ondc.org",
+        "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+        "bpp_uri": "https://ondc.ecomviser.com/api/v1",
+        "transaction_id": "0d4b4422-4561-4a23-89fd-6c98c823219b",
+        "message_id": "cc68b5a2-be2a-4164-bd81-7813862a8042",
+        "timestamp": "2025-01-06T11:46:15.671Z",
+        "bpp_id": "ondc.ecomviser.com",
+        "ttl": "PT30S"
+    },
+    "message": {
+        "order": {
+            "id": "2025-01-06-197962",
+            "state": "Created",
+            "billing": {
+                "address": {
+                    "name": "Ajeet Chauhan",
+                    "building": "ARV Park",
+                    "locality": "Unnamed Road",
+                    "city": "Noida",
+                    "state": "Uttar Pradesh",
+                    "country": "IND",
+                    "area_code": "201301"
+                },
+                "phone": "8574739650",
+                "name": "Ajeet Chauhan",
+                "email": "ajeetchauhan.symfony143@webkul.in",
+                "created_at": "2025-01-06T11:45:19.999Z",
+                "updated_at": "2025-01-06T11:45:19.999Z"
+            },
+            "items": [
+                {
+                    "id": "451",
+                    "quantity": {
+                        "count": 1
+                    },
+                    "fulfillment_id": "155",
+                    "tags": [
+                        {
+                            "code": "type",
+                            "list": [
+                                {
+                                    "code": "type",
+                                    "value": "item"
+                                }
+                            ]
+                        }
+                    ],
+                    "parent_item_id": "hjt9D5BeMUs/"
+                },
+                {
+                    "id": "93",
+                    "quantity": {
+                        "count": 1
+                    },
+                    "fulfillment_id": "155",
+                    "tags": [
+                        {
+                            "code": "type",
+                            "list": [
+                                {
+                                    "code": "type",
+                                    "value": "customization"
+                                }
+                            ]
+                        },
+                        {
+                            "code": "parent",
+                            "list": [
+                                {
+                                    "code": "id",
+                                    "value": "66zabcdefghi"
+                                }
+                            ]
+                        }
+                    ],
+                    "parent_item_id": "hjt9D5BeMUs/"
+                },
+                {
+                    "id": "96",
+                    "quantity": {
+                        "count": 1
+                    },
+                    "fulfillment_id": "155",
+                    "tags": [
+                        {
+                            "code": "type",
+                            "list": [
+                                {
+                                    "code": "type",
+                                    "value": "customization"
+                                }
+                            ]
+                        },
+                        {
+                            "code": "parent",
+                            "list": [
+                                {
+                                    "code": "id",
+                                    "value": "67zabcdefghi"
+                                }
+                            ]
+                        }
+                    ],
+                    "parent_item_id": "hjt9D5BeMUs/"
+                }
+            ],
+            "provider": {
+                "id": "84",
+                "locations": [
+                    {
+                        "id": "83"
+                    }
+                ]
+            },
+            "fulfillments": [
+                {
+                    "@ondc/org/TAT": "PT90M",
+                    "id": "155",
+                    "tracking": true,
+                    "end": {
+                        "contact": {
+                            "email": "ajeetchauhan.symfony143@webkul.in",
+                            "phone": "8574739650"
+                        },
+                        "person": {
+                            "name": "Ajeet Chauhan"
+                        },
+                        "location": {
+                            "gps": "28.629743,77.377795",
+                            "address": {
+                                "name": "Ajeet Chauhan",
+                                "building": "ARV Park",
+                                "locality": "Unnamed Road",
+                                "city": "Noida",
+                                "state": "Uttar Pradesh",
+                                "country": "IND",
+                                "area_code": "201301"
+                            }
+                        }
+                    },
+                    "type": "Delivery"
+                }
+            ],
+            "payment": {
+                "uri": "https://razorpay.com/",
+                "tl_method": "http/get",
+                "params": {
+                    "amount": "159.45",
+                    "currency": "INR",
+                    "transaction_id": "order_Pg96kAoxdJrCmf"
+                },
+                "status": "PAID",
+                "type": "ON-ORDER",
+                "collected_by": "BAP",
+                "@ondc/org/buyer_app_finder_fee_type": "percent",
+                "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+                "@ondc/org/settlement_details": [
+                    {
+                        "settlement_counterparty": "seller-app",
+                        "settlement_phase": "sale-amount",
+                        "settlement_type": "neft",
+                        "beneficiary_name": "fasdf asdfasdf",
+                        "settlement_bank_account_no": "534512341234132",
+                        "settlement_ifsc_code": "HDFC0000088",
+                        "bank_name": "fasdf",
+                        "branch_name": "noida",
+                        "settlement_status": "NOT-PAID"
+                    }
+                ]
+            },
+            "quote": {
+                "price": {
+                    "currency": "INR",
+                    "value": "159.45"
+                },
+                "breakup": [
+                    {
+                        "title": "Pizza Mania",
+                        "price": {
+                            "currency": "INR",
+                            "value": "99"
+                        },
+                        "@ondc/org/title_type": "item",
+                        "@ondc/org/item_id": "451",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
+                        },
+                        "item": {
+                            "price": {
+                                "currency": "INR",
+                                "value": "99"
+                            },
+                            "parent_item_id": "hjt9D5BeMUs/",
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "item"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "title": "Extra",
+                        "price": {
+                            "currency": "INR",
+                            "value": "5"
+                        },
+                        "@ondc/org/title_type": "item",
+                        "@ondc/org/item_id": "93",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
+                        },
+                        "item": {
+                            "price": {
+                                "currency": "INR",
+                                "value": "5"
+                            },
+                            "parent_item_id": "hjt9D5BeMUs/",
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "66zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "title": "Mutton",
+                        "price": {
+                            "currency": "INR",
+                            "value": "50"
+                        },
+                        "@ondc/org/title_type": "item",
+                        "@ondc/org/item_id": "96",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
+                        },
+                        "item": {
+                            "price": {
+                                "currency": "INR",
+                                "value": "50"
+                            },
+                            "parent_item_id": "hjt9D5BeMUs/",
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "67zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "title": "Convenience fee",
+                        "price": {
+                            "currency": "INR",
+                            "value": "5.45"
+                        },
+                        "@ondc/org/title_type": "misc",
+                        "@ondc/org/item_id": "155"
+                    },
+                    {
+                        "title": "Delivery charges",
+                        "price": {
+                            "currency": "INR",
+                            "value": "0"
+                        },
+                        "@ondc/org/title_type": "delivery",
+                        "@ondc/org/item_id": "155"
+                    }
+                ],
+                "ttl": "PT6H"
+            },
+            "tags": [
+                {
+                    "code": "bpp_terms",
+                    "list": [
+                        {
+                            "code": "tax_number",
+                            "value": "09AABCW0339G3ZD"
+                        },
+                        {
+                            "code": "provider_tax_number",
+                            "value": "DERTC3376R"
+                        }
+                    ]
+                },
+                {
+                    "code": "bap_terms",
+                    "list": [
+                        {
+                            "code": "tax_number",
+                            "value": "GSTIN1234567890"
+                        }
+                    ]
+                }
+            ],
+            "created_at": "2025-01-06T11:46:15.671Z",
+            "updated_at": "2025-01-06T11:46:15.671Z"
+        }
+    }
+}

--- a/eComviser/Seller App RET11/Flow-4/flow-4_validate_report.json
+++ b/eComviser/Seller App RET11/Flow-4/flow-4_validate_report.json
@@ -1,0 +1,17 @@
+{
+    "success": false,
+    "response": {
+        "message": "Logs were not verified successfully",
+        "report": {
+            "on_search_full_catalog_refresh": {
+                "message/catalog/bpp/providers0/categories/items": "No items are mapped with the given category_id 844147zabcde in providers0/items"
+            }
+        },
+        "bpp_id": "ondc.ecomviser.com",
+        "bap_id": "buyer-app-preprod-v2.ondc.org",
+        "domain": "ONDC:RET11",
+        "reportTimestamp": "2025-01-08T13:28:34.271Z"
+    },
+    "signature": "TMw1hEukwd7cNXCcCcEk07JlY0j8C08Wda9hd3uL4PL0MzEOwvZFGzp6xxqJfAgSV+c9nS29G0PzEyzKOZO1Ag==",
+    "signTimestamp": "2025-01-08T13:28:34.271Z"
+}

--- a/eComviser/Seller App RET11/Flow-4/flow-4_validate_request.json
+++ b/eComviser/Seller App RET11/Flow-4/flow-4_validate_request.json
@@ -1,0 +1,2733 @@
+{
+    "domain": "ONDC:RET11",
+    "version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bpp_id": "ondc.ecomviser.com",
+    "payload": {
+        "search_full_catalog_refresh": {
+            "context": {
+                "domain": "ONDC:RET11",
+                "action": "search",
+                "country": "IND",
+                "city": "std:0120",
+                "core_version": "1.2.0",
+                "bap_id": "buyer-app-preprod-v2.ondc.org",
+                "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+                "transaction_id": "0646bc94-5d3d-4b2d-6325-a8a33843dbb9",
+                "message_id": "36c56392-f004-4813-ace5-0d40033a8420",
+                "timestamp": "2025-01-06T16:47:42.734Z",
+                "ttl": "PT30S"
+            },
+            "message": {
+                "intent": {
+                    "fulfillment": {
+                        "type": "Delivery"
+                    },
+                    "payment": {
+                        "@ondc/org/buyer_app_finder_fee_type": "percent",
+                        "@ondc/org/buyer_app_finder_fee_amount": "3"
+                    }
+                }
+            }
+        },
+        "on_search_full_catalog_refresh": {
+            "context": {
+                "domain": "ONDC:RET11",
+                "action": "on_search",
+                "country": "IND",
+                "city": "std:0120",
+                "core_version": "1.2.0",
+                "bap_id": "buyer-app-preprod-v2.ondc.org",
+                "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+                "transaction_id": "0646bc94-5d3d-4b2d-6325-a8a33843dbb9",
+                "message_id": "36c56392-f004-4813-ace5-0d40033a8420",
+                "timestamp": "2025-01-06T11:17:49.476Z",
+                "ttl": "PT30S",
+                "bpp_id": "ondc.ecomviser.com",
+                "bpp_uri": "https://ondc.ecomviser.com/api/v1"
+            },
+            "message": {
+                "catalog": {
+                    "bpp/descriptor": {
+                        "name": "Webkul",
+                        "symbol": "https://ondc.ecomviser.com/public/img/webkul_logo.png",
+                        "short_desc": "Enterprise Digital Commerce & Marketplace Solution Experts",
+                        "long_desc": "Helping companies with our industry-leading digital commerce, ERP, and CRM solutions. In the last 13 years, we have served 150K+ clients worldwide to handle complex operations and grow their businesses",
+                        "images": [
+                            "https://ondc.ecomviser.com/public/img/webkul_banner.png",
+                            "https://ondc.ecomviser.com/public/img/webkul_clients.png",
+                            "https://ondc.ecomviser.com/public/img/webkul_awards.png"
+                        ],
+                        "tags": [
+                            {
+                                "code": "bpp_terms",
+                                "list": [
+                                    {
+                                        "code": "np_type",
+                                        "value": "MSN"
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                    "bpp/fulfillments": [
+                        {
+                            "id": "155",
+                            "type": "Delivery"
+                        }
+                    ],
+                    "bpp/providers": [
+                        {
+                            "id": "84",
+                            "time": {
+                                "label": "enable",
+                                "timestamp": "2025-01-06T10:47:48.872Z"
+                            },
+                            "descriptor": {
+                                "name": "Ajeet Food Shop",
+                                "symbol": "https://ondc-prepod-digital-delivery.s3.amazonaws.com/seller_shop_logo/84/39MylDtZVC.jpg",
+                                "short_desc": "short desc",
+                                "long_desc": "store desc",
+                                "images": [
+                                    "https://ondc-prepod-digital-delivery.s3.amazonaws.com/seller_shop_logo/84/39MylDtZVC.jpg"
+                                ]
+                            },
+                            "fulfillments": [
+                                {
+                                    "id": "155",
+                                    "type": "Delivery",
+                                    "contact": {
+                                        "phone": "9812345678",
+                                        "email": "ajeetchauhan.symfony143@webkul.in"
+                                    }
+                                }
+                            ],
+                            "locations": [
+                                {
+                                    "id": "83",
+                                    "gps": "28.62972640,77.37783230",
+                                    "address": {
+                                        "locality": "Noida",
+                                        "street": "H-28",
+                                        "city": "Gautam Buddh Nagar",
+                                        "area_code": "201301",
+                                        "state": "Uttar Pradesh"
+                                    },
+                                    "circle": {
+                                        "gps": "28.62972640,77.37783230",
+                                        "radius": {
+                                            "unit": "km",
+                                            "value": "5"
+                                        }
+                                    },
+                                    "time": {
+                                        "label": "enable",
+                                        "timestamp": "2025-01-06T10:47:48.872Z",
+                                        "days": "1,2,3,4,5,6,7",
+                                        "schedule": {
+                                            "holidays": []
+                                        },
+                                        "range": {
+                                            "start": "0800",
+                                            "end": "1707"
+                                        }
+                                    }
+                                }
+                            ],
+                            "@ondc/org/fssai_license_no": "12345678908898",
+                            "categories": [
+                                {
+                                    "id": "66zabcdefghi",
+                                    "descriptor": {
+                                        "name": "Cheese"
+                                    },
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "custom_group"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "config",
+                                            "list": [
+                                                {
+                                                    "code": "min",
+                                                    "value": "1"
+                                                },
+                                                {
+                                                    "code": "max",
+                                                    "value": "1"
+                                                },
+                                                {
+                                                    "code": "input",
+                                                    "value": "select"
+                                                },
+                                                {
+                                                    "code": "seq",
+                                                    "value": "1"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                {
+                                    "id": "67zabcdefghi",
+                                    "descriptor": {
+                                        "name": "Non-veg toppings"
+                                    },
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "custom_group"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "config",
+                                            "list": [
+                                                {
+                                                    "code": "min",
+                                                    "value": "1"
+                                                },
+                                                {
+                                                    "code": "max",
+                                                    "value": "1"
+                                                },
+                                                {
+                                                    "code": "input",
+                                                    "value": "select"
+                                                },
+                                                {
+                                                    "code": "seq",
+                                                    "value": "2"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                {
+                                    "id": "844147zabcde",
+                                    "parent_category_id": "",
+                                    "descriptor": {
+                                        "name": "Pizza",
+                                        "short_desc": "Pizza",
+                                        "long_desc": "Pizza"
+                                    },
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "custom_menu"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "display",
+                                            "list": [
+                                                {
+                                                    "code": "rank",
+                                                    "value": "1"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "timing",
+                                            "list": [
+                                                {
+                                                    "code": "day_from",
+                                                    "value": "1"
+                                                },
+                                                {
+                                                    "code": "day_to",
+                                                    "value": "5"
+                                                },
+                                                {
+                                                    "code": "time_from",
+                                                    "value": "0800"
+                                                },
+                                                {
+                                                    "code": "time_to",
+                                                    "value": "2200"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ],
+                            "items": [
+                                {
+                                    "id": "451",
+                                    "time": {
+                                        "label": "enable",
+                                        "timestamp": "2025-01-06T10:47:48.872Z"
+                                    },
+                                    "descriptor": {
+                                        "name": "Pizza Mania",
+                                        "symbol": "https://d3bhszwz094mhs.cloudfront.net/product_img/main_img/342/NipTw8cSUY.jpeg",
+                                        "short_desc": "pizza best small",
+                                        "long_desc": "best pizza",
+                                        "images": [
+                                            "https://d3bhszwz094mhs.cloudfront.net/product_img/main_img/342/NipTw8cSUY.jpeg"
+                                        ],
+                                        "code": "1:123456789876"
+                                    },
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "99",
+                                        "maximum_value": "110",
+                                        "tags": [
+                                            {
+                                                "code": "range",
+                                                "list": [
+                                                    {
+                                                        "code": "lower",
+                                                        "value": "99.00"
+                                                    },
+                                                    {
+                                                        "code": "upper",
+                                                        "value": "159"
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                "code": "default_selection",
+                                                "list": [
+                                                    {
+                                                        "code": "value",
+                                                        "value": "99.00"
+                                                    },
+                                                    {
+                                                        "code": "maximum_value",
+                                                        "value": "159"
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "quantity": {
+                                        "available": {
+                                            "count": "99"
+                                        },
+                                        "maximum": {
+                                            "count": "99"
+                                        },
+                                        "unitized": {
+                                            "measure": {
+                                                "unit": "gram",
+                                                "value": "200"
+                                            }
+                                        }
+                                    },
+                                    "location_id": "83",
+                                    "category_id": "F&B",
+                                    "fulfillment_id": "155",
+                                    "@ondc/org/time_to_ship": "PT1H",
+                                    "@ondc/org/cancellable": true,
+                                    "@ondc/org/seller_pickup_return": false,
+                                    "@ondc/org/returnable": false,
+                                    "@ondc/org/return_window": "PT0S",
+                                    "@ondc/org/available_on_cod": false,
+                                    "@ondc/org/contact_details_consumer_care": "ajeet,ajeetchauhan.symfony143@webkul.in,9812345678",
+                                    "tags": [
+                                        {
+                                            "code": "origin",
+                                            "list": [
+                                                {
+                                                    "code": "country",
+                                                    "value": "IND"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "item"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "custom_group",
+                                            "list": [
+                                                {
+                                                    "code": "id",
+                                                    "value": "66zabcdefghi"
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "category_ids": [
+                                        "844147zabcde:1"
+                                    ]
+                                },
+                                {
+                                    "id": "93",
+                                    "descriptor": {
+                                        "name": "Extra"
+                                    },
+                                    "quantity": {
+                                        "available": {
+                                            "count": "99"
+                                        },
+                                        "maximum": {
+                                            "count": "99"
+                                        }
+                                    },
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "5.00",
+                                        "maximum_value": "5.00"
+                                    },
+                                    "category_id": "F&B",
+                                    "related": true,
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "customization"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "parent",
+                                            "list": [
+                                                {
+                                                    "code": "id",
+                                                    "value": "66zabcdefghi"
+                                                },
+                                                {
+                                                    "code": "default",
+                                                    "value": "yes"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "veg_nonveg",
+                                            "list": [
+                                                {
+                                                    "code": "veg",
+                                                    "value": "yes"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "child",
+                                            "list": [
+                                                {
+                                                    "code": "id",
+                                                    "value": "67zabcdefghi"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                {
+                                    "id": "94",
+                                    "descriptor": {
+                                        "name": "Vegan"
+                                    },
+                                    "quantity": {
+                                        "available": {
+                                            "count": "99"
+                                        },
+                                        "maximum": {
+                                            "count": "99"
+                                        }
+                                    },
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "10.00",
+                                        "maximum_value": "10.00"
+                                    },
+                                    "category_id": "F&B",
+                                    "related": true,
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "customization"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "parent",
+                                            "list": [
+                                                {
+                                                    "code": "id",
+                                                    "value": "66zabcdefghi"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "veg_nonveg",
+                                            "list": [
+                                                {
+                                                    "code": "veg",
+                                                    "value": "yes"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "child",
+                                            "list": [
+                                                {
+                                                    "code": "id",
+                                                    "value": "67zabcdefghi"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                {
+                                    "id": "95",
+                                    "descriptor": {
+                                        "name": "Chicken"
+                                    },
+                                    "quantity": {
+                                        "available": {
+                                            "count": "99"
+                                        },
+                                        "maximum": {
+                                            "count": "99"
+                                        }
+                                    },
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "10.00",
+                                        "maximum_value": "10.00"
+                                    },
+                                    "category_id": "F&B",
+                                    "related": true,
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "customization"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "parent",
+                                            "list": [
+                                                {
+                                                    "code": "id",
+                                                    "value": "67zabcdefghi"
+                                                },
+                                                {
+                                                    "code": "default",
+                                                    "value": "yes"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "veg_nonveg",
+                                            "list": [
+                                                {
+                                                    "code": "non_veg",
+                                                    "value": "yes"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                {
+                                    "id": "96",
+                                    "descriptor": {
+                                        "name": "Mutton"
+                                    },
+                                    "quantity": {
+                                        "available": {
+                                            "count": "99"
+                                        },
+                                        "maximum": {
+                                            "count": "99"
+                                        }
+                                    },
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "50.00",
+                                        "maximum_value": "50.00"
+                                    },
+                                    "category_id": "F&B",
+                                    "related": true,
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "customization"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "parent",
+                                            "list": [
+                                                {
+                                                    "code": "id",
+                                                    "value": "67zabcdefghi"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "veg_nonveg",
+                                            "list": [
+                                                {
+                                                    "code": "veg",
+                                                    "value": "yes"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ],
+                            "tags": [
+                                {
+                                    "code": "timing",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "Order"
+                                        },
+                                        {
+                                            "code": "location",
+                                            "value": "83"
+                                        },
+                                        {
+                                            "code": "day_from",
+                                            "value": "1"
+                                        },
+                                        {
+                                            "code": "day_to",
+                                            "value": "7"
+                                        },
+                                        {
+                                            "code": "time_from",
+                                            "value": "0900"
+                                        },
+                                        {
+                                            "code": "time_to",
+                                            "value": "2300"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "timing",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "Delivery"
+                                        },
+                                        {
+                                            "code": "location",
+                                            "value": "83"
+                                        },
+                                        {
+                                            "code": "day_from",
+                                            "value": "1"
+                                        },
+                                        {
+                                            "code": "day_to",
+                                            "value": "7"
+                                        },
+                                        {
+                                            "code": "time_from",
+                                            "value": "1000"
+                                        },
+                                        {
+                                            "code": "time_to",
+                                            "value": "2100"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "serviceability",
+                                    "list": [
+                                        {
+                                            "code": "location",
+                                            "value": "83"
+                                        },
+                                        {
+                                            "code": "category",
+                                            "value": "F&B"
+                                        },
+                                        {
+                                            "code": "type",
+                                            "value": "10"
+                                        },
+                                        {
+                                            "code": "val",
+                                            "value": "5"
+                                        },
+                                        {
+                                            "code": "unit",
+                                            "value": "km"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "ttl": "P1D"
+                        }
+                    ]
+                }
+            }
+        },
+        "select": {
+            "context": {
+                "domain": "ONDC:RET11",
+                "country": "IND",
+                "city": "std:0120",
+                "action": "select",
+                "core_version": "1.2.0",
+                "bap_id": "buyer-app-preprod-v2.ondc.org",
+                "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+                "bpp_uri": "https://ondc.ecomviser.com/api/v1",
+                "transaction_id": "0d4b4422-4561-4a23-89fd-6c98c823219b",
+                "message_id": "129c8a01-6e7d-48f8-b4c0-3ad20cf7f512",
+                "timestamp": "2025-01-06T11:45:04.582Z",
+                "bpp_id": "ondc.ecomviser.com",
+                "ttl": "PT30S"
+            },
+            "message": {
+                "order": {
+                    "items": [
+                        {
+                            "id": "451",
+                            "quantity": {
+                                "count": 1
+                            },
+                            "location_id": "83",
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "item"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "parent_item_id": "hjt9D5BeMUs/"
+                        },
+                        {
+                            "id": "93",
+                            "quantity": {
+                                "count": 1
+                            },
+                            "location_id": "83",
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "66zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "parent_item_id": "hjt9D5BeMUs/"
+                        },
+                        {
+                            "id": "96",
+                            "quantity": {
+                                "count": 1
+                            },
+                            "location_id": "83",
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "67zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "parent_item_id": "hjt9D5BeMUs/"
+                        }
+                    ],
+                    "provider": {
+                        "id": "84",
+                        "locations": [
+                            {
+                                "id": "83"
+                            }
+                        ]
+                    },
+                    "fulfillments": [
+                        {
+                            "end": {
+                                "location": {
+                                    "gps": "28.629743,77.377795",
+                                    "address": {
+                                        "area_code": "201301"
+                                    }
+                                }
+                            }
+                        }
+                    ]
+                }
+            }
+        },
+        "on_select": {
+            "context": {
+                "domain": "ONDC:RET11",
+                "country": "IND",
+                "city": "std:0120",
+                "action": "on_select",
+                "core_version": "1.2.0",
+                "bap_id": "buyer-app-preprod-v2.ondc.org",
+                "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+                "bpp_uri": "https://ondc.ecomviser.com/api/v1",
+                "transaction_id": "0d4b4422-4561-4a23-89fd-6c98c823219b",
+                "message_id": "129c8a01-6e7d-48f8-b4c0-3ad20cf7f512",
+                "timestamp": "2025-01-06T11:45:06.956Z",
+                "bpp_id": "ondc.ecomviser.com"
+            },
+            "message": {
+                "order": {
+                    "provider": {
+                        "id": "84",
+                        "locations": [
+                            {
+                                "id": "83"
+                            }
+                        ]
+                    },
+                    "items": [
+                        {
+                            "id": "451",
+                            "fulfillment_id": "155",
+                            "parent_item_id": "hjt9D5BeMUs/",
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "item"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "93",
+                            "fulfillment_id": "155",
+                            "parent_item_id": "hjt9D5BeMUs/",
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "66zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "96",
+                            "fulfillment_id": "155",
+                            "parent_item_id": "hjt9D5BeMUs/",
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "67zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ],
+                    "fulfillments": [
+                        {
+                            "id": "155",
+                            "type": "Delivery",
+                            "@ondc/org/provider_name": "ondc.ecomviser.com",
+                            "tracking": true,
+                            "@ondc/org/category": "Immediate Delivery",
+                            "@ondc/org/TAT": "PT90M",
+                            "state": {
+                                "descriptor": {
+                                    "code": "Serviceable"
+                                }
+                            }
+                        }
+                    ],
+                    "quote": {
+                        "price": {
+                            "currency": "INR",
+                            "value": "159.45"
+                        },
+                        "breakup": [
+                            {
+                                "title": "Pizza Mania",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "99"
+                                },
+                                "@ondc/org/title_type": "item",
+                                "@ondc/org/item_id": "451",
+                                "@ondc/org/item_quantity": {
+                                    "count": 1
+                                },
+                                "item": {
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "99"
+                                    },
+                                    "quantity": {
+                                        "available": {
+                                            "count": "99"
+                                        },
+                                        "maximum": {
+                                            "count": "99"
+                                        }
+                                    },
+                                    "parent_item_id": "hjt9D5BeMUs/",
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "item"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "title": "Extra",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "5"
+                                },
+                                "@ondc/org/title_type": "item",
+                                "@ondc/org/item_id": "93",
+                                "@ondc/org/item_quantity": {
+                                    "count": 1
+                                },
+                                "item": {
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "5"
+                                    },
+                                    "quantity": {
+                                        "available": {
+                                            "count": "99"
+                                        },
+                                        "maximum": {
+                                            "count": "99"
+                                        }
+                                    },
+                                    "parent_item_id": "hjt9D5BeMUs/",
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "customization"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "parent",
+                                            "list": [
+                                                {
+                                                    "code": "id",
+                                                    "value": "66zabcdefghi"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "title": "Mutton",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "50"
+                                },
+                                "@ondc/org/title_type": "item",
+                                "@ondc/org/item_id": "96",
+                                "@ondc/org/item_quantity": {
+                                    "count": 1
+                                },
+                                "item": {
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "50"
+                                    },
+                                    "quantity": {
+                                        "available": {
+                                            "count": "99"
+                                        },
+                                        "maximum": {
+                                            "count": "99"
+                                        }
+                                    },
+                                    "parent_item_id": "hjt9D5BeMUs/",
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "customization"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "parent",
+                                            "list": [
+                                                {
+                                                    "code": "id",
+                                                    "value": "67zabcdefghi"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "title": "Convenience fee",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "5.45"
+                                },
+                                "@ondc/org/title_type": "misc",
+                                "@ondc/org/item_id": "155"
+                            },
+                            {
+                                "title": "Delivery charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "0"
+                                },
+                                "@ondc/org/title_type": "delivery",
+                                "@ondc/org/item_id": "155"
+                            }
+                        ],
+                        "ttl": "PT6H"
+                    }
+                }
+            }
+        },
+        "init": {
+            "context": {
+                "domain": "ONDC:RET11",
+                "country": "IND",
+                "city": "std:0120",
+                "action": "init",
+                "core_version": "1.2.0",
+                "bap_id": "buyer-app-preprod-v2.ondc.org",
+                "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+                "bpp_uri": "https://ondc.ecomviser.com/api/v1",
+                "transaction_id": "0d4b4422-4561-4a23-89fd-6c98c823219b",
+                "message_id": "dfe31e0a-8432-4764-a076-9ffd98a929cc",
+                "timestamp": "2025-01-06T11:45:19.999Z",
+                "bpp_id": "ondc.ecomviser.com",
+                "ttl": "PT30S"
+            },
+            "message": {
+                "order": {
+                    "provider": {
+                        "id": "84",
+                        "locations": [
+                            {
+                                "id": "83"
+                            }
+                        ]
+                    },
+                    "items": [
+                        {
+                            "id": "451",
+                            "quantity": {
+                                "count": 1
+                            },
+                            "location_id": "83",
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "item"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "parent_item_id": "hjt9D5BeMUs/",
+                            "fulfillment_id": "155"
+                        },
+                        {
+                            "id": "93",
+                            "quantity": {
+                                "count": 1
+                            },
+                            "location_id": "83",
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "66zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "fulfillment_id": "155",
+                            "parent_item_id": "hjt9D5BeMUs/"
+                        },
+                        {
+                            "id": "96",
+                            "quantity": {
+                                "count": 1
+                            },
+                            "location_id": "83",
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "67zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "fulfillment_id": "155",
+                            "parent_item_id": "hjt9D5BeMUs/"
+                        }
+                    ],
+                    "billing": {
+                        "address": {
+                            "building": "ARV Park",
+                            "city": "Noida",
+                            "state": "Uttar Pradesh",
+                            "country": "IND",
+                            "area_code": "201301",
+                            "locality": "Unnamed Road",
+                            "name": "Ajeet Chauhan"
+                        },
+                        "phone": "8574739650",
+                        "name": "Ajeet Chauhan",
+                        "email": "ajeetchauhan.symfony143@webkul.in",
+                        "created_at": "2025-01-06T11:45:19.999Z",
+                        "updated_at": "2025-01-06T11:45:19.999Z"
+                    },
+                    "fulfillments": [
+                        {
+                            "id": "155",
+                            "type": "Delivery",
+                            "end": {
+                                "contact": {
+                                    "email": "ajeetchauhan.symfony143@webkul.in",
+                                    "phone": "8574739650"
+                                },
+                                "location": {
+                                    "gps": "28.629743,77.377795",
+                                    "address": {
+                                        "building": "ARV Park",
+                                        "city": "Noida",
+                                        "state": "Uttar Pradesh",
+                                        "country": "IND",
+                                        "area_code": "201301",
+                                        "locality": "Unnamed Road",
+                                        "name": "Ajeet Chauhan"
+                                    }
+                                }
+                            }
+                        }
+                    ]
+                }
+            }
+        },
+        "on_init": {
+            "context": {
+                "domain": "ONDC:RET11",
+                "country": "IND",
+                "city": "std:0120",
+                "action": "on_init",
+                "core_version": "1.2.0",
+                "bap_id": "buyer-app-preprod-v2.ondc.org",
+                "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+                "bpp_uri": "https://ondc.ecomviser.com/api/v1",
+                "transaction_id": "0d4b4422-4561-4a23-89fd-6c98c823219b",
+                "message_id": "dfe31e0a-8432-4764-a076-9ffd98a929cc",
+                "timestamp": "2025-01-06T11:45:21.355Z",
+                "bpp_id": "ondc.ecomviser.com",
+                "ttl": "PT30S"
+            },
+            "message": {
+                "order": {
+                    "provider": {
+                        "id": "84",
+                        "locations": [
+                            {
+                                "id": "83"
+                            }
+                        ]
+                    },
+                    "items": [
+                        {
+                            "id": "451",
+                            "fulfillment_id": "155",
+                            "quantity": {
+                                "count": 1
+                            },
+                            "parent_item_id": "hjt9D5BeMUs/",
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "item"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "93",
+                            "fulfillment_id": "155",
+                            "quantity": {
+                                "count": 1
+                            },
+                            "parent_item_id": "hjt9D5BeMUs/",
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "66zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "96",
+                            "fulfillment_id": "155",
+                            "quantity": {
+                                "count": 1
+                            },
+                            "parent_item_id": "hjt9D5BeMUs/",
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "67zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ],
+                    "quote": {
+                        "price": {
+                            "currency": "INR",
+                            "value": "159.45"
+                        },
+                        "breakup": [
+                            {
+                                "title": "Pizza Mania",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "99"
+                                },
+                                "@ondc/org/title_type": "item",
+                                "@ondc/org/item_id": "451",
+                                "@ondc/org/item_quantity": {
+                                    "count": 1
+                                },
+                                "item": {
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "99"
+                                    },
+                                    "parent_item_id": "hjt9D5BeMUs/",
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "item"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "title": "Extra",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "5"
+                                },
+                                "@ondc/org/title_type": "item",
+                                "@ondc/org/item_id": "93",
+                                "@ondc/org/item_quantity": {
+                                    "count": 1
+                                },
+                                "item": {
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "5"
+                                    },
+                                    "parent_item_id": "hjt9D5BeMUs/",
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "customization"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "parent",
+                                            "list": [
+                                                {
+                                                    "code": "id",
+                                                    "value": "66zabcdefghi"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "title": "Mutton",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "50"
+                                },
+                                "@ondc/org/title_type": "item",
+                                "@ondc/org/item_id": "96",
+                                "@ondc/org/item_quantity": {
+                                    "count": 1
+                                },
+                                "item": {
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "50"
+                                    },
+                                    "parent_item_id": "hjt9D5BeMUs/",
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "customization"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "parent",
+                                            "list": [
+                                                {
+                                                    "code": "id",
+                                                    "value": "67zabcdefghi"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "title": "Convenience fee",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "5.45"
+                                },
+                                "@ondc/org/title_type": "misc",
+                                "@ondc/org/item_id": "155"
+                            },
+                            {
+                                "title": "Delivery charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "0"
+                                },
+                                "@ondc/org/title_type": "delivery",
+                                "@ondc/org/item_id": "155"
+                            }
+                        ],
+                        "ttl": "PT6H"
+                    },
+                    "billing": {
+                        "address": {
+                            "building": "ARV Park",
+                            "city": "Noida",
+                            "state": "Uttar Pradesh",
+                            "country": "IND",
+                            "area_code": "201301",
+                            "locality": "Unnamed Road",
+                            "name": "Ajeet Chauhan"
+                        },
+                        "phone": "8574739650",
+                        "name": "Ajeet Chauhan",
+                        "email": "ajeetchauhan.symfony143@webkul.in",
+                        "created_at": "2025-01-06T11:45:19.999Z",
+                        "updated_at": "2025-01-06T11:45:19.999Z"
+                    },
+                    "fulfillments": [
+                        {
+                            "id": "155",
+                            "type": "Delivery",
+                            "end": {
+                                "contact": {
+                                    "email": "ajeetchauhan.symfony143@webkul.in",
+                                    "phone": "8574739650"
+                                },
+                                "location": {
+                                    "gps": "28.629743,77.377795",
+                                    "address": {
+                                        "building": "ARV Park",
+                                        "city": "Noida",
+                                        "state": "Uttar Pradesh",
+                                        "country": "IND",
+                                        "area_code": "201301",
+                                        "locality": "Unnamed Road",
+                                        "name": "Ajeet Chauhan"
+                                    }
+                                }
+                            },
+                            "tracking": true
+                        }
+                    ],
+                    "payment": {
+                        "type": "ON-ORDER",
+                        "collected_by": "BAP",
+                        "@ondc/org/collected_by_status": "Agree",
+                        "@ondc/org/buyer_app_finder_fee_type": "percent",
+                        "@ondc/org/buyer_app_finder_fee_amount": "3",
+                        "@ondc/org/settlement_details": [
+                            {
+                                "settlement_counterparty": "seller-app",
+                                "settlement_phase": "sale-amount",
+                                "settlement_type": "neft",
+                                "beneficiary_name": "fasdf asdfasdf",
+                                "settlement_bank_account_no": "534512341234132",
+                                "settlement_ifsc_code": "HDFC0000088",
+                                "bank_name": "fasdf",
+                                "branch_name": "noida",
+                                "settlement_status": "NOT-PAID"
+                            }
+                        ]
+                    },
+                    "tags": [
+                        {
+                            "code": "bpp_terms",
+                            "list": [
+                                {
+                                    "code": "tax_number",
+                                    "value": "09AABCW0339G3ZD"
+                                },
+                                {
+                                    "code": "provider_tax_number",
+                                    "value": "DERTC3376R"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        },
+        "confirm": {
+            "context": {
+                "domain": "ONDC:RET11",
+                "country": "IND",
+                "city": "std:0120",
+                "action": "confirm",
+                "core_version": "1.2.0",
+                "bap_id": "buyer-app-preprod-v2.ondc.org",
+                "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+                "bpp_uri": "https://ondc.ecomviser.com/api/v1",
+                "transaction_id": "0d4b4422-4561-4a23-89fd-6c98c823219b",
+                "message_id": "cc68b5a2-be2a-4164-bd81-7813862a8042",
+                "timestamp": "2025-01-06T11:46:15.671Z",
+                "bpp_id": "ondc.ecomviser.com",
+                "ttl": "PT30S"
+            },
+            "message": {
+                "order": {
+                    "id": "2025-01-06-197962",
+                    "state": "Created",
+                    "billing": {
+                        "address": {
+                            "name": "Ajeet Chauhan",
+                            "building": "ARV Park",
+                            "locality": "Unnamed Road",
+                            "city": "Noida",
+                            "state": "Uttar Pradesh",
+                            "country": "IND",
+                            "area_code": "201301"
+                        },
+                        "phone": "8574739650",
+                        "name": "Ajeet Chauhan",
+                        "email": "ajeetchauhan.symfony143@webkul.in",
+                        "created_at": "2025-01-06T11:45:19.999Z",
+                        "updated_at": "2025-01-06T11:45:19.999Z"
+                    },
+                    "items": [
+                        {
+                            "id": "451",
+                            "quantity": {
+                                "count": 1
+                            },
+                            "fulfillment_id": "155",
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "item"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "parent_item_id": "hjt9D5BeMUs/"
+                        },
+                        {
+                            "id": "93",
+                            "quantity": {
+                                "count": 1
+                            },
+                            "fulfillment_id": "155",
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "66zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "parent_item_id": "hjt9D5BeMUs/"
+                        },
+                        {
+                            "id": "96",
+                            "quantity": {
+                                "count": 1
+                            },
+                            "fulfillment_id": "155",
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "67zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "parent_item_id": "hjt9D5BeMUs/"
+                        }
+                    ],
+                    "provider": {
+                        "id": "84",
+                        "locations": [
+                            {
+                                "id": "83"
+                            }
+                        ]
+                    },
+                    "fulfillments": [
+                        {
+                            "@ondc/org/TAT": "PT90M",
+                            "id": "155",
+                            "tracking": true,
+                            "end": {
+                                "contact": {
+                                    "email": "ajeetchauhan.symfony143@webkul.in",
+                                    "phone": "8574739650"
+                                },
+                                "person": {
+                                    "name": "Ajeet Chauhan"
+                                },
+                                "location": {
+                                    "gps": "28.629743,77.377795",
+                                    "address": {
+                                        "name": "Ajeet Chauhan",
+                                        "building": "ARV Park",
+                                        "locality": "Unnamed Road",
+                                        "city": "Noida",
+                                        "state": "Uttar Pradesh",
+                                        "country": "IND",
+                                        "area_code": "201301"
+                                    }
+                                }
+                            },
+                            "type": "Delivery"
+                        }
+                    ],
+                    "payment": {
+                        "uri": "https://razorpay.com/",
+                        "tl_method": "http/get",
+                        "params": {
+                            "amount": "159.45",
+                            "currency": "INR",
+                            "transaction_id": "order_Pg96kAoxdJrCmf"
+                        },
+                        "status": "PAID",
+                        "type": "ON-ORDER",
+                        "collected_by": "BAP",
+                        "@ondc/org/buyer_app_finder_fee_type": "percent",
+                        "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+                        "@ondc/org/settlement_details": [
+                            {
+                                "settlement_counterparty": "seller-app",
+                                "settlement_phase": "sale-amount",
+                                "settlement_type": "neft",
+                                "beneficiary_name": "fasdf asdfasdf",
+                                "settlement_bank_account_no": "534512341234132",
+                                "settlement_ifsc_code": "HDFC0000088",
+                                "bank_name": "fasdf",
+                                "branch_name": "noida",
+                                "settlement_status": "NOT-PAID"
+                            }
+                        ]
+                    },
+                    "quote": {
+                        "price": {
+                            "currency": "INR",
+                            "value": "159.45"
+                        },
+                        "breakup": [
+                            {
+                                "title": "Pizza Mania",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "99"
+                                },
+                                "@ondc/org/title_type": "item",
+                                "@ondc/org/item_id": "451",
+                                "@ondc/org/item_quantity": {
+                                    "count": 1
+                                },
+                                "item": {
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "99"
+                                    },
+                                    "parent_item_id": "hjt9D5BeMUs/",
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "item"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "title": "Extra",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "5"
+                                },
+                                "@ondc/org/title_type": "item",
+                                "@ondc/org/item_id": "93",
+                                "@ondc/org/item_quantity": {
+                                    "count": 1
+                                },
+                                "item": {
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "5"
+                                    },
+                                    "parent_item_id": "hjt9D5BeMUs/",
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "customization"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "parent",
+                                            "list": [
+                                                {
+                                                    "code": "id",
+                                                    "value": "66zabcdefghi"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "title": "Mutton",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "50"
+                                },
+                                "@ondc/org/title_type": "item",
+                                "@ondc/org/item_id": "96",
+                                "@ondc/org/item_quantity": {
+                                    "count": 1
+                                },
+                                "item": {
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "50"
+                                    },
+                                    "parent_item_id": "hjt9D5BeMUs/",
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "customization"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "parent",
+                                            "list": [
+                                                {
+                                                    "code": "id",
+                                                    "value": "67zabcdefghi"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "title": "Convenience fee",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "5.45"
+                                },
+                                "@ondc/org/title_type": "misc",
+                                "@ondc/org/item_id": "155"
+                            },
+                            {
+                                "title": "Delivery charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "0"
+                                },
+                                "@ondc/org/title_type": "delivery",
+                                "@ondc/org/item_id": "155"
+                            }
+                        ],
+                        "ttl": "PT6H"
+                    },
+                    "tags": [
+                        {
+                            "code": "bpp_terms",
+                            "list": [
+                                {
+                                    "code": "tax_number",
+                                    "value": "09AABCW0339G3ZD"
+                                },
+                                {
+                                    "code": "provider_tax_number",
+                                    "value": "DERTC3376R"
+                                }
+                            ]
+                        },
+                        {
+                            "code": "bap_terms",
+                            "list": [
+                                {
+                                    "code": "tax_number",
+                                    "value": "GSTIN1234567890"
+                                }
+                            ]
+                        }
+                    ],
+                    "created_at": "2025-01-06T11:46:15.671Z",
+                    "updated_at": "2025-01-06T11:46:15.671Z"
+                }
+            }
+        },
+        "on_confirm": {
+            "context": {
+                "domain": "ONDC:RET11",
+                "country": "IND",
+                "city": "std:0120",
+                "action": "on_confirm",
+                "core_version": "1.2.0",
+                "bap_id": "buyer-app-preprod-v2.ondc.org",
+                "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+                "bpp_uri": "https://ondc.ecomviser.com/api/v1",
+                "transaction_id": "0d4b4422-4561-4a23-89fd-6c98c823219b",
+                "message_id": "cc68b5a2-be2a-4164-bd81-7813862a8042",
+                "timestamp": "2025-01-06T11:46:19.906Z",
+                "bpp_id": "ondc.ecomviser.com"
+            },
+            "message": {
+                "order": {
+                    "id": "2025-01-06-197962",
+                    "state": "Created",
+                    "provider": {
+                        "id": "84",
+                        "locations": [
+                            {
+                                "id": "83"
+                            }
+                        ]
+                    },
+                    "items": [
+                        {
+                            "id": "451",
+                            "quantity": {
+                                "count": 1
+                            },
+                            "fulfillment_id": "155",
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "item"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "parent_item_id": "hjt9D5BeMUs/"
+                        },
+                        {
+                            "id": "93",
+                            "quantity": {
+                                "count": 1
+                            },
+                            "fulfillment_id": "155",
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "66zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "parent_item_id": "hjt9D5BeMUs/"
+                        },
+                        {
+                            "id": "96",
+                            "quantity": {
+                                "count": 1
+                            },
+                            "fulfillment_id": "155",
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "67zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "parent_item_id": "hjt9D5BeMUs/"
+                        }
+                    ],
+                    "billing": {
+                        "address": {
+                            "name": "Ajeet Chauhan",
+                            "building": "ARV Park",
+                            "locality": "Unnamed Road",
+                            "city": "Noida",
+                            "state": "Uttar Pradesh",
+                            "country": "IND",
+                            "area_code": "201301"
+                        },
+                        "phone": "8574739650",
+                        "name": "Ajeet Chauhan",
+                        "email": "ajeetchauhan.symfony143@webkul.in",
+                        "created_at": "2025-01-06T11:45:19.999Z",
+                        "updated_at": "2025-01-06T11:45:19.999Z"
+                    },
+                    "fulfillments": [
+                        {
+                            "@ondc/org/TAT": "PT90M",
+                            "id": "155",
+                            "tracking": true,
+                            "end": {
+                                "contact": {
+                                    "email": "ajeetchauhan.symfony143@webkul.in",
+                                    "phone": "8574739650"
+                                },
+                                "person": {
+                                    "name": "Ajeet Chauhan"
+                                },
+                                "location": {
+                                    "gps": "28.629743,77.377795",
+                                    "address": {
+                                        "name": "Ajeet Chauhan",
+                                        "building": "ARV Park",
+                                        "locality": "Unnamed Road",
+                                        "city": "Noida",
+                                        "state": "Uttar Pradesh",
+                                        "country": "IND",
+                                        "area_code": "201301"
+                                    }
+                                },
+                                "time": {
+                                    "range": {
+                                        "start": "2025-01-06T11:46:27.992Z",
+                                        "end": "2025-01-06T12:46:27.992Z"
+                                    }
+                                }
+                            },
+                            "type": "Delivery",
+                            "@ondc/org/provider_name": "ondc.ecomviser.com",
+                            "state": {
+                                "descriptor": {
+                                    "code": "Pending"
+                                }
+                            },
+                            "start": {
+                                "location": {
+                                    "id": "83",
+                                    "descriptor": {
+                                        "name": "Ajeet Food Shop"
+                                    },
+                                    "gps": "28.62972640,77.37783230",
+                                    "address": {
+                                        "locality": "Noida",
+                                        "city": "Gautam Buddh Nagar",
+                                        "area_code": "201301",
+                                        "state": "Uttar Pradesh"
+                                    }
+                                },
+                                "contact": {
+                                    "phone": "9876543210",
+                                    "email": "support@webkul.in"
+                                },
+                                "time": {
+                                    "range": {
+                                        "start": "2025-01-06T11:46:27.992Z",
+                                        "end": "2025-01-06T12:46:27.992Z"
+                                    }
+                                }
+                            }
+                        }
+                    ],
+                    "quote": {
+                        "price": {
+                            "currency": "INR",
+                            "value": "159.45"
+                        },
+                        "breakup": [
+                            {
+                                "title": "Pizza Mania",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "99"
+                                },
+                                "@ondc/org/title_type": "item",
+                                "@ondc/org/item_id": "451",
+                                "@ondc/org/item_quantity": {
+                                    "count": 1
+                                },
+                                "item": {
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "99"
+                                    },
+                                    "parent_item_id": "hjt9D5BeMUs/",
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "item"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "title": "Extra",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "5"
+                                },
+                                "@ondc/org/title_type": "item",
+                                "@ondc/org/item_id": "93",
+                                "@ondc/org/item_quantity": {
+                                    "count": 1
+                                },
+                                "item": {
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "5"
+                                    },
+                                    "parent_item_id": "hjt9D5BeMUs/",
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "customization"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "parent",
+                                            "list": [
+                                                {
+                                                    "code": "id",
+                                                    "value": "66zabcdefghi"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "title": "Mutton",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "50"
+                                },
+                                "@ondc/org/title_type": "item",
+                                "@ondc/org/item_id": "96",
+                                "@ondc/org/item_quantity": {
+                                    "count": 1
+                                },
+                                "item": {
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "50"
+                                    },
+                                    "parent_item_id": "hjt9D5BeMUs/",
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "customization"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "parent",
+                                            "list": [
+                                                {
+                                                    "code": "id",
+                                                    "value": "67zabcdefghi"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "title": "Convenience fee",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "5.45"
+                                },
+                                "@ondc/org/title_type": "misc",
+                                "@ondc/org/item_id": "155"
+                            },
+                            {
+                                "title": "Delivery charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "0"
+                                },
+                                "@ondc/org/title_type": "delivery",
+                                "@ondc/org/item_id": "155"
+                            }
+                        ],
+                        "ttl": "PT6H"
+                    },
+                    "payment": {
+                        "uri": "https://razorpay.com/",
+                        "tl_method": "http/get",
+                        "params": {
+                            "amount": "159.45",
+                            "currency": "INR",
+                            "transaction_id": "order_Pg96kAoxdJrCmf"
+                        },
+                        "status": "PAID",
+                        "type": "ON-ORDER",
+                        "collected_by": "BAP",
+                        "@ondc/org/buyer_app_finder_fee_type": "percent",
+                        "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+                        "@ondc/org/settlement_details": [
+                            {
+                                "settlement_counterparty": "seller-app",
+                                "settlement_phase": "sale-amount",
+                                "settlement_type": "neft",
+                                "beneficiary_name": "fasdf asdfasdf",
+                                "settlement_bank_account_no": "534512341234132",
+                                "settlement_ifsc_code": "HDFC0000088",
+                                "bank_name": "fasdf",
+                                "branch_name": "noida",
+                                "settlement_status": "NOT-PAID"
+                            }
+                        ]
+                    },
+                    "tags": [
+                        {
+                            "code": "bpp_terms",
+                            "list": [
+                                {
+                                    "code": "np_type",
+                                    "value": "MSN"
+                                },
+                                {
+                                    "code": "tax_number",
+                                    "value": "09AABCW0339G3ZD"
+                                },
+                                {
+                                    "code": "provider_tax_number",
+                                    "value": "DERTC3376R"
+                                }
+                            ]
+                        },
+                        {
+                            "code": "bap_terms",
+                            "list": [
+                                {
+                                    "code": "tax_number",
+                                    "value": "GSTIN1234567890"
+                                }
+                            ]
+                        }
+                    ],
+                    "created_at": "2025-01-06T11:46:15.671Z",
+                    "updated_at": "2025-01-06T11:46:19.906Z"
+                }
+            }
+        },
+        "cancel": {
+            "context": {
+                "domain": "ONDC:RET11",
+                "country": "IND",
+                "city": "std:0120",
+                "action": "cancel",
+                "core_version": "1.2.0",
+                "bap_id": "buyer-app-preprod-v2.ondc.org",
+                "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+                "bpp_uri": "https://ondc.ecomviser.com/api/v1",
+                "transaction_id": "0d4b4422-4561-4a23-89fd-6c98c823219b",
+                "message_id": "09053c59-c21d-4361-98ea-ea0b25954f22",
+                "timestamp": "2025-01-06T11:48:56.252Z",
+                "bpp_id": "ondc.ecomviser.com",
+                "ttl": "PT30S"
+            },
+            "message": {
+                "order_id": "2025-01-06-197962",
+                "cancellation_reason_id": "003"
+            }
+        },
+        "on_cancel": {
+            "context": {
+                "domain": "ONDC:RET11",
+                "country": "IND",
+                "city": "std:0120",
+                "action": "on_cancel",
+                "core_version": "1.2.0",
+                "bap_id": "buyer-app-preprod-v2.ondc.org",
+                "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+                "bpp_uri": "https://ondc.ecomviser.com/api/v1",
+                "transaction_id": "0d4b4422-4561-4a23-89fd-6c98c823219b",
+                "message_id": "09053c59-c21d-4361-98ea-ea0b25954f22",
+                "timestamp": "2025-01-06T11:48:59.897Z",
+                "bpp_id": "ondc.ecomviser.com",
+                "ttl": "PT30S"
+            },
+            "message": {
+                "order": {
+                    "id": "2025-01-06-197962",
+                    "state": "Cancelled",
+                    "provider": {
+                        "id": "84",
+                        "locations": [
+                            {
+                                "id": "83"
+                            }
+                        ]
+                    },
+                    "items": [
+                        {
+                            "id": "451",
+                            "fulfillment_id": "155",
+                            "quantity": {
+                                "count": 0
+                            }
+                        },
+                        {
+                            "id": "451",
+                            "fulfillment_id": "cancel-shipping",
+                            "quantity": {
+                                "count": 1
+                            }
+                        },
+                        {
+                            "id": "93",
+                            "fulfillment_id": "155",
+                            "quantity": {
+                                "count": 0
+                            }
+                        },
+                        {
+                            "id": "93",
+                            "fulfillment_id": "cancel-shipping",
+                            "quantity": {
+                                "count": 1
+                            }
+                        },
+                        {
+                            "id": "96",
+                            "fulfillment_id": "155",
+                            "quantity": {
+                                "count": 0
+                            }
+                        },
+                        {
+                            "id": "96",
+                            "fulfillment_id": "cancel-shipping",
+                            "quantity": {
+                                "count": 1
+                            }
+                        }
+                    ],
+                    "billing": {
+                        "name": "Ajeet Chauhan",
+                        "email": "ajeetchauhan.symfony143@webkul.in",
+                        "phone": "8574739650",
+                        "address": {
+                            "city": "Noida",
+                            "name": "Ajeet Chauhan",
+                            "state": "Uttar Pradesh",
+                            "country": "IND",
+                            "building": "ARV Park",
+                            "locality": "Unnamed Road",
+                            "area_code": "201301"
+                        },
+                        "created_at": "2025-01-06T11:45:19.999Z",
+                        "updated_at": "2025-01-06T11:45:19.999Z"
+                    },
+                    "cancellation": {
+                        "cancelled_by": "buyer-app-preprod-v2.ondc.org",
+                        "reason": {
+                            "id": "003"
+                        }
+                    },
+                    "fulfillments": [
+                        {
+                            "id": "155",
+                            "end": {
+                                "time": {
+                                    "range": {
+                                        "start": "2025-01-06T11:49:00.512Z",
+                                        "end": "2025-01-06T12:19:00.512Z"
+                                    }
+                                },
+                                "person": {
+                                    "name": "Ajeet Chauhan"
+                                },
+                                "contact": {
+                                    "email": "ajeetchauhan.symfony143@webkul.in",
+                                    "phone": "8574739650"
+                                },
+                                "location": {
+                                    "gps": "28.629743,77.377795",
+                                    "address": {
+                                        "city": "Noida",
+                                        "name": "Ajeet Chauhan",
+                                        "state": "Uttar Pradesh",
+                                        "country": "IND",
+                                        "building": "ARV Park",
+                                        "locality": "Unnamed Road",
+                                        "area_code": "201301"
+                                    }
+                                }
+                            },
+                            "type": "Delivery",
+                            "start": {
+                                "time": {
+                                    "range": {
+                                        "start": "2025-01-06T11:46:19.906Z",
+                                        "end": "2025-01-06T11:46:19.906Z"
+                                    }
+                                },
+                                "contact": {
+                                    "email": "support@webkul.in",
+                                    "phone": "9876543210"
+                                },
+                                "location": {
+                                    "id": "83",
+                                    "gps": "28.62972640,77.37783230",
+                                    "address": {
+                                        "city": "Gautam Buddh Nagar",
+                                        "state": "Uttar Pradesh",
+                                        "locality": "Noida",
+                                        "area_code": "201301"
+                                    },
+                                    "descriptor": {
+                                        "name": "Ajeet Food Shop"
+                                    }
+                                }
+                            },
+                            "state": {
+                                "descriptor": {
+                                    "code": "Cancelled"
+                                }
+                            },
+                            "tracking": true,
+                            "@ondc/org/TAT": "PT90M",
+                            "@ondc/org/provider_name": "ondc.ecomviser.com",
+                            "tags": [
+                                {
+                                    "code": "cancel_request",
+                                    "list": [
+                                        {
+                                            "code": "reason_id",
+                                            "value": "003"
+                                        },
+                                        {
+                                            "code": "initiated_by",
+                                            "value": "buyer-app-preprod-v2.ondc.org"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "precancel_state",
+                                    "list": [
+                                        {
+                                            "code": "fulfillment_state",
+                                            "value": "Pending"
+                                        },
+                                        {
+                                            "code": "updated_at",
+                                            "value": "2025-01-06T11:46:19.906Z"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "cancel-shipping",
+                            "type": "Cancel",
+                            "@ondc/org/provider_name": "ondc.ecomviser.com",
+                            "state": {
+                                "descriptor": {
+                                    "code": "Cancelled"
+                                }
+                            },
+                            "tags": [
+                                {
+                                    "code": "cancel_request",
+                                    "list": [
+                                        {
+                                            "code": "reason_id",
+                                            "value": "003"
+                                        },
+                                        {
+                                            "code": "initiated_by",
+                                            "value": "ondc.ecomviser.com"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "quote_trail",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "item"
+                                        },
+                                        {
+                                            "code": "id",
+                                            "value": "451"
+                                        },
+                                        {
+                                            "code": "currency",
+                                            "value": "INR"
+                                        },
+                                        {
+                                            "code": "value",
+                                            "value": "-99"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "quote_trail",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "item"
+                                        },
+                                        {
+                                            "code": "id",
+                                            "value": "93"
+                                        },
+                                        {
+                                            "code": "currency",
+                                            "value": "INR"
+                                        },
+                                        {
+                                            "code": "value",
+                                            "value": "-5"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "quote_trail",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "item"
+                                        },
+                                        {
+                                            "code": "id",
+                                            "value": "96"
+                                        },
+                                        {
+                                            "code": "currency",
+                                            "value": "INR"
+                                        },
+                                        {
+                                            "code": "value",
+                                            "value": "-50"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ],
+                    "quote": {
+                        "ttl": "PT6H",
+                        "price": {
+                            "value": "5.45",
+                            "currency": "INR"
+                        },
+                        "breakup": [
+                            {
+                                "item": {
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "item"
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "price": {
+                                        "value": "99",
+                                        "currency": "INR"
+                                    },
+                                    "parent_item_id": "hjt9D5BeMUs/"
+                                },
+                                "price": {
+                                    "value": "-55",
+                                    "currency": "INR"
+                                },
+                                "title": "Pizza Mania",
+                                "@ondc/org/item_id": "451",
+                                "@ondc/org/title_type": "item",
+                                "@ondc/org/item_quantity": {
+                                    "count": 0
+                                }
+                            },
+                            {
+                                "item": {
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "customization"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "parent",
+                                            "list": [
+                                                {
+                                                    "code": "id",
+                                                    "value": "66zabcdefghi"
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "price": {
+                                        "value": "5",
+                                        "currency": "INR"
+                                    },
+                                    "parent_item_id": "hjt9D5BeMUs/"
+                                },
+                                "price": {
+                                    "value": "5",
+                                    "currency": "INR"
+                                },
+                                "title": "Extra",
+                                "@ondc/org/item_id": "93",
+                                "@ondc/org/title_type": "item",
+                                "@ondc/org/item_quantity": {
+                                    "count": 1
+                                }
+                            },
+                            {
+                                "item": {
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "customization"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "parent",
+                                            "list": [
+                                                {
+                                                    "code": "id",
+                                                    "value": "67zabcdefghi"
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "price": {
+                                        "value": "50",
+                                        "currency": "INR"
+                                    },
+                                    "parent_item_id": "hjt9D5BeMUs/"
+                                },
+                                "price": {
+                                    "value": "50",
+                                    "currency": "INR"
+                                },
+                                "title": "Mutton",
+                                "@ondc/org/item_id": "96",
+                                "@ondc/org/title_type": "item",
+                                "@ondc/org/item_quantity": {
+                                    "count": 1
+                                }
+                            },
+                            {
+                                "price": {
+                                    "value": "5.45",
+                                    "currency": "INR"
+                                },
+                                "title": "Convenience fee",
+                                "@ondc/org/item_id": "155",
+                                "@ondc/org/title_type": "misc"
+                            },
+                            {
+                                "price": {
+                                    "value": "0",
+                                    "currency": "INR"
+                                },
+                                "title": "Delivery charges",
+                                "@ondc/org/item_id": "155",
+                                "@ondc/org/title_type": "delivery"
+                            }
+                        ]
+                    },
+                    "payment": {
+                        "uri": "https://razorpay.com/",
+                        "type": "ON-ORDER",
+                        "params": {
+                            "amount": "159.45",
+                            "currency": "INR",
+                            "transaction_id": "order_Pg96kAoxdJrCmf"
+                        },
+                        "status": "PAID",
+                        "tl_method": "http/get",
+                        "collected_by": "BAP",
+                        "@ondc/org/settlement_details": [
+                            {
+                                "bank_name": "fasdf",
+                                "branch_name": "noida",
+                                "settlement_type": "neft",
+                                "beneficiary_name": "fasdf asdfasdf",
+                                "settlement_phase": "sale-amount",
+                                "settlement_status": "NOT-PAID",
+                                "settlement_ifsc_code": "HDFC0000088",
+                                "settlement_counterparty": "seller-app",
+                                "settlement_bank_account_no": "534512341234132"
+                            }
+                        ],
+                        "@ondc/org/buyer_app_finder_fee_type": "percent",
+                        "@ondc/org/buyer_app_finder_fee_amount": "3.0"
+                    },
+                    "created_at": "2025-01-06T11:46:15.671Z",
+                    "updated_at": "2025-01-06T11:49:00.519Z"
+                }
+            }
+        }
+    },
+    "flow": "4"
+}

--- a/eComviser/Seller App RET11/Flow-4/init.json
+++ b/eComviser/Seller App RET11/Flow-4/init.json
@@ -1,0 +1,149 @@
+{
+    "context": {
+        "domain": "ONDC:RET11",
+        "country": "IND",
+        "city": "std:0120",
+        "action": "init",
+        "core_version": "1.2.0",
+        "bap_id": "buyer-app-preprod-v2.ondc.org",
+        "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+        "bpp_uri": "https://ondc.ecomviser.com/api/v1",
+        "transaction_id": "0d4b4422-4561-4a23-89fd-6c98c823219b",
+        "message_id": "dfe31e0a-8432-4764-a076-9ffd98a929cc",
+        "timestamp": "2025-01-06T11:45:19.999Z",
+        "bpp_id": "ondc.ecomviser.com",
+        "ttl": "PT30S"
+    },
+    "message": {
+        "order": {
+            "provider": {
+                "id": "84",
+                "locations": [
+                    {
+                        "id": "83"
+                    }
+                ]
+            },
+            "items": [
+                {
+                    "id": "451",
+                    "quantity": {
+                        "count": 1
+                    },
+                    "location_id": "83",
+                    "tags": [
+                        {
+                            "code": "type",
+                            "list": [
+                                {
+                                    "code": "type",
+                                    "value": "item"
+                                }
+                            ]
+                        }
+                    ],
+                    "parent_item_id": "hjt9D5BeMUs/",
+                    "fulfillment_id": "155"
+                },
+                {
+                    "id": "93",
+                    "quantity": {
+                        "count": 1
+                    },
+                    "location_id": "83",
+                    "tags": [
+                        {
+                            "code": "type",
+                            "list": [
+                                {
+                                    "code": "type",
+                                    "value": "customization"
+                                }
+                            ]
+                        },
+                        {
+                            "code": "parent",
+                            "list": [
+                                {
+                                    "code": "id",
+                                    "value": "66zabcdefghi"
+                                }
+                            ]
+                        }
+                    ],
+                    "fulfillment_id": "155",
+                    "parent_item_id": "hjt9D5BeMUs/"
+                },
+                {
+                    "id": "96",
+                    "quantity": {
+                        "count": 1
+                    },
+                    "location_id": "83",
+                    "tags": [
+                        {
+                            "code": "type",
+                            "list": [
+                                {
+                                    "code": "type",
+                                    "value": "customization"
+                                }
+                            ]
+                        },
+                        {
+                            "code": "parent",
+                            "list": [
+                                {
+                                    "code": "id",
+                                    "value": "67zabcdefghi"
+                                }
+                            ]
+                        }
+                    ],
+                    "fulfillment_id": "155",
+                    "parent_item_id": "hjt9D5BeMUs/"
+                }
+            ],
+            "billing": {
+                "address": {
+                    "building": "ARV Park",
+                    "city": "Noida",
+                    "state": "Uttar Pradesh",
+                    "country": "IND",
+                    "area_code": "201301",
+                    "locality": "Unnamed Road",
+                    "name": "Ajeet Chauhan"
+                },
+                "phone": "8574739650",
+                "name": "Ajeet Chauhan",
+                "email": "ajeetchauhan.symfony143@webkul.in",
+                "created_at": "2025-01-06T11:45:19.999Z",
+                "updated_at": "2025-01-06T11:45:19.999Z"
+            },
+            "fulfillments": [
+                {
+                    "id": "155",
+                    "type": "Delivery",
+                    "end": {
+                        "contact": {
+                            "email": "ajeetchauhan.symfony143@webkul.in",
+                            "phone": "8574739650"
+                        },
+                        "location": {
+                            "gps": "28.629743,77.377795",
+                            "address": {
+                                "building": "ARV Park",
+                                "city": "Noida",
+                                "state": "Uttar Pradesh",
+                                "country": "IND",
+                                "area_code": "201301",
+                                "locality": "Unnamed Road",
+                                "name": "Ajeet Chauhan"
+                            }
+                        }
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/eComviser/Seller App RET11/Flow-4/on_cancel.json
+++ b/eComviser/Seller App RET11/Flow-4/on_cancel.json
@@ -1,0 +1,443 @@
+{
+    "context": {
+        "domain": "ONDC:RET11",
+        "country": "IND",
+        "city": "std:0120",
+        "action": "on_cancel",
+        "core_version": "1.2.0",
+        "bap_id": "buyer-app-preprod-v2.ondc.org",
+        "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+        "bpp_uri": "https://ondc.ecomviser.com/api/v1",
+        "transaction_id": "0d4b4422-4561-4a23-89fd-6c98c823219b",
+        "message_id": "09053c59-c21d-4361-98ea-ea0b25954f22",
+        "timestamp": "2025-01-06T11:48:59.897Z",
+        "bpp_id": "ondc.ecomviser.com",
+        "ttl": "PT30S"
+    },
+    "message": {
+        "order": {
+            "id": "2025-01-06-197962",
+            "state": "Cancelled",
+            "provider": {
+                "id": "84",
+                "locations": [
+                    {
+                        "id": "83"
+                    }
+                ]
+            },
+            "items": [
+                {
+                    "id": "451",
+                    "fulfillment_id": "155",
+                    "quantity": {
+                        "count": 0
+                    }
+                },
+                {
+                    "id": "451",
+                    "fulfillment_id": "cancel-shipping",
+                    "quantity": {
+                        "count": 1
+                    }
+                },
+                {
+                    "id": "93",
+                    "fulfillment_id": "155",
+                    "quantity": {
+                        "count": 0
+                    }
+                },
+                {
+                    "id": "93",
+                    "fulfillment_id": "cancel-shipping",
+                    "quantity": {
+                        "count": 1
+                    }
+                },
+                {
+                    "id": "96",
+                    "fulfillment_id": "155",
+                    "quantity": {
+                        "count": 0
+                    }
+                },
+                {
+                    "id": "96",
+                    "fulfillment_id": "cancel-shipping",
+                    "quantity": {
+                        "count": 1
+                    }
+                }
+            ],
+            "billing": {
+                "name": "Ajeet Chauhan",
+                "email": "ajeetchauhan.symfony143@webkul.in",
+                "phone": "8574739650",
+                "address": {
+                    "city": "Noida",
+                    "name": "Ajeet Chauhan",
+                    "state": "Uttar Pradesh",
+                    "country": "IND",
+                    "building": "ARV Park",
+                    "locality": "Unnamed Road",
+                    "area_code": "201301"
+                },
+                "created_at": "2025-01-06T11:45:19.999Z",
+                "updated_at": "2025-01-06T11:45:19.999Z"
+            },
+            "cancellation": {
+                "cancelled_by": "buyer-app-preprod-v2.ondc.org",
+                "reason": {
+                    "id": "003"
+                }
+            },
+            "fulfillments": [
+                {
+                    "id": "155",
+                    "end": {
+                        "time": {
+                            "range": {
+                                "start": "2025-01-06T11:49:00.512Z",
+                                "end": "2025-01-06T12:19:00.512Z"
+                            }
+                        },
+                        "person": {
+                            "name": "Ajeet Chauhan"
+                        },
+                        "contact": {
+                            "email": "ajeetchauhan.symfony143@webkul.in",
+                            "phone": "8574739650"
+                        },
+                        "location": {
+                            "gps": "28.629743,77.377795",
+                            "address": {
+                                "city": "Noida",
+                                "name": "Ajeet Chauhan",
+                                "state": "Uttar Pradesh",
+                                "country": "IND",
+                                "building": "ARV Park",
+                                "locality": "Unnamed Road",
+                                "area_code": "201301"
+                            }
+                        }
+                    },
+                    "type": "Delivery",
+                    "start": {
+                        "time": {
+                            "range": {
+                                "start": "2025-01-06T11:46:19.906Z",
+                                "end": "2025-01-06T11:46:19.906Z"
+                            }
+                        },
+                        "contact": {
+                            "email": "support@webkul.in",
+                            "phone": "9876543210"
+                        },
+                        "location": {
+                            "id": "83",
+                            "gps": "28.62972640,77.37783230",
+                            "address": {
+                                "city": "Gautam Buddh Nagar",
+                                "state": "Uttar Pradesh",
+                                "locality": "Noida",
+                                "area_code": "201301"
+                            },
+                            "descriptor": {
+                                "name": "Ajeet Food Shop"
+                            }
+                        }
+                    },
+                    "state": {
+                        "descriptor": {
+                            "code": "Cancelled"
+                        }
+                    },
+                    "tracking": true,
+                    "@ondc/org/TAT": "PT90M",
+                    "@ondc/org/provider_name": "ondc.ecomviser.com",
+                    "tags": [
+                        {
+                            "code": "cancel_request",
+                            "list": [
+                                {
+                                    "code": "reason_id",
+                                    "value": "003"
+                                },
+                                {
+                                    "code": "initiated_by",
+                                    "value": "buyer-app-preprod-v2.ondc.org"
+                                }
+                            ]
+                        },
+                        {
+                            "code": "precancel_state",
+                            "list": [
+                                {
+                                    "code": "fulfillment_state",
+                                    "value": "Pending"
+                                },
+                                {
+                                    "code": "updated_at",
+                                    "value": "2025-01-06T11:46:19.906Z"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "id": "cancel-shipping",
+                    "type": "Cancel",
+                    "@ondc/org/provider_name": "ondc.ecomviser.com",
+                    "state": {
+                        "descriptor": {
+                            "code": "Cancelled"
+                        }
+                    },
+                    "tags": [
+                        {
+                            "code": "cancel_request",
+                            "list": [
+                                {
+                                    "code": "reason_id",
+                                    "value": "003"
+                                },
+                                {
+                                    "code": "initiated_by",
+                                    "value": "ondc.ecomviser.com"
+                                }
+                            ]
+                        },
+                        {
+                            "code": "quote_trail",
+                            "list": [
+                                {
+                                    "code": "type",
+                                    "value": "item"
+                                },
+                                {
+                                    "code": "id",
+                                    "value": "451"
+                                },
+                                {
+                                    "code": "currency",
+                                    "value": "INR"
+                                },
+                                {
+                                    "code": "value",
+                                    "value": "-99"
+                                }
+                            ]
+                        },
+                        {
+                            "code": "quote_trail",
+                            "list": [
+                                {
+                                    "code": "type",
+                                    "value": "item"
+                                },
+                                {
+                                    "code": "id",
+                                    "value": "93"
+                                },
+                                {
+                                    "code": "currency",
+                                    "value": "INR"
+                                },
+                                {
+                                    "code": "value",
+                                    "value": "-5"
+                                }
+                            ]
+                        },
+                        {
+                            "code": "quote_trail",
+                            "list": [
+                                {
+                                    "code": "type",
+                                    "value": "item"
+                                },
+                                {
+                                    "code": "id",
+                                    "value": "96"
+                                },
+                                {
+                                    "code": "currency",
+                                    "value": "INR"
+                                },
+                                {
+                                    "code": "value",
+                                    "value": "-50"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "quote": {
+                "ttl": "PT6H",
+                "price": {
+                    "value": "5.45",
+                    "currency": "INR"
+                },
+                "breakup": [
+                    {
+                        "item": {
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "item"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "price": {
+                                "value": "99",
+                                "currency": "INR"
+                            },
+                            "parent_item_id": "hjt9D5BeMUs/"
+                        },
+                        "price": {
+                            "value": "-55",
+                            "currency": "INR"
+                        },
+                        "title": "Pizza Mania",
+                        "@ondc/org/item_id": "451",
+                        "@ondc/org/title_type": "item",
+                        "@ondc/org/item_quantity": {
+                            "count": 0
+                        }
+                    },
+                    {
+                        "item": {
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "66zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "price": {
+                                "value": "5",
+                                "currency": "INR"
+                            },
+                            "parent_item_id": "hjt9D5BeMUs/"
+                        },
+                        "price": {
+                            "value": "5",
+                            "currency": "INR"
+                        },
+                        "title": "Extra",
+                        "@ondc/org/item_id": "93",
+                        "@ondc/org/title_type": "item",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
+                        }
+                    },
+                    {
+                        "item": {
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "67zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "price": {
+                                "value": "50",
+                                "currency": "INR"
+                            },
+                            "parent_item_id": "hjt9D5BeMUs/"
+                        },
+                        "price": {
+                            "value": "50",
+                            "currency": "INR"
+                        },
+                        "title": "Mutton",
+                        "@ondc/org/item_id": "96",
+                        "@ondc/org/title_type": "item",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
+                        }
+                    },
+                    {
+                        "price": {
+                            "value": "5.45",
+                            "currency": "INR"
+                        },
+                        "title": "Convenience fee",
+                        "@ondc/org/item_id": "155",
+                        "@ondc/org/title_type": "misc"
+                    },
+                    {
+                        "price": {
+                            "value": "0",
+                            "currency": "INR"
+                        },
+                        "title": "Delivery charges",
+                        "@ondc/org/item_id": "155",
+                        "@ondc/org/title_type": "delivery"
+                    }
+                ]
+            },
+            "payment": {
+                "uri": "https://razorpay.com/",
+                "type": "ON-ORDER",
+                "params": {
+                    "amount": "159.45",
+                    "currency": "INR",
+                    "transaction_id": "order_Pg96kAoxdJrCmf"
+                },
+                "status": "PAID",
+                "tl_method": "http/get",
+                "collected_by": "BAP",
+                "@ondc/org/settlement_details": [
+                    {
+                        "bank_name": "fasdf",
+                        "branch_name": "noida",
+                        "settlement_type": "neft",
+                        "beneficiary_name": "fasdf asdfasdf",
+                        "settlement_phase": "sale-amount",
+                        "settlement_status": "NOT-PAID",
+                        "settlement_ifsc_code": "HDFC0000088",
+                        "settlement_counterparty": "seller-app",
+                        "settlement_bank_account_no": "534512341234132"
+                    }
+                ],
+                "@ondc/org/buyer_app_finder_fee_type": "percent",
+                "@ondc/org/buyer_app_finder_fee_amount": "3.0"
+            },
+            "created_at": "2025-01-06T11:46:15.671Z",
+            "updated_at": "2025-01-06T11:49:00.519Z"
+        }
+    }
+}

--- a/eComviser/Seller App RET11/Flow-4/on_confirm.json
+++ b/eComviser/Seller App RET11/Flow-4/on_confirm.json
@@ -1,0 +1,381 @@
+{
+    "context": {
+        "domain": "ONDC:RET11",
+        "country": "IND",
+        "city": "std:0120",
+        "action": "on_confirm",
+        "core_version": "1.2.0",
+        "bap_id": "buyer-app-preprod-v2.ondc.org",
+        "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+        "bpp_uri": "https://ondc.ecomviser.com/api/v1",
+        "transaction_id": "0d4b4422-4561-4a23-89fd-6c98c823219b",
+        "message_id": "cc68b5a2-be2a-4164-bd81-7813862a8042",
+        "timestamp": "2025-01-06T11:46:19.906Z",
+        "bpp_id": "ondc.ecomviser.com"
+    },
+    "message": {
+        "order": {
+            "id": "2025-01-06-197962",
+            "state": "Created",
+            "provider": {
+                "id": "84",
+                "locations": [
+                    {
+                        "id": "83"
+                    }
+                ]
+            },
+            "items": [
+                {
+                    "id": "451",
+                    "quantity": {
+                        "count": 1
+                    },
+                    "fulfillment_id": "155",
+                    "tags": [
+                        {
+                            "code": "type",
+                            "list": [
+                                {
+                                    "code": "type",
+                                    "value": "item"
+                                }
+                            ]
+                        }
+                    ],
+                    "parent_item_id": "hjt9D5BeMUs/"
+                },
+                {
+                    "id": "93",
+                    "quantity": {
+                        "count": 1
+                    },
+                    "fulfillment_id": "155",
+                    "tags": [
+                        {
+                            "code": "type",
+                            "list": [
+                                {
+                                    "code": "type",
+                                    "value": "customization"
+                                }
+                            ]
+                        },
+                        {
+                            "code": "parent",
+                            "list": [
+                                {
+                                    "code": "id",
+                                    "value": "66zabcdefghi"
+                                }
+                            ]
+                        }
+                    ],
+                    "parent_item_id": "hjt9D5BeMUs/"
+                },
+                {
+                    "id": "96",
+                    "quantity": {
+                        "count": 1
+                    },
+                    "fulfillment_id": "155",
+                    "tags": [
+                        {
+                            "code": "type",
+                            "list": [
+                                {
+                                    "code": "type",
+                                    "value": "customization"
+                                }
+                            ]
+                        },
+                        {
+                            "code": "parent",
+                            "list": [
+                                {
+                                    "code": "id",
+                                    "value": "67zabcdefghi"
+                                }
+                            ]
+                        }
+                    ],
+                    "parent_item_id": "hjt9D5BeMUs/"
+                }
+            ],
+            "billing": {
+                "address": {
+                    "name": "Ajeet Chauhan",
+                    "building": "ARV Park",
+                    "locality": "Unnamed Road",
+                    "city": "Noida",
+                    "state": "Uttar Pradesh",
+                    "country": "IND",
+                    "area_code": "201301"
+                },
+                "phone": "8574739650",
+                "name": "Ajeet Chauhan",
+                "email": "ajeetchauhan.symfony143@webkul.in",
+                "created_at": "2025-01-06T11:45:19.999Z",
+                "updated_at": "2025-01-06T11:45:19.999Z"
+            },
+            "fulfillments": [
+                {
+                    "@ondc/org/TAT": "PT90M",
+                    "id": "155",
+                    "tracking": true,
+                    "end": {
+                        "contact": {
+                            "email": "ajeetchauhan.symfony143@webkul.in",
+                            "phone": "8574739650"
+                        },
+                        "person": {
+                            "name": "Ajeet Chauhan"
+                        },
+                        "location": {
+                            "gps": "28.629743,77.377795",
+                            "address": {
+                                "name": "Ajeet Chauhan",
+                                "building": "ARV Park",
+                                "locality": "Unnamed Road",
+                                "city": "Noida",
+                                "state": "Uttar Pradesh",
+                                "country": "IND",
+                                "area_code": "201301"
+                            }
+                        },
+                        "time": {
+                            "range": {
+                                "start": "2025-01-06T11:46:27.992Z",
+                                "end": "2025-01-06T12:46:27.992Z"
+                            }
+                        }
+                    },
+                    "type": "Delivery",
+                    "@ondc/org/provider_name": "ondc.ecomviser.com",
+                    "state": {
+                        "descriptor": {
+                            "code": "Pending"
+                        }
+                    },
+                    "start": {
+                        "location": {
+                            "id": "83",
+                            "descriptor": {
+                                "name": "Ajeet Food Shop"
+                            },
+                            "gps": "28.62972640,77.37783230",
+                            "address": {
+                                "locality": "Noida",
+                                "city": "Gautam Buddh Nagar",
+                                "area_code": "201301",
+                                "state": "Uttar Pradesh"
+                            }
+                        },
+                        "contact": {
+                            "phone": "9876543210",
+                            "email": "support@webkul.in"
+                        },
+                        "time": {
+                            "range": {
+                                "start": "2025-01-06T11:46:27.992Z",
+                                "end": "2025-01-06T12:46:27.992Z"
+                            }
+                        }
+                    }
+                }
+            ],
+            "quote": {
+                "price": {
+                    "currency": "INR",
+                    "value": "159.45"
+                },
+                "breakup": [
+                    {
+                        "title": "Pizza Mania",
+                        "price": {
+                            "currency": "INR",
+                            "value": "99"
+                        },
+                        "@ondc/org/title_type": "item",
+                        "@ondc/org/item_id": "451",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
+                        },
+                        "item": {
+                            "price": {
+                                "currency": "INR",
+                                "value": "99"
+                            },
+                            "parent_item_id": "hjt9D5BeMUs/",
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "item"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "title": "Extra",
+                        "price": {
+                            "currency": "INR",
+                            "value": "5"
+                        },
+                        "@ondc/org/title_type": "item",
+                        "@ondc/org/item_id": "93",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
+                        },
+                        "item": {
+                            "price": {
+                                "currency": "INR",
+                                "value": "5"
+                            },
+                            "parent_item_id": "hjt9D5BeMUs/",
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "66zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "title": "Mutton",
+                        "price": {
+                            "currency": "INR",
+                            "value": "50"
+                        },
+                        "@ondc/org/title_type": "item",
+                        "@ondc/org/item_id": "96",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
+                        },
+                        "item": {
+                            "price": {
+                                "currency": "INR",
+                                "value": "50"
+                            },
+                            "parent_item_id": "hjt9D5BeMUs/",
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "67zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "title": "Convenience fee",
+                        "price": {
+                            "currency": "INR",
+                            "value": "5.45"
+                        },
+                        "@ondc/org/title_type": "misc",
+                        "@ondc/org/item_id": "155"
+                    },
+                    {
+                        "title": "Delivery charges",
+                        "price": {
+                            "currency": "INR",
+                            "value": "0"
+                        },
+                        "@ondc/org/title_type": "delivery",
+                        "@ondc/org/item_id": "155"
+                    }
+                ],
+                "ttl": "PT6H"
+            },
+            "payment": {
+                "uri": "https://razorpay.com/",
+                "tl_method": "http/get",
+                "params": {
+                    "amount": "159.45",
+                    "currency": "INR",
+                    "transaction_id": "order_Pg96kAoxdJrCmf"
+                },
+                "status": "PAID",
+                "type": "ON-ORDER",
+                "collected_by": "BAP",
+                "@ondc/org/buyer_app_finder_fee_type": "percent",
+                "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+                "@ondc/org/settlement_details": [
+                    {
+                        "settlement_counterparty": "seller-app",
+                        "settlement_phase": "sale-amount",
+                        "settlement_type": "neft",
+                        "beneficiary_name": "fasdf asdfasdf",
+                        "settlement_bank_account_no": "534512341234132",
+                        "settlement_ifsc_code": "HDFC0000088",
+                        "bank_name": "fasdf",
+                        "branch_name": "noida",
+                        "settlement_status": "NOT-PAID"
+                    }
+                ]
+            },
+            "tags": [
+                {
+                    "code": "bpp_terms",
+                    "list": [
+                        {
+                            "code": "np_type",
+                            "value": "MSN"
+                        },
+                        {
+                            "code": "tax_number",
+                            "value": "09AABCW0339G3ZD"
+                        },
+                        {
+                            "code": "provider_tax_number",
+                            "value": "DERTC3376R"
+                        }
+                    ]
+                },
+                {
+                    "code": "bap_terms",
+                    "list": [
+                        {
+                            "code": "tax_number",
+                            "value": "GSTIN1234567890"
+                        }
+                    ]
+                }
+            ],
+            "created_at": "2025-01-06T11:46:15.671Z",
+            "updated_at": "2025-01-06T11:46:19.906Z"
+        }
+    }
+}

--- a/eComviser/Seller App RET11/Flow-4/on_init.json
+++ b/eComviser/Seller App RET11/Flow-4/on_init.json
@@ -1,0 +1,317 @@
+{
+    "context": {
+        "domain": "ONDC:RET11",
+        "country": "IND",
+        "city": "std:0120",
+        "action": "on_init",
+        "core_version": "1.2.0",
+        "bap_id": "buyer-app-preprod-v2.ondc.org",
+        "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+        "bpp_uri": "https://ondc.ecomviser.com/api/v1",
+        "transaction_id": "0d4b4422-4561-4a23-89fd-6c98c823219b",
+        "message_id": "dfe31e0a-8432-4764-a076-9ffd98a929cc",
+        "timestamp": "2025-01-06T11:45:21.355Z",
+        "bpp_id": "ondc.ecomviser.com",
+        "ttl": "PT30S"
+    },
+    "message": {
+        "order": {
+            "provider": {
+                "id": "84",
+                "locations": [
+                    {
+                        "id": "83"
+                    }
+                ]
+            },
+            "items": [
+                {
+                    "id": "451",
+                    "fulfillment_id": "155",
+                    "quantity": {
+                        "count": 1
+                    },
+                    "parent_item_id": "hjt9D5BeMUs/",
+                    "tags": [
+                        {
+                            "code": "type",
+                            "list": [
+                                {
+                                    "code": "type",
+                                    "value": "item"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "id": "93",
+                    "fulfillment_id": "155",
+                    "quantity": {
+                        "count": 1
+                    },
+                    "parent_item_id": "hjt9D5BeMUs/",
+                    "tags": [
+                        {
+                            "code": "type",
+                            "list": [
+                                {
+                                    "code": "type",
+                                    "value": "customization"
+                                }
+                            ]
+                        },
+                        {
+                            "code": "parent",
+                            "list": [
+                                {
+                                    "code": "id",
+                                    "value": "66zabcdefghi"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "id": "96",
+                    "fulfillment_id": "155",
+                    "quantity": {
+                        "count": 1
+                    },
+                    "parent_item_id": "hjt9D5BeMUs/",
+                    "tags": [
+                        {
+                            "code": "type",
+                            "list": [
+                                {
+                                    "code": "type",
+                                    "value": "customization"
+                                }
+                            ]
+                        },
+                        {
+                            "code": "parent",
+                            "list": [
+                                {
+                                    "code": "id",
+                                    "value": "67zabcdefghi"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "quote": {
+                "price": {
+                    "currency": "INR",
+                    "value": "159.45"
+                },
+                "breakup": [
+                    {
+                        "title": "Pizza Mania",
+                        "price": {
+                            "currency": "INR",
+                            "value": "99"
+                        },
+                        "@ondc/org/title_type": "item",
+                        "@ondc/org/item_id": "451",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
+                        },
+                        "item": {
+                            "price": {
+                                "currency": "INR",
+                                "value": "99"
+                            },
+                            "parent_item_id": "hjt9D5BeMUs/",
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "item"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "title": "Extra",
+                        "price": {
+                            "currency": "INR",
+                            "value": "5"
+                        },
+                        "@ondc/org/title_type": "item",
+                        "@ondc/org/item_id": "93",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
+                        },
+                        "item": {
+                            "price": {
+                                "currency": "INR",
+                                "value": "5"
+                            },
+                            "parent_item_id": "hjt9D5BeMUs/",
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "66zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "title": "Mutton",
+                        "price": {
+                            "currency": "INR",
+                            "value": "50"
+                        },
+                        "@ondc/org/title_type": "item",
+                        "@ondc/org/item_id": "96",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
+                        },
+                        "item": {
+                            "price": {
+                                "currency": "INR",
+                                "value": "50"
+                            },
+                            "parent_item_id": "hjt9D5BeMUs/",
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "67zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "title": "Convenience fee",
+                        "price": {
+                            "currency": "INR",
+                            "value": "5.45"
+                        },
+                        "@ondc/org/title_type": "misc",
+                        "@ondc/org/item_id": "155"
+                    },
+                    {
+                        "title": "Delivery charges",
+                        "price": {
+                            "currency": "INR",
+                            "value": "0"
+                        },
+                        "@ondc/org/title_type": "delivery",
+                        "@ondc/org/item_id": "155"
+                    }
+                ],
+                "ttl": "PT6H"
+            },
+            "billing": {
+                "address": {
+                    "building": "ARV Park",
+                    "city": "Noida",
+                    "state": "Uttar Pradesh",
+                    "country": "IND",
+                    "area_code": "201301",
+                    "locality": "Unnamed Road",
+                    "name": "Ajeet Chauhan"
+                },
+                "phone": "8574739650",
+                "name": "Ajeet Chauhan",
+                "email": "ajeetchauhan.symfony143@webkul.in",
+                "created_at": "2025-01-06T11:45:19.999Z",
+                "updated_at": "2025-01-06T11:45:19.999Z"
+            },
+            "fulfillments": [
+                {
+                    "id": "155",
+                    "type": "Delivery",
+                    "end": {
+                        "contact": {
+                            "email": "ajeetchauhan.symfony143@webkul.in",
+                            "phone": "8574739650"
+                        },
+                        "location": {
+                            "gps": "28.629743,77.377795",
+                            "address": {
+                                "building": "ARV Park",
+                                "city": "Noida",
+                                "state": "Uttar Pradesh",
+                                "country": "IND",
+                                "area_code": "201301",
+                                "locality": "Unnamed Road",
+                                "name": "Ajeet Chauhan"
+                            }
+                        }
+                    },
+                    "tracking": true
+                }
+            ],
+            "payment": {
+                "type": "ON-ORDER",
+                "collected_by": "BAP",
+                "@ondc/org/collected_by_status": "Agree",
+                "@ondc/org/buyer_app_finder_fee_type": "percent",
+                "@ondc/org/buyer_app_finder_fee_amount": "3",
+                "@ondc/org/settlement_details": [
+                    {
+                        "settlement_counterparty": "seller-app",
+                        "settlement_phase": "sale-amount",
+                        "settlement_type": "neft",
+                        "beneficiary_name": "fasdf asdfasdf",
+                        "settlement_bank_account_no": "534512341234132",
+                        "settlement_ifsc_code": "HDFC0000088",
+                        "bank_name": "fasdf",
+                        "branch_name": "noida",
+                        "settlement_status": "NOT-PAID"
+                    }
+                ]
+            },
+            "tags": [
+                {
+                    "code": "bpp_terms",
+                    "list": [
+                        {
+                            "code": "tax_number",
+                            "value": "09AABCW0339G3ZD"
+                        },
+                        {
+                            "code": "provider_tax_number",
+                            "value": "DERTC3376R"
+                        }
+                    ]
+                }
+            ]
+        }
+    }
+}

--- a/eComviser/Seller App RET11/Flow-4/on_search.json
+++ b/eComviser/Seller App RET11/Flow-4/on_search.json
@@ -1,0 +1,658 @@
+{
+    "context": {
+        "domain": "ONDC:RET11",
+        "action": "on_search",
+        "country": "IND",
+        "city": "std:0120",
+        "core_version": "1.2.0",
+        "bap_id": "buyer-app-preprod-v2.ondc.org",
+        "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+        "transaction_id": "0646bc94-5d3d-4b2d-6325-a8a33843dbb9",
+        "message_id": "36c56392-f004-4813-ace5-0d40033a8420",
+        "timestamp": "2025-01-06T11:17:49.476Z",
+        "ttl": "PT30S",
+        "bpp_id": "ondc.ecomviser.com",
+        "bpp_uri": "https://ondc.ecomviser.com/api/v1"
+    },
+    "message": {
+        "catalog": {
+            "bpp/descriptor": {
+                "name": "Webkul",
+                "symbol": "https://ondc.ecomviser.com/public/img/webkul_logo.png",
+                "short_desc": "Enterprise Digital Commerce & Marketplace Solution Experts",
+                "long_desc": "Helping companies with our industry-leading digital commerce, ERP, and CRM solutions. In the last 13 years, we have served 150K+ clients worldwide to handle complex operations and grow their businesses",
+                "images": [
+                    "https://ondc.ecomviser.com/public/img/webkul_banner.png",
+                    "https://ondc.ecomviser.com/public/img/webkul_clients.png",
+                    "https://ondc.ecomviser.com/public/img/webkul_awards.png"
+                ],
+                "tags": [
+                    {
+                        "code": "bpp_terms",
+                        "list": [
+                            {
+                                "code": "np_type",
+                                "value": "MSN"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "bpp/fulfillments": [
+                {
+                    "id": "155",
+                    "type": "Delivery"
+                }
+            ],
+            "bpp/providers": [
+                {
+                    "id": "84",
+                    "time": {
+                        "label": "enable",
+                        "timestamp": "2025-01-06T10:47:48.872Z"
+                    },
+                    "descriptor": {
+                        "name": "Ajeet Food Shop",
+                        "symbol": "https://ondc-prepod-digital-delivery.s3.amazonaws.com/seller_shop_logo/84/39MylDtZVC.jpg",
+                        "short_desc": "short desc",
+                        "long_desc": "store desc",
+                        "images": [
+                            "https://ondc-prepod-digital-delivery.s3.amazonaws.com/seller_shop_logo/84/39MylDtZVC.jpg"
+                        ]
+                    },
+                    "fulfillments": [
+                        {
+                            "id": "155",
+                            "type": "Delivery",
+                            "contact": {
+                                "phone": "9812345678",
+                                "email": "ajeetchauhan.symfony143@webkul.in"
+                            }
+                        }
+                    ],
+                    "locations": [
+                        {
+                            "id": "83",
+                            "gps": "28.62972640,77.37783230",
+                            "address": {
+                                "locality": "Noida",
+                                "street": "H-28",
+                                "city": "Gautam Buddh Nagar",
+                                "area_code": "201301",
+                                "state": "Uttar Pradesh"
+                            },
+                            "circle": {
+                                "gps": "28.62972640,77.37783230",
+                                "radius": {
+                                    "unit": "km",
+                                    "value": "5"
+                                }
+                            },
+                            "time": {
+                                "label": "enable",
+                                "timestamp": "2025-01-06T10:47:48.872Z",
+                                "days": "1,2,3,4,5,6,7",
+                                "schedule": {
+                                    "holidays": []
+                                },
+                                "range": {
+                                    "start": "0800",
+                                    "end": "1707"
+                                }
+                            }
+                        }
+                    ],
+                    "@ondc/org/fssai_license_no": "12345678908898",
+                    "categories": [
+                        {
+                            "id": "66zabcdefghi",
+                            "descriptor": {
+                                "name": "Cheese"
+                            },
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "custom_group"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "config",
+                                    "list": [
+                                        {
+                                            "code": "min",
+                                            "value": "1"
+                                        },
+                                        {
+                                            "code": "max",
+                                            "value": "1"
+                                        },
+                                        {
+                                            "code": "input",
+                                            "value": "select"
+                                        },
+                                        {
+                                            "code": "seq",
+                                            "value": "1"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "67zabcdefghi",
+                            "descriptor": {
+                                "name": "Non-veg toppings"
+                            },
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "custom_group"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "config",
+                                    "list": [
+                                        {
+                                            "code": "min",
+                                            "value": "1"
+                                        },
+                                        {
+                                            "code": "max",
+                                            "value": "1"
+                                        },
+                                        {
+                                            "code": "input",
+                                            "value": "select"
+                                        },
+                                        {
+                                            "code": "seq",
+                                            "value": "2"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "844147zabcde",
+                            "parent_category_id": "",
+                            "descriptor": {
+                                "name": "Pizza",
+                                "short_desc": "Pizza",
+                                "long_desc": "Pizza"
+                            },
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "custom_menu"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "display",
+                                    "list": [
+                                        {
+                                            "code": "rank",
+                                            "value": "1"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "timing",
+                                    "list": [
+                                        {
+                                            "code": "day_from",
+                                            "value": "1"
+                                        },
+                                        {
+                                            "code": "day_to",
+                                            "value": "5"
+                                        },
+                                        {
+                                            "code": "time_from",
+                                            "value": "0800"
+                                        },
+                                        {
+                                            "code": "time_to",
+                                            "value": "2200"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ],
+                    "items": [
+                        {
+                            "id": "451",
+                            "time": {
+                                "label": "enable",
+                                "timestamp": "2025-01-06T10:47:48.872Z"
+                            },
+                            "descriptor": {
+                                "name": "Pizza Mania",
+                                "symbol": "https://d3bhszwz094mhs.cloudfront.net/product_img/main_img/342/NipTw8cSUY.jpeg",
+                                "short_desc": "pizza best small",
+                                "long_desc": "best pizza",
+                                "images": [
+                                    "https://d3bhszwz094mhs.cloudfront.net/product_img/main_img/342/NipTw8cSUY.jpeg"
+                                ],
+                                "code": "1:123456789876"
+                            },
+                            "price": {
+                                "currency": "INR",
+                                "value": "99",
+                                "maximum_value": "110",
+                                "tags": [
+                                    {
+                                        "code": "range",
+                                        "list": [
+                                            {
+                                                "code": "lower",
+                                                "value": "99.00"
+                                            },
+                                            {
+                                                "code": "upper",
+                                                "value": "159"
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "code": "default_selection",
+                                        "list": [
+                                            {
+                                                "code": "value",
+                                                "value": "99.00"
+                                            },
+                                            {
+                                                "code": "maximum_value",
+                                                "value": "159"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            "quantity": {
+                                "available": {
+                                    "count": "99"
+                                },
+                                "maximum": {
+                                    "count": "99"
+                                },
+                                "unitized": {
+                                    "measure": {
+                                        "unit": "gram",
+                                        "value": "200"
+                                    }
+                                }
+                            },
+                            "location_id": "83",
+                            "category_id": "F&B",
+                            "fulfillment_id": "155",
+                            "@ondc/org/time_to_ship": "PT1H",
+                            "@ondc/org/cancellable": true,
+                            "@ondc/org/seller_pickup_return": false,
+                            "@ondc/org/returnable": false,
+                            "@ondc/org/return_window": "PT0S",
+                            "@ondc/org/available_on_cod": false,
+                            "@ondc/org/contact_details_consumer_care": "ajeet,ajeetchauhan.symfony143@webkul.in,9812345678",
+                            "tags": [
+                                {
+                                    "code": "origin",
+                                    "list": [
+                                        {
+                                            "code": "country",
+                                            "value": "IND"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "item"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "custom_group",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "66zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "category_ids": [
+                                "844147zabcde:1"
+                            ]
+                        },
+                        {
+                            "id": "93",
+                            "descriptor": {
+                                "name": "Extra"
+                            },
+                            "quantity": {
+                                "available": {
+                                    "count": "99"
+                                },
+                                "maximum": {
+                                    "count": "99"
+                                }
+                            },
+                            "price": {
+                                "currency": "INR",
+                                "value": "5.00",
+                                "maximum_value": "5.00"
+                            },
+                            "category_id": "F&B",
+                            "related": true,
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "66zabcdefghi"
+                                        },
+                                        {
+                                            "code": "default",
+                                            "value": "yes"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "veg_nonveg",
+                                    "list": [
+                                        {
+                                            "code": "veg",
+                                            "value": "yes"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "child",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "67zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "94",
+                            "descriptor": {
+                                "name": "Vegan"
+                            },
+                            "quantity": {
+                                "available": {
+                                    "count": "99"
+                                },
+                                "maximum": {
+                                    "count": "99"
+                                }
+                            },
+                            "price": {
+                                "currency": "INR",
+                                "value": "10.00",
+                                "maximum_value": "10.00"
+                            },
+                            "category_id": "F&B",
+                            "related": true,
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "66zabcdefghi"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "veg_nonveg",
+                                    "list": [
+                                        {
+                                            "code": "veg",
+                                            "value": "yes"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "child",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "67zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "95",
+                            "descriptor": {
+                                "name": "Chicken"
+                            },
+                            "quantity": {
+                                "available": {
+                                    "count": "99"
+                                },
+                                "maximum": {
+                                    "count": "99"
+                                }
+                            },
+                            "price": {
+                                "currency": "INR",
+                                "value": "10.00",
+                                "maximum_value": "10.00"
+                            },
+                            "category_id": "F&B",
+                            "related": true,
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "67zabcdefghi"
+                                        },
+                                        {
+                                            "code": "default",
+                                            "value": "yes"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "veg_nonveg",
+                                    "list": [
+                                        {
+                                            "code": "non_veg",
+                                            "value": "yes"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "96",
+                            "descriptor": {
+                                "name": "Mutton"
+                            },
+                            "quantity": {
+                                "available": {
+                                    "count": "99"
+                                },
+                                "maximum": {
+                                    "count": "99"
+                                }
+                            },
+                            "price": {
+                                "currency": "INR",
+                                "value": "50.00",
+                                "maximum_value": "50.00"
+                            },
+                            "category_id": "F&B",
+                            "related": true,
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "67zabcdefghi"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "veg_nonveg",
+                                    "list": [
+                                        {
+                                            "code": "veg",
+                                            "value": "yes"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ],
+                    "tags": [
+                        {
+                            "code": "timing",
+                            "list": [
+                                {
+                                    "code": "type",
+                                    "value": "Order"
+                                },
+                                {
+                                    "code": "location",
+                                    "value": "83"
+                                },
+                                {
+                                    "code": "day_from",
+                                    "value": "1"
+                                },
+                                {
+                                    "code": "day_to",
+                                    "value": "7"
+                                },
+                                {
+                                    "code": "time_from",
+                                    "value": "0900"
+                                },
+                                {
+                                    "code": "time_to",
+                                    "value": "2300"
+                                }
+                            ]
+                        },
+                        {
+                            "code": "timing",
+                            "list": [
+                                {
+                                    "code": "type",
+                                    "value": "Delivery"
+                                },
+                                {
+                                    "code": "location",
+                                    "value": "83"
+                                },
+                                {
+                                    "code": "day_from",
+                                    "value": "1"
+                                },
+                                {
+                                    "code": "day_to",
+                                    "value": "7"
+                                },
+                                {
+                                    "code": "time_from",
+                                    "value": "1000"
+                                },
+                                {
+                                    "code": "time_to",
+                                    "value": "2100"
+                                }
+                            ]
+                        },
+                        {
+                            "code": "serviceability",
+                            "list": [
+                                {
+                                    "code": "location",
+                                    "value": "83"
+                                },
+                                {
+                                    "code": "category",
+                                    "value": "F&B"
+                                },
+                                {
+                                    "code": "type",
+                                    "value": "10"
+                                },
+                                {
+                                    "code": "val",
+                                    "value": "5"
+                                },
+                                {
+                                    "code": "unit",
+                                    "value": "km"
+                                }
+                            ]
+                        }
+                    ],
+                    "ttl": "P1D"
+                }
+            ]
+        }
+    }
+}

--- a/eComviser/Seller App RET11/Flow-4/on_select.json
+++ b/eComviser/Seller App RET11/Flow-4/on_select.json
@@ -1,0 +1,270 @@
+{
+    "context": {
+        "domain": "ONDC:RET11",
+        "country": "IND",
+        "city": "std:0120",
+        "action": "on_select",
+        "core_version": "1.2.0",
+        "bap_id": "buyer-app-preprod-v2.ondc.org",
+        "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+        "bpp_uri": "https://ondc.ecomviser.com/api/v1",
+        "transaction_id": "0d4b4422-4561-4a23-89fd-6c98c823219b",
+        "message_id": "129c8a01-6e7d-48f8-b4c0-3ad20cf7f512",
+        "timestamp": "2025-01-06T11:45:06.956Z",
+        "bpp_id": "ondc.ecomviser.com"
+    },
+    "message": {
+        "order": {
+            "provider": {
+                "id": "84",
+                "locations": [
+                    {
+                        "id": "83"
+                    }
+                ]
+            },
+            "items": [
+                {
+                    "id": "451",
+                    "fulfillment_id": "155",
+                    "parent_item_id": "hjt9D5BeMUs/",
+                    "tags": [
+                        {
+                            "code": "type",
+                            "list": [
+                                {
+                                    "code": "type",
+                                    "value": "item"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "id": "93",
+                    "fulfillment_id": "155",
+                    "parent_item_id": "hjt9D5BeMUs/",
+                    "tags": [
+                        {
+                            "code": "type",
+                            "list": [
+                                {
+                                    "code": "type",
+                                    "value": "customization"
+                                }
+                            ]
+                        },
+                        {
+                            "code": "parent",
+                            "list": [
+                                {
+                                    "code": "id",
+                                    "value": "66zabcdefghi"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "id": "96",
+                    "fulfillment_id": "155",
+                    "parent_item_id": "hjt9D5BeMUs/",
+                    "tags": [
+                        {
+                            "code": "type",
+                            "list": [
+                                {
+                                    "code": "type",
+                                    "value": "customization"
+                                }
+                            ]
+                        },
+                        {
+                            "code": "parent",
+                            "list": [
+                                {
+                                    "code": "id",
+                                    "value": "67zabcdefghi"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "fulfillments": [
+                {
+                    "id": "155",
+                    "type": "Delivery",
+                    "@ondc/org/provider_name": "ondc.ecomviser.com",
+                    "tracking": true,
+                    "@ondc/org/category": "Immediate Delivery",
+                    "@ondc/org/TAT": "PT90M",
+                    "state": {
+                        "descriptor": {
+                            "code": "Serviceable"
+                        }
+                    }
+                }
+            ],
+            "quote": {
+                "price": {
+                    "currency": "INR",
+                    "value": "159.45"
+                },
+                "breakup": [
+                    {
+                        "title": "Pizza Mania",
+                        "price": {
+                            "currency": "INR",
+                            "value": "99"
+                        },
+                        "@ondc/org/title_type": "item",
+                        "@ondc/org/item_id": "451",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
+                        },
+                        "item": {
+                            "price": {
+                                "currency": "INR",
+                                "value": "99"
+                            },
+                            "quantity": {
+                                "available": {
+                                    "count": "99"
+                                },
+                                "maximum": {
+                                    "count": "99"
+                                }
+                            },
+                            "parent_item_id": "hjt9D5BeMUs/",
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "item"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "title": "Extra",
+                        "price": {
+                            "currency": "INR",
+                            "value": "5"
+                        },
+                        "@ondc/org/title_type": "item",
+                        "@ondc/org/item_id": "93",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
+                        },
+                        "item": {
+                            "price": {
+                                "currency": "INR",
+                                "value": "5"
+                            },
+                            "quantity": {
+                                "available": {
+                                    "count": "99"
+                                },
+                                "maximum": {
+                                    "count": "99"
+                                }
+                            },
+                            "parent_item_id": "hjt9D5BeMUs/",
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "66zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "title": "Mutton",
+                        "price": {
+                            "currency": "INR",
+                            "value": "50"
+                        },
+                        "@ondc/org/title_type": "item",
+                        "@ondc/org/item_id": "96",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
+                        },
+                        "item": {
+                            "price": {
+                                "currency": "INR",
+                                "value": "50"
+                            },
+                            "quantity": {
+                                "available": {
+                                    "count": "99"
+                                },
+                                "maximum": {
+                                    "count": "99"
+                                }
+                            },
+                            "parent_item_id": "hjt9D5BeMUs/",
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "67zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "title": "Convenience fee",
+                        "price": {
+                            "currency": "INR",
+                            "value": "5.45"
+                        },
+                        "@ondc/org/title_type": "misc",
+                        "@ondc/org/item_id": "155"
+                    },
+                    {
+                        "title": "Delivery charges",
+                        "price": {
+                            "currency": "INR",
+                            "value": "0"
+                        },
+                        "@ondc/org/title_type": "delivery",
+                        "@ondc/org/item_id": "155"
+                    }
+                ],
+                "ttl": "PT6H"
+            }
+        }
+    }
+}

--- a/eComviser/Seller App RET11/Flow-4/search.json
+++ b/eComviser/Seller App RET11/Flow-4/search.json
@@ -1,0 +1,26 @@
+{
+    "context": {
+        "domain": "ONDC:RET11",
+        "action": "search",
+        "country": "IND",
+        "city": "std:0120",
+        "core_version": "1.2.0",
+        "bap_id": "buyer-app-preprod-v2.ondc.org",
+        "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+        "transaction_id": "0646bc94-5d3d-4b2d-6325-a8a33843dbb9",
+        "message_id": "36c56392-f004-4813-ace5-0d40033a8420",
+        "timestamp": "2025-01-06T16:47:42.734Z",
+        "ttl": "PT30S"
+    },
+    "message": {
+        "intent": {
+            "fulfillment": {
+                "type": "Delivery"
+            },
+            "payment": {
+                "@ondc/org/buyer_app_finder_fee_type": "percent",
+                "@ondc/org/buyer_app_finder_fee_amount": "3"
+            }
+        }
+    }
+}

--- a/eComviser/Seller App RET11/Flow-4/select.json
+++ b/eComviser/Seller App RET11/Flow-4/select.json
@@ -1,0 +1,118 @@
+{
+    "context": {
+        "domain": "ONDC:RET11",
+        "country": "IND",
+        "city": "std:0120",
+        "action": "select",
+        "core_version": "1.2.0",
+        "bap_id": "buyer-app-preprod-v2.ondc.org",
+        "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+        "bpp_uri": "https://ondc.ecomviser.com/api/v1",
+        "transaction_id": "0d4b4422-4561-4a23-89fd-6c98c823219b",
+        "message_id": "129c8a01-6e7d-48f8-b4c0-3ad20cf7f512",
+        "timestamp": "2025-01-06T11:45:04.582Z",
+        "bpp_id": "ondc.ecomviser.com",
+        "ttl": "PT30S"
+    },
+    "message": {
+        "order": {
+            "items": [
+                {
+                    "id": "451",
+                    "quantity": {
+                        "count": 1
+                    },
+                    "location_id": "83",
+                    "tags": [
+                        {
+                            "code": "type",
+                            "list": [
+                                {
+                                    "code": "type",
+                                    "value": "item"
+                                }
+                            ]
+                        }
+                    ],
+                    "parent_item_id": "hjt9D5BeMUs/"
+                },
+                {
+                    "id": "93",
+                    "quantity": {
+                        "count": 1
+                    },
+                    "location_id": "83",
+                    "tags": [
+                        {
+                            "code": "type",
+                            "list": [
+                                {
+                                    "code": "type",
+                                    "value": "customization"
+                                }
+                            ]
+                        },
+                        {
+                            "code": "parent",
+                            "list": [
+                                {
+                                    "code": "id",
+                                    "value": "66zabcdefghi"
+                                }
+                            ]
+                        }
+                    ],
+                    "parent_item_id": "hjt9D5BeMUs/"
+                },
+                {
+                    "id": "96",
+                    "quantity": {
+                        "count": 1
+                    },
+                    "location_id": "83",
+                    "tags": [
+                        {
+                            "code": "type",
+                            "list": [
+                                {
+                                    "code": "type",
+                                    "value": "customization"
+                                }
+                            ]
+                        },
+                        {
+                            "code": "parent",
+                            "list": [
+                                {
+                                    "code": "id",
+                                    "value": "67zabcdefghi"
+                                }
+                            ]
+                        }
+                    ],
+                    "parent_item_id": "hjt9D5BeMUs/"
+                }
+            ],
+            "provider": {
+                "id": "84",
+                "locations": [
+                    {
+                        "id": "83"
+                    }
+                ]
+            },
+            "fulfillments": [
+                {
+                    "end": {
+                        "location": {
+                            "gps": "28.629743,77.377795",
+                            "address": {
+                                "area_code": "201301"
+                            }
+                        }
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/eComviser/Seller App RET11/Flow-5/confirm.json
+++ b/eComviser/Seller App RET11/Flow-5/confirm.json
@@ -1,0 +1,341 @@
+{
+    "context": {
+        "domain": "ONDC:RET11",
+        "country": "IND",
+        "city": "std:0120",
+        "action": "confirm",
+        "core_version": "1.2.0",
+        "bap_id": "buyer-app-preprod-v2.ondc.org",
+        "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+        "bpp_uri": "https://ondc.ecomviser.com/api/v1",
+        "transaction_id": "45cb5581-3284-46bc-9ee5-f46ce026af43",
+        "message_id": "2a68dd7f-1bb2-4a1e-9804-82d7788446d1",
+        "timestamp": "2025-01-07T13:49:36.442Z",
+        "bpp_id": "ondc.ecomviser.com",
+        "ttl": "PT30S"
+    },
+    "message": {
+        "order": {
+            "id": "2025-01-07-367431",
+            "state": "Created",
+            "billing": {
+                "address": {
+                    "name": "Ajeet Chauhan",
+                    "building": "ARV Park",
+                    "locality": "Unnamed Road",
+                    "city": "Noida",
+                    "state": "Uttar Pradesh",
+                    "country": "IND",
+                    "area_code": "201301"
+                },
+                "phone": "8574739650",
+                "name": "Ajeet Chauhan",
+                "email": "ajeetchauhan.symfony143@webkul.in",
+                "created_at": "2025-01-07T13:48:57.575Z",
+                "updated_at": "2025-01-07T13:48:57.575Z"
+            },
+            "items": [
+                {
+                    "id": "451",
+                    "quantity": {
+                        "count": 1
+                    },
+                    "fulfillment_id": "155",
+                    "tags": [
+                        {
+                            "code": "type",
+                            "list": [
+                                {
+                                    "code": "type",
+                                    "value": "item"
+                                }
+                            ]
+                        }
+                    ],
+                    "parent_item_id": "xXUeYhqy/JJR"
+                },
+                {
+                    "id": "93",
+                    "quantity": {
+                        "count": 1
+                    },
+                    "fulfillment_id": "155",
+                    "tags": [
+                        {
+                            "code": "type",
+                            "list": [
+                                {
+                                    "code": "type",
+                                    "value": "customization"
+                                }
+                            ]
+                        },
+                        {
+                            "code": "parent",
+                            "list": [
+                                {
+                                    "code": "id",
+                                    "value": "66zabcdefghi"
+                                }
+                            ]
+                        }
+                    ],
+                    "parent_item_id": "xXUeYhqy/JJR"
+                },
+                {
+                    "id": "95",
+                    "quantity": {
+                        "count": 1
+                    },
+                    "fulfillment_id": "155",
+                    "tags": [
+                        {
+                            "code": "type",
+                            "list": [
+                                {
+                                    "code": "type",
+                                    "value": "customization"
+                                }
+                            ]
+                        },
+                        {
+                            "code": "parent",
+                            "list": [
+                                {
+                                    "code": "id",
+                                    "value": "67zabcdefghi"
+                                }
+                            ]
+                        }
+                    ],
+                    "parent_item_id": "xXUeYhqy/JJR"
+                }
+            ],
+            "provider": {
+                "id": "84",
+                "locations": [
+                    {
+                        "id": "83"
+                    }
+                ]
+            },
+            "fulfillments": [
+                {
+                    "@ondc/org/TAT": "PT90M",
+                    "id": "155",
+                    "tracking": true,
+                    "end": {
+                        "contact": {
+                            "email": "ajeetchauhan.symfony143@webkul.in",
+                            "phone": "8574739650"
+                        },
+                        "person": {
+                            "name": "Ajeet Chauhan"
+                        },
+                        "location": {
+                            "gps": "28.629743,77.377795",
+                            "address": {
+                                "name": "Ajeet Chauhan",
+                                "building": "ARV Park",
+                                "locality": "Unnamed Road",
+                                "city": "Noida",
+                                "state": "Uttar Pradesh",
+                                "country": "IND",
+                                "area_code": "201301"
+                            }
+                        }
+                    },
+                    "type": "Delivery"
+                }
+            ],
+            "payment": {
+                "uri": "https://razorpay.com/",
+                "tl_method": "http/get",
+                "params": {
+                    "amount": "118.04",
+                    "currency": "INR",
+                    "transaction_id": "order_PgZkhFsKOgD7zY"
+                },
+                "status": "PAID",
+                "type": "ON-ORDER",
+                "collected_by": "BAP",
+                "@ondc/org/buyer_app_finder_fee_type": "percent",
+                "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+                "@ondc/org/settlement_details": [
+                    {
+                        "settlement_counterparty": "seller-app",
+                        "settlement_phase": "sale-amount",
+                        "settlement_type": "neft",
+                        "beneficiary_name": "fasdf asdfasdf",
+                        "settlement_bank_account_no": "534512341234132",
+                        "settlement_ifsc_code": "HDFC0000088",
+                        "bank_name": "fasdf",
+                        "branch_name": "noida",
+                        "settlement_status": "NOT-PAID"
+                    }
+                ]
+            },
+            "quote": {
+                "price": {
+                    "currency": "INR",
+                    "value": "118.04"
+                },
+                "breakup": [
+                    {
+                        "title": "Pizza Mania Updated",
+                        "price": {
+                            "currency": "INR",
+                            "value": "99"
+                        },
+                        "@ondc/org/title_type": "item",
+                        "@ondc/org/item_id": "451",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
+                        },
+                        "item": {
+                            "price": {
+                                "currency": "INR",
+                                "value": "99"
+                            },
+                            "parent_item_id": "xXUeYhqy/JJR",
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "item"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "title": "Extra",
+                        "price": {
+                            "currency": "INR",
+                            "value": "5"
+                        },
+                        "@ondc/org/title_type": "item",
+                        "@ondc/org/item_id": "93",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
+                        },
+                        "item": {
+                            "price": {
+                                "currency": "INR",
+                                "value": "5"
+                            },
+                            "parent_item_id": "xXUeYhqy/JJR",
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "66zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "title": "Chicken",
+                        "price": {
+                            "currency": "INR",
+                            "value": "10"
+                        },
+                        "@ondc/org/title_type": "item",
+                        "@ondc/org/item_id": "95",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
+                        },
+                        "item": {
+                            "price": {
+                                "currency": "INR",
+                                "value": "10"
+                            },
+                            "parent_item_id": "xXUeYhqy/JJR",
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "67zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "title": "Convenience fee",
+                        "price": {
+                            "currency": "INR",
+                            "value": "4.04"
+                        },
+                        "@ondc/org/title_type": "misc",
+                        "@ondc/org/item_id": "155"
+                    },
+                    {
+                        "title": "Delivery charges",
+                        "price": {
+                            "currency": "INR",
+                            "value": "0"
+                        },
+                        "@ondc/org/title_type": "delivery",
+                        "@ondc/org/item_id": "155"
+                    }
+                ],
+                "ttl": "PT6H"
+            },
+            "tags": [
+                {
+                    "code": "bpp_terms",
+                    "list": [
+                        {
+                            "code": "tax_number",
+                            "value": "09AABCW0339G3ZD"
+                        },
+                        {
+                            "code": "provider_tax_number",
+                            "value": "DERTC3376R"
+                        }
+                    ]
+                },
+                {
+                    "code": "bap_terms",
+                    "list": [
+                        {
+                            "code": "tax_number",
+                            "value": "GSTIN1234567890"
+                        }
+                    ]
+                }
+            ],
+            "created_at": "2025-01-07T13:49:36.442Z",
+            "updated_at": "2025-01-07T13:49:36.442Z"
+        }
+    }
+}

--- a/eComviser/Seller App RET11/Flow-5/flow-5_validate_report.json
+++ b/eComviser/Seller App RET11/Flow-5/flow-5_validate_report.json
@@ -1,0 +1,17 @@
+{
+    "success": false,
+    "response": {
+        "message": "Logs were not verified successfully",
+        "report": {
+            "on_search_full_catalog_refresh": {
+                "message/catalog/bpp/providers0/categories/items": "No items are mapped with the given category_id 844147zabcde in providers0/items"
+            }
+        },
+        "bpp_id": "ondc.ecomviser.com",
+        "bap_id": "buyer-app-preprod-v2.ondc.org",
+        "domain": "ONDC:RET11",
+        "reportTimestamp": "2025-01-08T13:39:59.681Z"
+    },
+    "signature": "pUZ7xScryKpa93mHmE9JbX/ntJ8GzjVX2H/R3gu69/8mUj+sDd7OT7VqB8fsSdPtqNfi/PmO600rsjWQBWKWAw==",
+    "signTimestamp": "2025-01-08T13:39:59.681Z"
+}

--- a/eComviser/Seller App RET11/Flow-5/flow-5_validate_request.json
+++ b/eComviser/Seller App RET11/Flow-5/flow-5_validate_request.json
@@ -1,0 +1,4772 @@
+{
+    "domain": "ONDC:RET11",
+    "version": "1.2.0",
+    "bap_id": "buyer-app-preprod-v2.ondc.org",
+    "bpp_id": "ondc.ecomviser.com",
+    "payload": {
+        "search_full_catalog_refresh": {
+            "context": {
+                "domain": "ONDC:RET11",
+                "action": "search",
+                "country": "IND",
+                "city": "std:0120",
+                "core_version": "1.2.0",
+                "bap_id": "buyer-app-preprod-v2.ondc.org",
+                "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+                "transaction_id": "81464ede-43ee-45a9-a77e-617a140037af",
+                "message_id": "eed481f9-1e78-4341-9c77-4f13169cc711",
+                "timestamp": "2025-01-07T19:17:41.632Z",
+                "ttl": "PT30S"
+            },
+            "message": {
+                "intent": {
+                    "fulfillment": {
+                        "type": "Delivery"
+                    },
+                    "payment": {
+                        "@ondc/org/buyer_app_finder_fee_type": "percent",
+                        "@ondc/org/buyer_app_finder_fee_amount": "3"
+                    }
+                }
+            }
+        },
+        "on_search_full_catalog_refresh": {
+            "context": {
+                "domain": "ONDC:RET11",
+                "action": "on_search",
+                "country": "IND",
+                "city": "std:0120",
+                "core_version": "1.2.0",
+                "bap_id": "buyer-app-preprod-v2.ondc.org",
+                "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+                "transaction_id": "81464ede-43ee-45a9-a77e-617a140037af",
+                "message_id": "eed481f9-1e78-4341-9c77-4f13169cc711",
+                "timestamp": "2025-01-07T13:48:11.740Z",
+                "ttl": "PT30S",
+                "bpp_id": "ondc.ecomviser.com",
+                "bpp_uri": "https://ondc.ecomviser.com/api/v1"
+            },
+            "message": {
+                "catalog": {
+                    "bpp/descriptor": {
+                        "name": "Webkul",
+                        "symbol": "https://ondc.ecomviser.com/public/img/webkul_logo.png",
+                        "short_desc": "Enterprise Digital Commerce & Marketplace Solution Experts",
+                        "long_desc": "Helping companies with our industry-leading digital commerce, ERP, and CRM solutions. In the last 13 years, we have served 150K+ clients worldwide to handle complex operations and grow their businesses",
+                        "images": [
+                            "https://ondc.ecomviser.com/public/img/webkul_banner.png",
+                            "https://ondc.ecomviser.com/public/img/webkul_clients.png",
+                            "https://ondc.ecomviser.com/public/img/webkul_awards.png"
+                        ],
+                        "tags": [
+                            {
+                                "code": "bpp_terms",
+                                "list": [
+                                    {
+                                        "code": "np_type",
+                                        "value": "MSN"
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                    "bpp/fulfillments": [
+                        {
+                            "id": "155",
+                            "type": "Delivery"
+                        }
+                    ],
+                    "bpp/providers": [
+                        {
+                            "id": "84",
+                            "time": {
+                                "label": "enable",
+                                "timestamp": "2025-01-07T13:18:11.136Z"
+                            },
+                            "descriptor": {
+                                "name": "Ajeet Food Shop",
+                                "symbol": "https://ondc-prepod-digital-delivery.s3.amazonaws.com/seller_shop_logo/84/39MylDtZVC.jpg",
+                                "short_desc": "short desc",
+                                "long_desc": "store desc",
+                                "images": [
+                                    "https://ondc-prepod-digital-delivery.s3.amazonaws.com/seller_shop_logo/84/39MylDtZVC.jpg"
+                                ]
+                            },
+                            "fulfillments": [
+                                {
+                                    "id": "155",
+                                    "type": "Delivery",
+                                    "contact": {
+                                        "phone": "9812345678",
+                                        "email": "ajeetchauhan.symfony143@webkul.in"
+                                    }
+                                }
+                            ],
+                            "locations": [
+                                {
+                                    "id": "83",
+                                    "gps": "28.62972640,77.37783230",
+                                    "address": {
+                                        "locality": "Noida",
+                                        "street": "H-28",
+                                        "city": "Gautam Buddh Nagar",
+                                        "area_code": "201301",
+                                        "state": "Uttar Pradesh"
+                                    },
+                                    "circle": {
+                                        "gps": "28.62972640,77.37783230",
+                                        "radius": {
+                                            "unit": "km",
+                                            "value": "5"
+                                        }
+                                    },
+                                    "time": {
+                                        "label": "enable",
+                                        "timestamp": "2025-01-07T13:18:11.136Z",
+                                        "days": "1,2,3,4,5,6,7",
+                                        "schedule": {
+                                            "holidays": []
+                                        },
+                                        "range": {
+                                            "start": "0800",
+                                            "end": "1707"
+                                        }
+                                    }
+                                }
+                            ],
+                            "@ondc/org/fssai_license_no": "12345678908898",
+                            "categories": [
+                                {
+                                    "id": "66zabcdefghi",
+                                    "descriptor": {
+                                        "name": "Cheese"
+                                    },
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "custom_group"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "config",
+                                            "list": [
+                                                {
+                                                    "code": "min",
+                                                    "value": "1"
+                                                },
+                                                {
+                                                    "code": "max",
+                                                    "value": "1"
+                                                },
+                                                {
+                                                    "code": "input",
+                                                    "value": "select"
+                                                },
+                                                {
+                                                    "code": "seq",
+                                                    "value": "1"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                {
+                                    "id": "67zabcdefghi",
+                                    "descriptor": {
+                                        "name": "Non-veg toppings"
+                                    },
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "custom_group"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "config",
+                                            "list": [
+                                                {
+                                                    "code": "min",
+                                                    "value": "1"
+                                                },
+                                                {
+                                                    "code": "max",
+                                                    "value": "1"
+                                                },
+                                                {
+                                                    "code": "input",
+                                                    "value": "select"
+                                                },
+                                                {
+                                                    "code": "seq",
+                                                    "value": "2"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                {
+                                    "id": "844147zabcde",
+                                    "parent_category_id": "",
+                                    "descriptor": {
+                                        "name": "Pizza",
+                                        "short_desc": "Pizza",
+                                        "long_desc": "Pizza"
+                                    },
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "custom_menu"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "display",
+                                            "list": [
+                                                {
+                                                    "code": "rank",
+                                                    "value": "1"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "timing",
+                                            "list": [
+                                                {
+                                                    "code": "day_from",
+                                                    "value": "1"
+                                                },
+                                                {
+                                                    "code": "day_to",
+                                                    "value": "5"
+                                                },
+                                                {
+                                                    "code": "time_from",
+                                                    "value": "0800"
+                                                },
+                                                {
+                                                    "code": "time_to",
+                                                    "value": "2200"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ],
+                            "items": [
+                                {
+                                    "id": "451",
+                                    "time": {
+                                        "label": "enable",
+                                        "timestamp": "2025-01-07T13:18:11.136Z"
+                                    },
+                                    "descriptor": {
+                                        "name": "Pizza Mania Updated",
+                                        "symbol": "https://d3bhszwz094mhs.cloudfront.net/product_img/main_img/342/NipTw8cSUY.jpeg",
+                                        "short_desc": "pizza best small",
+                                        "long_desc": "best pizza",
+                                        "images": [
+                                            "https://d3bhszwz094mhs.cloudfront.net/product_img/main_img/342/NipTw8cSUY.jpeg"
+                                        ],
+                                        "code": "1:123456789876"
+                                    },
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "99",
+                                        "maximum_value": "110",
+                                        "tags": [
+                                            {
+                                                "code": "range",
+                                                "list": [
+                                                    {
+                                                        "code": "lower",
+                                                        "value": "99.00"
+                                                    },
+                                                    {
+                                                        "code": "upper",
+                                                        "value": "159"
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                "code": "default_selection",
+                                                "list": [
+                                                    {
+                                                        "code": "value",
+                                                        "value": "99.00"
+                                                    },
+                                                    {
+                                                        "code": "maximum_value",
+                                                        "value": "159"
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "quantity": {
+                                        "available": {
+                                            "count": "99"
+                                        },
+                                        "maximum": {
+                                            "count": "99"
+                                        },
+                                        "unitized": {
+                                            "measure": {
+                                                "unit": "unit",
+                                                "value": "1"
+                                            }
+                                        }
+                                    },
+                                    "location_id": "83",
+                                    "category_id": "F&B",
+                                    "fulfillment_id": "155",
+                                    "@ondc/org/time_to_ship": "PT1H",
+                                    "@ondc/org/cancellable": true,
+                                    "@ondc/org/seller_pickup_return": true,
+                                    "@ondc/org/returnable": true,
+                                    "@ondc/org/return_window": "PT2H",
+                                    "@ondc/org/available_on_cod": false,
+                                    "@ondc/org/contact_details_consumer_care": "ajeet,ajeetchauhan.symfony143@webkul.in,9812345678",
+                                    "tags": [
+                                        {
+                                            "code": "origin",
+                                            "list": [
+                                                {
+                                                    "code": "country",
+                                                    "value": "IND"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "item"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "custom_group",
+                                            "list": [
+                                                {
+                                                    "code": "id",
+                                                    "value": "66zabcdefghi"
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "category_ids": [
+                                        "844147zabcde:1"
+                                    ]
+                                },
+                                {
+                                    "id": "93",
+                                    "descriptor": {
+                                        "name": "Extra"
+                                    },
+                                    "quantity": {
+                                        "available": {
+                                            "count": "99"
+                                        },
+                                        "maximum": {
+                                            "count": "99"
+                                        }
+                                    },
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "5.00",
+                                        "maximum_value": "5.00"
+                                    },
+                                    "category_id": "F&B",
+                                    "related": true,
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "customization"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "parent",
+                                            "list": [
+                                                {
+                                                    "code": "id",
+                                                    "value": "66zabcdefghi"
+                                                },
+                                                {
+                                                    "code": "default",
+                                                    "value": "yes"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "veg_nonveg",
+                                            "list": [
+                                                {
+                                                    "code": "veg",
+                                                    "value": "yes"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "child",
+                                            "list": [
+                                                {
+                                                    "code": "id",
+                                                    "value": "67zabcdefghi"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                {
+                                    "id": "94",
+                                    "descriptor": {
+                                        "name": "Vegan"
+                                    },
+                                    "quantity": {
+                                        "available": {
+                                            "count": "99"
+                                        },
+                                        "maximum": {
+                                            "count": "99"
+                                        }
+                                    },
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "10.00",
+                                        "maximum_value": "10.00"
+                                    },
+                                    "category_id": "F&B",
+                                    "related": true,
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "customization"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "parent",
+                                            "list": [
+                                                {
+                                                    "code": "id",
+                                                    "value": "66zabcdefghi"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "veg_nonveg",
+                                            "list": [
+                                                {
+                                                    "code": "veg",
+                                                    "value": "yes"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "child",
+                                            "list": [
+                                                {
+                                                    "code": "id",
+                                                    "value": "67zabcdefghi"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                {
+                                    "id": "95",
+                                    "descriptor": {
+                                        "name": "Chicken"
+                                    },
+                                    "quantity": {
+                                        "available": {
+                                            "count": "99"
+                                        },
+                                        "maximum": {
+                                            "count": "99"
+                                        }
+                                    },
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "10.00",
+                                        "maximum_value": "10.00"
+                                    },
+                                    "category_id": "F&B",
+                                    "related": true,
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "customization"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "parent",
+                                            "list": [
+                                                {
+                                                    "code": "id",
+                                                    "value": "67zabcdefghi"
+                                                },
+                                                {
+                                                    "code": "default",
+                                                    "value": "yes"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "veg_nonveg",
+                                            "list": [
+                                                {
+                                                    "code": "non_veg",
+                                                    "value": "yes"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                {
+                                    "id": "96",
+                                    "descriptor": {
+                                        "name": "Mutton"
+                                    },
+                                    "quantity": {
+                                        "available": {
+                                            "count": "99"
+                                        },
+                                        "maximum": {
+                                            "count": "99"
+                                        }
+                                    },
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "50.00",
+                                        "maximum_value": "50.00"
+                                    },
+                                    "category_id": "F&B",
+                                    "related": true,
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "customization"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "parent",
+                                            "list": [
+                                                {
+                                                    "code": "id",
+                                                    "value": "67zabcdefghi"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "veg_nonveg",
+                                            "list": [
+                                                {
+                                                    "code": "veg",
+                                                    "value": "yes"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ],
+                            "tags": [
+                                {
+                                    "code": "timing",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "Order"
+                                        },
+                                        {
+                                            "code": "location",
+                                            "value": "83"
+                                        },
+                                        {
+                                            "code": "day_from",
+                                            "value": "1"
+                                        },
+                                        {
+                                            "code": "day_to",
+                                            "value": "7"
+                                        },
+                                        {
+                                            "code": "time_from",
+                                            "value": "0900"
+                                        },
+                                        {
+                                            "code": "time_to",
+                                            "value": "2300"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "timing",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "Delivery"
+                                        },
+                                        {
+                                            "code": "location",
+                                            "value": "83"
+                                        },
+                                        {
+                                            "code": "day_from",
+                                            "value": "1"
+                                        },
+                                        {
+                                            "code": "day_to",
+                                            "value": "7"
+                                        },
+                                        {
+                                            "code": "time_from",
+                                            "value": "1000"
+                                        },
+                                        {
+                                            "code": "time_to",
+                                            "value": "2100"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "serviceability",
+                                    "list": [
+                                        {
+                                            "code": "location",
+                                            "value": "83"
+                                        },
+                                        {
+                                            "code": "category",
+                                            "value": "F&B"
+                                        },
+                                        {
+                                            "code": "type",
+                                            "value": "10"
+                                        },
+                                        {
+                                            "code": "val",
+                                            "value": "5"
+                                        },
+                                        {
+                                            "code": "unit",
+                                            "value": "km"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "ttl": "P1D"
+                        }
+                    ]
+                }
+            }
+        },
+        "select": {
+            "context": {
+                "domain": "ONDC:RET11",
+                "country": "IND",
+                "city": "std:0120",
+                "action": "select",
+                "core_version": "1.2.0",
+                "bap_id": "buyer-app-preprod-v2.ondc.org",
+                "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+                "bpp_uri": "https://ondc.ecomviser.com/api/v1",
+                "transaction_id": "45cb5581-3284-46bc-9ee5-f46ce026af43",
+                "message_id": "e7f8a941-a40b-4e44-b289-ce2ba1e1ed72",
+                "timestamp": "2025-01-07T13:48:39.526Z",
+                "bpp_id": "ondc.ecomviser.com",
+                "ttl": "PT30S"
+            },
+            "message": {
+                "order": {
+                    "items": [
+                        {
+                            "id": "451",
+                            "quantity": {
+                                "count": 1
+                            },
+                            "location_id": "83",
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "item"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "parent_item_id": "xXUeYhqy/JJR"
+                        },
+                        {
+                            "id": "93",
+                            "quantity": {
+                                "count": 1
+                            },
+                            "location_id": "83",
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "66zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "parent_item_id": "xXUeYhqy/JJR"
+                        },
+                        {
+                            "id": "95",
+                            "quantity": {
+                                "count": 1
+                            },
+                            "location_id": "83",
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "67zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "parent_item_id": "xXUeYhqy/JJR"
+                        }
+                    ],
+                    "provider": {
+                        "id": "84",
+                        "locations": [
+                            {
+                                "id": "83"
+                            }
+                        ]
+                    },
+                    "fulfillments": [
+                        {
+                            "end": {
+                                "location": {
+                                    "gps": "28.629743,77.377795",
+                                    "address": {
+                                        "area_code": "201301"
+                                    }
+                                }
+                            }
+                        }
+                    ]
+                }
+            }
+        },
+        "on_select": {
+            "context": {
+                "domain": "ONDC:RET11",
+                "country": "IND",
+                "city": "std:0120",
+                "action": "on_select",
+                "core_version": "1.2.0",
+                "bap_id": "buyer-app-preprod-v2.ondc.org",
+                "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+                "bpp_uri": "https://ondc.ecomviser.com/api/v1",
+                "transaction_id": "45cb5581-3284-46bc-9ee5-f46ce026af43",
+                "message_id": "e7f8a941-a40b-4e44-b289-ce2ba1e1ed72",
+                "timestamp": "2025-01-07T13:48:43.028Z",
+                "bpp_id": "ondc.ecomviser.com"
+            },
+            "message": {
+                "order": {
+                    "provider": {
+                        "id": "84",
+                        "locations": [
+                            {
+                                "id": "83"
+                            }
+                        ]
+                    },
+                    "items": [
+                        {
+                            "id": "451",
+                            "fulfillment_id": "155",
+                            "parent_item_id": "xXUeYhqy/JJR",
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "item"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "93",
+                            "fulfillment_id": "155",
+                            "parent_item_id": "xXUeYhqy/JJR",
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "66zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "95",
+                            "fulfillment_id": "155",
+                            "parent_item_id": "xXUeYhqy/JJR",
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "67zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ],
+                    "fulfillments": [
+                        {
+                            "id": "155",
+                            "type": "Delivery",
+                            "@ondc/org/provider_name": "ondc.ecomviser.com",
+                            "tracking": true,
+                            "@ondc/org/category": "Immediate Delivery",
+                            "@ondc/org/TAT": "PT90M",
+                            "state": {
+                                "descriptor": {
+                                    "code": "Serviceable"
+                                }
+                            }
+                        }
+                    ],
+                    "quote": {
+                        "price": {
+                            "currency": "INR",
+                            "value": "118.04"
+                        },
+                        "breakup": [
+                            {
+                                "title": "Pizza Mania Updated",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "99"
+                                },
+                                "@ondc/org/title_type": "item",
+                                "@ondc/org/item_id": "451",
+                                "@ondc/org/item_quantity": {
+                                    "count": 1
+                                },
+                                "item": {
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "99"
+                                    },
+                                    "quantity": {
+                                        "available": {
+                                            "count": "99"
+                                        },
+                                        "maximum": {
+                                            "count": "99"
+                                        }
+                                    },
+                                    "parent_item_id": "xXUeYhqy/JJR",
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "item"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "title": "Extra",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "5"
+                                },
+                                "@ondc/org/title_type": "item",
+                                "@ondc/org/item_id": "93",
+                                "@ondc/org/item_quantity": {
+                                    "count": 1
+                                },
+                                "item": {
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "5"
+                                    },
+                                    "quantity": {
+                                        "available": {
+                                            "count": "99"
+                                        },
+                                        "maximum": {
+                                            "count": "99"
+                                        }
+                                    },
+                                    "parent_item_id": "xXUeYhqy/JJR",
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "customization"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "parent",
+                                            "list": [
+                                                {
+                                                    "code": "id",
+                                                    "value": "66zabcdefghi"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "title": "Chicken",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "10"
+                                },
+                                "@ondc/org/title_type": "item",
+                                "@ondc/org/item_id": "95",
+                                "@ondc/org/item_quantity": {
+                                    "count": 1
+                                },
+                                "item": {
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "10"
+                                    },
+                                    "quantity": {
+                                        "available": {
+                                            "count": "99"
+                                        },
+                                        "maximum": {
+                                            "count": "99"
+                                        }
+                                    },
+                                    "parent_item_id": "xXUeYhqy/JJR",
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "customization"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "parent",
+                                            "list": [
+                                                {
+                                                    "code": "id",
+                                                    "value": "67zabcdefghi"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "title": "Convenience fee",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "4.04"
+                                },
+                                "@ondc/org/title_type": "misc",
+                                "@ondc/org/item_id": "155"
+                            },
+                            {
+                                "title": "Delivery charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "0"
+                                },
+                                "@ondc/org/title_type": "delivery",
+                                "@ondc/org/item_id": "155"
+                            }
+                        ],
+                        "ttl": "PT6H"
+                    }
+                }
+            }
+        },
+        "init": {
+            "context": {
+                "domain": "ONDC:RET11",
+                "country": "IND",
+                "city": "std:0120",
+                "action": "init",
+                "core_version": "1.2.0",
+                "bap_id": "buyer-app-preprod-v2.ondc.org",
+                "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+                "bpp_uri": "https://ondc.ecomviser.com/api/v1",
+                "transaction_id": "45cb5581-3284-46bc-9ee5-f46ce026af43",
+                "message_id": "4cd748df-104c-4edf-bf41-fa5b15073ad6",
+                "timestamp": "2025-01-07T13:48:57.575Z",
+                "bpp_id": "ondc.ecomviser.com",
+                "ttl": "PT30S"
+            },
+            "message": {
+                "order": {
+                    "provider": {
+                        "id": "84",
+                        "locations": [
+                            {
+                                "id": "83"
+                            }
+                        ]
+                    },
+                    "items": [
+                        {
+                            "id": "451",
+                            "quantity": {
+                                "count": 1
+                            },
+                            "location_id": "83",
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "item"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "parent_item_id": "xXUeYhqy/JJR",
+                            "fulfillment_id": "155"
+                        },
+                        {
+                            "id": "93",
+                            "quantity": {
+                                "count": 1
+                            },
+                            "location_id": "83",
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "66zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "fulfillment_id": "155",
+                            "parent_item_id": "xXUeYhqy/JJR"
+                        },
+                        {
+                            "id": "95",
+                            "quantity": {
+                                "count": 1
+                            },
+                            "location_id": "83",
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "67zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "fulfillment_id": "155",
+                            "parent_item_id": "xXUeYhqy/JJR"
+                        }
+                    ],
+                    "billing": {
+                        "address": {
+                            "building": "ARV Park",
+                            "city": "Noida",
+                            "state": "Uttar Pradesh",
+                            "country": "IND",
+                            "area_code": "201301",
+                            "locality": "Unnamed Road",
+                            "name": "Ajeet Chauhan"
+                        },
+                        "phone": "8574739650",
+                        "name": "Ajeet Chauhan",
+                        "email": "ajeetchauhan.symfony143@webkul.in",
+                        "created_at": "2025-01-07T13:48:57.575Z",
+                        "updated_at": "2025-01-07T13:48:57.575Z"
+                    },
+                    "fulfillments": [
+                        {
+                            "id": "155",
+                            "type": "Delivery",
+                            "end": {
+                                "contact": {
+                                    "email": "ajeetchauhan.symfony143@webkul.in",
+                                    "phone": "8574739650"
+                                },
+                                "location": {
+                                    "gps": "28.629743,77.377795",
+                                    "address": {
+                                        "building": "ARV Park",
+                                        "city": "Noida",
+                                        "state": "Uttar Pradesh",
+                                        "country": "IND",
+                                        "area_code": "201301",
+                                        "locality": "Unnamed Road",
+                                        "name": "Ajeet Chauhan"
+                                    }
+                                }
+                            }
+                        }
+                    ]
+                }
+            }
+        },
+        "on_init": {
+            "context": {
+                "domain": "ONDC:RET11",
+                "country": "IND",
+                "city": "std:0120",
+                "action": "on_init",
+                "core_version": "1.2.0",
+                "bap_id": "buyer-app-preprod-v2.ondc.org",
+                "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+                "bpp_uri": "https://ondc.ecomviser.com/api/v1",
+                "transaction_id": "45cb5581-3284-46bc-9ee5-f46ce026af43",
+                "message_id": "4cd748df-104c-4edf-bf41-fa5b15073ad6",
+                "timestamp": "2025-01-07T13:49:01.360Z",
+                "bpp_id": "ondc.ecomviser.com",
+                "ttl": "PT30S"
+            },
+            "message": {
+                "order": {
+                    "provider": {
+                        "id": "84",
+                        "locations": [
+                            {
+                                "id": "83"
+                            }
+                        ]
+                    },
+                    "items": [
+                        {
+                            "id": "451",
+                            "fulfillment_id": "155",
+                            "quantity": {
+                                "count": 1
+                            },
+                            "parent_item_id": "xXUeYhqy/JJR",
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "item"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "93",
+                            "fulfillment_id": "155",
+                            "quantity": {
+                                "count": 1
+                            },
+                            "parent_item_id": "xXUeYhqy/JJR",
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "66zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "95",
+                            "fulfillment_id": "155",
+                            "quantity": {
+                                "count": 1
+                            },
+                            "parent_item_id": "xXUeYhqy/JJR",
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "67zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ],
+                    "quote": {
+                        "price": {
+                            "currency": "INR",
+                            "value": "118.04"
+                        },
+                        "breakup": [
+                            {
+                                "title": "Pizza Mania Updated",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "99"
+                                },
+                                "@ondc/org/title_type": "item",
+                                "@ondc/org/item_id": "451",
+                                "@ondc/org/item_quantity": {
+                                    "count": 1
+                                },
+                                "item": {
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "99"
+                                    },
+                                    "parent_item_id": "xXUeYhqy/JJR",
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "item"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "title": "Extra",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "5"
+                                },
+                                "@ondc/org/title_type": "item",
+                                "@ondc/org/item_id": "93",
+                                "@ondc/org/item_quantity": {
+                                    "count": 1
+                                },
+                                "item": {
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "5"
+                                    },
+                                    "parent_item_id": "xXUeYhqy/JJR",
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "customization"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "parent",
+                                            "list": [
+                                                {
+                                                    "code": "id",
+                                                    "value": "66zabcdefghi"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "title": "Chicken",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "10"
+                                },
+                                "@ondc/org/title_type": "item",
+                                "@ondc/org/item_id": "95",
+                                "@ondc/org/item_quantity": {
+                                    "count": 1
+                                },
+                                "item": {
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "10"
+                                    },
+                                    "parent_item_id": "xXUeYhqy/JJR",
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "customization"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "parent",
+                                            "list": [
+                                                {
+                                                    "code": "id",
+                                                    "value": "67zabcdefghi"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "title": "Convenience fee",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "4.04"
+                                },
+                                "@ondc/org/title_type": "misc",
+                                "@ondc/org/item_id": "155"
+                            },
+                            {
+                                "title": "Delivery charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "0"
+                                },
+                                "@ondc/org/title_type": "delivery",
+                                "@ondc/org/item_id": "155"
+                            }
+                        ],
+                        "ttl": "PT6H"
+                    },
+                    "billing": {
+                        "address": {
+                            "building": "ARV Park",
+                            "city": "Noida",
+                            "state": "Uttar Pradesh",
+                            "country": "IND",
+                            "area_code": "201301",
+                            "locality": "Unnamed Road",
+                            "name": "Ajeet Chauhan"
+                        },
+                        "phone": "8574739650",
+                        "name": "Ajeet Chauhan",
+                        "email": "ajeetchauhan.symfony143@webkul.in",
+                        "created_at": "2025-01-07T13:48:57.575Z",
+                        "updated_at": "2025-01-07T13:48:57.575Z"
+                    },
+                    "fulfillments": [
+                        {
+                            "id": "155",
+                            "type": "Delivery",
+                            "end": {
+                                "contact": {
+                                    "email": "ajeetchauhan.symfony143@webkul.in",
+                                    "phone": "8574739650"
+                                },
+                                "location": {
+                                    "gps": "28.629743,77.377795",
+                                    "address": {
+                                        "building": "ARV Park",
+                                        "city": "Noida",
+                                        "state": "Uttar Pradesh",
+                                        "country": "IND",
+                                        "area_code": "201301",
+                                        "locality": "Unnamed Road",
+                                        "name": "Ajeet Chauhan"
+                                    }
+                                }
+                            },
+                            "tracking": true
+                        }
+                    ],
+                    "payment": {
+                        "type": "ON-ORDER",
+                        "collected_by": "BAP",
+                        "@ondc/org/collected_by_status": "Agree",
+                        "@ondc/org/buyer_app_finder_fee_type": "percent",
+                        "@ondc/org/buyer_app_finder_fee_amount": "3",
+                        "@ondc/org/settlement_details": [
+                            {
+                                "settlement_counterparty": "seller-app",
+                                "settlement_phase": "sale-amount",
+                                "settlement_type": "neft",
+                                "beneficiary_name": "fasdf asdfasdf",
+                                "settlement_bank_account_no": "534512341234132",
+                                "settlement_ifsc_code": "HDFC0000088",
+                                "bank_name": "fasdf",
+                                "branch_name": "noida",
+                                "settlement_status": "NOT-PAID"
+                            }
+                        ]
+                    },
+                    "tags": [
+                        {
+                            "code": "bpp_terms",
+                            "list": [
+                                {
+                                    "code": "tax_number",
+                                    "value": "09AABCW0339G3ZD"
+                                },
+                                {
+                                    "code": "provider_tax_number",
+                                    "value": "DERTC3376R"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        },
+        "confirm": {
+            "context": {
+                "domain": "ONDC:RET11",
+                "country": "IND",
+                "city": "std:0120",
+                "action": "confirm",
+                "core_version": "1.2.0",
+                "bap_id": "buyer-app-preprod-v2.ondc.org",
+                "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+                "bpp_uri": "https://ondc.ecomviser.com/api/v1",
+                "transaction_id": "45cb5581-3284-46bc-9ee5-f46ce026af43",
+                "message_id": "2a68dd7f-1bb2-4a1e-9804-82d7788446d1",
+                "timestamp": "2025-01-07T13:49:36.442Z",
+                "bpp_id": "ondc.ecomviser.com",
+                "ttl": "PT30S"
+            },
+            "message": {
+                "order": {
+                    "id": "2025-01-07-367431",
+                    "state": "Created",
+                    "billing": {
+                        "address": {
+                            "name": "Ajeet Chauhan",
+                            "building": "ARV Park",
+                            "locality": "Unnamed Road",
+                            "city": "Noida",
+                            "state": "Uttar Pradesh",
+                            "country": "IND",
+                            "area_code": "201301"
+                        },
+                        "phone": "8574739650",
+                        "name": "Ajeet Chauhan",
+                        "email": "ajeetchauhan.symfony143@webkul.in",
+                        "created_at": "2025-01-07T13:48:57.575Z",
+                        "updated_at": "2025-01-07T13:48:57.575Z"
+                    },
+                    "items": [
+                        {
+                            "id": "451",
+                            "quantity": {
+                                "count": 1
+                            },
+                            "fulfillment_id": "155",
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "item"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "parent_item_id": "xXUeYhqy/JJR"
+                        },
+                        {
+                            "id": "93",
+                            "quantity": {
+                                "count": 1
+                            },
+                            "fulfillment_id": "155",
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "66zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "parent_item_id": "xXUeYhqy/JJR"
+                        },
+                        {
+                            "id": "95",
+                            "quantity": {
+                                "count": 1
+                            },
+                            "fulfillment_id": "155",
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "67zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "parent_item_id": "xXUeYhqy/JJR"
+                        }
+                    ],
+                    "provider": {
+                        "id": "84",
+                        "locations": [
+                            {
+                                "id": "83"
+                            }
+                        ]
+                    },
+                    "fulfillments": [
+                        {
+                            "@ondc/org/TAT": "PT90M",
+                            "id": "155",
+                            "tracking": true,
+                            "end": {
+                                "contact": {
+                                    "email": "ajeetchauhan.symfony143@webkul.in",
+                                    "phone": "8574739650"
+                                },
+                                "person": {
+                                    "name": "Ajeet Chauhan"
+                                },
+                                "location": {
+                                    "gps": "28.629743,77.377795",
+                                    "address": {
+                                        "name": "Ajeet Chauhan",
+                                        "building": "ARV Park",
+                                        "locality": "Unnamed Road",
+                                        "city": "Noida",
+                                        "state": "Uttar Pradesh",
+                                        "country": "IND",
+                                        "area_code": "201301"
+                                    }
+                                }
+                            },
+                            "type": "Delivery"
+                        }
+                    ],
+                    "payment": {
+                        "uri": "https://razorpay.com/",
+                        "tl_method": "http/get",
+                        "params": {
+                            "amount": "118.04",
+                            "currency": "INR",
+                            "transaction_id": "order_PgZkhFsKOgD7zY"
+                        },
+                        "status": "PAID",
+                        "type": "ON-ORDER",
+                        "collected_by": "BAP",
+                        "@ondc/org/buyer_app_finder_fee_type": "percent",
+                        "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+                        "@ondc/org/settlement_details": [
+                            {
+                                "settlement_counterparty": "seller-app",
+                                "settlement_phase": "sale-amount",
+                                "settlement_type": "neft",
+                                "beneficiary_name": "fasdf asdfasdf",
+                                "settlement_bank_account_no": "534512341234132",
+                                "settlement_ifsc_code": "HDFC0000088",
+                                "bank_name": "fasdf",
+                                "branch_name": "noida",
+                                "settlement_status": "NOT-PAID"
+                            }
+                        ]
+                    },
+                    "quote": {
+                        "price": {
+                            "currency": "INR",
+                            "value": "118.04"
+                        },
+                        "breakup": [
+                            {
+                                "title": "Pizza Mania Updated",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "99"
+                                },
+                                "@ondc/org/title_type": "item",
+                                "@ondc/org/item_id": "451",
+                                "@ondc/org/item_quantity": {
+                                    "count": 1
+                                },
+                                "item": {
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "99"
+                                    },
+                                    "parent_item_id": "xXUeYhqy/JJR",
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "item"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "title": "Extra",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "5"
+                                },
+                                "@ondc/org/title_type": "item",
+                                "@ondc/org/item_id": "93",
+                                "@ondc/org/item_quantity": {
+                                    "count": 1
+                                },
+                                "item": {
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "5"
+                                    },
+                                    "parent_item_id": "xXUeYhqy/JJR",
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "customization"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "parent",
+                                            "list": [
+                                                {
+                                                    "code": "id",
+                                                    "value": "66zabcdefghi"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "title": "Chicken",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "10"
+                                },
+                                "@ondc/org/title_type": "item",
+                                "@ondc/org/item_id": "95",
+                                "@ondc/org/item_quantity": {
+                                    "count": 1
+                                },
+                                "item": {
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "10"
+                                    },
+                                    "parent_item_id": "xXUeYhqy/JJR",
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "customization"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "parent",
+                                            "list": [
+                                                {
+                                                    "code": "id",
+                                                    "value": "67zabcdefghi"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "title": "Convenience fee",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "4.04"
+                                },
+                                "@ondc/org/title_type": "misc",
+                                "@ondc/org/item_id": "155"
+                            },
+                            {
+                                "title": "Delivery charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "0"
+                                },
+                                "@ondc/org/title_type": "delivery",
+                                "@ondc/org/item_id": "155"
+                            }
+                        ],
+                        "ttl": "PT6H"
+                    },
+                    "tags": [
+                        {
+                            "code": "bpp_terms",
+                            "list": [
+                                {
+                                    "code": "tax_number",
+                                    "value": "09AABCW0339G3ZD"
+                                },
+                                {
+                                    "code": "provider_tax_number",
+                                    "value": "DERTC3376R"
+                                }
+                            ]
+                        },
+                        {
+                            "code": "bap_terms",
+                            "list": [
+                                {
+                                    "code": "tax_number",
+                                    "value": "GSTIN1234567890"
+                                }
+                            ]
+                        }
+                    ],
+                    "created_at": "2025-01-07T13:49:36.442Z",
+                    "updated_at": "2025-01-07T13:49:36.442Z"
+                }
+            }
+        },
+        "on_confirm": {
+            "context": {
+                "domain": "ONDC:RET11",
+                "country": "IND",
+                "city": "std:0120",
+                "action": "on_confirm",
+                "core_version": "1.2.0",
+                "bap_id": "buyer-app-preprod-v2.ondc.org",
+                "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+                "bpp_uri": "https://ondc.ecomviser.com/api/v1",
+                "transaction_id": "45cb5581-3284-46bc-9ee5-f46ce026af43",
+                "message_id": "2a68dd7f-1bb2-4a1e-9804-82d7788446d1",
+                "timestamp": "2025-01-07T13:49:40.282Z",
+                "bpp_id": "ondc.ecomviser.com"
+            },
+            "message": {
+                "order": {
+                    "id": "2025-01-07-367431",
+                    "state": "Created",
+                    "provider": {
+                        "id": "84",
+                        "locations": [
+                            {
+                                "id": "83"
+                            }
+                        ]
+                    },
+                    "items": [
+                        {
+                            "id": "451",
+                            "quantity": {
+                                "count": 1
+                            },
+                            "fulfillment_id": "155",
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "item"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "parent_item_id": "xXUeYhqy/JJR"
+                        },
+                        {
+                            "id": "93",
+                            "quantity": {
+                                "count": 1
+                            },
+                            "fulfillment_id": "155",
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "66zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "parent_item_id": "xXUeYhqy/JJR"
+                        },
+                        {
+                            "id": "95",
+                            "quantity": {
+                                "count": 1
+                            },
+                            "fulfillment_id": "155",
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "67zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "parent_item_id": "xXUeYhqy/JJR"
+                        }
+                    ],
+                    "billing": {
+                        "address": {
+                            "name": "Ajeet Chauhan",
+                            "building": "ARV Park",
+                            "locality": "Unnamed Road",
+                            "city": "Noida",
+                            "state": "Uttar Pradesh",
+                            "country": "IND",
+                            "area_code": "201301"
+                        },
+                        "phone": "8574739650",
+                        "name": "Ajeet Chauhan",
+                        "email": "ajeetchauhan.symfony143@webkul.in",
+                        "created_at": "2025-01-07T13:48:57.575Z",
+                        "updated_at": "2025-01-07T13:48:57.575Z"
+                    },
+                    "fulfillments": [
+                        {
+                            "@ondc/org/TAT": "PT90M",
+                            "id": "155",
+                            "tracking": true,
+                            "end": {
+                                "contact": {
+                                    "email": "ajeetchauhan.symfony143@webkul.in",
+                                    "phone": "8574739650"
+                                },
+                                "person": {
+                                    "name": "Ajeet Chauhan"
+                                },
+                                "location": {
+                                    "gps": "28.629743,77.377795",
+                                    "address": {
+                                        "name": "Ajeet Chauhan",
+                                        "building": "ARV Park",
+                                        "locality": "Unnamed Road",
+                                        "city": "Noida",
+                                        "state": "Uttar Pradesh",
+                                        "country": "IND",
+                                        "area_code": "201301"
+                                    }
+                                },
+                                "time": {
+                                    "range": {
+                                        "start": "2025-01-07T13:49:43.355Z",
+                                        "end": "2025-01-07T14:49:43.355Z"
+                                    }
+                                }
+                            },
+                            "type": "Delivery",
+                            "@ondc/org/provider_name": "ondc.ecomviser.com",
+                            "state": {
+                                "descriptor": {
+                                    "code": "Pending"
+                                }
+                            },
+                            "start": {
+                                "location": {
+                                    "id": "83",
+                                    "descriptor": {
+                                        "name": "Ajeet Food Shop"
+                                    },
+                                    "gps": "28.62972640,77.37783230",
+                                    "address": {
+                                        "locality": "Noida",
+                                        "city": "Gautam Buddh Nagar",
+                                        "area_code": "201301",
+                                        "state": "Uttar Pradesh"
+                                    }
+                                },
+                                "contact": {
+                                    "phone": "9876543210",
+                                    "email": "support@webkul.in"
+                                },
+                                "time": {
+                                    "range": {
+                                        "start": "2025-01-07T13:49:43.355Z",
+                                        "end": "2025-01-07T14:49:43.355Z"
+                                    }
+                                }
+                            }
+                        }
+                    ],
+                    "quote": {
+                        "price": {
+                            "currency": "INR",
+                            "value": "118.04"
+                        },
+                        "breakup": [
+                            {
+                                "title": "Pizza Mania Updated",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "99"
+                                },
+                                "@ondc/org/title_type": "item",
+                                "@ondc/org/item_id": "451",
+                                "@ondc/org/item_quantity": {
+                                    "count": 1
+                                },
+                                "item": {
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "99"
+                                    },
+                                    "parent_item_id": "xXUeYhqy/JJR",
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "item"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "title": "Extra",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "5"
+                                },
+                                "@ondc/org/title_type": "item",
+                                "@ondc/org/item_id": "93",
+                                "@ondc/org/item_quantity": {
+                                    "count": 1
+                                },
+                                "item": {
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "5"
+                                    },
+                                    "parent_item_id": "xXUeYhqy/JJR",
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "customization"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "parent",
+                                            "list": [
+                                                {
+                                                    "code": "id",
+                                                    "value": "66zabcdefghi"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "title": "Chicken",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "10"
+                                },
+                                "@ondc/org/title_type": "item",
+                                "@ondc/org/item_id": "95",
+                                "@ondc/org/item_quantity": {
+                                    "count": 1
+                                },
+                                "item": {
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "10"
+                                    },
+                                    "parent_item_id": "xXUeYhqy/JJR",
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "customization"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "parent",
+                                            "list": [
+                                                {
+                                                    "code": "id",
+                                                    "value": "67zabcdefghi"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "title": "Convenience fee",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "4.04"
+                                },
+                                "@ondc/org/title_type": "misc",
+                                "@ondc/org/item_id": "155"
+                            },
+                            {
+                                "title": "Delivery charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "0"
+                                },
+                                "@ondc/org/title_type": "delivery",
+                                "@ondc/org/item_id": "155"
+                            }
+                        ],
+                        "ttl": "PT6H"
+                    },
+                    "payment": {
+                        "uri": "https://razorpay.com/",
+                        "tl_method": "http/get",
+                        "params": {
+                            "amount": "118.04",
+                            "currency": "INR",
+                            "transaction_id": "order_PgZkhFsKOgD7zY"
+                        },
+                        "status": "PAID",
+                        "type": "ON-ORDER",
+                        "collected_by": "BAP",
+                        "@ondc/org/buyer_app_finder_fee_type": "percent",
+                        "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+                        "@ondc/org/settlement_details": [
+                            {
+                                "settlement_counterparty": "seller-app",
+                                "settlement_phase": "sale-amount",
+                                "settlement_type": "neft",
+                                "beneficiary_name": "fasdf asdfasdf",
+                                "settlement_bank_account_no": "534512341234132",
+                                "settlement_ifsc_code": "HDFC0000088",
+                                "bank_name": "fasdf",
+                                "branch_name": "noida",
+                                "settlement_status": "NOT-PAID"
+                            }
+                        ]
+                    },
+                    "tags": [
+                        {
+                            "code": "bpp_terms",
+                            "list": [
+                                {
+                                    "code": "np_type",
+                                    "value": "MSN"
+                                },
+                                {
+                                    "code": "tax_number",
+                                    "value": "09AABCW0339G3ZD"
+                                },
+                                {
+                                    "code": "provider_tax_number",
+                                    "value": "DERTC3376R"
+                                }
+                            ]
+                        },
+                        {
+                            "code": "bap_terms",
+                            "list": [
+                                {
+                                    "code": "tax_number",
+                                    "value": "GSTIN1234567890"
+                                }
+                            ]
+                        }
+                    ],
+                    "created_at": "2025-01-07T13:49:36.442Z",
+                    "updated_at": "2025-01-07T13:49:40.282Z"
+                }
+            }
+        },
+        "on_status_pending": {
+            "context": {
+                "domain": "ONDC:RET11",
+                "country": "IND",
+                "city": "std:0120",
+                "action": "on_status",
+                "core_version": "1.2.0",
+                "bap_id": "buyer-app-preprod-v2.ondc.org",
+                "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+                "bpp_uri": "https://ondc.ecomviser.com/api/v1",
+                "transaction_id": "45cb5581-3284-46bc-9ee5-f46ce026af43",
+                "message_id": "677d3114ede0c3878aa05-dbcc",
+                "timestamp": "2025-01-07T13:50:12.974Z",
+                "bpp_id": "ondc.ecomviser.com",
+                "ttl": "PT30S"
+            },
+            "message": {
+                "order": {
+                    "id": "2025-01-07-367431",
+                    "state": "Accepted",
+                    "provider": {
+                        "id": "84",
+                        "locations": [
+                            {
+                                "id": "83"
+                            }
+                        ]
+                    },
+                    "items": [
+                        {
+                            "id": "451",
+                            "fulfillment_id": "155",
+                            "quantity": {
+                                "count": 1
+                            }
+                        }
+                    ],
+                    "fulfillments": [
+                        {
+                            "id": "155",
+                            "end": {
+                                "time": {
+                                    "range": {
+                                        "end": "2025-01-07T14:49:43.355Z",
+                                        "start": "2025-01-07T13:49:43.355Z"
+                                    }
+                                },
+                                "person": {
+                                    "name": "Ajeet Chauhan"
+                                },
+                                "contact": {
+                                    "email": "ajeetchauhan.symfony143@webkul.in",
+                                    "phone": "8574739650"
+                                },
+                                "location": {
+                                    "gps": "28.629743,77.377795",
+                                    "address": {
+                                        "city": "Noida",
+                                        "name": "Ajeet Chauhan",
+                                        "state": "Uttar Pradesh",
+                                        "country": "IND",
+                                        "building": "ARV Park",
+                                        "locality": "Unnamed Road",
+                                        "area_code": "201301"
+                                    }
+                                }
+                            },
+                            "type": "Delivery",
+                            "start": {
+                                "time": {
+                                    "range": {
+                                        "end": "2025-01-07T14:49:43.355Z",
+                                        "start": "2025-01-07T13:49:43.355Z"
+                                    }
+                                },
+                                "contact": {
+                                    "email": "support@webkul.in",
+                                    "phone": "9876543210"
+                                },
+                                "location": {
+                                    "id": "83",
+                                    "gps": "28.62972640,77.37783230",
+                                    "address": {
+                                        "city": "Gautam Buddh Nagar",
+                                        "state": "Uttar Pradesh",
+                                        "locality": "Noida",
+                                        "area_code": "201301"
+                                    },
+                                    "descriptor": {
+                                        "name": "Ajeet Food Shop"
+                                    }
+                                }
+                            },
+                            "state": {
+                                "descriptor": {
+                                    "code": "Pending"
+                                }
+                            },
+                            "tracking": true,
+                            "@ondc/org/TAT": "PT90M",
+                            "@ondc/org/provider_name": "ondc.ecomviser.com"
+                        }
+                    ],
+                    "quote": {
+                        "ttl": "PT6H",
+                        "price": {
+                            "value": "118.04",
+                            "currency": "INR"
+                        },
+                        "breakup": [
+                            {
+                                "item": {
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "item"
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "price": {
+                                        "value": "99",
+                                        "currency": "INR"
+                                    },
+                                    "parent_item_id": "xXUeYhqy/JJR"
+                                },
+                                "price": {
+                                    "value": "99",
+                                    "currency": "INR"
+                                },
+                                "title": "Pizza Mania Updated",
+                                "@ondc/org/item_id": "451",
+                                "@ondc/org/title_type": "item",
+                                "@ondc/org/item_quantity": {
+                                    "count": 1
+                                }
+                            },
+                            {
+                                "item": {
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "customization"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "parent",
+                                            "list": [
+                                                {
+                                                    "code": "id",
+                                                    "value": "66zabcdefghi"
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "price": {
+                                        "value": "5",
+                                        "currency": "INR"
+                                    },
+                                    "parent_item_id": "xXUeYhqy/JJR"
+                                },
+                                "price": {
+                                    "value": "5",
+                                    "currency": "INR"
+                                },
+                                "title": "Extra",
+                                "@ondc/org/item_id": "93",
+                                "@ondc/org/title_type": "item",
+                                "@ondc/org/item_quantity": {
+                                    "count": 1
+                                }
+                            },
+                            {
+                                "item": {
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "customization"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "parent",
+                                            "list": [
+                                                {
+                                                    "code": "id",
+                                                    "value": "67zabcdefghi"
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "price": {
+                                        "value": "10",
+                                        "currency": "INR"
+                                    },
+                                    "parent_item_id": "xXUeYhqy/JJR"
+                                },
+                                "price": {
+                                    "value": "10",
+                                    "currency": "INR"
+                                },
+                                "title": "Chicken",
+                                "@ondc/org/item_id": "95",
+                                "@ondc/org/title_type": "item",
+                                "@ondc/org/item_quantity": {
+                                    "count": 1
+                                }
+                            },
+                            {
+                                "price": {
+                                    "value": "4.04",
+                                    "currency": "INR"
+                                },
+                                "title": "Convenience fee",
+                                "@ondc/org/item_id": "155",
+                                "@ondc/org/title_type": "misc"
+                            },
+                            {
+                                "price": {
+                                    "value": "0",
+                                    "currency": "INR"
+                                },
+                                "title": "Delivery charges",
+                                "@ondc/org/item_id": "155",
+                                "@ondc/org/title_type": "delivery"
+                            }
+                        ]
+                    },
+                    "billing": {
+                        "name": "Ajeet Chauhan",
+                        "email": "ajeetchauhan.symfony143@webkul.in",
+                        "phone": "8574739650",
+                        "address": {
+                            "city": "Noida",
+                            "name": "Ajeet Chauhan",
+                            "state": "Uttar Pradesh",
+                            "country": "IND",
+                            "building": "ARV Park",
+                            "locality": "Unnamed Road",
+                            "area_code": "201301"
+                        },
+                        "created_at": "2025-01-07T13:48:57.575Z",
+                        "updated_at": "2025-01-07T13:48:57.575Z"
+                    },
+                    "payment": {
+                        "uri": "https://razorpay.com/",
+                        "type": "ON-ORDER",
+                        "params": {
+                            "amount": "118.04",
+                            "currency": "INR",
+                            "transaction_id": "order_PgZkhFsKOgD7zY"
+                        },
+                        "status": "PAID",
+                        "tl_method": "http/get",
+                        "collected_by": "BAP",
+                        "@ondc/org/settlement_details": [
+                            {
+                                "bank_name": "fasdf",
+                                "branch_name": "noida",
+                                "settlement_type": "neft",
+                                "beneficiary_name": "fasdf asdfasdf",
+                                "settlement_phase": "sale-amount",
+                                "settlement_status": "NOT-PAID",
+                                "settlement_ifsc_code": "HDFC0000088",
+                                "settlement_counterparty": "seller-app",
+                                "settlement_bank_account_no": "534512341234132"
+                            }
+                        ],
+                        "@ondc/org/buyer_app_finder_fee_type": "percent",
+                        "@ondc/org/buyer_app_finder_fee_amount": "3.0"
+                    },
+                    "created_at": "2025-01-07T13:49:36.442Z",
+                    "updated_at": "2025-01-07T13:50:12.974Z"
+                }
+            }
+        },
+        "on_status_packed": {
+            "context": {
+                "domain": "ONDC:RET11",
+                "country": "IND",
+                "city": "std:0120",
+                "action": "on_status",
+                "core_version": "1.2.0",
+                "bap_id": "buyer-app-preprod-v2.ondc.org",
+                "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+                "bpp_uri": "https://ondc.ecomviser.com/api/v1",
+                "transaction_id": "45cb5581-3284-46bc-9ee5-f46ce026af43",
+                "message_id": "677d3128578de70276196-7bbe",
+                "timestamp": "2025-01-07T13:50:32.359Z",
+                "bpp_id": "ondc.ecomviser.com",
+                "ttl": "PT30S"
+            },
+            "message": {
+                "order": {
+                    "id": "2025-01-07-367431",
+                    "state": "In-progress",
+                    "provider": {
+                        "id": "84",
+                        "locations": [
+                            {
+                                "id": "83"
+                            }
+                        ]
+                    },
+                    "items": [
+                        {
+                            "id": "451",
+                            "fulfillment_id": "155",
+                            "quantity": {
+                                "count": 1
+                            }
+                        }
+                    ],
+                    "fulfillments": [
+                        {
+                            "id": "155",
+                            "end": {
+                                "time": {
+                                    "range": {
+                                        "end": "2025-01-07T14:49:43.355Z",
+                                        "start": "2025-01-07T13:49:43.355Z"
+                                    }
+                                },
+                                "person": {
+                                    "name": "Ajeet Chauhan"
+                                },
+                                "contact": {
+                                    "email": "ajeetchauhan.symfony143@webkul.in",
+                                    "phone": "8574739650"
+                                },
+                                "location": {
+                                    "gps": "28.629743,77.377795",
+                                    "address": {
+                                        "city": "Noida",
+                                        "name": "Ajeet Chauhan",
+                                        "state": "Uttar Pradesh",
+                                        "country": "IND",
+                                        "building": "ARV Park",
+                                        "locality": "Unnamed Road",
+                                        "area_code": "201301"
+                                    }
+                                }
+                            },
+                            "type": "Delivery",
+                            "start": {
+                                "time": {
+                                    "range": {
+                                        "end": "2025-01-07T14:49:43.355Z",
+                                        "start": "2025-01-07T13:49:43.355Z"
+                                    }
+                                },
+                                "contact": {
+                                    "email": "support@webkul.in",
+                                    "phone": "9876543210"
+                                },
+                                "location": {
+                                    "id": "83",
+                                    "gps": "28.62972640,77.37783230",
+                                    "address": {
+                                        "city": "Gautam Buddh Nagar",
+                                        "state": "Uttar Pradesh",
+                                        "locality": "Noida",
+                                        "area_code": "201301"
+                                    },
+                                    "descriptor": {
+                                        "name": "Ajeet Food Shop"
+                                    }
+                                }
+                            },
+                            "state": {
+                                "descriptor": {
+                                    "code": "Packed"
+                                }
+                            },
+                            "tracking": true,
+                            "@ondc/org/TAT": "PT90M",
+                            "@ondc/org/provider_name": "ondc.ecomviser.com"
+                        }
+                    ],
+                    "quote": {
+                        "ttl": "PT6H",
+                        "price": {
+                            "value": "118.04",
+                            "currency": "INR"
+                        },
+                        "breakup": [
+                            {
+                                "item": {
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "item"
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "price": {
+                                        "value": "99",
+                                        "currency": "INR"
+                                    },
+                                    "parent_item_id": "xXUeYhqy/JJR"
+                                },
+                                "price": {
+                                    "value": "99",
+                                    "currency": "INR"
+                                },
+                                "title": "Pizza Mania Updated",
+                                "@ondc/org/item_id": "451",
+                                "@ondc/org/title_type": "item",
+                                "@ondc/org/item_quantity": {
+                                    "count": 1
+                                }
+                            },
+                            {
+                                "item": {
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "customization"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "parent",
+                                            "list": [
+                                                {
+                                                    "code": "id",
+                                                    "value": "66zabcdefghi"
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "price": {
+                                        "value": "5",
+                                        "currency": "INR"
+                                    },
+                                    "parent_item_id": "xXUeYhqy/JJR"
+                                },
+                                "price": {
+                                    "value": "5",
+                                    "currency": "INR"
+                                },
+                                "title": "Extra",
+                                "@ondc/org/item_id": "93",
+                                "@ondc/org/title_type": "item",
+                                "@ondc/org/item_quantity": {
+                                    "count": 1
+                                }
+                            },
+                            {
+                                "item": {
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "customization"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "parent",
+                                            "list": [
+                                                {
+                                                    "code": "id",
+                                                    "value": "67zabcdefghi"
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "price": {
+                                        "value": "10",
+                                        "currency": "INR"
+                                    },
+                                    "parent_item_id": "xXUeYhqy/JJR"
+                                },
+                                "price": {
+                                    "value": "10",
+                                    "currency": "INR"
+                                },
+                                "title": "Chicken",
+                                "@ondc/org/item_id": "95",
+                                "@ondc/org/title_type": "item",
+                                "@ondc/org/item_quantity": {
+                                    "count": 1
+                                }
+                            },
+                            {
+                                "price": {
+                                    "value": "4.04",
+                                    "currency": "INR"
+                                },
+                                "title": "Convenience fee",
+                                "@ondc/org/item_id": "155",
+                                "@ondc/org/title_type": "misc"
+                            },
+                            {
+                                "price": {
+                                    "value": "0",
+                                    "currency": "INR"
+                                },
+                                "title": "Delivery charges",
+                                "@ondc/org/item_id": "155",
+                                "@ondc/org/title_type": "delivery"
+                            }
+                        ]
+                    },
+                    "billing": {
+                        "name": "Ajeet Chauhan",
+                        "email": "ajeetchauhan.symfony143@webkul.in",
+                        "phone": "8574739650",
+                        "address": {
+                            "city": "Noida",
+                            "name": "Ajeet Chauhan",
+                            "state": "Uttar Pradesh",
+                            "country": "IND",
+                            "building": "ARV Park",
+                            "locality": "Unnamed Road",
+                            "area_code": "201301"
+                        },
+                        "created_at": "2025-01-07T13:48:57.575Z",
+                        "updated_at": "2025-01-07T13:48:57.575Z"
+                    },
+                    "payment": {
+                        "uri": "https://razorpay.com/",
+                        "type": "ON-ORDER",
+                        "params": {
+                            "amount": "118.04",
+                            "currency": "INR",
+                            "transaction_id": "order_PgZkhFsKOgD7zY"
+                        },
+                        "status": "PAID",
+                        "tl_method": "http/get",
+                        "collected_by": "BAP",
+                        "@ondc/org/settlement_details": [
+                            {
+                                "bank_name": "fasdf",
+                                "branch_name": "noida",
+                                "settlement_type": "neft",
+                                "beneficiary_name": "fasdf asdfasdf",
+                                "settlement_phase": "sale-amount",
+                                "settlement_status": "NOT-PAID",
+                                "settlement_ifsc_code": "HDFC0000088",
+                                "settlement_counterparty": "seller-app",
+                                "settlement_bank_account_no": "534512341234132"
+                            }
+                        ],
+                        "@ondc/org/buyer_app_finder_fee_type": "percent",
+                        "@ondc/org/buyer_app_finder_fee_amount": "3.0"
+                    },
+                    "created_at": "2025-01-07T13:49:36.442Z",
+                    "updated_at": "2025-01-07T13:50:32.359Z"
+                }
+            }
+        },
+        "on_status_agent_assigned": {
+            "context": {
+                "domain": "ONDC:RET11",
+                "country": "IND",
+                "city": "std:0120",
+                "action": "on_status",
+                "core_version": "1.2.0",
+                "bap_id": "buyer-app-preprod-v2.ondc.org",
+                "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+                "bpp_uri": "https://ondc.ecomviser.com/api/v1",
+                "transaction_id": "45cb5581-3284-46bc-9ee5-f46ce026af43",
+                "message_id": "677d3134789ad26df0ec0-f022",
+                "timestamp": "2025-01-07T13:50:44.494Z",
+                "bpp_id": "ondc.ecomviser.com",
+                "ttl": "PT30S"
+            },
+            "message": {
+                "order": {
+                    "id": "2025-01-07-367431",
+                    "state": "In-progress",
+                    "provider": {
+                        "id": "84",
+                        "locations": [
+                            {
+                                "id": "83"
+                            }
+                        ]
+                    },
+                    "items": [
+                        {
+                            "id": "451",
+                            "fulfillment_id": "155",
+                            "quantity": {
+                                "count": 1
+                            }
+                        }
+                    ],
+                    "fulfillments": [
+                        {
+                            "id": "155",
+                            "end": {
+                                "time": {
+                                    "range": {
+                                        "end": "2025-01-07T14:49:43.355Z",
+                                        "start": "2025-01-07T13:49:43.355Z"
+                                    }
+                                },
+                                "person": {
+                                    "name": "Ajeet Chauhan"
+                                },
+                                "contact": {
+                                    "email": "ajeetchauhan.symfony143@webkul.in",
+                                    "phone": "8574739650"
+                                },
+                                "location": {
+                                    "gps": "28.629743,77.377795",
+                                    "address": {
+                                        "city": "Noida",
+                                        "name": "Ajeet Chauhan",
+                                        "state": "Uttar Pradesh",
+                                        "country": "IND",
+                                        "building": "ARV Park",
+                                        "locality": "Unnamed Road",
+                                        "area_code": "201301"
+                                    }
+                                }
+                            },
+                            "type": "Delivery",
+                            "start": {
+                                "time": {
+                                    "range": {
+                                        "end": "2025-01-07T14:49:43.355Z",
+                                        "start": "2025-01-07T13:49:43.355Z"
+                                    }
+                                },
+                                "contact": {
+                                    "email": "support@webkul.in",
+                                    "phone": "9876543210"
+                                },
+                                "location": {
+                                    "id": "83",
+                                    "gps": "28.62972640,77.37783230",
+                                    "address": {
+                                        "city": "Gautam Buddh Nagar",
+                                        "state": "Uttar Pradesh",
+                                        "locality": "Noida",
+                                        "area_code": "201301"
+                                    },
+                                    "descriptor": {
+                                        "name": "Ajeet Food Shop"
+                                    }
+                                }
+                            },
+                            "state": {
+                                "descriptor": {
+                                    "code": "Agent-assigned"
+                                }
+                            },
+                            "tracking": true,
+                            "@ondc/org/TAT": "PT90M",
+                            "@ondc/org/provider_name": "ondc.ecomviser.com"
+                        }
+                    ],
+                    "quote": {
+                        "ttl": "PT6H",
+                        "price": {
+                            "value": "118.04",
+                            "currency": "INR"
+                        },
+                        "breakup": [
+                            {
+                                "item": {
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "item"
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "price": {
+                                        "value": "99",
+                                        "currency": "INR"
+                                    },
+                                    "parent_item_id": "xXUeYhqy/JJR"
+                                },
+                                "price": {
+                                    "value": "99",
+                                    "currency": "INR"
+                                },
+                                "title": "Pizza Mania Updated",
+                                "@ondc/org/item_id": "451",
+                                "@ondc/org/title_type": "item",
+                                "@ondc/org/item_quantity": {
+                                    "count": 1
+                                }
+                            },
+                            {
+                                "item": {
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "customization"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "parent",
+                                            "list": [
+                                                {
+                                                    "code": "id",
+                                                    "value": "66zabcdefghi"
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "price": {
+                                        "value": "5",
+                                        "currency": "INR"
+                                    },
+                                    "parent_item_id": "xXUeYhqy/JJR"
+                                },
+                                "price": {
+                                    "value": "5",
+                                    "currency": "INR"
+                                },
+                                "title": "Extra",
+                                "@ondc/org/item_id": "93",
+                                "@ondc/org/title_type": "item",
+                                "@ondc/org/item_quantity": {
+                                    "count": 1
+                                }
+                            },
+                            {
+                                "item": {
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "customization"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "parent",
+                                            "list": [
+                                                {
+                                                    "code": "id",
+                                                    "value": "67zabcdefghi"
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "price": {
+                                        "value": "10",
+                                        "currency": "INR"
+                                    },
+                                    "parent_item_id": "xXUeYhqy/JJR"
+                                },
+                                "price": {
+                                    "value": "10",
+                                    "currency": "INR"
+                                },
+                                "title": "Chicken",
+                                "@ondc/org/item_id": "95",
+                                "@ondc/org/title_type": "item",
+                                "@ondc/org/item_quantity": {
+                                    "count": 1
+                                }
+                            },
+                            {
+                                "price": {
+                                    "value": "4.04",
+                                    "currency": "INR"
+                                },
+                                "title": "Convenience fee",
+                                "@ondc/org/item_id": "155",
+                                "@ondc/org/title_type": "misc"
+                            },
+                            {
+                                "price": {
+                                    "value": "0",
+                                    "currency": "INR"
+                                },
+                                "title": "Delivery charges",
+                                "@ondc/org/item_id": "155",
+                                "@ondc/org/title_type": "delivery"
+                            }
+                        ]
+                    },
+                    "billing": {
+                        "name": "Ajeet Chauhan",
+                        "email": "ajeetchauhan.symfony143@webkul.in",
+                        "phone": "8574739650",
+                        "address": {
+                            "city": "Noida",
+                            "name": "Ajeet Chauhan",
+                            "state": "Uttar Pradesh",
+                            "country": "IND",
+                            "building": "ARV Park",
+                            "locality": "Unnamed Road",
+                            "area_code": "201301"
+                        },
+                        "created_at": "2025-01-07T13:48:57.575Z",
+                        "updated_at": "2025-01-07T13:48:57.575Z"
+                    },
+                    "payment": {
+                        "uri": "https://razorpay.com/",
+                        "type": "ON-ORDER",
+                        "params": {
+                            "amount": "118.04",
+                            "currency": "INR",
+                            "transaction_id": "order_PgZkhFsKOgD7zY"
+                        },
+                        "status": "PAID",
+                        "tl_method": "http/get",
+                        "collected_by": "BAP",
+                        "@ondc/org/settlement_details": [
+                            {
+                                "bank_name": "fasdf",
+                                "branch_name": "noida",
+                                "settlement_type": "neft",
+                                "beneficiary_name": "fasdf asdfasdf",
+                                "settlement_phase": "sale-amount",
+                                "settlement_status": "NOT-PAID",
+                                "settlement_ifsc_code": "HDFC0000088",
+                                "settlement_counterparty": "seller-app",
+                                "settlement_bank_account_no": "534512341234132"
+                            }
+                        ],
+                        "@ondc/org/buyer_app_finder_fee_type": "percent",
+                        "@ondc/org/buyer_app_finder_fee_amount": "3.0"
+                    },
+                    "created_at": "2025-01-07T13:49:36.442Z",
+                    "updated_at": "2025-01-07T13:50:44.494Z"
+                }
+            }
+        },
+        "on_status_picked": {
+            "context": {
+                "domain": "ONDC:RET11",
+                "country": "IND",
+                "city": "std:0120",
+                "action": "on_status",
+                "core_version": "1.2.0",
+                "bap_id": "buyer-app-preprod-v2.ondc.org",
+                "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+                "bpp_uri": "https://ondc.ecomviser.com/api/v1",
+                "transaction_id": "45cb5581-3284-46bc-9ee5-f46ce026af43",
+                "message_id": "677d313e1a863c1a5e8e9-e8f3",
+                "timestamp": "2025-01-07T13:50:54.109Z",
+                "bpp_id": "ondc.ecomviser.com",
+                "ttl": "PT30S"
+            },
+            "message": {
+                "order": {
+                    "id": "2025-01-07-367431",
+                    "state": "In-progress",
+                    "provider": {
+                        "id": "84",
+                        "locations": [
+                            {
+                                "id": "83"
+                            }
+                        ]
+                    },
+                    "items": [
+                        {
+                            "id": "451",
+                            "fulfillment_id": "155",
+                            "quantity": {
+                                "count": 1
+                            }
+                        }
+                    ],
+                    "fulfillments": [
+                        {
+                            "id": "155",
+                            "end": {
+                                "time": {
+                                    "range": {
+                                        "end": "2025-01-07T14:49:43.355Z",
+                                        "start": "2025-01-07T13:49:43.355Z"
+                                    }
+                                },
+                                "person": {
+                                    "name": "Ajeet Chauhan"
+                                },
+                                "contact": {
+                                    "email": "ajeetchauhan.symfony143@webkul.in",
+                                    "phone": "8574739650"
+                                },
+                                "location": {
+                                    "gps": "28.629743,77.377795",
+                                    "address": {
+                                        "city": "Noida",
+                                        "name": "Ajeet Chauhan",
+                                        "state": "Uttar Pradesh",
+                                        "country": "IND",
+                                        "building": "ARV Park",
+                                        "locality": "Unnamed Road",
+                                        "area_code": "201301"
+                                    }
+                                }
+                            },
+                            "type": "Delivery",
+                            "start": {
+                                "time": {
+                                    "range": {
+                                        "end": "2025-01-07T14:49:43.355Z",
+                                        "start": "2025-01-07T13:49:43.355Z"
+                                    },
+                                    "timestamp": "2025-01-07T13:50:53.527Z"
+                                },
+                                "contact": {
+                                    "email": "support@webkul.in",
+                                    "phone": "9876543210"
+                                },
+                                "location": {
+                                    "id": "83",
+                                    "gps": "28.62972640,77.37783230",
+                                    "address": {
+                                        "city": "Gautam Buddh Nagar",
+                                        "state": "Uttar Pradesh",
+                                        "locality": "Noida",
+                                        "area_code": "201301"
+                                    },
+                                    "descriptor": {
+                                        "name": "Ajeet Food Shop"
+                                    }
+                                },
+                                "instructions": {
+                                    "code": "2",
+                                    "name": "ONDC Order",
+                                    "short_desc": "ae34fd",
+                                    "long_desc": "additional instructions for pickup"
+                                }
+                            },
+                            "state": {
+                                "descriptor": {
+                                    "code": "Order-picked-up"
+                                }
+                            },
+                            "tracking": true,
+                            "@ondc/org/TAT": "PT90M",
+                            "@ondc/org/provider_name": "ondc.ecomviser.com",
+                            "tags": [
+                                {
+                                    "code": "routing",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "P2P"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "tracking",
+                                    "list": [
+                                        {
+                                            "code": "gps_enabled",
+                                            "value": "yes"
+                                        },
+                                        {
+                                            "code": "url_enabled",
+                                            "value": "no"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ],
+                    "quote": {
+                        "ttl": "PT6H",
+                        "price": {
+                            "value": "118.04",
+                            "currency": "INR"
+                        },
+                        "breakup": [
+                            {
+                                "item": {
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "item"
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "price": {
+                                        "value": "99",
+                                        "currency": "INR"
+                                    },
+                                    "parent_item_id": "xXUeYhqy/JJR"
+                                },
+                                "price": {
+                                    "value": "99",
+                                    "currency": "INR"
+                                },
+                                "title": "Pizza Mania Updated",
+                                "@ondc/org/item_id": "451",
+                                "@ondc/org/title_type": "item",
+                                "@ondc/org/item_quantity": {
+                                    "count": 1
+                                }
+                            },
+                            {
+                                "item": {
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "customization"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "parent",
+                                            "list": [
+                                                {
+                                                    "code": "id",
+                                                    "value": "66zabcdefghi"
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "price": {
+                                        "value": "5",
+                                        "currency": "INR"
+                                    },
+                                    "parent_item_id": "xXUeYhqy/JJR"
+                                },
+                                "price": {
+                                    "value": "5",
+                                    "currency": "INR"
+                                },
+                                "title": "Extra",
+                                "@ondc/org/item_id": "93",
+                                "@ondc/org/title_type": "item",
+                                "@ondc/org/item_quantity": {
+                                    "count": 1
+                                }
+                            },
+                            {
+                                "item": {
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "customization"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "parent",
+                                            "list": [
+                                                {
+                                                    "code": "id",
+                                                    "value": "67zabcdefghi"
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "price": {
+                                        "value": "10",
+                                        "currency": "INR"
+                                    },
+                                    "parent_item_id": "xXUeYhqy/JJR"
+                                },
+                                "price": {
+                                    "value": "10",
+                                    "currency": "INR"
+                                },
+                                "title": "Chicken",
+                                "@ondc/org/item_id": "95",
+                                "@ondc/org/title_type": "item",
+                                "@ondc/org/item_quantity": {
+                                    "count": 1
+                                }
+                            },
+                            {
+                                "price": {
+                                    "value": "4.04",
+                                    "currency": "INR"
+                                },
+                                "title": "Convenience fee",
+                                "@ondc/org/item_id": "155",
+                                "@ondc/org/title_type": "misc"
+                            },
+                            {
+                                "price": {
+                                    "value": "0",
+                                    "currency": "INR"
+                                },
+                                "title": "Delivery charges",
+                                "@ondc/org/item_id": "155",
+                                "@ondc/org/title_type": "delivery"
+                            }
+                        ]
+                    },
+                    "billing": {
+                        "name": "Ajeet Chauhan",
+                        "email": "ajeetchauhan.symfony143@webkul.in",
+                        "phone": "8574739650",
+                        "address": {
+                            "city": "Noida",
+                            "name": "Ajeet Chauhan",
+                            "state": "Uttar Pradesh",
+                            "country": "IND",
+                            "building": "ARV Park",
+                            "locality": "Unnamed Road",
+                            "area_code": "201301"
+                        },
+                        "created_at": "2025-01-07T13:48:57.575Z",
+                        "updated_at": "2025-01-07T13:48:57.575Z"
+                    },
+                    "payment": {
+                        "uri": "https://razorpay.com/",
+                        "type": "ON-ORDER",
+                        "params": {
+                            "amount": "118.04",
+                            "currency": "INR",
+                            "transaction_id": "order_PgZkhFsKOgD7zY"
+                        },
+                        "status": "PAID",
+                        "tl_method": "http/get",
+                        "collected_by": "BAP",
+                        "@ondc/org/settlement_details": [
+                            {
+                                "bank_name": "fasdf",
+                                "branch_name": "noida",
+                                "settlement_type": "neft",
+                                "beneficiary_name": "fasdf asdfasdf",
+                                "settlement_phase": "sale-amount",
+                                "settlement_status": "NOT-PAID",
+                                "settlement_ifsc_code": "HDFC0000088",
+                                "settlement_counterparty": "seller-app",
+                                "settlement_bank_account_no": "534512341234132"
+                            }
+                        ],
+                        "@ondc/org/buyer_app_finder_fee_type": "percent",
+                        "@ondc/org/buyer_app_finder_fee_amount": "3.0"
+                    },
+                    "created_at": "2025-01-07T13:49:36.442Z",
+                    "updated_at": "2025-01-07T13:50:54.109Z",
+                    "documents": [
+                        {
+                            "label": "Invoice",
+                            "url": "https://ecomviser-prepod.sp-seller-preprod.ecomviser.com/index.php?p=invoice_download&key=MTgxOjg0OmVjb212aXNlcg=="
+                        }
+                    ]
+                }
+            }
+        },
+        "on_status_out_for_delivery": {
+            "context": {
+                "domain": "ONDC:RET11",
+                "country": "IND",
+                "city": "std:0120",
+                "action": "on_status",
+                "core_version": "1.2.0",
+                "bap_id": "buyer-app-preprod-v2.ondc.org",
+                "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+                "bpp_uri": "https://ondc.ecomviser.com/api/v1",
+                "transaction_id": "45cb5581-3284-46bc-9ee5-f46ce026af43",
+                "message_id": "677d314900b3d1a93d025-5938",
+                "timestamp": "2025-01-07T13:51:05.003Z",
+                "bpp_id": "ondc.ecomviser.com",
+                "ttl": "PT30S"
+            },
+            "message": {
+                "order": {
+                    "id": "2025-01-07-367431",
+                    "state": "In-progress",
+                    "provider": {
+                        "id": "84",
+                        "locations": [
+                            {
+                                "id": "83"
+                            }
+                        ]
+                    },
+                    "items": [
+                        {
+                            "id": "451",
+                            "fulfillment_id": "155",
+                            "quantity": {
+                                "count": 1
+                            }
+                        }
+                    ],
+                    "fulfillments": [
+                        {
+                            "id": "155",
+                            "end": {
+                                "time": {
+                                    "range": {
+                                        "end": "2025-01-07T14:49:43.355Z",
+                                        "start": "2025-01-07T13:49:43.355Z"
+                                    }
+                                },
+                                "person": {
+                                    "name": "Ajeet Chauhan"
+                                },
+                                "contact": {
+                                    "email": "ajeetchauhan.symfony143@webkul.in",
+                                    "phone": "8574739650"
+                                },
+                                "location": {
+                                    "gps": "28.629743,77.377795",
+                                    "address": {
+                                        "city": "Noida",
+                                        "name": "Ajeet Chauhan",
+                                        "state": "Uttar Pradesh",
+                                        "country": "IND",
+                                        "building": "ARV Park",
+                                        "locality": "Unnamed Road",
+                                        "area_code": "201301"
+                                    }
+                                }
+                            },
+                            "type": "Delivery",
+                            "start": {
+                                "time": {
+                                    "range": {
+                                        "end": "2025-01-07T14:49:43.355Z",
+                                        "start": "2025-01-07T13:49:43.355Z"
+                                    },
+                                    "timestamp": "2025-01-07T13:50:53.527Z"
+                                },
+                                "contact": {
+                                    "email": "support@webkul.in",
+                                    "phone": "9876543210"
+                                },
+                                "location": {
+                                    "id": "83",
+                                    "gps": "28.62972640,77.37783230",
+                                    "address": {
+                                        "city": "Gautam Buddh Nagar",
+                                        "state": "Uttar Pradesh",
+                                        "locality": "Noida",
+                                        "area_code": "201301"
+                                    },
+                                    "descriptor": {
+                                        "name": "Ajeet Food Shop"
+                                    }
+                                }
+                            },
+                            "state": {
+                                "descriptor": {
+                                    "code": "Out-for-delivery"
+                                }
+                            },
+                            "tracking": true,
+                            "@ondc/org/TAT": "PT90M",
+                            "@ondc/org/provider_name": "ondc.ecomviser.com",
+                            "tags": [
+                                {
+                                    "code": "routing",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "P2P"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "tracking",
+                                    "list": [
+                                        {
+                                            "code": "gps_enabled",
+                                            "value": "yes"
+                                        },
+                                        {
+                                            "code": "url_enabled",
+                                            "value": "no"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ],
+                    "quote": {
+                        "ttl": "PT6H",
+                        "price": {
+                            "value": "118.04",
+                            "currency": "INR"
+                        },
+                        "breakup": [
+                            {
+                                "item": {
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "item"
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "price": {
+                                        "value": "99",
+                                        "currency": "INR"
+                                    },
+                                    "parent_item_id": "xXUeYhqy/JJR"
+                                },
+                                "price": {
+                                    "value": "99",
+                                    "currency": "INR"
+                                },
+                                "title": "Pizza Mania Updated",
+                                "@ondc/org/item_id": "451",
+                                "@ondc/org/title_type": "item",
+                                "@ondc/org/item_quantity": {
+                                    "count": 1
+                                }
+                            },
+                            {
+                                "item": {
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "customization"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "parent",
+                                            "list": [
+                                                {
+                                                    "code": "id",
+                                                    "value": "66zabcdefghi"
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "price": {
+                                        "value": "5",
+                                        "currency": "INR"
+                                    },
+                                    "parent_item_id": "xXUeYhqy/JJR"
+                                },
+                                "price": {
+                                    "value": "5",
+                                    "currency": "INR"
+                                },
+                                "title": "Extra",
+                                "@ondc/org/item_id": "93",
+                                "@ondc/org/title_type": "item",
+                                "@ondc/org/item_quantity": {
+                                    "count": 1
+                                }
+                            },
+                            {
+                                "item": {
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "customization"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "parent",
+                                            "list": [
+                                                {
+                                                    "code": "id",
+                                                    "value": "67zabcdefghi"
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "price": {
+                                        "value": "10",
+                                        "currency": "INR"
+                                    },
+                                    "parent_item_id": "xXUeYhqy/JJR"
+                                },
+                                "price": {
+                                    "value": "10",
+                                    "currency": "INR"
+                                },
+                                "title": "Chicken",
+                                "@ondc/org/item_id": "95",
+                                "@ondc/org/title_type": "item",
+                                "@ondc/org/item_quantity": {
+                                    "count": 1
+                                }
+                            },
+                            {
+                                "price": {
+                                    "value": "4.04",
+                                    "currency": "INR"
+                                },
+                                "title": "Convenience fee",
+                                "@ondc/org/item_id": "155",
+                                "@ondc/org/title_type": "misc"
+                            },
+                            {
+                                "price": {
+                                    "value": "0",
+                                    "currency": "INR"
+                                },
+                                "title": "Delivery charges",
+                                "@ondc/org/item_id": "155",
+                                "@ondc/org/title_type": "delivery"
+                            }
+                        ]
+                    },
+                    "billing": {
+                        "name": "Ajeet Chauhan",
+                        "email": "ajeetchauhan.symfony143@webkul.in",
+                        "phone": "8574739650",
+                        "address": {
+                            "city": "Noida",
+                            "name": "Ajeet Chauhan",
+                            "state": "Uttar Pradesh",
+                            "country": "IND",
+                            "building": "ARV Park",
+                            "locality": "Unnamed Road",
+                            "area_code": "201301"
+                        },
+                        "created_at": "2025-01-07T13:48:57.575Z",
+                        "updated_at": "2025-01-07T13:48:57.575Z"
+                    },
+                    "payment": {
+                        "uri": "https://razorpay.com/",
+                        "type": "ON-ORDER",
+                        "params": {
+                            "amount": "118.04",
+                            "currency": "INR",
+                            "transaction_id": "order_PgZkhFsKOgD7zY"
+                        },
+                        "status": "PAID",
+                        "tl_method": "http/get",
+                        "collected_by": "BAP",
+                        "@ondc/org/settlement_details": [
+                            {
+                                "bank_name": "fasdf",
+                                "branch_name": "noida",
+                                "settlement_type": "neft",
+                                "beneficiary_name": "fasdf asdfasdf",
+                                "settlement_phase": "sale-amount",
+                                "settlement_status": "NOT-PAID",
+                                "settlement_ifsc_code": "HDFC0000088",
+                                "settlement_counterparty": "seller-app",
+                                "settlement_bank_account_no": "534512341234132"
+                            }
+                        ],
+                        "@ondc/org/buyer_app_finder_fee_type": "percent",
+                        "@ondc/org/buyer_app_finder_fee_amount": "3.0"
+                    },
+                    "created_at": "2025-01-07T13:49:36.442Z",
+                    "updated_at": "2025-01-07T13:51:05.003Z",
+                    "documents": [
+                        {
+                            "label": "Invoice",
+                            "url": "https://ecomviser-prepod.sp-seller-preprod.ecomviser.com/index.php?p=invoice_download&key=MTgxOjg0OmVjb212aXNlcg=="
+                        }
+                    ]
+                }
+            }
+        },
+        "on_cancel": {
+            "context": {
+                "domain": "ONDC:RET11",
+                "country": "IND",
+                "city": "std:0120",
+                "action": "on_cancel",
+                "core_version": "1.2.0",
+                "bap_id": "buyer-app-preprod-v2.ondc.org",
+                "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+                "bpp_uri": "https://ondc.ecomviser.com/api/v1",
+                "transaction_id": "45cb5581-3284-46bc-9ee5-f46ce026af43",
+                "message_id": "677d3158858946906be14-e95c",
+                "timestamp": "2025-01-07T13:51:20.547Z",
+                "bpp_id": "ondc.ecomviser.com",
+                "ttl": "PT30S"
+            },
+            "message": {
+                "order": {
+                    "id": "2025-01-07-367431",
+                    "state": "Cancelled",
+                    "provider": {
+                        "id": "84",
+                        "locations": [
+                            {
+                                "id": "83"
+                            }
+                        ]
+                    },
+                    "items": [
+                        {
+                            "id": "451",
+                            "fulfillment_id": "155",
+                            "quantity": {
+                                "count": 0
+                            }
+                        },
+                        {
+                            "id": "93",
+                            "fulfillment_id": "155",
+                            "quantity": {
+                                "count": 0
+                            }
+                        },
+                        {
+                            "id": "95",
+                            "fulfillment_id": "155",
+                            "quantity": {
+                                "count": 0
+                            }
+                        },
+                        {
+                            "id": "451",
+                            "fulfillment_id": "rto-shipping",
+                            "quantity": {
+                                "count": 1
+                            }
+                        },
+                        {
+                            "id": "93",
+                            "fulfillment_id": "rto-shipping",
+                            "quantity": {
+                                "count": 1
+                            }
+                        },
+                        {
+                            "id": "95",
+                            "fulfillment_id": "rto-shipping",
+                            "quantity": {
+                                "count": 1
+                            }
+                        }
+                    ],
+                    "billing": {
+                        "name": "Ajeet Chauhan",
+                        "email": "ajeetchauhan.symfony143@webkul.in",
+                        "phone": "8574739650",
+                        "address": {
+                            "city": "Noida",
+                            "name": "Ajeet Chauhan",
+                            "state": "Uttar Pradesh",
+                            "country": "IND",
+                            "building": "ARV Park",
+                            "locality": "Unnamed Road",
+                            "area_code": "201301"
+                        },
+                        "created_at": "2025-01-07T13:48:57.575Z",
+                        "updated_at": "2025-01-07T13:48:57.575Z"
+                    },
+                    "fulfillments": [
+                        {
+                            "id": "155",
+                            "end": {
+                                "time": {
+                                    "timestamp": "2025-01-07T14:21:20.562Z",
+                                    "range": {
+                                        "start": "2025-01-07T13:51:20.562Z",
+                                        "end": "2025-01-07T14:21:20.562Z"
+                                    }
+                                },
+                                "person": {
+                                    "name": "Ajeet Chauhan"
+                                },
+                                "contact": {
+                                    "email": "ajeetchauhan.symfony143@webkul.in",
+                                    "phone": "8574739650"
+                                },
+                                "location": {
+                                    "gps": "28.629743,77.377795",
+                                    "address": {
+                                        "city": "Noida",
+                                        "name": "Ajeet Chauhan",
+                                        "state": "Uttar Pradesh",
+                                        "country": "IND",
+                                        "building": "ARV Park",
+                                        "locality": "Unnamed Road",
+                                        "area_code": "201301"
+                                    }
+                                }
+                            },
+                            "type": "Delivery",
+                            "start": {
+                                "time": {
+                                    "timestamp": "2025-01-07T14:21:20.562Z",
+                                    "range": {
+                                        "start": "2025-01-07T13:51:20.562Z",
+                                        "end": "2025-01-07T14:21:20.562Z"
+                                    }
+                                },
+                                "contact": {
+                                    "email": "support@webkul.in",
+                                    "phone": "9876543210"
+                                },
+                                "location": {
+                                    "id": "83",
+                                    "gps": "28.62972640,77.37783230",
+                                    "address": {
+                                        "city": "Gautam Buddh Nagar",
+                                        "state": "Uttar Pradesh",
+                                        "locality": "Noida",
+                                        "area_code": "201301"
+                                    },
+                                    "descriptor": {
+                                        "name": "Ajeet Food Shop"
+                                    }
+                                }
+                            },
+                            "state": {
+                                "descriptor": {
+                                    "code": "Cancelled"
+                                }
+                            },
+                            "tracking": true,
+                            "@ondc/org/TAT": "PT90M",
+                            "@ondc/org/provider_name": "ondc.ecomviser.com",
+                            "tags": [
+                                {
+                                    "code": "cancel_request",
+                                    "list": [
+                                        {
+                                            "code": "retry_count",
+                                            "value": "3"
+                                        },
+                                        {
+                                            "code": "rto_id",
+                                            "value": "rto-shipping"
+                                        },
+                                        {
+                                            "code": "reason_id",
+                                            "value": "015"
+                                        },
+                                        {
+                                            "code": "initiated_by",
+                                            "value": "ondc.ecomviser.com"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "precancel_state",
+                                    "list": [
+                                        {
+                                            "code": "fulfillment_state",
+                                            "value": "Out-for-delivery"
+                                        },
+                                        {
+                                            "code": "updated_at",
+                                            "value": "2025-01-07T13:51:05.003Z"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "rto-shipping",
+                            "type": "RTO",
+                            "state": {
+                                "descriptor": {
+                                    "code": "RTO-Initiated"
+                                }
+                            },
+                            "start": {
+                                "time": {
+                                    "timestamp": "2025-01-07T14:21:20.562Z",
+                                    "range": {
+                                        "start": "2025-01-07T13:51:20.562Z",
+                                        "end": "2025-01-07T14:21:20.562Z"
+                                    }
+                                },
+                                "person": {
+                                    "name": "Ajeet Chauhan"
+                                },
+                                "contact": {
+                                    "email": "ajeetchauhan.symfony143@webkul.in",
+                                    "phone": "8574739650"
+                                },
+                                "location": {
+                                    "gps": "28.629743,77.377795",
+                                    "address": {
+                                        "city": "Noida",
+                                        "name": "Ajeet Chauhan",
+                                        "state": "Uttar Pradesh",
+                                        "country": "IND",
+                                        "building": "ARV Park",
+                                        "locality": "Unnamed Road",
+                                        "area_code": "201301"
+                                    }
+                                }
+                            },
+                            "end": {
+                                "contact": {
+                                    "email": "support@webkul.in",
+                                    "phone": "9876543210"
+                                },
+                                "location": {
+                                    "id": "83",
+                                    "gps": "28.62972640,77.37783230",
+                                    "address": {
+                                        "city": "Gautam Buddh Nagar",
+                                        "state": "Uttar Pradesh",
+                                        "locality": "Noida",
+                                        "area_code": "201301"
+                                    },
+                                    "descriptor": {
+                                        "name": "Ajeet Food Shop"
+                                    }
+                                }
+                            },
+                            "tags": [
+                                {
+                                    "code": "quote_trail",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "item"
+                                        },
+                                        {
+                                            "code": "id",
+                                            "value": "451"
+                                        },
+                                        {
+                                            "code": "currency",
+                                            "value": "INR"
+                                        },
+                                        {
+                                            "code": "value",
+                                            "value": "-99.00"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "quote_trail",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "item"
+                                        },
+                                        {
+                                            "code": "id",
+                                            "value": "93"
+                                        },
+                                        {
+                                            "code": "currency",
+                                            "value": "INR"
+                                        },
+                                        {
+                                            "code": "value",
+                                            "value": "-5.00"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "quote_trail",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "item"
+                                        },
+                                        {
+                                            "code": "id",
+                                            "value": "95"
+                                        },
+                                        {
+                                            "code": "currency",
+                                            "value": "INR"
+                                        },
+                                        {
+                                            "code": "value",
+                                            "value": "-10.00"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "quote_trail",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "misc"
+                                        },
+                                        {
+                                            "code": "id",
+                                            "value": "155"
+                                        },
+                                        {
+                                            "code": "currency",
+                                            "value": "INR"
+                                        },
+                                        {
+                                            "code": "value",
+                                            "value": "-4.04"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ],
+                    "quote": {
+                        "ttl": "PT6H",
+                        "price": {
+                            "value": "0.00",
+                            "currency": "INR"
+                        },
+                        "breakup": [
+                            {
+                                "item": {
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "item"
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "price": {
+                                        "value": "99",
+                                        "currency": "INR"
+                                    },
+                                    "parent_item_id": "xXUeYhqy/JJR"
+                                },
+                                "price": {
+                                    "value": "0.00",
+                                    "currency": "INR"
+                                },
+                                "title": "Pizza Mania Updated",
+                                "@ondc/org/item_id": "451",
+                                "@ondc/org/title_type": "item",
+                                "@ondc/org/item_quantity": {
+                                    "count": 0
+                                }
+                            },
+                            {
+                                "item": {
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "customization"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "parent",
+                                            "list": [
+                                                {
+                                                    "code": "id",
+                                                    "value": "66zabcdefghi"
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "price": {
+                                        "value": "5",
+                                        "currency": "INR"
+                                    },
+                                    "parent_item_id": "xXUeYhqy/JJR"
+                                },
+                                "price": {
+                                    "value": "0.00",
+                                    "currency": "INR"
+                                },
+                                "title": "Extra",
+                                "@ondc/org/item_id": "93",
+                                "@ondc/org/title_type": "item",
+                                "@ondc/org/item_quantity": {
+                                    "count": 0
+                                }
+                            },
+                            {
+                                "item": {
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "customization"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "parent",
+                                            "list": [
+                                                {
+                                                    "code": "id",
+                                                    "value": "67zabcdefghi"
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "price": {
+                                        "value": "10",
+                                        "currency": "INR"
+                                    },
+                                    "parent_item_id": "xXUeYhqy/JJR"
+                                },
+                                "price": {
+                                    "value": "0.00",
+                                    "currency": "INR"
+                                },
+                                "title": "Chicken",
+                                "@ondc/org/item_id": "95",
+                                "@ondc/org/title_type": "item",
+                                "@ondc/org/item_quantity": {
+                                    "count": 0
+                                }
+                            },
+                            {
+                                "price": {
+                                    "value": "0.00",
+                                    "currency": "INR"
+                                },
+                                "title": "Convenience fee",
+                                "@ondc/org/item_id": "155",
+                                "@ondc/org/title_type": "misc"
+                            },
+                            {
+                                "price": {
+                                    "value": "0.00",
+                                    "currency": "INR"
+                                },
+                                "title": "Delivery charges",
+                                "@ondc/org/item_id": "155",
+                                "@ondc/org/title_type": "delivery"
+                            }
+                        ]
+                    },
+                    "payment": {
+                        "uri": "https://razorpay.com/",
+                        "type": "ON-ORDER",
+                        "params": {
+                            "amount": "118.04",
+                            "currency": "INR",
+                            "transaction_id": "order_PgZkhFsKOgD7zY"
+                        },
+                        "status": "PAID",
+                        "tl_method": "http/get",
+                        "collected_by": "BAP",
+                        "@ondc/org/settlement_details": [
+                            {
+                                "bank_name": "fasdf",
+                                "branch_name": "noida",
+                                "settlement_type": "neft",
+                                "beneficiary_name": "fasdf asdfasdf",
+                                "settlement_phase": "sale-amount",
+                                "settlement_status": "NOT-PAID",
+                                "settlement_ifsc_code": "HDFC0000088",
+                                "settlement_counterparty": "seller-app",
+                                "settlement_bank_account_no": "534512341234132"
+                            }
+                        ],
+                        "@ondc/org/buyer_app_finder_fee_type": "percent",
+                        "@ondc/org/buyer_app_finder_fee_amount": "3.0"
+                    },
+                    "created_at": "2025-01-07T13:49:36.442Z",
+                    "updated_at": "2025-01-07T14:21:20.563Z"
+                }
+            }
+        },
+        "on_status_rto_delivered/disposed": {
+            "context": {
+                "domain": "ONDC:RET11",
+                "country": "IND",
+                "city": "std:0120",
+                "action": "on_status",
+                "core_version": "1.2.0",
+                "bap_id": "buyer-app-preprod-v2.ondc.org",
+                "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+                "bpp_uri": "https://ondc.ecomviser.com/api/v1",
+                "transaction_id": "45cb5581-3284-46bc-9ee5-f46ce026af43",
+                "message_id": "677d3171646117e7a7427-4bf5",
+                "timestamp": "2025-01-07T13:51:45.411Z",
+                "bpp_id": "ondc.ecomviser.com",
+                "ttl": "PT30S"
+            },
+            "message": {
+                "order": {
+                    "id": "2025-01-07-367431",
+                    "state": "Cancelled",
+                    "provider": {
+                        "id": "84",
+                        "locations": [
+                            {
+                                "id": "83"
+                            }
+                        ]
+                    },
+                    "items": [
+                        {
+                            "id": "451",
+                            "fulfillment_id": "155",
+                            "quantity": {
+                                "count": 0
+                            }
+                        },
+                        {
+                            "id": "93",
+                            "fulfillment_id": "155",
+                            "quantity": {
+                                "count": 0
+                            }
+                        },
+                        {
+                            "id": "95",
+                            "fulfillment_id": "155",
+                            "quantity": {
+                                "count": 0
+                            }
+                        },
+                        {
+                            "id": "451",
+                            "fulfillment_id": "rto-shipping",
+                            "quantity": {
+                                "count": 1
+                            }
+                        },
+                        {
+                            "id": "93",
+                            "fulfillment_id": "rto-shipping",
+                            "quantity": {
+                                "count": 1
+                            }
+                        },
+                        {
+                            "id": "95",
+                            "fulfillment_id": "rto-shipping",
+                            "quantity": {
+                                "count": 1
+                            }
+                        }
+                    ],
+                    "billing": {
+                        "name": "Ajeet Chauhan",
+                        "email": "ajeetchauhan.symfony143@webkul.in",
+                        "phone": "8574739650",
+                        "address": {
+                            "city": "Noida",
+                            "name": "Ajeet Chauhan",
+                            "state": "Uttar Pradesh",
+                            "country": "IND",
+                            "building": "ARV Park",
+                            "locality": "Unnamed Road",
+                            "area_code": "201301"
+                        },
+                        "created_at": "2025-01-07T13:48:57.575Z",
+                        "updated_at": "2025-01-07T13:48:57.575Z"
+                    },
+                    "fulfillments": [
+                        {
+                            "id": "155",
+                            "end": {
+                                "time": {
+                                    "timestamp": "2025-01-07T14:21:20.562Z",
+                                    "range": {
+                                        "start": "2025-01-07T13:51:20.562Z",
+                                        "end": "2025-01-07T14:21:20.562Z"
+                                    }
+                                },
+                                "person": {
+                                    "name": "Ajeet Chauhan"
+                                },
+                                "contact": {
+                                    "email": "ajeetchauhan.symfony143@webkul.in",
+                                    "phone": "8574739650"
+                                },
+                                "location": {
+                                    "gps": "28.629743,77.377795",
+                                    "address": {
+                                        "city": "Noida",
+                                        "name": "Ajeet Chauhan",
+                                        "state": "Uttar Pradesh",
+                                        "country": "IND",
+                                        "building": "ARV Park",
+                                        "locality": "Unnamed Road",
+                                        "area_code": "201301"
+                                    }
+                                }
+                            },
+                            "type": "Delivery",
+                            "start": {
+                                "time": {
+                                    "timestamp": "2025-01-07T14:21:20.562Z",
+                                    "range": {
+                                        "start": "2025-01-07T13:51:20.562Z",
+                                        "end": "2025-01-07T14:21:20.562Z"
+                                    }
+                                },
+                                "contact": {
+                                    "email": "support@webkul.in",
+                                    "phone": "9876543210"
+                                },
+                                "location": {
+                                    "id": "83",
+                                    "gps": "28.62972640,77.37783230",
+                                    "address": {
+                                        "city": "Gautam Buddh Nagar",
+                                        "state": "Uttar Pradesh",
+                                        "locality": "Noida",
+                                        "area_code": "201301"
+                                    },
+                                    "descriptor": {
+                                        "name": "Ajeet Food Shop"
+                                    }
+                                }
+                            },
+                            "state": {
+                                "descriptor": {
+                                    "code": "Cancelled"
+                                }
+                            },
+                            "tracking": true,
+                            "@ondc/org/TAT": "PT90M",
+                            "@ondc/org/provider_name": "ondc.ecomviser.com",
+                            "tags": [
+                                {
+                                    "code": "cancel_request",
+                                    "list": [
+                                        {
+                                            "code": "retry_count",
+                                            "value": "3"
+                                        },
+                                        {
+                                            "code": "rto_id",
+                                            "value": "rto-shipping"
+                                        },
+                                        {
+                                            "code": "reason_id",
+                                            "value": "015"
+                                        },
+                                        {
+                                            "code": "initiated_by",
+                                            "value": "ondc.ecomviser.com"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "precancel_state",
+                                    "list": [
+                                        {
+                                            "code": "fulfillment_state",
+                                            "value": "Out-for-delivery"
+                                        },
+                                        {
+                                            "code": "updated_at",
+                                            "value": "2025-01-07T13:51:05.003Z"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "rto-shipping",
+                            "type": "RTO",
+                            "state": {
+                                "descriptor": {
+                                    "code": "RTO-Disposed"
+                                }
+                            },
+                            "start": {
+                                "time": {
+                                    "timestamp": "2025-01-07T14:21:20.562Z",
+                                    "range": {
+                                        "start": "2025-01-07T13:51:20.562Z",
+                                        "end": "2025-01-07T14:21:20.562Z"
+                                    }
+                                },
+                                "person": {
+                                    "name": "Ajeet Chauhan"
+                                },
+                                "contact": {
+                                    "email": "ajeetchauhan.symfony143@webkul.in",
+                                    "phone": "8574739650"
+                                },
+                                "location": {
+                                    "gps": "28.629743,77.377795",
+                                    "address": {
+                                        "city": "Noida",
+                                        "name": "Ajeet Chauhan",
+                                        "state": "Uttar Pradesh",
+                                        "country": "IND",
+                                        "building": "ARV Park",
+                                        "locality": "Unnamed Road",
+                                        "area_code": "201301"
+                                    }
+                                }
+                            },
+                            "end": {
+                                "time": {
+                                    "timestamp": "2025-01-07T13:51:45.417Z"
+                                },
+                                "contact": {
+                                    "email": "support@webkul.in",
+                                    "phone": "9876543210"
+                                },
+                                "location": {
+                                    "id": "83",
+                                    "gps": "28.62972640,77.37783230",
+                                    "address": {
+                                        "city": "Gautam Buddh Nagar",
+                                        "state": "Uttar Pradesh",
+                                        "locality": "Noida",
+                                        "area_code": "201301"
+                                    },
+                                    "descriptor": {
+                                        "name": "Ajeet Food Shop"
+                                    }
+                                }
+                            },
+                            "tags": [
+                                {
+                                    "code": "quote_trail",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "item"
+                                        },
+                                        {
+                                            "code": "id",
+                                            "value": "451"
+                                        },
+                                        {
+                                            "code": "currency",
+                                            "value": "INR"
+                                        },
+                                        {
+                                            "code": "value",
+                                            "value": "-99.00"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "quote_trail",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "item"
+                                        },
+                                        {
+                                            "code": "id",
+                                            "value": "93"
+                                        },
+                                        {
+                                            "code": "currency",
+                                            "value": "INR"
+                                        },
+                                        {
+                                            "code": "value",
+                                            "value": "-5.00"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "quote_trail",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "item"
+                                        },
+                                        {
+                                            "code": "id",
+                                            "value": "95"
+                                        },
+                                        {
+                                            "code": "currency",
+                                            "value": "INR"
+                                        },
+                                        {
+                                            "code": "value",
+                                            "value": "-10.00"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "quote_trail",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "misc"
+                                        },
+                                        {
+                                            "code": "id",
+                                            "value": "155"
+                                        },
+                                        {
+                                            "code": "currency",
+                                            "value": "INR"
+                                        },
+                                        {
+                                            "code": "value",
+                                            "value": "-4.04"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ],
+                    "quote": {
+                        "ttl": "PT6H",
+                        "price": {
+                            "value": "0.00",
+                            "currency": "INR"
+                        },
+                        "breakup": [
+                            {
+                                "item": {
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "item"
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "price": {
+                                        "value": "99",
+                                        "currency": "INR"
+                                    },
+                                    "parent_item_id": "xXUeYhqy/JJR"
+                                },
+                                "price": {
+                                    "value": "0.00",
+                                    "currency": "INR"
+                                },
+                                "title": "Pizza Mania Updated",
+                                "@ondc/org/item_id": "451",
+                                "@ondc/org/title_type": "item",
+                                "@ondc/org/item_quantity": {
+                                    "count": 0
+                                }
+                            },
+                            {
+                                "item": {
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "customization"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "parent",
+                                            "list": [
+                                                {
+                                                    "code": "id",
+                                                    "value": "66zabcdefghi"
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "price": {
+                                        "value": "5",
+                                        "currency": "INR"
+                                    },
+                                    "parent_item_id": "xXUeYhqy/JJR"
+                                },
+                                "price": {
+                                    "value": "0.00",
+                                    "currency": "INR"
+                                },
+                                "title": "Extra",
+                                "@ondc/org/item_id": "93",
+                                "@ondc/org/title_type": "item",
+                                "@ondc/org/item_quantity": {
+                                    "count": 0
+                                }
+                            },
+                            {
+                                "item": {
+                                    "tags": [
+                                        {
+                                            "code": "type",
+                                            "list": [
+                                                {
+                                                    "code": "type",
+                                                    "value": "customization"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "parent",
+                                            "list": [
+                                                {
+                                                    "code": "id",
+                                                    "value": "67zabcdefghi"
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "price": {
+                                        "value": "10",
+                                        "currency": "INR"
+                                    },
+                                    "parent_item_id": "xXUeYhqy/JJR"
+                                },
+                                "price": {
+                                    "value": "0.00",
+                                    "currency": "INR"
+                                },
+                                "title": "Chicken",
+                                "@ondc/org/item_id": "95",
+                                "@ondc/org/title_type": "item",
+                                "@ondc/org/item_quantity": {
+                                    "count": 0
+                                }
+                            },
+                            {
+                                "price": {
+                                    "value": "0.00",
+                                    "currency": "INR"
+                                },
+                                "title": "Convenience fee",
+                                "@ondc/org/item_id": "155",
+                                "@ondc/org/title_type": "misc"
+                            },
+                            {
+                                "price": {
+                                    "value": "0.00",
+                                    "currency": "INR"
+                                },
+                                "title": "Delivery charges",
+                                "@ondc/org/item_id": "155",
+                                "@ondc/org/title_type": "delivery"
+                            }
+                        ]
+                    },
+                    "payment": {
+                        "uri": "https://razorpay.com/",
+                        "type": "ON-ORDER",
+                        "params": {
+                            "amount": "118.04",
+                            "currency": "INR",
+                            "transaction_id": "order_PgZkhFsKOgD7zY"
+                        },
+                        "status": "PAID",
+                        "tl_method": "http/get",
+                        "collected_by": "BAP",
+                        "@ondc/org/settlement_details": [
+                            {
+                                "bank_name": "fasdf",
+                                "branch_name": "noida",
+                                "settlement_type": "neft",
+                                "beneficiary_name": "fasdf asdfasdf",
+                                "settlement_phase": "sale-amount",
+                                "settlement_status": "NOT-PAID",
+                                "settlement_ifsc_code": "HDFC0000088",
+                                "settlement_counterparty": "seller-app",
+                                "settlement_bank_account_no": "534512341234132"
+                            }
+                        ],
+                        "@ondc/org/buyer_app_finder_fee_type": "percent",
+                        "@ondc/org/buyer_app_finder_fee_amount": "3.0"
+                    },
+                    "created_at": "2025-01-07T13:49:36.442Z",
+                    "updated_at": "2025-01-07T14:21:45.417Z"
+                }
+            }
+        }
+    },
+    "flow": "5"
+}

--- a/eComviser/Seller App RET11/Flow-5/init.json
+++ b/eComviser/Seller App RET11/Flow-5/init.json
@@ -1,0 +1,149 @@
+{
+    "context": {
+        "domain": "ONDC:RET11",
+        "country": "IND",
+        "city": "std:0120",
+        "action": "init",
+        "core_version": "1.2.0",
+        "bap_id": "buyer-app-preprod-v2.ondc.org",
+        "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+        "bpp_uri": "https://ondc.ecomviser.com/api/v1",
+        "transaction_id": "45cb5581-3284-46bc-9ee5-f46ce026af43",
+        "message_id": "4cd748df-104c-4edf-bf41-fa5b15073ad6",
+        "timestamp": "2025-01-07T13:48:57.575Z",
+        "bpp_id": "ondc.ecomviser.com",
+        "ttl": "PT30S"
+    },
+    "message": {
+        "order": {
+            "provider": {
+                "id": "84",
+                "locations": [
+                    {
+                        "id": "83"
+                    }
+                ]
+            },
+            "items": [
+                {
+                    "id": "451",
+                    "quantity": {
+                        "count": 1
+                    },
+                    "location_id": "83",
+                    "tags": [
+                        {
+                            "code": "type",
+                            "list": [
+                                {
+                                    "code": "type",
+                                    "value": "item"
+                                }
+                            ]
+                        }
+                    ],
+                    "parent_item_id": "xXUeYhqy/JJR",
+                    "fulfillment_id": "155"
+                },
+                {
+                    "id": "93",
+                    "quantity": {
+                        "count": 1
+                    },
+                    "location_id": "83",
+                    "tags": [
+                        {
+                            "code": "type",
+                            "list": [
+                                {
+                                    "code": "type",
+                                    "value": "customization"
+                                }
+                            ]
+                        },
+                        {
+                            "code": "parent",
+                            "list": [
+                                {
+                                    "code": "id",
+                                    "value": "66zabcdefghi"
+                                }
+                            ]
+                        }
+                    ],
+                    "fulfillment_id": "155",
+                    "parent_item_id": "xXUeYhqy/JJR"
+                },
+                {
+                    "id": "95",
+                    "quantity": {
+                        "count": 1
+                    },
+                    "location_id": "83",
+                    "tags": [
+                        {
+                            "code": "type",
+                            "list": [
+                                {
+                                    "code": "type",
+                                    "value": "customization"
+                                }
+                            ]
+                        },
+                        {
+                            "code": "parent",
+                            "list": [
+                                {
+                                    "code": "id",
+                                    "value": "67zabcdefghi"
+                                }
+                            ]
+                        }
+                    ],
+                    "fulfillment_id": "155",
+                    "parent_item_id": "xXUeYhqy/JJR"
+                }
+            ],
+            "billing": {
+                "address": {
+                    "building": "ARV Park",
+                    "city": "Noida",
+                    "state": "Uttar Pradesh",
+                    "country": "IND",
+                    "area_code": "201301",
+                    "locality": "Unnamed Road",
+                    "name": "Ajeet Chauhan"
+                },
+                "phone": "8574739650",
+                "name": "Ajeet Chauhan",
+                "email": "ajeetchauhan.symfony143@webkul.in",
+                "created_at": "2025-01-07T13:48:57.575Z",
+                "updated_at": "2025-01-07T13:48:57.575Z"
+            },
+            "fulfillments": [
+                {
+                    "id": "155",
+                    "type": "Delivery",
+                    "end": {
+                        "contact": {
+                            "email": "ajeetchauhan.symfony143@webkul.in",
+                            "phone": "8574739650"
+                        },
+                        "location": {
+                            "gps": "28.629743,77.377795",
+                            "address": {
+                                "building": "ARV Park",
+                                "city": "Noida",
+                                "state": "Uttar Pradesh",
+                                "country": "IND",
+                                "area_code": "201301",
+                                "locality": "Unnamed Road",
+                                "name": "Ajeet Chauhan"
+                            }
+                        }
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/eComviser/Seller App RET11/Flow-5/on_cancel.json
+++ b/eComviser/Seller App RET11/Flow-5/on_cancel.json
@@ -1,0 +1,501 @@
+{
+    "context": {
+        "domain": "ONDC:RET11",
+        "country": "IND",
+        "city": "std:0120",
+        "action": "on_cancel",
+        "core_version": "1.2.0",
+        "bap_id": "buyer-app-preprod-v2.ondc.org",
+        "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+        "bpp_uri": "https://ondc.ecomviser.com/api/v1",
+        "transaction_id": "45cb5581-3284-46bc-9ee5-f46ce026af43",
+        "message_id": "677d3158858946906be14-e95c",
+        "timestamp": "2025-01-07T13:51:20.547Z",
+        "bpp_id": "ondc.ecomviser.com",
+        "ttl": "PT30S"
+    },
+    "message": {
+        "order": {
+            "id": "2025-01-07-367431",
+            "state": "Cancelled",
+            "provider": {
+                "id": "84",
+                "locations": [
+                    {
+                        "id": "83"
+                    }
+                ]
+            },
+            "items": [
+                {
+                    "id": "451",
+                    "fulfillment_id": "155",
+                    "quantity": {
+                        "count": 0
+                    }
+                },
+                {
+                    "id": "93",
+                    "fulfillment_id": "155",
+                    "quantity": {
+                        "count": 0
+                    }
+                },
+                {
+                    "id": "95",
+                    "fulfillment_id": "155",
+                    "quantity": {
+                        "count": 0
+                    }
+                },
+                {
+                    "id": "451",
+                    "fulfillment_id": "rto-shipping",
+                    "quantity": {
+                        "count": 1
+                    }
+                },
+                {
+                    "id": "93",
+                    "fulfillment_id": "rto-shipping",
+                    "quantity": {
+                        "count": 1
+                    }
+                },
+                {
+                    "id": "95",
+                    "fulfillment_id": "rto-shipping",
+                    "quantity": {
+                        "count": 1
+                    }
+                }
+            ],
+            "billing": {
+                "name": "Ajeet Chauhan",
+                "email": "ajeetchauhan.symfony143@webkul.in",
+                "phone": "8574739650",
+                "address": {
+                    "city": "Noida",
+                    "name": "Ajeet Chauhan",
+                    "state": "Uttar Pradesh",
+                    "country": "IND",
+                    "building": "ARV Park",
+                    "locality": "Unnamed Road",
+                    "area_code": "201301"
+                },
+                "created_at": "2025-01-07T13:48:57.575Z",
+                "updated_at": "2025-01-07T13:48:57.575Z"
+            },
+            "fulfillments": [
+                {
+                    "id": "155",
+                    "end": {
+                        "time": {
+                            "timestamp": "2025-01-07T14:21:20.562Z",
+                            "range": {
+                                "start": "2025-01-07T13:51:20.562Z",
+                                "end": "2025-01-07T14:21:20.562Z"
+                            }
+                        },
+                        "person": {
+                            "name": "Ajeet Chauhan"
+                        },
+                        "contact": {
+                            "email": "ajeetchauhan.symfony143@webkul.in",
+                            "phone": "8574739650"
+                        },
+                        "location": {
+                            "gps": "28.629743,77.377795",
+                            "address": {
+                                "city": "Noida",
+                                "name": "Ajeet Chauhan",
+                                "state": "Uttar Pradesh",
+                                "country": "IND",
+                                "building": "ARV Park",
+                                "locality": "Unnamed Road",
+                                "area_code": "201301"
+                            }
+                        }
+                    },
+                    "type": "Delivery",
+                    "start": {
+                        "time": {
+                            "timestamp": "2025-01-07T14:21:20.562Z",
+                            "range": {
+                                "start": "2025-01-07T13:51:20.562Z",
+                                "end": "2025-01-07T14:21:20.562Z"
+                            }
+                        },
+                        "contact": {
+                            "email": "support@webkul.in",
+                            "phone": "9876543210"
+                        },
+                        "location": {
+                            "id": "83",
+                            "gps": "28.62972640,77.37783230",
+                            "address": {
+                                "city": "Gautam Buddh Nagar",
+                                "state": "Uttar Pradesh",
+                                "locality": "Noida",
+                                "area_code": "201301"
+                            },
+                            "descriptor": {
+                                "name": "Ajeet Food Shop"
+                            }
+                        }
+                    },
+                    "state": {
+                        "descriptor": {
+                            "code": "Cancelled"
+                        }
+                    },
+                    "tracking": true,
+                    "@ondc/org/TAT": "PT90M",
+                    "@ondc/org/provider_name": "ondc.ecomviser.com",
+                    "tags": [
+                        {
+                            "code": "cancel_request",
+                            "list": [
+                                {
+                                    "code": "retry_count",
+                                    "value": "3"
+                                },
+                                {
+                                    "code": "rto_id",
+                                    "value": "rto-shipping"
+                                },
+                                {
+                                    "code": "reason_id",
+                                    "value": "015"
+                                },
+                                {
+                                    "code": "initiated_by",
+                                    "value": "ondc.ecomviser.com"
+                                }
+                            ]
+                        },
+                        {
+                            "code": "precancel_state",
+                            "list": [
+                                {
+                                    "code": "fulfillment_state",
+                                    "value": "Out-for-delivery"
+                                },
+                                {
+                                    "code": "updated_at",
+                                    "value": "2025-01-07T13:51:05.003Z"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "id": "rto-shipping",
+                    "type": "RTO",
+                    "state": {
+                        "descriptor": {
+                            "code": "RTO-Initiated"
+                        }
+                    },
+                    "start": {
+                        "time": {
+                            "timestamp": "2025-01-07T14:21:20.562Z",
+                            "range": {
+                                "start": "2025-01-07T13:51:20.562Z",
+                                "end": "2025-01-07T14:21:20.562Z"
+                            }
+                        },
+                        "person": {
+                            "name": "Ajeet Chauhan"
+                        },
+                        "contact": {
+                            "email": "ajeetchauhan.symfony143@webkul.in",
+                            "phone": "8574739650"
+                        },
+                        "location": {
+                            "gps": "28.629743,77.377795",
+                            "address": {
+                                "city": "Noida",
+                                "name": "Ajeet Chauhan",
+                                "state": "Uttar Pradesh",
+                                "country": "IND",
+                                "building": "ARV Park",
+                                "locality": "Unnamed Road",
+                                "area_code": "201301"
+                            }
+                        }
+                    },
+                    "end": {
+                        "contact": {
+                            "email": "support@webkul.in",
+                            "phone": "9876543210"
+                        },
+                        "location": {
+                            "id": "83",
+                            "gps": "28.62972640,77.37783230",
+                            "address": {
+                                "city": "Gautam Buddh Nagar",
+                                "state": "Uttar Pradesh",
+                                "locality": "Noida",
+                                "area_code": "201301"
+                            },
+                            "descriptor": {
+                                "name": "Ajeet Food Shop"
+                            }
+                        }
+                    },
+                    "tags": [
+                        {
+                            "code": "quote_trail",
+                            "list": [
+                                {
+                                    "code": "type",
+                                    "value": "item"
+                                },
+                                {
+                                    "code": "id",
+                                    "value": "451"
+                                },
+                                {
+                                    "code": "currency",
+                                    "value": "INR"
+                                },
+                                {
+                                    "code": "value",
+                                    "value": "-99.00"
+                                }
+                            ]
+                        },
+                        {
+                            "code": "quote_trail",
+                            "list": [
+                                {
+                                    "code": "type",
+                                    "value": "item"
+                                },
+                                {
+                                    "code": "id",
+                                    "value": "93"
+                                },
+                                {
+                                    "code": "currency",
+                                    "value": "INR"
+                                },
+                                {
+                                    "code": "value",
+                                    "value": "-5.00"
+                                }
+                            ]
+                        },
+                        {
+                            "code": "quote_trail",
+                            "list": [
+                                {
+                                    "code": "type",
+                                    "value": "item"
+                                },
+                                {
+                                    "code": "id",
+                                    "value": "95"
+                                },
+                                {
+                                    "code": "currency",
+                                    "value": "INR"
+                                },
+                                {
+                                    "code": "value",
+                                    "value": "-10.00"
+                                }
+                            ]
+                        },
+                        {
+                            "code": "quote_trail",
+                            "list": [
+                                {
+                                    "code": "type",
+                                    "value": "misc"
+                                },
+                                {
+                                    "code": "id",
+                                    "value": "155"
+                                },
+                                {
+                                    "code": "currency",
+                                    "value": "INR"
+                                },
+                                {
+                                    "code": "value",
+                                    "value": "-4.04"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "quote": {
+                "ttl": "PT6H",
+                "price": {
+                    "value": "0.00",
+                    "currency": "INR"
+                },
+                "breakup": [
+                    {
+                        "item": {
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "item"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "price": {
+                                "value": "99",
+                                "currency": "INR"
+                            },
+                            "parent_item_id": "xXUeYhqy/JJR"
+                        },
+                        "price": {
+                            "value": "0.00",
+                            "currency": "INR"
+                        },
+                        "title": "Pizza Mania Updated",
+                        "@ondc/org/item_id": "451",
+                        "@ondc/org/title_type": "item",
+                        "@ondc/org/item_quantity": {
+                            "count": 0
+                        }
+                    },
+                    {
+                        "item": {
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "66zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "price": {
+                                "value": "5",
+                                "currency": "INR"
+                            },
+                            "parent_item_id": "xXUeYhqy/JJR"
+                        },
+                        "price": {
+                            "value": "0.00",
+                            "currency": "INR"
+                        },
+                        "title": "Extra",
+                        "@ondc/org/item_id": "93",
+                        "@ondc/org/title_type": "item",
+                        "@ondc/org/item_quantity": {
+                            "count": 0
+                        }
+                    },
+                    {
+                        "item": {
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "67zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "price": {
+                                "value": "10",
+                                "currency": "INR"
+                            },
+                            "parent_item_id": "xXUeYhqy/JJR"
+                        },
+                        "price": {
+                            "value": "0.00",
+                            "currency": "INR"
+                        },
+                        "title": "Chicken",
+                        "@ondc/org/item_id": "95",
+                        "@ondc/org/title_type": "item",
+                        "@ondc/org/item_quantity": {
+                            "count": 0
+                        }
+                    },
+                    {
+                        "price": {
+                            "value": "0.00",
+                            "currency": "INR"
+                        },
+                        "title": "Convenience fee",
+                        "@ondc/org/item_id": "155",
+                        "@ondc/org/title_type": "misc"
+                    },
+                    {
+                        "price": {
+                            "value": "0.00",
+                            "currency": "INR"
+                        },
+                        "title": "Delivery charges",
+                        "@ondc/org/item_id": "155",
+                        "@ondc/org/title_type": "delivery"
+                    }
+                ]
+            },
+            "payment": {
+                "uri": "https://razorpay.com/",
+                "type": "ON-ORDER",
+                "params": {
+                    "amount": "118.04",
+                    "currency": "INR",
+                    "transaction_id": "order_PgZkhFsKOgD7zY"
+                },
+                "status": "PAID",
+                "tl_method": "http/get",
+                "collected_by": "BAP",
+                "@ondc/org/settlement_details": [
+                    {
+                        "bank_name": "fasdf",
+                        "branch_name": "noida",
+                        "settlement_type": "neft",
+                        "beneficiary_name": "fasdf asdfasdf",
+                        "settlement_phase": "sale-amount",
+                        "settlement_status": "NOT-PAID",
+                        "settlement_ifsc_code": "HDFC0000088",
+                        "settlement_counterparty": "seller-app",
+                        "settlement_bank_account_no": "534512341234132"
+                    }
+                ],
+                "@ondc/org/buyer_app_finder_fee_type": "percent",
+                "@ondc/org/buyer_app_finder_fee_amount": "3.0"
+            },
+            "created_at": "2025-01-07T13:49:36.442Z",
+            "updated_at": "2025-01-07T14:21:20.563Z"
+        }
+    }
+}

--- a/eComviser/Seller App RET11/Flow-5/on_confirm.json
+++ b/eComviser/Seller App RET11/Flow-5/on_confirm.json
@@ -1,0 +1,381 @@
+{
+    "context": {
+        "domain": "ONDC:RET11",
+        "country": "IND",
+        "city": "std:0120",
+        "action": "on_confirm",
+        "core_version": "1.2.0",
+        "bap_id": "buyer-app-preprod-v2.ondc.org",
+        "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+        "bpp_uri": "https://ondc.ecomviser.com/api/v1",
+        "transaction_id": "45cb5581-3284-46bc-9ee5-f46ce026af43",
+        "message_id": "2a68dd7f-1bb2-4a1e-9804-82d7788446d1",
+        "timestamp": "2025-01-07T13:49:40.282Z",
+        "bpp_id": "ondc.ecomviser.com"
+    },
+    "message": {
+        "order": {
+            "id": "2025-01-07-367431",
+            "state": "Created",
+            "provider": {
+                "id": "84",
+                "locations": [
+                    {
+                        "id": "83"
+                    }
+                ]
+            },
+            "items": [
+                {
+                    "id": "451",
+                    "quantity": {
+                        "count": 1
+                    },
+                    "fulfillment_id": "155",
+                    "tags": [
+                        {
+                            "code": "type",
+                            "list": [
+                                {
+                                    "code": "type",
+                                    "value": "item"
+                                }
+                            ]
+                        }
+                    ],
+                    "parent_item_id": "xXUeYhqy/JJR"
+                },
+                {
+                    "id": "93",
+                    "quantity": {
+                        "count": 1
+                    },
+                    "fulfillment_id": "155",
+                    "tags": [
+                        {
+                            "code": "type",
+                            "list": [
+                                {
+                                    "code": "type",
+                                    "value": "customization"
+                                }
+                            ]
+                        },
+                        {
+                            "code": "parent",
+                            "list": [
+                                {
+                                    "code": "id",
+                                    "value": "66zabcdefghi"
+                                }
+                            ]
+                        }
+                    ],
+                    "parent_item_id": "xXUeYhqy/JJR"
+                },
+                {
+                    "id": "95",
+                    "quantity": {
+                        "count": 1
+                    },
+                    "fulfillment_id": "155",
+                    "tags": [
+                        {
+                            "code": "type",
+                            "list": [
+                                {
+                                    "code": "type",
+                                    "value": "customization"
+                                }
+                            ]
+                        },
+                        {
+                            "code": "parent",
+                            "list": [
+                                {
+                                    "code": "id",
+                                    "value": "67zabcdefghi"
+                                }
+                            ]
+                        }
+                    ],
+                    "parent_item_id": "xXUeYhqy/JJR"
+                }
+            ],
+            "billing": {
+                "address": {
+                    "name": "Ajeet Chauhan",
+                    "building": "ARV Park",
+                    "locality": "Unnamed Road",
+                    "city": "Noida",
+                    "state": "Uttar Pradesh",
+                    "country": "IND",
+                    "area_code": "201301"
+                },
+                "phone": "8574739650",
+                "name": "Ajeet Chauhan",
+                "email": "ajeetchauhan.symfony143@webkul.in",
+                "created_at": "2025-01-07T13:48:57.575Z",
+                "updated_at": "2025-01-07T13:48:57.575Z"
+            },
+            "fulfillments": [
+                {
+                    "@ondc/org/TAT": "PT90M",
+                    "id": "155",
+                    "tracking": true,
+                    "end": {
+                        "contact": {
+                            "email": "ajeetchauhan.symfony143@webkul.in",
+                            "phone": "8574739650"
+                        },
+                        "person": {
+                            "name": "Ajeet Chauhan"
+                        },
+                        "location": {
+                            "gps": "28.629743,77.377795",
+                            "address": {
+                                "name": "Ajeet Chauhan",
+                                "building": "ARV Park",
+                                "locality": "Unnamed Road",
+                                "city": "Noida",
+                                "state": "Uttar Pradesh",
+                                "country": "IND",
+                                "area_code": "201301"
+                            }
+                        },
+                        "time": {
+                            "range": {
+                                "start": "2025-01-07T13:49:43.355Z",
+                                "end": "2025-01-07T14:49:43.355Z"
+                            }
+                        }
+                    },
+                    "type": "Delivery",
+                    "@ondc/org/provider_name": "ondc.ecomviser.com",
+                    "state": {
+                        "descriptor": {
+                            "code": "Pending"
+                        }
+                    },
+                    "start": {
+                        "location": {
+                            "id": "83",
+                            "descriptor": {
+                                "name": "Ajeet Food Shop"
+                            },
+                            "gps": "28.62972640,77.37783230",
+                            "address": {
+                                "locality": "Noida",
+                                "city": "Gautam Buddh Nagar",
+                                "area_code": "201301",
+                                "state": "Uttar Pradesh"
+                            }
+                        },
+                        "contact": {
+                            "phone": "9876543210",
+                            "email": "support@webkul.in"
+                        },
+                        "time": {
+                            "range": {
+                                "start": "2025-01-07T13:49:43.355Z",
+                                "end": "2025-01-07T14:49:43.355Z"
+                            }
+                        }
+                    }
+                }
+            ],
+            "quote": {
+                "price": {
+                    "currency": "INR",
+                    "value": "118.04"
+                },
+                "breakup": [
+                    {
+                        "title": "Pizza Mania Updated",
+                        "price": {
+                            "currency": "INR",
+                            "value": "99"
+                        },
+                        "@ondc/org/title_type": "item",
+                        "@ondc/org/item_id": "451",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
+                        },
+                        "item": {
+                            "price": {
+                                "currency": "INR",
+                                "value": "99"
+                            },
+                            "parent_item_id": "xXUeYhqy/JJR",
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "item"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "title": "Extra",
+                        "price": {
+                            "currency": "INR",
+                            "value": "5"
+                        },
+                        "@ondc/org/title_type": "item",
+                        "@ondc/org/item_id": "93",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
+                        },
+                        "item": {
+                            "price": {
+                                "currency": "INR",
+                                "value": "5"
+                            },
+                            "parent_item_id": "xXUeYhqy/JJR",
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "66zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "title": "Chicken",
+                        "price": {
+                            "currency": "INR",
+                            "value": "10"
+                        },
+                        "@ondc/org/title_type": "item",
+                        "@ondc/org/item_id": "95",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
+                        },
+                        "item": {
+                            "price": {
+                                "currency": "INR",
+                                "value": "10"
+                            },
+                            "parent_item_id": "xXUeYhqy/JJR",
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "67zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "title": "Convenience fee",
+                        "price": {
+                            "currency": "INR",
+                            "value": "4.04"
+                        },
+                        "@ondc/org/title_type": "misc",
+                        "@ondc/org/item_id": "155"
+                    },
+                    {
+                        "title": "Delivery charges",
+                        "price": {
+                            "currency": "INR",
+                            "value": "0"
+                        },
+                        "@ondc/org/title_type": "delivery",
+                        "@ondc/org/item_id": "155"
+                    }
+                ],
+                "ttl": "PT6H"
+            },
+            "payment": {
+                "uri": "https://razorpay.com/",
+                "tl_method": "http/get",
+                "params": {
+                    "amount": "118.04",
+                    "currency": "INR",
+                    "transaction_id": "order_PgZkhFsKOgD7zY"
+                },
+                "status": "PAID",
+                "type": "ON-ORDER",
+                "collected_by": "BAP",
+                "@ondc/org/buyer_app_finder_fee_type": "percent",
+                "@ondc/org/buyer_app_finder_fee_amount": "3.0",
+                "@ondc/org/settlement_details": [
+                    {
+                        "settlement_counterparty": "seller-app",
+                        "settlement_phase": "sale-amount",
+                        "settlement_type": "neft",
+                        "beneficiary_name": "fasdf asdfasdf",
+                        "settlement_bank_account_no": "534512341234132",
+                        "settlement_ifsc_code": "HDFC0000088",
+                        "bank_name": "fasdf",
+                        "branch_name": "noida",
+                        "settlement_status": "NOT-PAID"
+                    }
+                ]
+            },
+            "tags": [
+                {
+                    "code": "bpp_terms",
+                    "list": [
+                        {
+                            "code": "np_type",
+                            "value": "MSN"
+                        },
+                        {
+                            "code": "tax_number",
+                            "value": "09AABCW0339G3ZD"
+                        },
+                        {
+                            "code": "provider_tax_number",
+                            "value": "DERTC3376R"
+                        }
+                    ]
+                },
+                {
+                    "code": "bap_terms",
+                    "list": [
+                        {
+                            "code": "tax_number",
+                            "value": "GSTIN1234567890"
+                        }
+                    ]
+                }
+            ],
+            "created_at": "2025-01-07T13:49:36.442Z",
+            "updated_at": "2025-01-07T13:49:40.282Z"
+        }
+    }
+}

--- a/eComviser/Seller App RET11/Flow-5/on_init.json
+++ b/eComviser/Seller App RET11/Flow-5/on_init.json
@@ -1,0 +1,317 @@
+{
+    "context": {
+        "domain": "ONDC:RET11",
+        "country": "IND",
+        "city": "std:0120",
+        "action": "on_init",
+        "core_version": "1.2.0",
+        "bap_id": "buyer-app-preprod-v2.ondc.org",
+        "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+        "bpp_uri": "https://ondc.ecomviser.com/api/v1",
+        "transaction_id": "45cb5581-3284-46bc-9ee5-f46ce026af43",
+        "message_id": "4cd748df-104c-4edf-bf41-fa5b15073ad6",
+        "timestamp": "2025-01-07T13:49:01.360Z",
+        "bpp_id": "ondc.ecomviser.com",
+        "ttl": "PT30S"
+    },
+    "message": {
+        "order": {
+            "provider": {
+                "id": "84",
+                "locations": [
+                    {
+                        "id": "83"
+                    }
+                ]
+            },
+            "items": [
+                {
+                    "id": "451",
+                    "fulfillment_id": "155",
+                    "quantity": {
+                        "count": 1
+                    },
+                    "parent_item_id": "xXUeYhqy/JJR",
+                    "tags": [
+                        {
+                            "code": "type",
+                            "list": [
+                                {
+                                    "code": "type",
+                                    "value": "item"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "id": "93",
+                    "fulfillment_id": "155",
+                    "quantity": {
+                        "count": 1
+                    },
+                    "parent_item_id": "xXUeYhqy/JJR",
+                    "tags": [
+                        {
+                            "code": "type",
+                            "list": [
+                                {
+                                    "code": "type",
+                                    "value": "customization"
+                                }
+                            ]
+                        },
+                        {
+                            "code": "parent",
+                            "list": [
+                                {
+                                    "code": "id",
+                                    "value": "66zabcdefghi"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "id": "95",
+                    "fulfillment_id": "155",
+                    "quantity": {
+                        "count": 1
+                    },
+                    "parent_item_id": "xXUeYhqy/JJR",
+                    "tags": [
+                        {
+                            "code": "type",
+                            "list": [
+                                {
+                                    "code": "type",
+                                    "value": "customization"
+                                }
+                            ]
+                        },
+                        {
+                            "code": "parent",
+                            "list": [
+                                {
+                                    "code": "id",
+                                    "value": "67zabcdefghi"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "quote": {
+                "price": {
+                    "currency": "INR",
+                    "value": "118.04"
+                },
+                "breakup": [
+                    {
+                        "title": "Pizza Mania Updated",
+                        "price": {
+                            "currency": "INR",
+                            "value": "99"
+                        },
+                        "@ondc/org/title_type": "item",
+                        "@ondc/org/item_id": "451",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
+                        },
+                        "item": {
+                            "price": {
+                                "currency": "INR",
+                                "value": "99"
+                            },
+                            "parent_item_id": "xXUeYhqy/JJR",
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "item"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "title": "Extra",
+                        "price": {
+                            "currency": "INR",
+                            "value": "5"
+                        },
+                        "@ondc/org/title_type": "item",
+                        "@ondc/org/item_id": "93",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
+                        },
+                        "item": {
+                            "price": {
+                                "currency": "INR",
+                                "value": "5"
+                            },
+                            "parent_item_id": "xXUeYhqy/JJR",
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "66zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "title": "Chicken",
+                        "price": {
+                            "currency": "INR",
+                            "value": "10"
+                        },
+                        "@ondc/org/title_type": "item",
+                        "@ondc/org/item_id": "95",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
+                        },
+                        "item": {
+                            "price": {
+                                "currency": "INR",
+                                "value": "10"
+                            },
+                            "parent_item_id": "xXUeYhqy/JJR",
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "67zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "title": "Convenience fee",
+                        "price": {
+                            "currency": "INR",
+                            "value": "4.04"
+                        },
+                        "@ondc/org/title_type": "misc",
+                        "@ondc/org/item_id": "155"
+                    },
+                    {
+                        "title": "Delivery charges",
+                        "price": {
+                            "currency": "INR",
+                            "value": "0"
+                        },
+                        "@ondc/org/title_type": "delivery",
+                        "@ondc/org/item_id": "155"
+                    }
+                ],
+                "ttl": "PT6H"
+            },
+            "billing": {
+                "address": {
+                    "building": "ARV Park",
+                    "city": "Noida",
+                    "state": "Uttar Pradesh",
+                    "country": "IND",
+                    "area_code": "201301",
+                    "locality": "Unnamed Road",
+                    "name": "Ajeet Chauhan"
+                },
+                "phone": "8574739650",
+                "name": "Ajeet Chauhan",
+                "email": "ajeetchauhan.symfony143@webkul.in",
+                "created_at": "2025-01-07T13:48:57.575Z",
+                "updated_at": "2025-01-07T13:48:57.575Z"
+            },
+            "fulfillments": [
+                {
+                    "id": "155",
+                    "type": "Delivery",
+                    "end": {
+                        "contact": {
+                            "email": "ajeetchauhan.symfony143@webkul.in",
+                            "phone": "8574739650"
+                        },
+                        "location": {
+                            "gps": "28.629743,77.377795",
+                            "address": {
+                                "building": "ARV Park",
+                                "city": "Noida",
+                                "state": "Uttar Pradesh",
+                                "country": "IND",
+                                "area_code": "201301",
+                                "locality": "Unnamed Road",
+                                "name": "Ajeet Chauhan"
+                            }
+                        }
+                    },
+                    "tracking": true
+                }
+            ],
+            "payment": {
+                "type": "ON-ORDER",
+                "collected_by": "BAP",
+                "@ondc/org/collected_by_status": "Agree",
+                "@ondc/org/buyer_app_finder_fee_type": "percent",
+                "@ondc/org/buyer_app_finder_fee_amount": "3",
+                "@ondc/org/settlement_details": [
+                    {
+                        "settlement_counterparty": "seller-app",
+                        "settlement_phase": "sale-amount",
+                        "settlement_type": "neft",
+                        "beneficiary_name": "fasdf asdfasdf",
+                        "settlement_bank_account_no": "534512341234132",
+                        "settlement_ifsc_code": "HDFC0000088",
+                        "bank_name": "fasdf",
+                        "branch_name": "noida",
+                        "settlement_status": "NOT-PAID"
+                    }
+                ]
+            },
+            "tags": [
+                {
+                    "code": "bpp_terms",
+                    "list": [
+                        {
+                            "code": "tax_number",
+                            "value": "09AABCW0339G3ZD"
+                        },
+                        {
+                            "code": "provider_tax_number",
+                            "value": "DERTC3376R"
+                        }
+                    ]
+                }
+            ]
+        }
+    }
+}

--- a/eComviser/Seller App RET11/Flow-5/on_search.json
+++ b/eComviser/Seller App RET11/Flow-5/on_search.json
@@ -1,0 +1,658 @@
+{
+    "context": {
+        "domain": "ONDC:RET11",
+        "action": "on_search",
+        "country": "IND",
+        "city": "std:0120",
+        "core_version": "1.2.0",
+        "bap_id": "buyer-app-preprod-v2.ondc.org",
+        "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+        "transaction_id": "81464ede-43ee-45a9-a77e-617a140037af",
+        "message_id": "eed481f9-1e78-4341-9c77-4f13169cc711",
+        "timestamp": "2025-01-07T13:48:11.740Z",
+        "ttl": "PT30S",
+        "bpp_id": "ondc.ecomviser.com",
+        "bpp_uri": "https://ondc.ecomviser.com/api/v1"
+    },
+    "message": {
+        "catalog": {
+            "bpp/descriptor": {
+                "name": "Webkul",
+                "symbol": "https://ondc.ecomviser.com/public/img/webkul_logo.png",
+                "short_desc": "Enterprise Digital Commerce & Marketplace Solution Experts",
+                "long_desc": "Helping companies with our industry-leading digital commerce, ERP, and CRM solutions. In the last 13 years, we have served 150K+ clients worldwide to handle complex operations and grow their businesses",
+                "images": [
+                    "https://ondc.ecomviser.com/public/img/webkul_banner.png",
+                    "https://ondc.ecomviser.com/public/img/webkul_clients.png",
+                    "https://ondc.ecomviser.com/public/img/webkul_awards.png"
+                ],
+                "tags": [
+                    {
+                        "code": "bpp_terms",
+                        "list": [
+                            {
+                                "code": "np_type",
+                                "value": "MSN"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "bpp/fulfillments": [
+                {
+                    "id": "155",
+                    "type": "Delivery"
+                }
+            ],
+            "bpp/providers": [
+                {
+                    "id": "84",
+                    "time": {
+                        "label": "enable",
+                        "timestamp": "2025-01-07T13:18:11.136Z"
+                    },
+                    "descriptor": {
+                        "name": "Ajeet Food Shop",
+                        "symbol": "https://ondc-prepod-digital-delivery.s3.amazonaws.com/seller_shop_logo/84/39MylDtZVC.jpg",
+                        "short_desc": "short desc",
+                        "long_desc": "store desc",
+                        "images": [
+                            "https://ondc-prepod-digital-delivery.s3.amazonaws.com/seller_shop_logo/84/39MylDtZVC.jpg"
+                        ]
+                    },
+                    "fulfillments": [
+                        {
+                            "id": "155",
+                            "type": "Delivery",
+                            "contact": {
+                                "phone": "9812345678",
+                                "email": "ajeetchauhan.symfony143@webkul.in"
+                            }
+                        }
+                    ],
+                    "locations": [
+                        {
+                            "id": "83",
+                            "gps": "28.62972640,77.37783230",
+                            "address": {
+                                "locality": "Noida",
+                                "street": "H-28",
+                                "city": "Gautam Buddh Nagar",
+                                "area_code": "201301",
+                                "state": "Uttar Pradesh"
+                            },
+                            "circle": {
+                                "gps": "28.62972640,77.37783230",
+                                "radius": {
+                                    "unit": "km",
+                                    "value": "5"
+                                }
+                            },
+                            "time": {
+                                "label": "enable",
+                                "timestamp": "2025-01-07T13:18:11.136Z",
+                                "days": "1,2,3,4,5,6,7",
+                                "schedule": {
+                                    "holidays": []
+                                },
+                                "range": {
+                                    "start": "0800",
+                                    "end": "1707"
+                                }
+                            }
+                        }
+                    ],
+                    "@ondc/org/fssai_license_no": "12345678908898",
+                    "categories": [
+                        {
+                            "id": "66zabcdefghi",
+                            "descriptor": {
+                                "name": "Cheese"
+                            },
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "custom_group"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "config",
+                                    "list": [
+                                        {
+                                            "code": "min",
+                                            "value": "1"
+                                        },
+                                        {
+                                            "code": "max",
+                                            "value": "1"
+                                        },
+                                        {
+                                            "code": "input",
+                                            "value": "select"
+                                        },
+                                        {
+                                            "code": "seq",
+                                            "value": "1"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "67zabcdefghi",
+                            "descriptor": {
+                                "name": "Non-veg toppings"
+                            },
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "custom_group"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "config",
+                                    "list": [
+                                        {
+                                            "code": "min",
+                                            "value": "1"
+                                        },
+                                        {
+                                            "code": "max",
+                                            "value": "1"
+                                        },
+                                        {
+                                            "code": "input",
+                                            "value": "select"
+                                        },
+                                        {
+                                            "code": "seq",
+                                            "value": "2"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "844147zabcde",
+                            "parent_category_id": "",
+                            "descriptor": {
+                                "name": "Pizza",
+                                "short_desc": "Pizza",
+                                "long_desc": "Pizza"
+                            },
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "custom_menu"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "display",
+                                    "list": [
+                                        {
+                                            "code": "rank",
+                                            "value": "1"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "timing",
+                                    "list": [
+                                        {
+                                            "code": "day_from",
+                                            "value": "1"
+                                        },
+                                        {
+                                            "code": "day_to",
+                                            "value": "5"
+                                        },
+                                        {
+                                            "code": "time_from",
+                                            "value": "0800"
+                                        },
+                                        {
+                                            "code": "time_to",
+                                            "value": "2200"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ],
+                    "items": [
+                        {
+                            "id": "451",
+                            "time": {
+                                "label": "enable",
+                                "timestamp": "2025-01-07T13:18:11.136Z"
+                            },
+                            "descriptor": {
+                                "name": "Pizza Mania Updated",
+                                "symbol": "https://d3bhszwz094mhs.cloudfront.net/product_img/main_img/342/NipTw8cSUY.jpeg",
+                                "short_desc": "pizza best small",
+                                "long_desc": "best pizza",
+                                "images": [
+                                    "https://d3bhszwz094mhs.cloudfront.net/product_img/main_img/342/NipTw8cSUY.jpeg"
+                                ],
+                                "code": "1:123456789876"
+                            },
+                            "price": {
+                                "currency": "INR",
+                                "value": "99",
+                                "maximum_value": "110",
+                                "tags": [
+                                    {
+                                        "code": "range",
+                                        "list": [
+                                            {
+                                                "code": "lower",
+                                                "value": "99.00"
+                                            },
+                                            {
+                                                "code": "upper",
+                                                "value": "159"
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "code": "default_selection",
+                                        "list": [
+                                            {
+                                                "code": "value",
+                                                "value": "99.00"
+                                            },
+                                            {
+                                                "code": "maximum_value",
+                                                "value": "159"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            "quantity": {
+                                "available": {
+                                    "count": "99"
+                                },
+                                "maximum": {
+                                    "count": "99"
+                                },
+                                "unitized": {
+                                    "measure": {
+                                        "unit": "unit",
+                                        "value": "1"
+                                    }
+                                }
+                            },
+                            "location_id": "83",
+                            "category_id": "F&B",
+                            "fulfillment_id": "155",
+                            "@ondc/org/time_to_ship": "PT1H",
+                            "@ondc/org/cancellable": true,
+                            "@ondc/org/seller_pickup_return": true,
+                            "@ondc/org/returnable": true,
+                            "@ondc/org/return_window": "PT2H",
+                            "@ondc/org/available_on_cod": false,
+                            "@ondc/org/contact_details_consumer_care": "ajeet,ajeetchauhan.symfony143@webkul.in,9812345678",
+                            "tags": [
+                                {
+                                    "code": "origin",
+                                    "list": [
+                                        {
+                                            "code": "country",
+                                            "value": "IND"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "item"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "custom_group",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "66zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "category_ids": [
+                                "844147zabcde:1"
+                            ]
+                        },
+                        {
+                            "id": "93",
+                            "descriptor": {
+                                "name": "Extra"
+                            },
+                            "quantity": {
+                                "available": {
+                                    "count": "99"
+                                },
+                                "maximum": {
+                                    "count": "99"
+                                }
+                            },
+                            "price": {
+                                "currency": "INR",
+                                "value": "5.00",
+                                "maximum_value": "5.00"
+                            },
+                            "category_id": "F&B",
+                            "related": true,
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "66zabcdefghi"
+                                        },
+                                        {
+                                            "code": "default",
+                                            "value": "yes"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "veg_nonveg",
+                                    "list": [
+                                        {
+                                            "code": "veg",
+                                            "value": "yes"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "child",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "67zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "94",
+                            "descriptor": {
+                                "name": "Vegan"
+                            },
+                            "quantity": {
+                                "available": {
+                                    "count": "99"
+                                },
+                                "maximum": {
+                                    "count": "99"
+                                }
+                            },
+                            "price": {
+                                "currency": "INR",
+                                "value": "10.00",
+                                "maximum_value": "10.00"
+                            },
+                            "category_id": "F&B",
+                            "related": true,
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "66zabcdefghi"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "veg_nonveg",
+                                    "list": [
+                                        {
+                                            "code": "veg",
+                                            "value": "yes"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "child",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "67zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "95",
+                            "descriptor": {
+                                "name": "Chicken"
+                            },
+                            "quantity": {
+                                "available": {
+                                    "count": "99"
+                                },
+                                "maximum": {
+                                    "count": "99"
+                                }
+                            },
+                            "price": {
+                                "currency": "INR",
+                                "value": "10.00",
+                                "maximum_value": "10.00"
+                            },
+                            "category_id": "F&B",
+                            "related": true,
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "67zabcdefghi"
+                                        },
+                                        {
+                                            "code": "default",
+                                            "value": "yes"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "veg_nonveg",
+                                    "list": [
+                                        {
+                                            "code": "non_veg",
+                                            "value": "yes"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "96",
+                            "descriptor": {
+                                "name": "Mutton"
+                            },
+                            "quantity": {
+                                "available": {
+                                    "count": "99"
+                                },
+                                "maximum": {
+                                    "count": "99"
+                                }
+                            },
+                            "price": {
+                                "currency": "INR",
+                                "value": "50.00",
+                                "maximum_value": "50.00"
+                            },
+                            "category_id": "F&B",
+                            "related": true,
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "67zabcdefghi"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "veg_nonveg",
+                                    "list": [
+                                        {
+                                            "code": "veg",
+                                            "value": "yes"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ],
+                    "tags": [
+                        {
+                            "code": "timing",
+                            "list": [
+                                {
+                                    "code": "type",
+                                    "value": "Order"
+                                },
+                                {
+                                    "code": "location",
+                                    "value": "83"
+                                },
+                                {
+                                    "code": "day_from",
+                                    "value": "1"
+                                },
+                                {
+                                    "code": "day_to",
+                                    "value": "7"
+                                },
+                                {
+                                    "code": "time_from",
+                                    "value": "0900"
+                                },
+                                {
+                                    "code": "time_to",
+                                    "value": "2300"
+                                }
+                            ]
+                        },
+                        {
+                            "code": "timing",
+                            "list": [
+                                {
+                                    "code": "type",
+                                    "value": "Delivery"
+                                },
+                                {
+                                    "code": "location",
+                                    "value": "83"
+                                },
+                                {
+                                    "code": "day_from",
+                                    "value": "1"
+                                },
+                                {
+                                    "code": "day_to",
+                                    "value": "7"
+                                },
+                                {
+                                    "code": "time_from",
+                                    "value": "1000"
+                                },
+                                {
+                                    "code": "time_to",
+                                    "value": "2100"
+                                }
+                            ]
+                        },
+                        {
+                            "code": "serviceability",
+                            "list": [
+                                {
+                                    "code": "location",
+                                    "value": "83"
+                                },
+                                {
+                                    "code": "category",
+                                    "value": "F&B"
+                                },
+                                {
+                                    "code": "type",
+                                    "value": "10"
+                                },
+                                {
+                                    "code": "val",
+                                    "value": "5"
+                                },
+                                {
+                                    "code": "unit",
+                                    "value": "km"
+                                }
+                            ]
+                        }
+                    ],
+                    "ttl": "P1D"
+                }
+            ]
+        }
+    }
+}

--- a/eComviser/Seller App RET11/Flow-5/on_select.json
+++ b/eComviser/Seller App RET11/Flow-5/on_select.json
@@ -1,0 +1,270 @@
+{
+    "context": {
+        "domain": "ONDC:RET11",
+        "country": "IND",
+        "city": "std:0120",
+        "action": "on_select",
+        "core_version": "1.2.0",
+        "bap_id": "buyer-app-preprod-v2.ondc.org",
+        "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+        "bpp_uri": "https://ondc.ecomviser.com/api/v1",
+        "transaction_id": "45cb5581-3284-46bc-9ee5-f46ce026af43",
+        "message_id": "e7f8a941-a40b-4e44-b289-ce2ba1e1ed72",
+        "timestamp": "2025-01-07T13:48:43.028Z",
+        "bpp_id": "ondc.ecomviser.com"
+    },
+    "message": {
+        "order": {
+            "provider": {
+                "id": "84",
+                "locations": [
+                    {
+                        "id": "83"
+                    }
+                ]
+            },
+            "items": [
+                {
+                    "id": "451",
+                    "fulfillment_id": "155",
+                    "parent_item_id": "xXUeYhqy/JJR",
+                    "tags": [
+                        {
+                            "code": "type",
+                            "list": [
+                                {
+                                    "code": "type",
+                                    "value": "item"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "id": "93",
+                    "fulfillment_id": "155",
+                    "parent_item_id": "xXUeYhqy/JJR",
+                    "tags": [
+                        {
+                            "code": "type",
+                            "list": [
+                                {
+                                    "code": "type",
+                                    "value": "customization"
+                                }
+                            ]
+                        },
+                        {
+                            "code": "parent",
+                            "list": [
+                                {
+                                    "code": "id",
+                                    "value": "66zabcdefghi"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "id": "95",
+                    "fulfillment_id": "155",
+                    "parent_item_id": "xXUeYhqy/JJR",
+                    "tags": [
+                        {
+                            "code": "type",
+                            "list": [
+                                {
+                                    "code": "type",
+                                    "value": "customization"
+                                }
+                            ]
+                        },
+                        {
+                            "code": "parent",
+                            "list": [
+                                {
+                                    "code": "id",
+                                    "value": "67zabcdefghi"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "fulfillments": [
+                {
+                    "id": "155",
+                    "type": "Delivery",
+                    "@ondc/org/provider_name": "ondc.ecomviser.com",
+                    "tracking": true,
+                    "@ondc/org/category": "Immediate Delivery",
+                    "@ondc/org/TAT": "PT90M",
+                    "state": {
+                        "descriptor": {
+                            "code": "Serviceable"
+                        }
+                    }
+                }
+            ],
+            "quote": {
+                "price": {
+                    "currency": "INR",
+                    "value": "118.04"
+                },
+                "breakup": [
+                    {
+                        "title": "Pizza Mania Updated",
+                        "price": {
+                            "currency": "INR",
+                            "value": "99"
+                        },
+                        "@ondc/org/title_type": "item",
+                        "@ondc/org/item_id": "451",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
+                        },
+                        "item": {
+                            "price": {
+                                "currency": "INR",
+                                "value": "99"
+                            },
+                            "quantity": {
+                                "available": {
+                                    "count": "99"
+                                },
+                                "maximum": {
+                                    "count": "99"
+                                }
+                            },
+                            "parent_item_id": "xXUeYhqy/JJR",
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "item"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "title": "Extra",
+                        "price": {
+                            "currency": "INR",
+                            "value": "5"
+                        },
+                        "@ondc/org/title_type": "item",
+                        "@ondc/org/item_id": "93",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
+                        },
+                        "item": {
+                            "price": {
+                                "currency": "INR",
+                                "value": "5"
+                            },
+                            "quantity": {
+                                "available": {
+                                    "count": "99"
+                                },
+                                "maximum": {
+                                    "count": "99"
+                                }
+                            },
+                            "parent_item_id": "xXUeYhqy/JJR",
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "66zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "title": "Chicken",
+                        "price": {
+                            "currency": "INR",
+                            "value": "10"
+                        },
+                        "@ondc/org/title_type": "item",
+                        "@ondc/org/item_id": "95",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
+                        },
+                        "item": {
+                            "price": {
+                                "currency": "INR",
+                                "value": "10"
+                            },
+                            "quantity": {
+                                "available": {
+                                    "count": "99"
+                                },
+                                "maximum": {
+                                    "count": "99"
+                                }
+                            },
+                            "parent_item_id": "xXUeYhqy/JJR",
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "67zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "title": "Convenience fee",
+                        "price": {
+                            "currency": "INR",
+                            "value": "4.04"
+                        },
+                        "@ondc/org/title_type": "misc",
+                        "@ondc/org/item_id": "155"
+                    },
+                    {
+                        "title": "Delivery charges",
+                        "price": {
+                            "currency": "INR",
+                            "value": "0"
+                        },
+                        "@ondc/org/title_type": "delivery",
+                        "@ondc/org/item_id": "155"
+                    }
+                ],
+                "ttl": "PT6H"
+            }
+        }
+    }
+}

--- a/eComviser/Seller App RET11/Flow-5/on_status_agent_assigned.json
+++ b/eComviser/Seller App RET11/Flow-5/on_status_agent_assigned.json
@@ -1,0 +1,286 @@
+{
+    "context": {
+        "domain": "ONDC:RET11",
+        "country": "IND",
+        "city": "std:0120",
+        "action": "on_status",
+        "core_version": "1.2.0",
+        "bap_id": "buyer-app-preprod-v2.ondc.org",
+        "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+        "bpp_uri": "https://ondc.ecomviser.com/api/v1",
+        "transaction_id": "45cb5581-3284-46bc-9ee5-f46ce026af43",
+        "message_id": "677d3134789ad26df0ec0-f022",
+        "timestamp": "2025-01-07T13:50:44.494Z",
+        "bpp_id": "ondc.ecomviser.com",
+        "ttl": "PT30S"
+    },
+    "message": {
+        "order": {
+            "id": "2025-01-07-367431",
+            "state": "In-progress",
+            "provider": {
+                "id": "84",
+                "locations": [
+                    {
+                        "id": "83"
+                    }
+                ]
+            },
+            "items": [
+                {
+                    "id": "451",
+                    "fulfillment_id": "155",
+                    "quantity": {
+                        "count": 1
+                    }
+                }
+            ],
+            "fulfillments": [
+                {
+                    "id": "155",
+                    "end": {
+                        "time": {
+                            "range": {
+                                "end": "2025-01-07T14:49:43.355Z",
+                                "start": "2025-01-07T13:49:43.355Z"
+                            }
+                        },
+                        "person": {
+                            "name": "Ajeet Chauhan"
+                        },
+                        "contact": {
+                            "email": "ajeetchauhan.symfony143@webkul.in",
+                            "phone": "8574739650"
+                        },
+                        "location": {
+                            "gps": "28.629743,77.377795",
+                            "address": {
+                                "city": "Noida",
+                                "name": "Ajeet Chauhan",
+                                "state": "Uttar Pradesh",
+                                "country": "IND",
+                                "building": "ARV Park",
+                                "locality": "Unnamed Road",
+                                "area_code": "201301"
+                            }
+                        }
+                    },
+                    "type": "Delivery",
+                    "start": {
+                        "time": {
+                            "range": {
+                                "end": "2025-01-07T14:49:43.355Z",
+                                "start": "2025-01-07T13:49:43.355Z"
+                            }
+                        },
+                        "contact": {
+                            "email": "support@webkul.in",
+                            "phone": "9876543210"
+                        },
+                        "location": {
+                            "id": "83",
+                            "gps": "28.62972640,77.37783230",
+                            "address": {
+                                "city": "Gautam Buddh Nagar",
+                                "state": "Uttar Pradesh",
+                                "locality": "Noida",
+                                "area_code": "201301"
+                            },
+                            "descriptor": {
+                                "name": "Ajeet Food Shop"
+                            }
+                        }
+                    },
+                    "state": {
+                        "descriptor": {
+                            "code": "Agent-assigned"
+                        }
+                    },
+                    "tracking": true,
+                    "@ondc/org/TAT": "PT90M",
+                    "@ondc/org/provider_name": "ondc.ecomviser.com"
+                }
+            ],
+            "quote": {
+                "ttl": "PT6H",
+                "price": {
+                    "value": "118.04",
+                    "currency": "INR"
+                },
+                "breakup": [
+                    {
+                        "item": {
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "item"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "price": {
+                                "value": "99",
+                                "currency": "INR"
+                            },
+                            "parent_item_id": "xXUeYhqy/JJR"
+                        },
+                        "price": {
+                            "value": "99",
+                            "currency": "INR"
+                        },
+                        "title": "Pizza Mania Updated",
+                        "@ondc/org/item_id": "451",
+                        "@ondc/org/title_type": "item",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
+                        }
+                    },
+                    {
+                        "item": {
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "66zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "price": {
+                                "value": "5",
+                                "currency": "INR"
+                            },
+                            "parent_item_id": "xXUeYhqy/JJR"
+                        },
+                        "price": {
+                            "value": "5",
+                            "currency": "INR"
+                        },
+                        "title": "Extra",
+                        "@ondc/org/item_id": "93",
+                        "@ondc/org/title_type": "item",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
+                        }
+                    },
+                    {
+                        "item": {
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "67zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "price": {
+                                "value": "10",
+                                "currency": "INR"
+                            },
+                            "parent_item_id": "xXUeYhqy/JJR"
+                        },
+                        "price": {
+                            "value": "10",
+                            "currency": "INR"
+                        },
+                        "title": "Chicken",
+                        "@ondc/org/item_id": "95",
+                        "@ondc/org/title_type": "item",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
+                        }
+                    },
+                    {
+                        "price": {
+                            "value": "4.04",
+                            "currency": "INR"
+                        },
+                        "title": "Convenience fee",
+                        "@ondc/org/item_id": "155",
+                        "@ondc/org/title_type": "misc"
+                    },
+                    {
+                        "price": {
+                            "value": "0",
+                            "currency": "INR"
+                        },
+                        "title": "Delivery charges",
+                        "@ondc/org/item_id": "155",
+                        "@ondc/org/title_type": "delivery"
+                    }
+                ]
+            },
+            "billing": {
+                "name": "Ajeet Chauhan",
+                "email": "ajeetchauhan.symfony143@webkul.in",
+                "phone": "8574739650",
+                "address": {
+                    "city": "Noida",
+                    "name": "Ajeet Chauhan",
+                    "state": "Uttar Pradesh",
+                    "country": "IND",
+                    "building": "ARV Park",
+                    "locality": "Unnamed Road",
+                    "area_code": "201301"
+                },
+                "created_at": "2025-01-07T13:48:57.575Z",
+                "updated_at": "2025-01-07T13:48:57.575Z"
+            },
+            "payment": {
+                "uri": "https://razorpay.com/",
+                "type": "ON-ORDER",
+                "params": {
+                    "amount": "118.04",
+                    "currency": "INR",
+                    "transaction_id": "order_PgZkhFsKOgD7zY"
+                },
+                "status": "PAID",
+                "tl_method": "http/get",
+                "collected_by": "BAP",
+                "@ondc/org/settlement_details": [
+                    {
+                        "bank_name": "fasdf",
+                        "branch_name": "noida",
+                        "settlement_type": "neft",
+                        "beneficiary_name": "fasdf asdfasdf",
+                        "settlement_phase": "sale-amount",
+                        "settlement_status": "NOT-PAID",
+                        "settlement_ifsc_code": "HDFC0000088",
+                        "settlement_counterparty": "seller-app",
+                        "settlement_bank_account_no": "534512341234132"
+                    }
+                ],
+                "@ondc/org/buyer_app_finder_fee_type": "percent",
+                "@ondc/org/buyer_app_finder_fee_amount": "3.0"
+            },
+            "created_at": "2025-01-07T13:49:36.442Z",
+            "updated_at": "2025-01-07T13:50:44.494Z"
+        }
+    }
+}

--- a/eComviser/Seller App RET11/Flow-5/on_status_out_for_delivery.json
+++ b/eComviser/Seller App RET11/Flow-5/on_status_out_for_delivery.json
@@ -1,0 +1,317 @@
+{
+    "context": {
+        "domain": "ONDC:RET11",
+        "country": "IND",
+        "city": "std:0120",
+        "action": "on_status",
+        "core_version": "1.2.0",
+        "bap_id": "buyer-app-preprod-v2.ondc.org",
+        "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+        "bpp_uri": "https://ondc.ecomviser.com/api/v1",
+        "transaction_id": "45cb5581-3284-46bc-9ee5-f46ce026af43",
+        "message_id": "677d314900b3d1a93d025-5938",
+        "timestamp": "2025-01-07T13:51:05.003Z",
+        "bpp_id": "ondc.ecomviser.com",
+        "ttl": "PT30S"
+    },
+    "message": {
+        "order": {
+            "id": "2025-01-07-367431",
+            "state": "In-progress",
+            "provider": {
+                "id": "84",
+                "locations": [
+                    {
+                        "id": "83"
+                    }
+                ]
+            },
+            "items": [
+                {
+                    "id": "451",
+                    "fulfillment_id": "155",
+                    "quantity": {
+                        "count": 1
+                    }
+                }
+            ],
+            "fulfillments": [
+                {
+                    "id": "155",
+                    "end": {
+                        "time": {
+                            "range": {
+                                "end": "2025-01-07T14:49:43.355Z",
+                                "start": "2025-01-07T13:49:43.355Z"
+                            }
+                        },
+                        "person": {
+                            "name": "Ajeet Chauhan"
+                        },
+                        "contact": {
+                            "email": "ajeetchauhan.symfony143@webkul.in",
+                            "phone": "8574739650"
+                        },
+                        "location": {
+                            "gps": "28.629743,77.377795",
+                            "address": {
+                                "city": "Noida",
+                                "name": "Ajeet Chauhan",
+                                "state": "Uttar Pradesh",
+                                "country": "IND",
+                                "building": "ARV Park",
+                                "locality": "Unnamed Road",
+                                "area_code": "201301"
+                            }
+                        }
+                    },
+                    "type": "Delivery",
+                    "start": {
+                        "time": {
+                            "range": {
+                                "end": "2025-01-07T14:49:43.355Z",
+                                "start": "2025-01-07T13:49:43.355Z"
+                            },
+                            "timestamp": "2025-01-07T13:50:53.527Z"
+                        },
+                        "contact": {
+                            "email": "support@webkul.in",
+                            "phone": "9876543210"
+                        },
+                        "location": {
+                            "id": "83",
+                            "gps": "28.62972640,77.37783230",
+                            "address": {
+                                "city": "Gautam Buddh Nagar",
+                                "state": "Uttar Pradesh",
+                                "locality": "Noida",
+                                "area_code": "201301"
+                            },
+                            "descriptor": {
+                                "name": "Ajeet Food Shop"
+                            }
+                        }
+                    },
+                    "state": {
+                        "descriptor": {
+                            "code": "Out-for-delivery"
+                        }
+                    },
+                    "tracking": true,
+                    "@ondc/org/TAT": "PT90M",
+                    "@ondc/org/provider_name": "ondc.ecomviser.com",
+                    "tags": [
+                        {
+                            "code": "routing",
+                            "list": [
+                                {
+                                    "code": "type",
+                                    "value": "P2P"
+                                }
+                            ]
+                        },
+                        {
+                            "code": "tracking",
+                            "list": [
+                                {
+                                    "code": "gps_enabled",
+                                    "value": "yes"
+                                },
+                                {
+                                    "code": "url_enabled",
+                                    "value": "no"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "quote": {
+                "ttl": "PT6H",
+                "price": {
+                    "value": "118.04",
+                    "currency": "INR"
+                },
+                "breakup": [
+                    {
+                        "item": {
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "item"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "price": {
+                                "value": "99",
+                                "currency": "INR"
+                            },
+                            "parent_item_id": "xXUeYhqy/JJR"
+                        },
+                        "price": {
+                            "value": "99",
+                            "currency": "INR"
+                        },
+                        "title": "Pizza Mania Updated",
+                        "@ondc/org/item_id": "451",
+                        "@ondc/org/title_type": "item",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
+                        }
+                    },
+                    {
+                        "item": {
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "66zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "price": {
+                                "value": "5",
+                                "currency": "INR"
+                            },
+                            "parent_item_id": "xXUeYhqy/JJR"
+                        },
+                        "price": {
+                            "value": "5",
+                            "currency": "INR"
+                        },
+                        "title": "Extra",
+                        "@ondc/org/item_id": "93",
+                        "@ondc/org/title_type": "item",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
+                        }
+                    },
+                    {
+                        "item": {
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "67zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "price": {
+                                "value": "10",
+                                "currency": "INR"
+                            },
+                            "parent_item_id": "xXUeYhqy/JJR"
+                        },
+                        "price": {
+                            "value": "10",
+                            "currency": "INR"
+                        },
+                        "title": "Chicken",
+                        "@ondc/org/item_id": "95",
+                        "@ondc/org/title_type": "item",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
+                        }
+                    },
+                    {
+                        "price": {
+                            "value": "4.04",
+                            "currency": "INR"
+                        },
+                        "title": "Convenience fee",
+                        "@ondc/org/item_id": "155",
+                        "@ondc/org/title_type": "misc"
+                    },
+                    {
+                        "price": {
+                            "value": "0",
+                            "currency": "INR"
+                        },
+                        "title": "Delivery charges",
+                        "@ondc/org/item_id": "155",
+                        "@ondc/org/title_type": "delivery"
+                    }
+                ]
+            },
+            "billing": {
+                "name": "Ajeet Chauhan",
+                "email": "ajeetchauhan.symfony143@webkul.in",
+                "phone": "8574739650",
+                "address": {
+                    "city": "Noida",
+                    "name": "Ajeet Chauhan",
+                    "state": "Uttar Pradesh",
+                    "country": "IND",
+                    "building": "ARV Park",
+                    "locality": "Unnamed Road",
+                    "area_code": "201301"
+                },
+                "created_at": "2025-01-07T13:48:57.575Z",
+                "updated_at": "2025-01-07T13:48:57.575Z"
+            },
+            "payment": {
+                "uri": "https://razorpay.com/",
+                "type": "ON-ORDER",
+                "params": {
+                    "amount": "118.04",
+                    "currency": "INR",
+                    "transaction_id": "order_PgZkhFsKOgD7zY"
+                },
+                "status": "PAID",
+                "tl_method": "http/get",
+                "collected_by": "BAP",
+                "@ondc/org/settlement_details": [
+                    {
+                        "bank_name": "fasdf",
+                        "branch_name": "noida",
+                        "settlement_type": "neft",
+                        "beneficiary_name": "fasdf asdfasdf",
+                        "settlement_phase": "sale-amount",
+                        "settlement_status": "NOT-PAID",
+                        "settlement_ifsc_code": "HDFC0000088",
+                        "settlement_counterparty": "seller-app",
+                        "settlement_bank_account_no": "534512341234132"
+                    }
+                ],
+                "@ondc/org/buyer_app_finder_fee_type": "percent",
+                "@ondc/org/buyer_app_finder_fee_amount": "3.0"
+            },
+            "created_at": "2025-01-07T13:49:36.442Z",
+            "updated_at": "2025-01-07T13:51:05.003Z",
+            "documents": [
+                {
+                    "label": "Invoice",
+                    "url": "https://ecomviser-prepod.sp-seller-preprod.ecomviser.com/index.php?p=invoice_download&key=MTgxOjg0OmVjb212aXNlcg=="
+                }
+            ]
+        }
+    }
+}

--- a/eComviser/Seller App RET11/Flow-5/on_status_packed.json
+++ b/eComviser/Seller App RET11/Flow-5/on_status_packed.json
@@ -1,0 +1,286 @@
+{
+    "context": {
+        "domain": "ONDC:RET11",
+        "country": "IND",
+        "city": "std:0120",
+        "action": "on_status",
+        "core_version": "1.2.0",
+        "bap_id": "buyer-app-preprod-v2.ondc.org",
+        "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+        "bpp_uri": "https://ondc.ecomviser.com/api/v1",
+        "transaction_id": "45cb5581-3284-46bc-9ee5-f46ce026af43",
+        "message_id": "677d3128578de70276196-7bbe",
+        "timestamp": "2025-01-07T13:50:32.359Z",
+        "bpp_id": "ondc.ecomviser.com",
+        "ttl": "PT30S"
+    },
+    "message": {
+        "order": {
+            "id": "2025-01-07-367431",
+            "state": "In-progress",
+            "provider": {
+                "id": "84",
+                "locations": [
+                    {
+                        "id": "83"
+                    }
+                ]
+            },
+            "items": [
+                {
+                    "id": "451",
+                    "fulfillment_id": "155",
+                    "quantity": {
+                        "count": 1
+                    }
+                }
+            ],
+            "fulfillments": [
+                {
+                    "id": "155",
+                    "end": {
+                        "time": {
+                            "range": {
+                                "end": "2025-01-07T14:49:43.355Z",
+                                "start": "2025-01-07T13:49:43.355Z"
+                            }
+                        },
+                        "person": {
+                            "name": "Ajeet Chauhan"
+                        },
+                        "contact": {
+                            "email": "ajeetchauhan.symfony143@webkul.in",
+                            "phone": "8574739650"
+                        },
+                        "location": {
+                            "gps": "28.629743,77.377795",
+                            "address": {
+                                "city": "Noida",
+                                "name": "Ajeet Chauhan",
+                                "state": "Uttar Pradesh",
+                                "country": "IND",
+                                "building": "ARV Park",
+                                "locality": "Unnamed Road",
+                                "area_code": "201301"
+                            }
+                        }
+                    },
+                    "type": "Delivery",
+                    "start": {
+                        "time": {
+                            "range": {
+                                "end": "2025-01-07T14:49:43.355Z",
+                                "start": "2025-01-07T13:49:43.355Z"
+                            }
+                        },
+                        "contact": {
+                            "email": "support@webkul.in",
+                            "phone": "9876543210"
+                        },
+                        "location": {
+                            "id": "83",
+                            "gps": "28.62972640,77.37783230",
+                            "address": {
+                                "city": "Gautam Buddh Nagar",
+                                "state": "Uttar Pradesh",
+                                "locality": "Noida",
+                                "area_code": "201301"
+                            },
+                            "descriptor": {
+                                "name": "Ajeet Food Shop"
+                            }
+                        }
+                    },
+                    "state": {
+                        "descriptor": {
+                            "code": "Packed"
+                        }
+                    },
+                    "tracking": true,
+                    "@ondc/org/TAT": "PT90M",
+                    "@ondc/org/provider_name": "ondc.ecomviser.com"
+                }
+            ],
+            "quote": {
+                "ttl": "PT6H",
+                "price": {
+                    "value": "118.04",
+                    "currency": "INR"
+                },
+                "breakup": [
+                    {
+                        "item": {
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "item"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "price": {
+                                "value": "99",
+                                "currency": "INR"
+                            },
+                            "parent_item_id": "xXUeYhqy/JJR"
+                        },
+                        "price": {
+                            "value": "99",
+                            "currency": "INR"
+                        },
+                        "title": "Pizza Mania Updated",
+                        "@ondc/org/item_id": "451",
+                        "@ondc/org/title_type": "item",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
+                        }
+                    },
+                    {
+                        "item": {
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "66zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "price": {
+                                "value": "5",
+                                "currency": "INR"
+                            },
+                            "parent_item_id": "xXUeYhqy/JJR"
+                        },
+                        "price": {
+                            "value": "5",
+                            "currency": "INR"
+                        },
+                        "title": "Extra",
+                        "@ondc/org/item_id": "93",
+                        "@ondc/org/title_type": "item",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
+                        }
+                    },
+                    {
+                        "item": {
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "67zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "price": {
+                                "value": "10",
+                                "currency": "INR"
+                            },
+                            "parent_item_id": "xXUeYhqy/JJR"
+                        },
+                        "price": {
+                            "value": "10",
+                            "currency": "INR"
+                        },
+                        "title": "Chicken",
+                        "@ondc/org/item_id": "95",
+                        "@ondc/org/title_type": "item",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
+                        }
+                    },
+                    {
+                        "price": {
+                            "value": "4.04",
+                            "currency": "INR"
+                        },
+                        "title": "Convenience fee",
+                        "@ondc/org/item_id": "155",
+                        "@ondc/org/title_type": "misc"
+                    },
+                    {
+                        "price": {
+                            "value": "0",
+                            "currency": "INR"
+                        },
+                        "title": "Delivery charges",
+                        "@ondc/org/item_id": "155",
+                        "@ondc/org/title_type": "delivery"
+                    }
+                ]
+            },
+            "billing": {
+                "name": "Ajeet Chauhan",
+                "email": "ajeetchauhan.symfony143@webkul.in",
+                "phone": "8574739650",
+                "address": {
+                    "city": "Noida",
+                    "name": "Ajeet Chauhan",
+                    "state": "Uttar Pradesh",
+                    "country": "IND",
+                    "building": "ARV Park",
+                    "locality": "Unnamed Road",
+                    "area_code": "201301"
+                },
+                "created_at": "2025-01-07T13:48:57.575Z",
+                "updated_at": "2025-01-07T13:48:57.575Z"
+            },
+            "payment": {
+                "uri": "https://razorpay.com/",
+                "type": "ON-ORDER",
+                "params": {
+                    "amount": "118.04",
+                    "currency": "INR",
+                    "transaction_id": "order_PgZkhFsKOgD7zY"
+                },
+                "status": "PAID",
+                "tl_method": "http/get",
+                "collected_by": "BAP",
+                "@ondc/org/settlement_details": [
+                    {
+                        "bank_name": "fasdf",
+                        "branch_name": "noida",
+                        "settlement_type": "neft",
+                        "beneficiary_name": "fasdf asdfasdf",
+                        "settlement_phase": "sale-amount",
+                        "settlement_status": "NOT-PAID",
+                        "settlement_ifsc_code": "HDFC0000088",
+                        "settlement_counterparty": "seller-app",
+                        "settlement_bank_account_no": "534512341234132"
+                    }
+                ],
+                "@ondc/org/buyer_app_finder_fee_type": "percent",
+                "@ondc/org/buyer_app_finder_fee_amount": "3.0"
+            },
+            "created_at": "2025-01-07T13:49:36.442Z",
+            "updated_at": "2025-01-07T13:50:32.359Z"
+        }
+    }
+}

--- a/eComviser/Seller App RET11/Flow-5/on_status_pending.json
+++ b/eComviser/Seller App RET11/Flow-5/on_status_pending.json
@@ -1,0 +1,286 @@
+{
+    "context": {
+        "domain": "ONDC:RET11",
+        "country": "IND",
+        "city": "std:0120",
+        "action": "on_status",
+        "core_version": "1.2.0",
+        "bap_id": "buyer-app-preprod-v2.ondc.org",
+        "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+        "bpp_uri": "https://ondc.ecomviser.com/api/v1",
+        "transaction_id": "45cb5581-3284-46bc-9ee5-f46ce026af43",
+        "message_id": "677d3114ede0c3878aa05-dbcc",
+        "timestamp": "2025-01-07T13:50:12.974Z",
+        "bpp_id": "ondc.ecomviser.com",
+        "ttl": "PT30S"
+    },
+    "message": {
+        "order": {
+            "id": "2025-01-07-367431",
+            "state": "Accepted",
+            "provider": {
+                "id": "84",
+                "locations": [
+                    {
+                        "id": "83"
+                    }
+                ]
+            },
+            "items": [
+                {
+                    "id": "451",
+                    "fulfillment_id": "155",
+                    "quantity": {
+                        "count": 1
+                    }
+                }
+            ],
+            "fulfillments": [
+                {
+                    "id": "155",
+                    "end": {
+                        "time": {
+                            "range": {
+                                "end": "2025-01-07T14:49:43.355Z",
+                                "start": "2025-01-07T13:49:43.355Z"
+                            }
+                        },
+                        "person": {
+                            "name": "Ajeet Chauhan"
+                        },
+                        "contact": {
+                            "email": "ajeetchauhan.symfony143@webkul.in",
+                            "phone": "8574739650"
+                        },
+                        "location": {
+                            "gps": "28.629743,77.377795",
+                            "address": {
+                                "city": "Noida",
+                                "name": "Ajeet Chauhan",
+                                "state": "Uttar Pradesh",
+                                "country": "IND",
+                                "building": "ARV Park",
+                                "locality": "Unnamed Road",
+                                "area_code": "201301"
+                            }
+                        }
+                    },
+                    "type": "Delivery",
+                    "start": {
+                        "time": {
+                            "range": {
+                                "end": "2025-01-07T14:49:43.355Z",
+                                "start": "2025-01-07T13:49:43.355Z"
+                            }
+                        },
+                        "contact": {
+                            "email": "support@webkul.in",
+                            "phone": "9876543210"
+                        },
+                        "location": {
+                            "id": "83",
+                            "gps": "28.62972640,77.37783230",
+                            "address": {
+                                "city": "Gautam Buddh Nagar",
+                                "state": "Uttar Pradesh",
+                                "locality": "Noida",
+                                "area_code": "201301"
+                            },
+                            "descriptor": {
+                                "name": "Ajeet Food Shop"
+                            }
+                        }
+                    },
+                    "state": {
+                        "descriptor": {
+                            "code": "Pending"
+                        }
+                    },
+                    "tracking": true,
+                    "@ondc/org/TAT": "PT90M",
+                    "@ondc/org/provider_name": "ondc.ecomviser.com"
+                }
+            ],
+            "quote": {
+                "ttl": "PT6H",
+                "price": {
+                    "value": "118.04",
+                    "currency": "INR"
+                },
+                "breakup": [
+                    {
+                        "item": {
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "item"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "price": {
+                                "value": "99",
+                                "currency": "INR"
+                            },
+                            "parent_item_id": "xXUeYhqy/JJR"
+                        },
+                        "price": {
+                            "value": "99",
+                            "currency": "INR"
+                        },
+                        "title": "Pizza Mania Updated",
+                        "@ondc/org/item_id": "451",
+                        "@ondc/org/title_type": "item",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
+                        }
+                    },
+                    {
+                        "item": {
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "66zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "price": {
+                                "value": "5",
+                                "currency": "INR"
+                            },
+                            "parent_item_id": "xXUeYhqy/JJR"
+                        },
+                        "price": {
+                            "value": "5",
+                            "currency": "INR"
+                        },
+                        "title": "Extra",
+                        "@ondc/org/item_id": "93",
+                        "@ondc/org/title_type": "item",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
+                        }
+                    },
+                    {
+                        "item": {
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "67zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "price": {
+                                "value": "10",
+                                "currency": "INR"
+                            },
+                            "parent_item_id": "xXUeYhqy/JJR"
+                        },
+                        "price": {
+                            "value": "10",
+                            "currency": "INR"
+                        },
+                        "title": "Chicken",
+                        "@ondc/org/item_id": "95",
+                        "@ondc/org/title_type": "item",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
+                        }
+                    },
+                    {
+                        "price": {
+                            "value": "4.04",
+                            "currency": "INR"
+                        },
+                        "title": "Convenience fee",
+                        "@ondc/org/item_id": "155",
+                        "@ondc/org/title_type": "misc"
+                    },
+                    {
+                        "price": {
+                            "value": "0",
+                            "currency": "INR"
+                        },
+                        "title": "Delivery charges",
+                        "@ondc/org/item_id": "155",
+                        "@ondc/org/title_type": "delivery"
+                    }
+                ]
+            },
+            "billing": {
+                "name": "Ajeet Chauhan",
+                "email": "ajeetchauhan.symfony143@webkul.in",
+                "phone": "8574739650",
+                "address": {
+                    "city": "Noida",
+                    "name": "Ajeet Chauhan",
+                    "state": "Uttar Pradesh",
+                    "country": "IND",
+                    "building": "ARV Park",
+                    "locality": "Unnamed Road",
+                    "area_code": "201301"
+                },
+                "created_at": "2025-01-07T13:48:57.575Z",
+                "updated_at": "2025-01-07T13:48:57.575Z"
+            },
+            "payment": {
+                "uri": "https://razorpay.com/",
+                "type": "ON-ORDER",
+                "params": {
+                    "amount": "118.04",
+                    "currency": "INR",
+                    "transaction_id": "order_PgZkhFsKOgD7zY"
+                },
+                "status": "PAID",
+                "tl_method": "http/get",
+                "collected_by": "BAP",
+                "@ondc/org/settlement_details": [
+                    {
+                        "bank_name": "fasdf",
+                        "branch_name": "noida",
+                        "settlement_type": "neft",
+                        "beneficiary_name": "fasdf asdfasdf",
+                        "settlement_phase": "sale-amount",
+                        "settlement_status": "NOT-PAID",
+                        "settlement_ifsc_code": "HDFC0000088",
+                        "settlement_counterparty": "seller-app",
+                        "settlement_bank_account_no": "534512341234132"
+                    }
+                ],
+                "@ondc/org/buyer_app_finder_fee_type": "percent",
+                "@ondc/org/buyer_app_finder_fee_amount": "3.0"
+            },
+            "created_at": "2025-01-07T13:49:36.442Z",
+            "updated_at": "2025-01-07T13:50:12.974Z"
+        }
+    }
+}

--- a/eComviser/Seller App RET11/Flow-5/on_status_picked.json
+++ b/eComviser/Seller App RET11/Flow-5/on_status_picked.json
@@ -1,0 +1,323 @@
+{
+    "context": {
+        "domain": "ONDC:RET11",
+        "country": "IND",
+        "city": "std:0120",
+        "action": "on_status",
+        "core_version": "1.2.0",
+        "bap_id": "buyer-app-preprod-v2.ondc.org",
+        "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+        "bpp_uri": "https://ondc.ecomviser.com/api/v1",
+        "transaction_id": "45cb5581-3284-46bc-9ee5-f46ce026af43",
+        "message_id": "677d313e1a863c1a5e8e9-e8f3",
+        "timestamp": "2025-01-07T13:50:54.109Z",
+        "bpp_id": "ondc.ecomviser.com",
+        "ttl": "PT30S"
+    },
+    "message": {
+        "order": {
+            "id": "2025-01-07-367431",
+            "state": "In-progress",
+            "provider": {
+                "id": "84",
+                "locations": [
+                    {
+                        "id": "83"
+                    }
+                ]
+            },
+            "items": [
+                {
+                    "id": "451",
+                    "fulfillment_id": "155",
+                    "quantity": {
+                        "count": 1
+                    }
+                }
+            ],
+            "fulfillments": [
+                {
+                    "id": "155",
+                    "end": {
+                        "time": {
+                            "range": {
+                                "end": "2025-01-07T14:49:43.355Z",
+                                "start": "2025-01-07T13:49:43.355Z"
+                            }
+                        },
+                        "person": {
+                            "name": "Ajeet Chauhan"
+                        },
+                        "contact": {
+                            "email": "ajeetchauhan.symfony143@webkul.in",
+                            "phone": "8574739650"
+                        },
+                        "location": {
+                            "gps": "28.629743,77.377795",
+                            "address": {
+                                "city": "Noida",
+                                "name": "Ajeet Chauhan",
+                                "state": "Uttar Pradesh",
+                                "country": "IND",
+                                "building": "ARV Park",
+                                "locality": "Unnamed Road",
+                                "area_code": "201301"
+                            }
+                        }
+                    },
+                    "type": "Delivery",
+                    "start": {
+                        "time": {
+                            "range": {
+                                "end": "2025-01-07T14:49:43.355Z",
+                                "start": "2025-01-07T13:49:43.355Z"
+                            },
+                            "timestamp": "2025-01-07T13:50:53.527Z"
+                        },
+                        "contact": {
+                            "email": "support@webkul.in",
+                            "phone": "9876543210"
+                        },
+                        "location": {
+                            "id": "83",
+                            "gps": "28.62972640,77.37783230",
+                            "address": {
+                                "city": "Gautam Buddh Nagar",
+                                "state": "Uttar Pradesh",
+                                "locality": "Noida",
+                                "area_code": "201301"
+                            },
+                            "descriptor": {
+                                "name": "Ajeet Food Shop"
+                            }
+                        },
+                        "instructions": {
+                            "code": "2",
+                            "name": "ONDC Order",
+                            "short_desc": "ae34fd",
+                            "long_desc": "additional instructions for pickup"
+                        }
+                    },
+                    "state": {
+                        "descriptor": {
+                            "code": "Order-picked-up"
+                        }
+                    },
+                    "tracking": true,
+                    "@ondc/org/TAT": "PT90M",
+                    "@ondc/org/provider_name": "ondc.ecomviser.com",
+                    "tags": [
+                        {
+                            "code": "routing",
+                            "list": [
+                                {
+                                    "code": "type",
+                                    "value": "P2P"
+                                }
+                            ]
+                        },
+                        {
+                            "code": "tracking",
+                            "list": [
+                                {
+                                    "code": "gps_enabled",
+                                    "value": "yes"
+                                },
+                                {
+                                    "code": "url_enabled",
+                                    "value": "no"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "quote": {
+                "ttl": "PT6H",
+                "price": {
+                    "value": "118.04",
+                    "currency": "INR"
+                },
+                "breakup": [
+                    {
+                        "item": {
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "item"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "price": {
+                                "value": "99",
+                                "currency": "INR"
+                            },
+                            "parent_item_id": "xXUeYhqy/JJR"
+                        },
+                        "price": {
+                            "value": "99",
+                            "currency": "INR"
+                        },
+                        "title": "Pizza Mania Updated",
+                        "@ondc/org/item_id": "451",
+                        "@ondc/org/title_type": "item",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
+                        }
+                    },
+                    {
+                        "item": {
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "66zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "price": {
+                                "value": "5",
+                                "currency": "INR"
+                            },
+                            "parent_item_id": "xXUeYhqy/JJR"
+                        },
+                        "price": {
+                            "value": "5",
+                            "currency": "INR"
+                        },
+                        "title": "Extra",
+                        "@ondc/org/item_id": "93",
+                        "@ondc/org/title_type": "item",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
+                        }
+                    },
+                    {
+                        "item": {
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "67zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "price": {
+                                "value": "10",
+                                "currency": "INR"
+                            },
+                            "parent_item_id": "xXUeYhqy/JJR"
+                        },
+                        "price": {
+                            "value": "10",
+                            "currency": "INR"
+                        },
+                        "title": "Chicken",
+                        "@ondc/org/item_id": "95",
+                        "@ondc/org/title_type": "item",
+                        "@ondc/org/item_quantity": {
+                            "count": 1
+                        }
+                    },
+                    {
+                        "price": {
+                            "value": "4.04",
+                            "currency": "INR"
+                        },
+                        "title": "Convenience fee",
+                        "@ondc/org/item_id": "155",
+                        "@ondc/org/title_type": "misc"
+                    },
+                    {
+                        "price": {
+                            "value": "0",
+                            "currency": "INR"
+                        },
+                        "title": "Delivery charges",
+                        "@ondc/org/item_id": "155",
+                        "@ondc/org/title_type": "delivery"
+                    }
+                ]
+            },
+            "billing": {
+                "name": "Ajeet Chauhan",
+                "email": "ajeetchauhan.symfony143@webkul.in",
+                "phone": "8574739650",
+                "address": {
+                    "city": "Noida",
+                    "name": "Ajeet Chauhan",
+                    "state": "Uttar Pradesh",
+                    "country": "IND",
+                    "building": "ARV Park",
+                    "locality": "Unnamed Road",
+                    "area_code": "201301"
+                },
+                "created_at": "2025-01-07T13:48:57.575Z",
+                "updated_at": "2025-01-07T13:48:57.575Z"
+            },
+            "payment": {
+                "uri": "https://razorpay.com/",
+                "type": "ON-ORDER",
+                "params": {
+                    "amount": "118.04",
+                    "currency": "INR",
+                    "transaction_id": "order_PgZkhFsKOgD7zY"
+                },
+                "status": "PAID",
+                "tl_method": "http/get",
+                "collected_by": "BAP",
+                "@ondc/org/settlement_details": [
+                    {
+                        "bank_name": "fasdf",
+                        "branch_name": "noida",
+                        "settlement_type": "neft",
+                        "beneficiary_name": "fasdf asdfasdf",
+                        "settlement_phase": "sale-amount",
+                        "settlement_status": "NOT-PAID",
+                        "settlement_ifsc_code": "HDFC0000088",
+                        "settlement_counterparty": "seller-app",
+                        "settlement_bank_account_no": "534512341234132"
+                    }
+                ],
+                "@ondc/org/buyer_app_finder_fee_type": "percent",
+                "@ondc/org/buyer_app_finder_fee_amount": "3.0"
+            },
+            "created_at": "2025-01-07T13:49:36.442Z",
+            "updated_at": "2025-01-07T13:50:54.109Z",
+            "documents": [
+                {
+                    "label": "Invoice",
+                    "url": "https://ecomviser-prepod.sp-seller-preprod.ecomviser.com/index.php?p=invoice_download&key=MTgxOjg0OmVjb212aXNlcg=="
+                }
+            ]
+        }
+    }
+}

--- a/eComviser/Seller App RET11/Flow-5/on_status_rto_delivered.json
+++ b/eComviser/Seller App RET11/Flow-5/on_status_rto_delivered.json
@@ -1,0 +1,504 @@
+{
+    "context": {
+        "domain": "ONDC:RET11",
+        "country": "IND",
+        "city": "std:0120",
+        "action": "on_status",
+        "core_version": "1.2.0",
+        "bap_id": "buyer-app-preprod-v2.ondc.org",
+        "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+        "bpp_uri": "https://ondc.ecomviser.com/api/v1",
+        "transaction_id": "45cb5581-3284-46bc-9ee5-f46ce026af43",
+        "message_id": "677d3171646117e7a7427-4bf5",
+        "timestamp": "2025-01-07T13:51:45.411Z",
+        "bpp_id": "ondc.ecomviser.com",
+        "ttl": "PT30S"
+    },
+    "message": {
+        "order": {
+            "id": "2025-01-07-367431",
+            "state": "Cancelled",
+            "provider": {
+                "id": "84",
+                "locations": [
+                    {
+                        "id": "83"
+                    }
+                ]
+            },
+            "items": [
+                {
+                    "id": "451",
+                    "fulfillment_id": "155",
+                    "quantity": {
+                        "count": 0
+                    }
+                },
+                {
+                    "id": "93",
+                    "fulfillment_id": "155",
+                    "quantity": {
+                        "count": 0
+                    }
+                },
+                {
+                    "id": "95",
+                    "fulfillment_id": "155",
+                    "quantity": {
+                        "count": 0
+                    }
+                },
+                {
+                    "id": "451",
+                    "fulfillment_id": "rto-shipping",
+                    "quantity": {
+                        "count": 1
+                    }
+                },
+                {
+                    "id": "93",
+                    "fulfillment_id": "rto-shipping",
+                    "quantity": {
+                        "count": 1
+                    }
+                },
+                {
+                    "id": "95",
+                    "fulfillment_id": "rto-shipping",
+                    "quantity": {
+                        "count": 1
+                    }
+                }
+            ],
+            "billing": {
+                "name": "Ajeet Chauhan",
+                "email": "ajeetchauhan.symfony143@webkul.in",
+                "phone": "8574739650",
+                "address": {
+                    "city": "Noida",
+                    "name": "Ajeet Chauhan",
+                    "state": "Uttar Pradesh",
+                    "country": "IND",
+                    "building": "ARV Park",
+                    "locality": "Unnamed Road",
+                    "area_code": "201301"
+                },
+                "created_at": "2025-01-07T13:48:57.575Z",
+                "updated_at": "2025-01-07T13:48:57.575Z"
+            },
+            "fulfillments": [
+                {
+                    "id": "155",
+                    "end": {
+                        "time": {
+                            "timestamp": "2025-01-07T14:21:20.562Z",
+                            "range": {
+                                "start": "2025-01-07T13:51:20.562Z",
+                                "end": "2025-01-07T14:21:20.562Z"
+                            }
+                        },
+                        "person": {
+                            "name": "Ajeet Chauhan"
+                        },
+                        "contact": {
+                            "email": "ajeetchauhan.symfony143@webkul.in",
+                            "phone": "8574739650"
+                        },
+                        "location": {
+                            "gps": "28.629743,77.377795",
+                            "address": {
+                                "city": "Noida",
+                                "name": "Ajeet Chauhan",
+                                "state": "Uttar Pradesh",
+                                "country": "IND",
+                                "building": "ARV Park",
+                                "locality": "Unnamed Road",
+                                "area_code": "201301"
+                            }
+                        }
+                    },
+                    "type": "Delivery",
+                    "start": {
+                        "time": {
+                            "timestamp": "2025-01-07T14:21:20.562Z",
+                            "range": {
+                                "start": "2025-01-07T13:51:20.562Z",
+                                "end": "2025-01-07T14:21:20.562Z"
+                            }
+                        },
+                        "contact": {
+                            "email": "support@webkul.in",
+                            "phone": "9876543210"
+                        },
+                        "location": {
+                            "id": "83",
+                            "gps": "28.62972640,77.37783230",
+                            "address": {
+                                "city": "Gautam Buddh Nagar",
+                                "state": "Uttar Pradesh",
+                                "locality": "Noida",
+                                "area_code": "201301"
+                            },
+                            "descriptor": {
+                                "name": "Ajeet Food Shop"
+                            }
+                        }
+                    },
+                    "state": {
+                        "descriptor": {
+                            "code": "Cancelled"
+                        }
+                    },
+                    "tracking": true,
+                    "@ondc/org/TAT": "PT90M",
+                    "@ondc/org/provider_name": "ondc.ecomviser.com",
+                    "tags": [
+                        {
+                            "code": "cancel_request",
+                            "list": [
+                                {
+                                    "code": "retry_count",
+                                    "value": "3"
+                                },
+                                {
+                                    "code": "rto_id",
+                                    "value": "rto-shipping"
+                                },
+                                {
+                                    "code": "reason_id",
+                                    "value": "015"
+                                },
+                                {
+                                    "code": "initiated_by",
+                                    "value": "ondc.ecomviser.com"
+                                }
+                            ]
+                        },
+                        {
+                            "code": "precancel_state",
+                            "list": [
+                                {
+                                    "code": "fulfillment_state",
+                                    "value": "Out-for-delivery"
+                                },
+                                {
+                                    "code": "updated_at",
+                                    "value": "2025-01-07T13:51:05.003Z"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "id": "rto-shipping",
+                    "type": "RTO",
+                    "state": {
+                        "descriptor": {
+                            "code": "RTO-Disposed"
+                        }
+                    },
+                    "start": {
+                        "time": {
+                            "timestamp": "2025-01-07T14:21:20.562Z",
+                            "range": {
+                                "start": "2025-01-07T13:51:20.562Z",
+                                "end": "2025-01-07T14:21:20.562Z"
+                            }
+                        },
+                        "person": {
+                            "name": "Ajeet Chauhan"
+                        },
+                        "contact": {
+                            "email": "ajeetchauhan.symfony143@webkul.in",
+                            "phone": "8574739650"
+                        },
+                        "location": {
+                            "gps": "28.629743,77.377795",
+                            "address": {
+                                "city": "Noida",
+                                "name": "Ajeet Chauhan",
+                                "state": "Uttar Pradesh",
+                                "country": "IND",
+                                "building": "ARV Park",
+                                "locality": "Unnamed Road",
+                                "area_code": "201301"
+                            }
+                        }
+                    },
+                    "end": {
+                        "time": {
+                            "timestamp": "2025-01-07T13:51:45.417Z"
+                        },
+                        "contact": {
+                            "email": "support@webkul.in",
+                            "phone": "9876543210"
+                        },
+                        "location": {
+                            "id": "83",
+                            "gps": "28.62972640,77.37783230",
+                            "address": {
+                                "city": "Gautam Buddh Nagar",
+                                "state": "Uttar Pradesh",
+                                "locality": "Noida",
+                                "area_code": "201301"
+                            },
+                            "descriptor": {
+                                "name": "Ajeet Food Shop"
+                            }
+                        }
+                    },
+                    "tags": [
+                        {
+                            "code": "quote_trail",
+                            "list": [
+                                {
+                                    "code": "type",
+                                    "value": "item"
+                                },
+                                {
+                                    "code": "id",
+                                    "value": "451"
+                                },
+                                {
+                                    "code": "currency",
+                                    "value": "INR"
+                                },
+                                {
+                                    "code": "value",
+                                    "value": "-99.00"
+                                }
+                            ]
+                        },
+                        {
+                            "code": "quote_trail",
+                            "list": [
+                                {
+                                    "code": "type",
+                                    "value": "item"
+                                },
+                                {
+                                    "code": "id",
+                                    "value": "93"
+                                },
+                                {
+                                    "code": "currency",
+                                    "value": "INR"
+                                },
+                                {
+                                    "code": "value",
+                                    "value": "-5.00"
+                                }
+                            ]
+                        },
+                        {
+                            "code": "quote_trail",
+                            "list": [
+                                {
+                                    "code": "type",
+                                    "value": "item"
+                                },
+                                {
+                                    "code": "id",
+                                    "value": "95"
+                                },
+                                {
+                                    "code": "currency",
+                                    "value": "INR"
+                                },
+                                {
+                                    "code": "value",
+                                    "value": "-10.00"
+                                }
+                            ]
+                        },
+                        {
+                            "code": "quote_trail",
+                            "list": [
+                                {
+                                    "code": "type",
+                                    "value": "misc"
+                                },
+                                {
+                                    "code": "id",
+                                    "value": "155"
+                                },
+                                {
+                                    "code": "currency",
+                                    "value": "INR"
+                                },
+                                {
+                                    "code": "value",
+                                    "value": "-4.04"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "quote": {
+                "ttl": "PT6H",
+                "price": {
+                    "value": "0.00",
+                    "currency": "INR"
+                },
+                "breakup": [
+                    {
+                        "item": {
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "item"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "price": {
+                                "value": "99",
+                                "currency": "INR"
+                            },
+                            "parent_item_id": "xXUeYhqy/JJR"
+                        },
+                        "price": {
+                            "value": "0.00",
+                            "currency": "INR"
+                        },
+                        "title": "Pizza Mania Updated",
+                        "@ondc/org/item_id": "451",
+                        "@ondc/org/title_type": "item",
+                        "@ondc/org/item_quantity": {
+                            "count": 0
+                        }
+                    },
+                    {
+                        "item": {
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "66zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "price": {
+                                "value": "5",
+                                "currency": "INR"
+                            },
+                            "parent_item_id": "xXUeYhqy/JJR"
+                        },
+                        "price": {
+                            "value": "0.00",
+                            "currency": "INR"
+                        },
+                        "title": "Extra",
+                        "@ondc/org/item_id": "93",
+                        "@ondc/org/title_type": "item",
+                        "@ondc/org/item_quantity": {
+                            "count": 0
+                        }
+                    },
+                    {
+                        "item": {
+                            "tags": [
+                                {
+                                    "code": "type",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "customization"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "parent",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "67zabcdefghi"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "price": {
+                                "value": "10",
+                                "currency": "INR"
+                            },
+                            "parent_item_id": "xXUeYhqy/JJR"
+                        },
+                        "price": {
+                            "value": "0.00",
+                            "currency": "INR"
+                        },
+                        "title": "Chicken",
+                        "@ondc/org/item_id": "95",
+                        "@ondc/org/title_type": "item",
+                        "@ondc/org/item_quantity": {
+                            "count": 0
+                        }
+                    },
+                    {
+                        "price": {
+                            "value": "0.00",
+                            "currency": "INR"
+                        },
+                        "title": "Convenience fee",
+                        "@ondc/org/item_id": "155",
+                        "@ondc/org/title_type": "misc"
+                    },
+                    {
+                        "price": {
+                            "value": "0.00",
+                            "currency": "INR"
+                        },
+                        "title": "Delivery charges",
+                        "@ondc/org/item_id": "155",
+                        "@ondc/org/title_type": "delivery"
+                    }
+                ]
+            },
+            "payment": {
+                "uri": "https://razorpay.com/",
+                "type": "ON-ORDER",
+                "params": {
+                    "amount": "118.04",
+                    "currency": "INR",
+                    "transaction_id": "order_PgZkhFsKOgD7zY"
+                },
+                "status": "PAID",
+                "tl_method": "http/get",
+                "collected_by": "BAP",
+                "@ondc/org/settlement_details": [
+                    {
+                        "bank_name": "fasdf",
+                        "branch_name": "noida",
+                        "settlement_type": "neft",
+                        "beneficiary_name": "fasdf asdfasdf",
+                        "settlement_phase": "sale-amount",
+                        "settlement_status": "NOT-PAID",
+                        "settlement_ifsc_code": "HDFC0000088",
+                        "settlement_counterparty": "seller-app",
+                        "settlement_bank_account_no": "534512341234132"
+                    }
+                ],
+                "@ondc/org/buyer_app_finder_fee_type": "percent",
+                "@ondc/org/buyer_app_finder_fee_amount": "3.0"
+            },
+            "created_at": "2025-01-07T13:49:36.442Z",
+            "updated_at": "2025-01-07T14:21:45.417Z"
+        }
+    }
+}

--- a/eComviser/Seller App RET11/Flow-5/search.json
+++ b/eComviser/Seller App RET11/Flow-5/search.json
@@ -1,0 +1,26 @@
+{
+    "context": {
+        "domain": "ONDC:RET11",
+        "action": "search",
+        "country": "IND",
+        "city": "std:0120",
+        "core_version": "1.2.0",
+        "bap_id": "buyer-app-preprod-v2.ondc.org",
+        "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+        "transaction_id": "81464ede-43ee-45a9-a77e-617a140037af",
+        "message_id": "eed481f9-1e78-4341-9c77-4f13169cc711",
+        "timestamp": "2025-01-07T19:17:41.632Z",
+        "ttl": "PT30S"
+    },
+    "message": {
+        "intent": {
+            "fulfillment": {
+                "type": "Delivery"
+            },
+            "payment": {
+                "@ondc/org/buyer_app_finder_fee_type": "percent",
+                "@ondc/org/buyer_app_finder_fee_amount": "3"
+            }
+        }
+    }
+}

--- a/eComviser/Seller App RET11/Flow-5/select.json
+++ b/eComviser/Seller App RET11/Flow-5/select.json
@@ -1,0 +1,118 @@
+{
+    "context": {
+        "domain": "ONDC:RET11",
+        "country": "IND",
+        "city": "std:0120",
+        "action": "select",
+        "core_version": "1.2.0",
+        "bap_id": "buyer-app-preprod-v2.ondc.org",
+        "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
+        "bpp_uri": "https://ondc.ecomviser.com/api/v1",
+        "transaction_id": "45cb5581-3284-46bc-9ee5-f46ce026af43",
+        "message_id": "e7f8a941-a40b-4e44-b289-ce2ba1e1ed72",
+        "timestamp": "2025-01-07T13:48:39.526Z",
+        "bpp_id": "ondc.ecomviser.com",
+        "ttl": "PT30S"
+    },
+    "message": {
+        "order": {
+            "items": [
+                {
+                    "id": "451",
+                    "quantity": {
+                        "count": 1
+                    },
+                    "location_id": "83",
+                    "tags": [
+                        {
+                            "code": "type",
+                            "list": [
+                                {
+                                    "code": "type",
+                                    "value": "item"
+                                }
+                            ]
+                        }
+                    ],
+                    "parent_item_id": "xXUeYhqy/JJR"
+                },
+                {
+                    "id": "93",
+                    "quantity": {
+                        "count": 1
+                    },
+                    "location_id": "83",
+                    "tags": [
+                        {
+                            "code": "type",
+                            "list": [
+                                {
+                                    "code": "type",
+                                    "value": "customization"
+                                }
+                            ]
+                        },
+                        {
+                            "code": "parent",
+                            "list": [
+                                {
+                                    "code": "id",
+                                    "value": "66zabcdefghi"
+                                }
+                            ]
+                        }
+                    ],
+                    "parent_item_id": "xXUeYhqy/JJR"
+                },
+                {
+                    "id": "95",
+                    "quantity": {
+                        "count": 1
+                    },
+                    "location_id": "83",
+                    "tags": [
+                        {
+                            "code": "type",
+                            "list": [
+                                {
+                                    "code": "type",
+                                    "value": "customization"
+                                }
+                            ]
+                        },
+                        {
+                            "code": "parent",
+                            "list": [
+                                {
+                                    "code": "id",
+                                    "value": "67zabcdefghi"
+                                }
+                            ]
+                        }
+                    ],
+                    "parent_item_id": "xXUeYhqy/JJR"
+                }
+            ],
+            "provider": {
+                "id": "84",
+                "locations": [
+                    {
+                        "id": "83"
+                    }
+                ]
+            },
+            "fulfillments": [
+                {
+                    "end": {
+                        "location": {
+                            "gps": "28.629743,77.377795",
+                            "address": {
+                                "area_code": "201301"
+                            }
+                        }
+                    }
+                }
+            ]
+        }
+    }
+}


### PR DESCRIPTION
**Added log validation report for RET11**

We are getting

```
{
    "report": {
        "on_search_full_catalog_refresh": {
            "message/catalog/bpp/providers0/categories/items": "No items are mapped with the given category_id 844147zabcde in providers0/items"
        }
    }
}
```

This issue occurs in all flow validation and is ignored after a discussion with the ONDC team's Devendra on the 11 AM call. Please check accordingly.