### PR TITLE
fix: RSF flow 2 & 3 plantix

### DIFF
--- a/Plantix/RSF/flow-2/0_settle.json
+++ b/Plantix/RSF/flow-2/0_settle.json
@@ -8,16 +8,16 @@
     "bap_uri": "https://onca.dev.peat-cloud.com/ondc/v1",
     "bpp_id": "rsf-mock-service.ondc.org/seller_protocol_server_preprod",
     "bpp_uri": "https://rsf-mock-service.ondc.org/seller_protocol_server_preprod/ondc",
-    "transaction_id": "1061c914-3d2e-4cbe-ae9a-ccde181795a2",
-    "message_id": "2db1f349-7b4f-4340-95e5-7e803767e874",
-    "timestamp": "2024-11-27T11:11:58.651Z",
-    "ttl": "PT10M"
+    "transaction_id": "294d1ccf-55ee-4440-9c22-e1a002a33e5e",
+    "message_id": "5c1d7004-0fa0-4dbe-9c3b-cad23e9b1581",
+    "timestamp": "2025-01-09T10:28:23.431Z",
+    "ttl": "P1D"
   },
   "message": {
     "collector_app_id": "onca.dev.peat-cloud.com",
     "receiver_app_id": "preprod-ondc.addble.com",
     "settlement": {
-      "id": "05db7665-38f6-4b53-9903-70be0cb6fbd7",
+      "id": "c9a3a49f-4855-4aca-be8b-09aab6acf7bc",
       "type": "NP-NP",
       "orders": [
         {

--- a/Plantix/RSF/flow-2/1_on_settle.json
+++ b/Plantix/RSF/flow-2/1_on_settle.json
@@ -2,12 +2,12 @@
   "context": {
     "bap_id": "onca.dev.peat-cloud.com",
     "bap_uri": "https://onca.dev.peat-cloud.com/ondc/v1",
-    "bpp_id": "rsf-mock-service.ondc.org/seller_protocol_server_preprod",
-    "bpp_uri": "https://rsf-mock-service.ondc.org/seller_protocol_server_preprod",
+    "bpp_id": "rsf-mock-service.ondc.org/seller_protocol_server",
+    "bpp_uri": "https://rsf-mock-service.ondc.org/seller_protocol_server",
     "location": { "country": { "code": "IND" }, "city": { "code": "*" } },
-    "transaction_id": "1061c914-3d2e-4cbe-ae9a-ccde181795a2",
-    "message_id": "2db1f349-7b4f-4340-95e5-7e803767e874",
-    "timestamp": "2024-11-27T11:13:32.852Z",
+    "transaction_id": "294d1ccf-55ee-4440-9c22-e1a002a33e5e",
+    "message_id": "5c1d7004-0fa0-4dbe-9c3b-cad23e9b1581",
+    "timestamp": "2025-01-09T10:29:29.047Z",
     "domain": "ONDC:NTS10",
     "version": "2.0.0",
     "ttl": "PT10M",
@@ -18,7 +18,7 @@
     "receiver_app_id": "preprod-ondc.addble.com",
     "settlement": {
       "type": "NP-NP",
-      "id": "05db7665-38f6-4b53-9903-70be0cb6fbd7",
+      "id": "c9a3a49f-4855-4aca-be8b-09aab6acf7bc",
       "orders": [
         {
           "id": "98e695ab-fb42-4a53-8d8a-9c78d806282a",
@@ -34,7 +34,7 @@
             "status": "NOT_SETTLED",
             "reference_no": "1238683618634"
           },
-          "error": { "code": "70023" }
+          "error": { "code": "70023", "message": "Collector value mismatch" }
         }
       ]
     }

--- a/Plantix/RSF/flow-2/2_report.json
+++ b/Plantix/RSF/flow-2/2_report.json
@@ -8,13 +8,13 @@
     "bap_uri": "https://onca.dev.peat-cloud.com/ondc/v1",
     "bpp_id": "rsf-mock-service.ondc.org/seller_protocol_server_preprod",
     "bpp_uri": "https://rsf-mock-service.ondc.org/seller_protocol_server_preprod/ondc",
-    "transaction_id": "1061c914-3d2e-4cbe-ae9a-ccde181795a2",
-    "message_id": "a2d725d6-1153-42fd-89e9-7ea6d38155f9",
-    "timestamp": "2024-11-27T11:17:28.526Z",
-    "ttl": "PT10M"
+    "transaction_id": "294d1ccf-55ee-4440-9c22-e1a002a33e5e",
+    "message_id": "f71430c9-b8e1-4b29-a3dc-e303cd28b955",
+    "timestamp": "2025-01-09T10:30:10.212Z",
+    "ttl": "P1D"
   },
   "message": {
-    "ref_transaction_id": "1061c914-3d2e-4cbe-ae9a-ccde181795a2",
-    "ref_message_id": "2db1f349-7b4f-4340-95e5-7e803767e874"
+    "ref_transaction_id": "294d1ccf-55ee-4440-9c22-e1a002a33e5e",
+    "ref_message_id": "5c1d7004-0fa0-4dbe-9c3b-cad23e9b1581"
   }
 }

--- a/Plantix/RSF/flow-2/3_on_report.json
+++ b/Plantix/RSF/flow-2/3_on_report.json
@@ -2,12 +2,12 @@
   "context": {
     "bap_id": "onca.dev.peat-cloud.com",
     "bap_uri": "https://onca.dev.peat-cloud.com/ondc/v1",
-    "bpp_id": "rsf-mock-service.ondc.org/seller_protocol_server_preprod",
-    "bpp_uri": "https://rsf-mock-service.ondc.org/seller_protocol_server_preprod",
+    "bpp_id": "rsf-mock-service.ondc.org/seller_protocol_server",
+    "bpp_uri": "https://rsf-mock-service.ondc.org/seller_protocol_server",
     "location": { "country": { "code": "IND" }, "city": { "code": "*" } },
-    "transaction_id": "1061c914-3d2e-4cbe-ae9a-ccde181795a2",
-    "message_id": "a2d725d6-1153-42fd-89e9-7ea6d38155f9",
-    "timestamp": "2024-11-27T11:18:34.977Z",
+    "transaction_id": "294d1ccf-55ee-4440-9c22-e1a002a33e5e",
+    "message_id": "f71430c9-b8e1-4b29-a3dc-e303cd28b955",
+    "timestamp": "2025-01-09T10:30:44.603Z",
     "domain": "ONDC:NTS10",
     "version": "2.0.0",
     "ttl": "PT10M",
@@ -18,7 +18,7 @@
     "receiver_app_id": "preprod-ondc.addble.com",
     "settlement": {
       "type": "NP-NP",
-      "id": "05db7665-38f6-4b53-9903-70be0cb6fbd7",
+      "id": "c9a3a49f-4855-4aca-be8b-09aab6acf7bc",
       "orders": [
         {
           "id": "98e695ab-fb42-4a53-8d8a-9c78d806282a",
@@ -31,10 +31,6 @@
           "collector": { "amount": { "value": "110.50", "currency": "INR" } },
           "self": {
             "amount": { "value": "110.50", "currency": "INR" },
-            "status": "NOT_SETTLED",
-            "reference_no": "1238683618634"
-          },
-          "provider": {
             "status": "NOT_SETTLED",
             "reference_no": "1238683618634"
           },

--- a/Plantix/RSF/flow-2/4_recon.json
+++ b/Plantix/RSF/flow-2/4_recon.json
@@ -3,32 +3,32 @@
     "bap_id": "onca.dev.peat-cloud.com",
     "bap_uri": "https://onca.dev.peat-cloud.com/ondc/v1",
     "bpp_id": "rsf-mock-service.ondc.org/seller_protocol_server_preprod",
-    "bpp_uri": "https://rsf-mock-service.ondc.org/seller_protocol_server_preprod",
+    "bpp_uri": "https://rsf-mock-service.ondc.org/seller_protocol_server_preprod/ondc",
     "location": { "country": { "code": "IND" }, "city": { "code": "*" } },
-    "transaction_id": "1061c914-3d2e-4cbe-ae9a-ccde181795a2",
-    "message_id": "a2d725d6-1153-42fd-89e9-7ea6d38155f9",
-    "timestamp": "2024-11-27T11:20:40.282Z",
+    "transaction_id": "294d1ccf-55ee-4440-9c22-e1a002a33e5e",
+    "message_id": "1f57c543-bac4-4597-bf08-2935cc8977ab",
+    "timestamp": "2025-01-09T10:31:30.989Z",
     "domain": "ONDC:NTS10",
     "version": "2.0.0",
-    "ttl": "PT10M",
+    "ttl": "P1D",
     "action": "recon"
   },
   "message": {
     "orders": [
       {
         "id": "98e695ab-fb42-4a53-8d8a-9c78d806282a",
-        "amount": { "value": "110.50", "currency": "INR" },
+        "amount": { "value": "2260.00", "currency": "INR" },
         "settlements": [
           {
-            "id": "05db7665-38f6-4b53-9903-70be0cb6fbd7",
-            "payment_id": "test-payment-id",
-            "amount": { "value": "2260", "currency": "INR" },
-            "commission": { "value": "100", "currency": "INR" },
+            "id": "c9a3a49f-4855-4aca-be8b-09aab6acf7bc",
+            "payment_id": "pay_POQUgB82fxz6YH",
+            "status": "TO_BE_INITIATED",
+            "amount": { "value": "2260.00", "currency": "INR" },
+            "commission": { "value": "110.50", "currency": "INR" },
             "withholding_amount": { "value": "0", "currency": "INR" },
             "tcs": { "value": "0", "currency": "INR" },
             "tds": { "value": "0", "currency": "INR" },
-            "settlement_ref_no": "test-settlement-ref-no",
-            "updated_at": "2024-11-27T11:20:40.282Z"
+            "updated_at": "2025-01-09T10:31:30.990Z"
           }
         ]
       }

--- a/Plantix/RSF/flow-2/5_on_recon.json
+++ b/Plantix/RSF/flow-2/5_on_recon.json
@@ -6,28 +6,33 @@
     "action": "on_recon",
     "bap_id": "onca.dev.peat-cloud.com",
     "bap_uri": "https://onca.dev.peat-cloud.com/ondc/v1",
-    "bpp_id": "rsf-mock-service.ondc.org/seller_protocol_server_preprod",
-    "bpp_uri": "https://rsf-mock-service.ondc.org/seller_protocol_server_preprod",
-    "transaction_id": "1061c914-3d2e-4cbe-ae9a-ccde181795a2",
-    "message_id": "a2d725d6-1153-42fd-89e9-7ea6d38155f9",
-    "timestamp": "2024-11-27T11:22:45.694Z",
-    "ttl": "P1D"
+    "bpp_id": "rsf-mock-service.ondc.org/seller_protocol_server",
+    "bpp_uri": "https://rsf-mock-service.ondc.org/seller_protocol_server",
+    "transaction_id": "294d1ccf-55ee-4440-9c22-e1a002a33e5e",
+    "message_id": "1f57c543-bac4-4597-bf08-2935cc8977ab",
+    "timestamp": "2025-01-09T10:33:09.698Z",
+    "ttl": "PT10M"
   },
   "message": {
     "orders": [
       {
         "id": "98e695ab-fb42-4a53-8d8a-9c78d806282a",
-        "amount": { "value": "110.50", "currency": "INR" },
+        "amount": { "value": "2260.00", "currency": "INR" },
         "recon_accord": true,
         "settlements": [
           {
-            "id": "05db7665-38f6-4b53-9903-70be0cb6fbd7",
-            "payment_id": "test-payment-id",
-            "amount": { "value": "2260", "currency": "INR", "diff_value": "0" },
-            "commission": {
-              "value": "100",
+            "id": "c9a3a49f-4855-4aca-be8b-09aab6acf7bc",
+            "payment_id": "pay_POQUgB82fxz6YH",
+            "status": "TO_BE_INITIATED",
+            "amount": {
+              "value": "2260.00",
               "currency": "INR",
               "diff_value": "0"
+            },
+            "commission": {
+              "value": "110.50",
+              "currency": "INR",
+              "diff_value": "10.50"
             },
             "withholding_amount": {
               "value": "0",
@@ -36,8 +41,7 @@
             },
             "tcs": { "value": "0", "currency": "INR", "diff_value": "0" },
             "tds": { "value": "0", "currency": "INR", "diff_value": "0" },
-            "settlement_ref_no": "test-settlement-ref-no",
-            "updated_at": "2024-11-27T11:20:40.282Z"
+            "updated_at": "2025-01-09T10:31:30.990Z"
           }
         ]
       }

--- a/Plantix/RSF/flow-2/6_settle.json
+++ b/Plantix/RSF/flow-2/6_settle.json
@@ -8,25 +8,25 @@
     "bap_uri": "https://onca.dev.peat-cloud.com/ondc/v1",
     "bpp_id": "rsf-mock-service.ondc.org/seller_protocol_server_preprod",
     "bpp_uri": "https://rsf-mock-service.ondc.org/seller_protocol_server_preprod/ondc",
-    "transaction_id": "fb990ba1-a396-4508-9711-8bc2f09430dd",
-    "message_id": "22547d74-61e1-4b5b-9943-105a810cbf6a",
-    "timestamp": "2024-11-27T11:23:36.666Z",
-    "ttl": "PT10M"
+    "transaction_id": "7be81450-a278-408b-bfc0-bae7d359a86b",
+    "message_id": "51a227cd-c776-4b52-9e68-7da3616ba4cb",
+    "timestamp": "2025-01-09T10:34:41.634Z",
+    "ttl": "P1D"
   },
   "message": {
     "collector_app_id": "onca.dev.peat-cloud.com",
     "receiver_app_id": "rsf-mock-service.ondc.org/seller_protocol_server_preprod",
     "settlement": {
-      "id": "bf5014c1-e250-4b28-a477-2c06b28cf0c8",
+      "id": "386ead1b-c30a-461d-a564-236de0f657f8",
       "type": "NP-NP",
       "orders": [
         {
           "id": "98e695ab-fb42-4a53-8d8a-9c78d806282a",
           "inter_participant": {
-            "amount": { "value": "2160", "currency": "INR" }
+            "amount": { "value": "2149.50", "currency": "INR" }
           },
-          "collector": { "amount": { "value": "100", "currency": "INR" } },
-          "self": { "amount": { "value": "100", "currency": "INR" } }
+          "collector": { "amount": { "value": "110.50", "currency": "INR" } },
+          "self": { "amount": { "value": "110.50", "currency": "INR" } }
         }
       ]
     }

--- a/Plantix/RSF/flow-2/7_on_settle.json
+++ b/Plantix/RSF/flow-2/7_on_settle.json
@@ -2,12 +2,12 @@
   "context": {
     "bap_id": "onca.dev.peat-cloud.com",
     "bap_uri": "https://onca.dev.peat-cloud.com/ondc/v1",
-    "bpp_id": "rsf-mock-service.ondc.org/seller_protocol_server_preprod",
-    "bpp_uri": "https://rsf-mock-service.ondc.org/seller_protocol_server_preprod",
+    "bpp_id": "rsf-mock-service.ondc.org/seller_protocol_server",
+    "bpp_uri": "https://rsf-mock-service.ondc.org/seller_protocol_server",
     "location": { "country": { "code": "IND" }, "city": { "code": "*" } },
-    "transaction_id": "fb990ba1-a396-4508-9711-8bc2f09430dd",
-    "message_id": "22547d74-61e1-4b5b-9943-105a810cbf6a",
-    "timestamp": "2024-11-27T11:24:43.901Z",
+    "transaction_id": "7be81450-a278-408b-bfc0-bae7d359a86b",
+    "message_id": "51a227cd-c776-4b52-9e68-7da3616ba4cb",
+    "timestamp": "2025-01-09T10:35:23.777Z",
     "domain": "ONDC:NTS10",
     "version": "2.0.0",
     "ttl": "PT10M",
@@ -18,19 +18,19 @@
     "receiver_app_id": "rsf-mock-service.ondc.org/seller_protocol_server_preprod",
     "settlement": {
       "type": "NP-NP",
-      "id": "bf5014c1-e250-4b28-a477-2c06b28cf0c8",
+      "id": "386ead1b-c30a-461d-a564-236de0f657f8",
       "orders": [
         {
           "id": "98e695ab-fb42-4a53-8d8a-9c78d806282a",
           "inter_participant": {
-            "amount": { "value": "2160", "currency": "INR" },
-            "settled_amount": { "value": "2160", "currency": "INR" },
+            "amount": { "value": "2149.50", "currency": "INR" },
+            "settled_amount": { "value": "2149.50", "currency": "INR" },
             "status": "SETTLED",
             "reference_no": "1238683618634"
           },
-          "collector": { "amount": { "value": "100", "currency": "INR" } },
+          "collector": { "amount": { "value": "110.50", "currency": "INR" } },
           "self": {
-            "amount": { "value": "100", "currency": "INR" },
+            "amount": { "value": "110.50", "currency": "INR" },
             "status": "SETTLED",
             "reference_no": "1238683618634"
           }

--- a/Plantix/RSF/flow-3/0_settle.json
+++ b/Plantix/RSF/flow-3/0_settle.json
@@ -8,16 +8,16 @@
     "bap_uri": "https://onca.dev.peat-cloud.com/ondc/v1",
     "bpp_id": "rsf-mock-service.ondc.org/seller_protocol_server_preprod",
     "bpp_uri": "https://rsf-mock-service.ondc.org/seller_protocol_server_preprod/ondc",
-    "transaction_id": "8e14b2df-0881-4e58-b50d-c143a0460f50",
-    "message_id": "6a6cb563-1817-48eb-89df-d4cb4b750545",
-    "timestamp": "2024-11-27T11:30:02.832Z",
-    "ttl": "PT10M"
+    "transaction_id": "384b879d-f79c-4a88-804f-0e39498fe9bc",
+    "message_id": "6877769b-9ba0-42bf-86f5-cfaf37cfc659",
+    "timestamp": "2025-01-09T11:29:02.537Z",
+    "ttl": "P1D"
   },
   "message": {
     "collector_app_id": "onca.dev.peat-cloud.com",
     "receiver_app_id": "preprod-ondc.addble.com",
     "settlement": {
-      "id": "24866810-612d-41b7-be2a-37542e169dcd",
+      "id": "4e73c9b4-1637-4597-91c7-f495ff141ab7",
       "type": "NP-NP",
       "orders": [
         {

--- a/Plantix/RSF/flow-3/1_on_settle.json
+++ b/Plantix/RSF/flow-3/1_on_settle.json
@@ -2,12 +2,12 @@
   "context": {
     "bap_id": "onca.dev.peat-cloud.com",
     "bap_uri": "https://onca.dev.peat-cloud.com/ondc/v1",
-    "bpp_id": "rsf-mock-service.ondc.org/seller_protocol_server_preprod",
-    "bpp_uri": "https://rsf-mock-service.ondc.org/seller_protocol_server_preprod",
+    "bpp_id": "rsf-mock-service.ondc.org/seller_protocol_server",
+    "bpp_uri": "https://rsf-mock-service.ondc.org/seller_protocol_server",
     "location": { "country": { "code": "IND" }, "city": { "code": "*" } },
-    "transaction_id": "8e14b2df-0881-4e58-b50d-c143a0460f50",
-    "message_id": "6a6cb563-1817-48eb-89df-d4cb4b750545",
-    "timestamp": "2024-11-27T11:31:36.890Z",
+    "transaction_id": "384b879d-f79c-4a88-804f-0e39498fe9bc",
+    "message_id": "6877769b-9ba0-42bf-86f5-cfaf37cfc659",
+    "timestamp": "2025-01-09T11:30:09.456Z",
     "domain": "ONDC:NTS10",
     "version": "2.0.0",
     "ttl": "PT10M",
@@ -18,7 +18,7 @@
     "receiver_app_id": "preprod-ondc.addble.com",
     "settlement": {
       "type": "NP-NP",
-      "id": "24866810-612d-41b7-be2a-37542e169dcd",
+      "id": "4e73c9b4-1637-4597-91c7-f495ff141ab7",
       "orders": [
         {
           "id": "98e695ab-fb42-4a53-8d8a-9c78d806282a",
@@ -34,7 +34,7 @@
             "status": "NOT_SETTLED",
             "reference_no": "1238683618634"
           },
-          "error": { "code": "70023" }
+          "error": { "code": "70023", "message": "Collector value mismatch" }
         }
       ]
     }

--- a/Plantix/RSF/flow-3/2_report.json
+++ b/Plantix/RSF/flow-3/2_report.json
@@ -8,13 +8,13 @@
     "bap_uri": "https://onca.dev.peat-cloud.com/ondc/v1",
     "bpp_id": "rsf-mock-service.ondc.org/seller_protocol_server_preprod",
     "bpp_uri": "https://rsf-mock-service.ondc.org/seller_protocol_server_preprod/ondc",
-    "transaction_id": "8e14b2df-0881-4e58-b50d-c143a0460f50",
-    "message_id": "17a38d8d-a9c4-417b-90fc-0326f23bd28a",
-    "timestamp": "2024-11-27T11:32:28.644Z",
-    "ttl": "PT10M"
+    "transaction_id": "384b879d-f79c-4a88-804f-0e39498fe9bc",
+    "message_id": "e88e89db-29c1-4c74-8202-74fc287c6595",
+    "timestamp": "2025-01-09T11:30:55.008Z",
+    "ttl": "P1D"
   },
   "message": {
-    "ref_transaction_id": "8e14b2df-0881-4e58-b50d-c143a0460f50",
-    "ref_message_id": "6a6cb563-1817-48eb-89df-d4cb4b750545"
+    "ref_transaction_id": "384b879d-f79c-4a88-804f-0e39498fe9bc",
+    "ref_message_id": "6877769b-9ba0-42bf-86f5-cfaf37cfc659"
   }
 }

--- a/Plantix/RSF/flow-3/3_on_report.json
+++ b/Plantix/RSF/flow-3/3_on_report.json
@@ -2,12 +2,12 @@
   "context": {
     "bap_id": "onca.dev.peat-cloud.com",
     "bap_uri": "https://onca.dev.peat-cloud.com/ondc/v1",
-    "bpp_id": "rsf-mock-service.ondc.org/seller_protocol_server_preprod",
-    "bpp_uri": "https://rsf-mock-service.ondc.org/seller_protocol_server_preprod",
+    "bpp_id": "rsf-mock-service.ondc.org/seller_protocol_server",
+    "bpp_uri": "https://rsf-mock-service.ondc.org/seller_protocol_server",
     "location": { "country": { "code": "IND" }, "city": { "code": "*" } },
-    "transaction_id": "8e14b2df-0881-4e58-b50d-c143a0460f50",
-    "message_id": "17a38d8d-a9c4-417b-90fc-0326f23bd28a",
-    "timestamp": "2024-11-27T11:33:00.715Z",
+    "transaction_id": "384b879d-f79c-4a88-804f-0e39498fe9bc",
+    "message_id": "e88e89db-29c1-4c74-8202-74fc287c6595",
+    "timestamp": "2025-01-09T11:31:57.942Z",
     "domain": "ONDC:NTS10",
     "version": "2.0.0",
     "ttl": "PT10M",
@@ -18,7 +18,7 @@
     "receiver_app_id": "preprod-ondc.addble.com",
     "settlement": {
       "type": "NP-NP",
-      "id": "24866810-612d-41b7-be2a-37542e169dcd",
+      "id": "4e73c9b4-1637-4597-91c7-f495ff141ab7",
       "orders": [
         {
           "id": "98e695ab-fb42-4a53-8d8a-9c78d806282a",
@@ -31,10 +31,6 @@
           "collector": { "amount": { "value": "110.50", "currency": "INR" } },
           "self": {
             "amount": { "value": "110.50", "currency": "INR" },
-            "status": "NOT_SETTLED",
-            "reference_no": "1238683618634"
-          },
-          "provider": {
             "status": "NOT_SETTLED",
             "reference_no": "1238683618634"
           },

--- a/Plantix/RSF/flow-3/4_recon.json
+++ b/Plantix/RSF/flow-3/4_recon.json
@@ -2,12 +2,12 @@
   "context": {
     "bap_id": "onca.dev.peat-cloud.com",
     "bap_uri": "https://onca.dev.peat-cloud.com/ondc/v1",
-    "bpp_id": "rsf-mock-service.ondc.org/seller_protocol_server_preprod",
-    "bpp_uri": "https://rsf-mock-service.ondc.org/seller_protocol_server_preprod",
+    "bpp_id": "rsf-mock-service.ondc.org/seller_protocol_server",
+    "bpp_uri": "https://rsf-mock-service.ondc.org/seller_protocol_server",
     "location": { "country": { "code": "IND" }, "city": { "code": "*" } },
-    "transaction_id": "8e14b2df-0881-4e58-b50d-c143a0460f50",
-    "message_id": "17a38d8d-a9c4-417b-90fc-0326f23bd28a",
-    "timestamp": "2024-11-27T11:34:44.672Z",
+    "transaction_id": "384b879d-f79c-4a88-804f-0e39498fe9bc",
+    "message_id": "e88e89db-29c1-4c74-8202-74fc287c6595",
+    "timestamp": "2025-01-09T11:34:13.262Z",
     "domain": "ONDC:NTS10",
     "version": "2.0.0",
     "ttl": "PT10M",
@@ -20,15 +20,16 @@
         "amount": { "value": "110.50", "currency": "INR" },
         "settlements": [
           {
-            "id": "24866810-612d-41b7-be2a-37542e169dcd",
+            "id": "4e73c9b4-1637-4597-91c7-f495ff141ab7",
             "payment_id": "test-payment-id",
+            "status": "TO_BE_INITIATED",
             "amount": { "value": "2260", "currency": "INR" },
             "commission": { "value": "100", "currency": "INR" },
             "withholding_amount": { "value": "0", "currency": "INR" },
             "tcs": { "value": "0", "currency": "INR" },
             "tds": { "value": "0", "currency": "INR" },
             "settlement_ref_no": "test-settlement-ref-no",
-            "updated_at": "2024-11-27T11:34:44.673Z"
+            "updated_at": "2025-01-09T11:34:13.263Z"
           }
         ]
       }

--- a/Plantix/RSF/flow-3/5_on_recon.json
+++ b/Plantix/RSF/flow-3/5_on_recon.json
@@ -7,10 +7,10 @@
     "bap_id": "onca.dev.peat-cloud.com",
     "bap_uri": "https://onca.dev.peat-cloud.com/ondc/v1",
     "bpp_id": "rsf-mock-service.ondc.org/seller_protocol_server_preprod",
-    "bpp_uri": "https://rsf-mock-service.ondc.org/seller_protocol_server_preprod",
-    "transaction_id": "8e14b2df-0881-4e58-b50d-c143a0460f50",
-    "message_id": "17a38d8d-a9c4-417b-90fc-0326f23bd28a",
-    "timestamp": "2024-11-27T11:35:57.192Z",
+    "bpp_uri": "https://rsf-mock-service.ondc.org/seller_protocol_server_preprod/ondc",
+    "transaction_id": "384b879d-f79c-4a88-804f-0e39498fe9bc",
+    "message_id": "e88e89db-29c1-4c74-8202-74fc287c6595",
+    "timestamp": "2025-01-09T11:36:05.058Z",
     "ttl": "P1D"
   },
   "message": {
@@ -21,7 +21,7 @@
         "recon_accord": false,
         "settlements": [
           {
-            "id": "24866810-612d-41b7-be2a-37542e169dcd",
+            "id": "4e73c9b4-1637-4597-91c7-f495ff141ab7",
             "status": "TO_BE_INITIATED",
             "amount": {
               "value": "2260.00",
@@ -41,7 +41,7 @@
             "tcs": { "value": "0", "currency": "INR", "diff_value": "0" },
             "tds": { "value": "0", "currency": "INR", "diff_value": "0" },
             "settlement_ref_no": "test-settlement-ref-no",
-            "updated_at": "2024-11-27T11:34:44.673Z"
+            "updated_at": "2025-01-09T11:34:13.263Z"
           }
         ]
       }

--- a/Plantix/RSF/flow-3/6_recon.json
+++ b/Plantix/RSF/flow-3/6_recon.json
@@ -8,9 +8,9 @@
     "bap_uri": "https://onca.dev.peat-cloud.com/ondc/v1",
     "bpp_id": "rsf-mock-service.ondc.org/seller_protocol_server_preprod",
     "bpp_uri": "https://rsf-mock-service.ondc.org/seller_protocol_server_preprod/ondc",
-    "transaction_id": "a713fa06-2c9f-4cc5-8002-6beb9eaea966",
-    "message_id": "3ce37bf0-6805-4455-b239-31b1e6028ce9",
-    "timestamp": "2024-11-27T11:36:48.964Z",
+    "transaction_id": "384b879d-f79c-4a88-804f-0e39498fe9bc",
+    "message_id": "b0205d8c-5266-4602-90b4-b819e6f0ca1b",
+    "timestamp": "2025-01-09T11:36:54.813Z",
     "ttl": "P1D"
   },
   "message": {
@@ -20,14 +20,15 @@
         "amount": { "value": "2260.00", "currency": "INR" },
         "settlements": [
           {
-            "id": "24866810-612d-41b7-be2a-37542e169dcd",
+            "id": "4e73c9b4-1637-4597-91c7-f495ff141ab7",
+            "payment_id": "pay_POQUgB82fxz6YH",
             "status": "TO_BE_INITIATED",
             "amount": { "value": "2260.00", "currency": "INR" },
             "commission": { "value": "110.50", "currency": "INR" },
             "withholding_amount": { "value": "0", "currency": "INR" },
             "tcs": { "value": "0", "currency": "INR" },
             "tds": { "value": "0", "currency": "INR" },
-            "updated_at": "2024-11-27T11:36:48.965Z"
+            "updated_at": "2025-01-09T11:36:54.813Z"
           }
         ]
       }


### PR DESCRIPTION
I tried to solve the problems brought up [here](https://github.com/ONDC-Official/v1.2.0-logs/issues/2860).
**Flow 2:** We will always be the Collector that is why we didn't implement the other way around. In the Issue linked above we where asked to send the recon request instead of letting the mock server do it because the mock server did not send a `message/orders/0/settlements/0/status`. This if course means the logs are not really showing what is requested in Flow 2 now because the Receiver (mock server) would need to send us the recon (like we did before).

**Flow 3:** We rerecorded the flow, but as long as the mock server is sending the incorrect bpp_id and bpp_uri there will always be a mismatch, nothing we can do about that. If we would send the first recon here it would mean the other side (mock server) would have to send the second recon what it can not do)