### PR TITLE
RET-10 domain logs corrected. Issue #2828

### DIFF
--- a/Pirimid/SellerApp/Retail/RET-10/FLOW_1/log_validation_utility_request.json
+++ b/Pirimid/SellerApp/Retail/RET-10/FLOW_1/log_validation_utility_request.json
@@ -13,9 +13,9 @@
                 "core_version": "1.2.0",
                 "bap_id": "buyer-app-preprod-v2.ondc.org",
                 "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
-                "transaction_id": "579594ce-3827-480c-96ec-1d93c4ff7075",
-                "message_id": "eaae33e9-6729-4fa2-86bb-0d85f7c0ceeb",
-                "timestamp": "2025-01-15T18:00:04.302Z",
+                "transaction_id": "2a274964-3eec-4793-888c-1d30ef845cd1",
+                "message_id": "c5c58f68-8483-4490-b318-a1436c6ee88b",
+                "timestamp": "2025-01-23T12:00:01.908Z",
                 "ttl": "PT30S"
             },
             "message": {
@@ -41,9 +41,9 @@
                 "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
                 "bpp_id": "ondc.pirimidtech.com/v2/seller",
                 "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-                "transaction_id": "579594ce-3827-480c-96ec-1d93c4ff7075",
-                "message_id": "eaae33e9-6729-4fa2-86bb-0d85f7c0ceeb",
-                "timestamp": "2025-01-15T18:00:32.138Z",
+                "transaction_id": "2a274964-3eec-4793-888c-1d30ef845cd1",
+                "message_id": "c5c58f68-8483-4490-b318-a1436c6ee88b",
+                "timestamp": "2025-01-23T12:00:21.519Z",
                 "ttl": "PT30S"
             },
             "message": {
@@ -90,70 +90,8 @@
                             "@ondc/org/fssai_license_no": "12345678912345",
                             "time": {
                                 "label": "enable",
-                                "timestamp": "2025-01-15T18:00:32.138Z"
+                                "timestamp": "2025-01-23T12:00:21.519Z"
                             },
-                            "categories": [
-                                {
-                                    "id": "variant10000",
-                                    "descriptor": {
-                                        "name": "Variant for Nutraj-California-Almonds-1Kg"
-                                    },
-                                    "tags": [
-                                        {
-                                            "code": "type",
-                                            "list": [
-                                                {
-                                                    "code": "type",
-                                                    "value": "variant_group"
-                                                }
-                                            ]
-                                        },
-                                        {
-                                            "code": "attr",
-                                            "list": [
-                                                {
-                                                    "code": "name",
-                                                    "value": "item.quantity.unitized.measure"
-                                                },
-                                                {
-                                                    "code": "seq",
-                                                    "value": "1"
-                                                }
-                                            ]
-                                        }
-                                    ]
-                                },
-                                {
-                                    "id": "variant10001",
-                                    "descriptor": {
-                                        "name": "Variant for Cashews"
-                                    },
-                                    "tags": [
-                                        {
-                                            "code": "type",
-                                            "list": [
-                                                {
-                                                    "code": "type",
-                                                    "value": "variant_group"
-                                                }
-                                            ]
-                                        },
-                                        {
-                                            "code": "attr",
-                                            "list": [
-                                                {
-                                                    "code": "name",
-                                                    "value": "item.quantity.unitized.measure"
-                                                },
-                                                {
-                                                    "code": "seq",
-                                                    "value": "1"
-                                                }
-                                            ]
-                                        }
-                                    ]
-                                }
-                            ],
                             "fulfillments": [
                                 {
                                     "id": "1",
@@ -173,11 +111,11 @@
                                         "locality": "Ashok Vatika",
                                         "city": "Ahmedabad",
                                         "state": "Gujarat",
-                                        "area_code": "380058"
+                                        "area_code": "380054"
                                     },
                                     "time": {
                                         "label": "enable",
-                                        "timestamp": "2024-12-04T13:50:34.608Z",
+                                        "timestamp": "2025-01-22T07:34:34.534Z",
                                         "range": {
                                             "start": "0930",
                                             "end": "1930"
@@ -194,12 +132,85 @@
                             ],
                             "items": [
                                 {
+                                    "id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+                                    "descriptor": {
+                                        "name": "Walnuts",
+                                        "code": "1:12345678",
+                                        "symbol": "https://c8.alamy.com/comp/2HCTDG2/modern-design-walnut-leaf-nature-green-logo-design-2HCTDG2.jpg",
+                                        "short_desc": "WONDERLAND California Whole Walnut Walnuts (Akhrot)  (500 g)",
+                                        "long_desc": "WONDERLAND California Whole Walnut Walnuts (Akhrot)  (500 g)",
+                                        "images": [
+                                            "https://rukminim2.flixcart.com/image/416/416/xif0q/nut-dry-fruit/h/x/t/500-california-whole-walnut-1-pouch-wonderland-original-imagy632bnvk8fde.jpeg?q=70",
+                                            "https://rukminim2.flixcart.com/image/416/416/xif0q/nut-dry-fruit/q/r/t/500-california-whole-walnut-1-pouch-wonderland-original-imagy6326hdk68cd.jpeg?q=70"
+                                        ]
+                                    },
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "120.0",
+                                        "maximum_value": "200.0"
+                                    },
+                                    "quantity": {
+                                        "available": {
+                                            "count": "99"
+                                        },
+                                        "maximum": {
+                                            "count": "99"
+                                        },
+                                        "unitized": {
+                                            "measure": {
+                                                "value": "500",
+                                                "unit": "gram"
+                                            }
+                                        }
+                                    },
+                                    "category_id": "Snacks, Dry Fruits, Nuts",
+                                    "fulfillment_id": "1",
+                                    "location_id": "39550822-c3bb-4918-bd25-2d19ef6a9aca",
+                                    "time": {
+                                        "label": "enable",
+                                        "timestamp": "2025-01-23T12:00:21.519Z"
+                                    },
+                                    "@ondc/org/returnable": true,
+                                    "@ondc/org/seller_pickup_return": false,
+                                    "@ondc/org/return_window": "P7D",
+                                    "@ondc/org/cancellable": true,
+                                    "@ondc/org/time_to_ship": "PT3H",
+                                    "@ondc/org/available_on_cod": false,
+                                    "@ondc/org/contact_details_consumer_care": "PirimidFintech,user@gmail.com,7744774477",
+                                    "@ondc/org/statutory_reqs_prepackaged_food": {
+                                        "nutritional_info": "nutritional_info",
+                                        "additives_info": "additives_info",
+                                        "brand_owner_FSSAI_license_no": "12345678912345",
+                                        "other_FSSAI_license_no": "12345678912345",
+                                        "importer_FSSAI_license_no": "12345678912345"
+                                    },
+                                    "tags": [
+                                        {
+                                            "code": "origin",
+                                            "list": [
+                                                {
+                                                    "code": "Country",
+                                                    "value": "IND"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "veg_nonveg",
+                                            "list": [
+                                                {
+                                                    "code": "veg",
+                                                    "value": "yes"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                {
                                     "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
-                                    "parent_item_id": "variant10000",
                                     "descriptor": {
                                         "name": "Nutraj-California-Almonds-1Kg",
                                         "code": "1:12345678",
-                                        "symbol": "symbols.in/symbol.jpg",
+                                        "symbol": "https://img.freepik.com/premium-vector/almonds-nuts-nature-farm-vintage-logo-icon-symbol-vector-illustration-minimalist-design_889650-491.jpg?semt=ais_hybrid",
                                         "short_desc": "Nutraj California Almond kernels 1kg Pouch|Badam Giri|Dry Fruits and Nuts|Grocery",
                                         "long_desc": "Nutraj California Almond kernels 1kg Pouch|Badam Giri|Dry Fruits and Nuts|Grocery",
                                         "images": [
@@ -230,7 +241,7 @@
                                     "location_id": "39550822-c3bb-4918-bd25-2d19ef6a9aca",
                                     "time": {
                                         "label": "enable",
-                                        "timestamp": "2025-01-15T18:00:32.138Z"
+                                        "timestamp": "2025-01-23T12:00:21.519Z"
                                     },
                                     "@ondc/org/returnable": true,
                                     "@ondc/org/seller_pickup_return": false,
@@ -269,11 +280,10 @@
                                 },
                                 {
                                     "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
-                                    "parent_item_id": "variant10001",
                                     "descriptor": {
                                         "name": "Cashews",
                                         "code": "1:12345678",
-                                        "symbol": "symbols.in/symbol.jpg",
+                                        "symbol": "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTVlckKW1pwOvmkj9_s_rPbAvcsr_EdmIStMA&s",
                                         "short_desc": "Emart Brand - Vedaka Whole Cashews | 500 Gram | Kaju Nuts Grade W320 | Plant Based Protein | Gluten-Free | Nutty Flavor | Healthy Snack | Rich Delicious Taste",
                                         "long_desc": "Emart Brand - Vedaka Whole Cashews | 500 Gram | Kaju Nuts Grade W320 | Plant Based Protein | Gluten-Free | Nutty Flavor | Healthy Snack | Rich Delicious Taste",
                                         "images": [
@@ -282,8 +292,8 @@
                                     },
                                     "price": {
                                         "currency": "INR",
-                                        "value": "339.0",
-                                        "maximum_value": "400.0"
+                                        "value": "120.0",
+                                        "maximum_value": "212.0"
                                     },
                                     "quantity": {
                                         "available": {
@@ -294,8 +304,8 @@
                                         },
                                         "unitized": {
                                             "measure": {
-                                                "value": "1",
-                                                "unit": "kilogram"
+                                                "value": "500",
+                                                "unit": "gram"
                                             }
                                         }
                                     },
@@ -304,7 +314,7 @@
                                     "location_id": "39550822-c3bb-4918-bd25-2d19ef6a9aca",
                                     "time": {
                                         "label": "enable",
-                                        "timestamp": "2025-01-15T18:00:32.138Z"
+                                        "timestamp": "2025-01-23T12:00:21.519Z"
                                     },
                                     "@ondc/org/returnable": true,
                                     "@ondc/org/seller_pickup_return": false,
@@ -374,36 +384,7 @@
                                     "list": [
                                         {
                                             "code": "type",
-                                            "value": "Order"
-                                        },
-                                        {
-                                            "code": "location",
-                                            "value": "39550822-c3bb-4918-bd25-2d19ef6a9aca"
-                                        },
-                                        {
-                                            "code": "day_from",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "day_to",
-                                            "value": "7"
-                                        },
-                                        {
-                                            "code": "time_from",
-                                            "value": "0930"
-                                        },
-                                        {
-                                            "code": "time_to",
-                                            "value": "1930"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "timing",
-                                    "list": [
-                                        {
-                                            "code": "type",
-                                            "value": "Delivery"
+                                            "value": "All"
                                         },
                                         {
                                             "code": "location",
@@ -442,9 +423,9 @@
                 "core_version": "1.2.0",
                 "bap_id": "buyer-app-preprod-v2.ondc.org",
                 "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
-                "transaction_id": "ef993dfe-e031-4143-944e-fca653af18fb",
-                "message_id": "edb2d472-a57f-4674-aa64-8bcb06167795",
-                "timestamp": "2025-01-15T21:30:17.323Z",
+                "transaction_id": "87f18445-6977-4807-9170-747ffdc9b4a2",
+                "message_id": "cf02de24-eb4c-4fb4-958e-49bd423f770b",
+                "timestamp": "2025-01-23T21:30:17.698Z",
                 "ttl": "PT30S"
             },
             "message": {
@@ -478,9 +459,9 @@
                 "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
                 "bpp_id": "ondc.pirimidtech.com/v2/seller",
                 "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-                "transaction_id": "ef993dfe-e031-4143-944e-fca653af18fb",
-                "message_id": "d900fe5f-8737-4b37-8813-d106f2af6047",
-                "timestamp": "2025-01-15T21:30:17.965Z",
+                "transaction_id": "87f18445-6977-4807-9170-747ffdc9b4a2",
+                "message_id": "706680db-f489-4517-b674-64901eb706bb",
+                "timestamp": "2025-01-23T21:30:20.358Z",
                 "ttl": "PT30S"
             },
             "message": {
@@ -500,40 +481,8 @@
                             "@ondc/org/fssai_license_no": "12345678912345",
                             "time": {
                                 "label": "enable",
-                                "timestamp": "2025-01-15T21:30:17.965Z"
+                                "timestamp": "2025-01-23T21:30:20.358Z"
                             },
-                            "categories": [
-                                {
-                                    "id": "variant10000",
-                                    "descriptor": {
-                                        "name": "Variant for Cashews"
-                                    },
-                                    "tags": [
-                                        {
-                                            "code": "type",
-                                            "list": [
-                                                {
-                                                    "code": "type",
-                                                    "value": "variant_group"
-                                                }
-                                            ]
-                                        },
-                                        {
-                                            "code": "attr",
-                                            "list": [
-                                                {
-                                                    "code": "name",
-                                                    "value": "item.quantity.unitized.measure"
-                                                },
-                                                {
-                                                    "code": "seq",
-                                                    "value": "1"
-                                                }
-                                            ]
-                                        }
-                                    ]
-                                }
-                            ],
                             "fulfillments": [
                                 {
                                     "id": "1",
@@ -547,11 +496,10 @@
                             "items": [
                                 {
                                     "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
-                                    "parent_item_id": "variant10000",
                                     "descriptor": {
                                         "name": "Cashews",
                                         "code": "1:12345678",
-                                        "symbol": "symbols.in/symbol.jpg",
+                                        "symbol": "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTVlckKW1pwOvmkj9_s_rPbAvcsr_EdmIStMA&s",
                                         "short_desc": "Emart Brand - Vedaka Whole Cashews | 500 Gram | Kaju Nuts Grade W320 | Plant Based Protein | Gluten-Free | Nutty Flavor | Healthy Snack | Rich Delicious Taste",
                                         "long_desc": "Emart Brand - Vedaka Whole Cashews | 500 Gram | Kaju Nuts Grade W320 | Plant Based Protein | Gluten-Free | Nutty Flavor | Healthy Snack | Rich Delicious Taste",
                                         "images": [
@@ -560,8 +508,8 @@
                                     },
                                     "price": {
                                         "currency": "INR",
-                                        "value": "339.0",
-                                        "maximum_value": "410.0"
+                                        "value": "120.0",
+                                        "maximum_value": "220.0"
                                     },
                                     "quantity": {
                                         "available": {
@@ -572,8 +520,8 @@
                                         },
                                         "unitized": {
                                             "measure": {
-                                                "value": "1",
-                                                "unit": "kilogram"
+                                                "value": "500",
+                                                "unit": "gram"
                                             }
                                         }
                                     },
@@ -582,7 +530,7 @@
                                     "location_id": "39550822-c3bb-4918-bd25-2d19ef6a9aca",
                                     "time": {
                                         "label": "enable",
-                                        "timestamp": "2025-01-15T21:30:17.965Z"
+                                        "timestamp": "2025-01-23T21:30:20.358Z"
                                     },
                                     "@ondc/org/returnable": true,
                                     "@ondc/org/seller_pickup_return": false,
@@ -652,36 +600,7 @@
                                     "list": [
                                         {
                                             "code": "type",
-                                            "value": "Order"
-                                        },
-                                        {
-                                            "code": "location",
-                                            "value": "39550822-c3bb-4918-bd25-2d19ef6a9aca"
-                                        },
-                                        {
-                                            "code": "day_from",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "day_to",
-                                            "value": "7"
-                                        },
-                                        {
-                                            "code": "time_from",
-                                            "value": "0930"
-                                        },
-                                        {
-                                            "code": "time_to",
-                                            "value": "1930"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "timing",
-                                    "list": [
-                                        {
-                                            "code": "type",
-                                            "value": "Delivery"
+                                            "value": "All"
                                         },
                                         {
                                             "code": "location",

--- a/Pirimid/SellerApp/Retail/RET-10/FLOW_1/log_validation_utitlity_response.json
+++ b/Pirimid/SellerApp/Retail/RET-10/FLOW_1/log_validation_utitlity_response.json
@@ -1,13 +1,17 @@
 {
-    "success": true,
+    "success": false,
     "response": {
-        "message": "Logs were verified successfully",
-        "report": {},
+        "message": "Logs were not verified successfully",
+        "report": {
+            "on_search_full_catalog_refresh": {
+                "prvdr0categories": "Support for variants is mandatory, categories must be present in bpp/providers[0]"
+            }
+        },
         "bpp_id": "ondc.pirimidtech.com/v2/seller",
         "bap_id": "buyer-app-preprod-v2.ondc.org",
         "domain": "ONDC:RET10",
-        "reportTimestamp": "2025-01-19T04:34:02.257Z"
+        "reportTimestamp": "2025-01-24T05:56:42.028Z"
     },
-    "signature": "RjDgJ5P0o6d/bz14GEjyh84WDh11D6ODAiGAvuzTeUAGmQ43k4VwAl5vNrH1Hyjy7K0WNJV9afnpWBtpd3ikCA==",
-    "signTimestamp": "2025-01-19T04:34:02.257Z"
+    "signature": "0RGwBZGhquS25I9xflw9+acMoAf4dgaskSSIC3x47LApbeLOrldDsd/zD+poJRltxs//VpZM80ETkhX7+UjMDw==",
+    "signTimestamp": "2025-01-24T05:56:42.028Z"
 }

--- a/Pirimid/SellerApp/Retail/RET-10/FLOW_1/on_search_full_catalog_refresh.json
+++ b/Pirimid/SellerApp/Retail/RET-10/FLOW_1/on_search_full_catalog_refresh.json
@@ -9,9 +9,9 @@
     "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
     "bpp_id": "ondc.pirimidtech.com/v2/seller",
     "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-    "transaction_id": "579594ce-3827-480c-96ec-1d93c4ff7075",
-    "message_id": "eaae33e9-6729-4fa2-86bb-0d85f7c0ceeb",
-    "timestamp": "2025-01-15T18:00:32.138Z",
+    "transaction_id": "2a274964-3eec-4793-888c-1d30ef845cd1",
+    "message_id": "c5c58f68-8483-4490-b318-a1436c6ee88b",
+    "timestamp": "2025-01-23T12:00:21.519Z",
     "ttl": "PT30S"
   },
   "message": {
@@ -58,70 +58,8 @@
           "@ondc/org/fssai_license_no": "12345678912345",
           "time": {
             "label": "enable",
-            "timestamp": "2025-01-15T18:00:32.138Z"
+            "timestamp": "2025-01-23T12:00:21.519Z"
           },
-          "categories": [
-            {
-              "id": "variant10000",
-              "descriptor": {
-                "name": "Variant for Nutraj-California-Almonds-1Kg"
-              },
-              "tags": [
-                {
-                  "code": "type",
-                  "list": [
-                    {
-                      "code": "type",
-                      "value": "variant_group"
-                    }
-                  ]
-                },
-                {
-                  "code": "attr",
-                  "list": [
-                    {
-                      "code": "name",
-                      "value": "item.quantity.unitized.measure"
-                    },
-                    {
-                      "code": "seq",
-                      "value": "1"
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "id": "variant10001",
-              "descriptor": {
-                "name": "Variant for Cashews"
-              },
-              "tags": [
-                {
-                  "code": "type",
-                  "list": [
-                    {
-                      "code": "type",
-                      "value": "variant_group"
-                    }
-                  ]
-                },
-                {
-                  "code": "attr",
-                  "list": [
-                    {
-                      "code": "name",
-                      "value": "item.quantity.unitized.measure"
-                    },
-                    {
-                      "code": "seq",
-                      "value": "1"
-                    }
-                  ]
-                }
-              ]
-            }
-          ],
           "fulfillments": [
             {
               "id": "1",
@@ -141,11 +79,11 @@
                 "locality": "Ashok Vatika",
                 "city": "Ahmedabad",
                 "state": "Gujarat",
-                "area_code": "380058"
+                "area_code": "380054"
               },
               "time": {
                 "label": "enable",
-                "timestamp": "2024-12-04T13:50:34.608Z",
+                "timestamp": "2025-01-22T07:34:34.534Z",
                 "range": {
                   "start": "0930",
                   "end": "1930"
@@ -162,12 +100,85 @@
           ],
           "items": [
             {
+              "id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+              "descriptor": {
+                "name": "Walnuts",
+                "code": "1:12345678",
+                "symbol": "https://c8.alamy.com/comp/2HCTDG2/modern-design-walnut-leaf-nature-green-logo-design-2HCTDG2.jpg",
+                "short_desc": "WONDERLAND California Whole Walnut Walnuts (Akhrot)  (500 g)",
+                "long_desc": "WONDERLAND California Whole Walnut Walnuts (Akhrot)  (500 g)",
+                "images": [
+                  "https://rukminim2.flixcart.com/image/416/416/xif0q/nut-dry-fruit/h/x/t/500-california-whole-walnut-1-pouch-wonderland-original-imagy632bnvk8fde.jpeg?q=70",
+                  "https://rukminim2.flixcart.com/image/416/416/xif0q/nut-dry-fruit/q/r/t/500-california-whole-walnut-1-pouch-wonderland-original-imagy6326hdk68cd.jpeg?q=70"
+                ]
+              },
+              "price": {
+                "currency": "INR",
+                "value": "120.0",
+                "maximum_value": "200.0"
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "value": "500",
+                    "unit": "gram"
+                  }
+                }
+              },
+              "category_id": "Snacks, Dry Fruits, Nuts",
+              "fulfillment_id": "1",
+              "location_id": "39550822-c3bb-4918-bd25-2d19ef6a9aca",
+              "time": {
+                "label": "enable",
+                "timestamp": "2025-01-23T12:00:21.519Z"
+              },
+              "@ondc/org/returnable": true,
+              "@ondc/org/seller_pickup_return": false,
+              "@ondc/org/return_window": "P7D",
+              "@ondc/org/cancellable": true,
+              "@ondc/org/time_to_ship": "PT3H",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "PirimidFintech,user@gmail.com,7744774477",
+              "@ondc/org/statutory_reqs_prepackaged_food": {
+                "nutritional_info": "nutritional_info",
+                "additives_info": "additives_info",
+                "brand_owner_FSSAI_license_no": "12345678912345",
+                "other_FSSAI_license_no": "12345678912345",
+                "importer_FSSAI_license_no": "12345678912345"
+              },
+              "tags": [
+                {
+                  "code": "origin",
+                  "list": [
+                    {
+                      "code": "Country",
+                      "value": "IND"
+                    }
+                  ]
+                },
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
               "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
-              "parent_item_id": "variant10000",
               "descriptor": {
                 "name": "Nutraj-California-Almonds-1Kg",
                 "code": "1:12345678",
-                "symbol": "symbols.in/symbol.jpg",
+                "symbol": "https://img.freepik.com/premium-vector/almonds-nuts-nature-farm-vintage-logo-icon-symbol-vector-illustration-minimalist-design_889650-491.jpg?semt=ais_hybrid",
                 "short_desc": "Nutraj California Almond kernels 1kg Pouch|Badam Giri|Dry Fruits and Nuts|Grocery",
                 "long_desc": "Nutraj California Almond kernels 1kg Pouch|Badam Giri|Dry Fruits and Nuts|Grocery",
                 "images": [
@@ -198,7 +209,7 @@
               "location_id": "39550822-c3bb-4918-bd25-2d19ef6a9aca",
               "time": {
                 "label": "enable",
-                "timestamp": "2025-01-15T18:00:32.138Z"
+                "timestamp": "2025-01-23T12:00:21.519Z"
               },
               "@ondc/org/returnable": true,
               "@ondc/org/seller_pickup_return": false,
@@ -237,11 +248,10 @@
             },
             {
               "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
-              "parent_item_id": "variant10001",
               "descriptor": {
                 "name": "Cashews",
                 "code": "1:12345678",
-                "symbol": "symbols.in/symbol.jpg",
+                "symbol": "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTVlckKW1pwOvmkj9_s_rPbAvcsr_EdmIStMA&s",
                 "short_desc": "Emart Brand - Vedaka Whole Cashews | 500 Gram | Kaju Nuts Grade W320 | Plant Based Protein | Gluten-Free | Nutty Flavor | Healthy Snack | Rich Delicious Taste",
                 "long_desc": "Emart Brand - Vedaka Whole Cashews | 500 Gram | Kaju Nuts Grade W320 | Plant Based Protein | Gluten-Free | Nutty Flavor | Healthy Snack | Rich Delicious Taste",
                 "images": [
@@ -250,8 +260,8 @@
               },
               "price": {
                 "currency": "INR",
-                "value": "339.0",
-                "maximum_value": "400.0"
+                "value": "120.0",
+                "maximum_value": "212.0"
               },
               "quantity": {
                 "available": {
@@ -262,8 +272,8 @@
                 },
                 "unitized": {
                   "measure": {
-                    "value": "1",
-                    "unit": "kilogram"
+                    "value": "500",
+                    "unit": "gram"
                   }
                 }
               },
@@ -272,7 +282,7 @@
               "location_id": "39550822-c3bb-4918-bd25-2d19ef6a9aca",
               "time": {
                 "label": "enable",
-                "timestamp": "2025-01-15T18:00:32.138Z"
+                "timestamp": "2025-01-23T12:00:21.519Z"
               },
               "@ondc/org/returnable": true,
               "@ondc/org/seller_pickup_return": false,
@@ -342,36 +352,7 @@
               "list": [
                 {
                   "code": "type",
-                  "value": "Order"
-                },
-                {
-                  "code": "location",
-                  "value": "39550822-c3bb-4918-bd25-2d19ef6a9aca"
-                },
-                {
-                  "code": "day_from",
-                  "value": "1"
-                },
-                {
-                  "code": "day_to",
-                  "value": "7"
-                },
-                {
-                  "code": "time_from",
-                  "value": "0930"
-                },
-                {
-                  "code": "time_to",
-                  "value": "1930"
-                }
-              ]
-            },
-            {
-              "code": "timing",
-              "list": [
-                {
-                  "code": "type",
-                  "value": "Delivery"
+                  "value": "All"
                 },
                 {
                   "code": "location",

--- a/Pirimid/SellerApp/Retail/RET-10/FLOW_1/on_search_inc_refresh.json
+++ b/Pirimid/SellerApp/Retail/RET-10/FLOW_1/on_search_inc_refresh.json
@@ -9,9 +9,9 @@
     "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
     "bpp_id": "ondc.pirimidtech.com/v2/seller",
     "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-    "transaction_id": "ef993dfe-e031-4143-944e-fca653af18fb",
-    "message_id": "d900fe5f-8737-4b37-8813-d106f2af6047",
-    "timestamp": "2025-01-15T21:30:17.965Z",
+    "transaction_id": "87f18445-6977-4807-9170-747ffdc9b4a2",
+    "message_id": "706680db-f489-4517-b674-64901eb706bb",
+    "timestamp": "2025-01-23T21:30:20.358Z",
     "ttl": "PT30S"
   },
   "message": {
@@ -31,40 +31,8 @@
           "@ondc/org/fssai_license_no": "12345678912345",
           "time": {
             "label": "enable",
-            "timestamp": "2025-01-15T21:30:17.965Z"
+            "timestamp": "2025-01-23T21:30:20.358Z"
           },
-          "categories": [
-            {
-              "id": "variant10000",
-              "descriptor": {
-                "name": "Variant for Cashews"
-              },
-              "tags": [
-                {
-                  "code": "type",
-                  "list": [
-                    {
-                      "code": "type",
-                      "value": "variant_group"
-                    }
-                  ]
-                },
-                {
-                  "code": "attr",
-                  "list": [
-                    {
-                      "code": "name",
-                      "value": "item.quantity.unitized.measure"
-                    },
-                    {
-                      "code": "seq",
-                      "value": "1"
-                    }
-                  ]
-                }
-              ]
-            }
-          ],
           "fulfillments": [
             {
               "id": "1",
@@ -78,11 +46,10 @@
           "items": [
             {
               "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
-              "parent_item_id": "variant10000",
               "descriptor": {
                 "name": "Cashews",
                 "code": "1:12345678",
-                "symbol": "symbols.in/symbol.jpg",
+                "symbol": "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTVlckKW1pwOvmkj9_s_rPbAvcsr_EdmIStMA&s",
                 "short_desc": "Emart Brand - Vedaka Whole Cashews | 500 Gram | Kaju Nuts Grade W320 | Plant Based Protein | Gluten-Free | Nutty Flavor | Healthy Snack | Rich Delicious Taste",
                 "long_desc": "Emart Brand - Vedaka Whole Cashews | 500 Gram | Kaju Nuts Grade W320 | Plant Based Protein | Gluten-Free | Nutty Flavor | Healthy Snack | Rich Delicious Taste",
                 "images": [
@@ -91,8 +58,8 @@
               },
               "price": {
                 "currency": "INR",
-                "value": "339.0",
-                "maximum_value": "410.0"
+                "value": "120.0",
+                "maximum_value": "220.0"
               },
               "quantity": {
                 "available": {
@@ -103,8 +70,8 @@
                 },
                 "unitized": {
                   "measure": {
-                    "value": "1",
-                    "unit": "kilogram"
+                    "value": "500",
+                    "unit": "gram"
                   }
                 }
               },
@@ -113,7 +80,7 @@
               "location_id": "39550822-c3bb-4918-bd25-2d19ef6a9aca",
               "time": {
                 "label": "enable",
-                "timestamp": "2025-01-15T21:30:17.965Z"
+                "timestamp": "2025-01-23T21:30:20.358Z"
               },
               "@ondc/org/returnable": true,
               "@ondc/org/seller_pickup_return": false,
@@ -183,36 +150,7 @@
               "list": [
                 {
                   "code": "type",
-                  "value": "Order"
-                },
-                {
-                  "code": "location",
-                  "value": "39550822-c3bb-4918-bd25-2d19ef6a9aca"
-                },
-                {
-                  "code": "day_from",
-                  "value": "1"
-                },
-                {
-                  "code": "day_to",
-                  "value": "7"
-                },
-                {
-                  "code": "time_from",
-                  "value": "0930"
-                },
-                {
-                  "code": "time_to",
-                  "value": "1930"
-                }
-              ]
-            },
-            {
-              "code": "timing",
-              "list": [
-                {
-                  "code": "type",
-                  "value": "Delivery"
+                  "value": "All"
                 },
                 {
                   "code": "location",

--- a/Pirimid/SellerApp/Retail/RET-10/FLOW_1/search_full_catalog_refresh.json
+++ b/Pirimid/SellerApp/Retail/RET-10/FLOW_1/search_full_catalog_refresh.json
@@ -7,9 +7,9 @@
     "core_version": "1.2.0",
     "bap_id": "buyer-app-preprod-v2.ondc.org",
     "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
-    "transaction_id": "579594ce-3827-480c-96ec-1d93c4ff7075",
-    "message_id": "eaae33e9-6729-4fa2-86bb-0d85f7c0ceeb",
-    "timestamp": "2025-01-15T18:00:04.302Z",
+    "transaction_id": "2a274964-3eec-4793-888c-1d30ef845cd1",
+    "message_id": "c5c58f68-8483-4490-b318-a1436c6ee88b",
+    "timestamp": "2025-01-23T12:00:01.908Z",
     "ttl": "PT30S"
   },
   "message": {

--- a/Pirimid/SellerApp/Retail/RET-10/FLOW_1/search_inc_refresh.json
+++ b/Pirimid/SellerApp/Retail/RET-10/FLOW_1/search_inc_refresh.json
@@ -7,9 +7,9 @@
     "core_version": "1.2.0",
     "bap_id": "buyer-app-preprod-v2.ondc.org",
     "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
-    "transaction_id": "ef993dfe-e031-4143-944e-fca653af18fb",
-    "message_id": "edb2d472-a57f-4674-aa64-8bcb06167795",
-    "timestamp": "2025-01-15T21:30:17.323Z",
+    "transaction_id": "87f18445-6977-4807-9170-747ffdc9b4a2",
+    "message_id": "cf02de24-eb4c-4fb4-958e-49bd423f770b",
+    "timestamp": "2025-01-23T21:30:17.698Z",
     "ttl": "PT30S"
   },
   "message": {

--- a/Pirimid/SellerApp/Retail/RET-10/FLOW_2/confirm.json
+++ b/Pirimid/SellerApp/Retail/RET-10/FLOW_2/confirm.json
@@ -8,15 +8,15 @@
     "bap_id": "buyer-app-preprod-v2.ondc.org",
     "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
     "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-    "transaction_id": "4b210a13-f55d-4aca-8feb-815d4a383d81",
-    "message_id": "730a42f5-eb45-4d0c-827c-e44b177a5d11",
-    "timestamp": "2025-01-18T04:24:10.828Z",
+    "transaction_id": "b2f44b86-f815-40dc-8a59-1fae65fbd30c",
+    "message_id": "da5dcdaf-006d-4269-a868-12ed29b258a1",
+    "timestamp": "2025-01-23T12:16:47.408Z",
     "bpp_id": "ondc.pirimidtech.com/v2/seller",
     "ttl": "PT30S"
   },
   "message": {
     "order": {
-      "id": "2025-01-18-851979",
+      "id": "2025-01-23-232372",
       "state": "Created",
       "billing": {
         "address": {
@@ -31,23 +31,30 @@
         "phone": "7202959020",
         "name": "Hemanshu Faldu",
         "email": "fhemanshu@gmail.com",
-        "created_at": "2025-01-18T04:23:45.679Z",
-        "updated_at": "2025-01-18T04:23:45.679Z"
+        "created_at": "2025-01-23T12:16:16.800Z",
+        "updated_at": "2025-01-23T12:16:16.800Z"
       },
       "items": [
         {
           "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
           "quantity": {
-            "count": 3
+            "count": 2
           },
-          "fulfillment_id": "07888647-89a1-4a41-b3d2-2936471fc816"
+          "fulfillment_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b"
         },
         {
           "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
           "quantity": {
-            "count": 3
+            "count": 2
           },
-          "fulfillment_id": "07888647-89a1-4a41-b3d2-2936471fc816"
+          "fulfillment_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b"
+        },
+        {
+          "id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b"
         }
       ],
       "provider": {
@@ -61,7 +68,7 @@
       "fulfillments": [
         {
           "@ondc/org/TAT": "PT99H",
-          "id": "07888647-89a1-4a41-b3d2-2936471fc816",
+          "id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
           "tracking": false,
           "end": {
             "contact": {
@@ -91,9 +98,9 @@
         "uri": "https://razorpay.com/",
         "tl_method": "http/get",
         "params": {
-          "amount": "1401.72",
+          "amount": "1364.71",
           "currency": "INR",
-          "transaction_id": "order_PklzhEb4pJDTsN"
+          "transaction_id": "order_PmsiPwsbCPBCII"
         },
         "status": "PAID",
         "type": "ON-ORDER",
@@ -120,13 +127,13 @@
       "quote": {
         "price": {
           "currency": "INR",
-          "value": "1401.72"
+          "value": "1364.71"
         },
         "breakup": [
           {
             "@ondc/org/item_id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
             "@ondc/org/item_quantity": {
-              "count": 3
+              "count": 2
             },
             "@ondc/org/title_type": "item",
             "item": {
@@ -138,11 +145,11 @@
             "title": "Nutraj-California-Almonds-1Kg",
             "price": {
               "currency": "INR",
-              "value": "660.0"
+              "value": "440.0"
             }
           },
           {
-            "@ondc/org/item_id": "07888647-89a1-4a41-b3d2-2936471fc816",
+            "@ondc/org/item_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
             "@ondc/org/title_type": "packing",
             "title": "Packing Charges",
             "price": {
@@ -151,7 +158,7 @@
             }
           },
           {
-            "@ondc/org/item_id": "07888647-89a1-4a41-b3d2-2936471fc816",
+            "@ondc/org/item_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
             "@ondc/org/title_type": "delivery",
             "title": "Delivery Charges",
             "price": {
@@ -165,13 +172,13 @@
             "title": "Tax",
             "price": {
               "currency": "INR",
-              "value": "122.1"
+              "value": "81.4"
             }
           },
           {
             "@ondc/org/item_id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
             "@ondc/org/item_quantity": {
-              "count": 3
+              "count": 2
             },
             "@ondc/org/title_type": "item",
             "item": {
@@ -183,11 +190,11 @@
             "title": "Cashews",
             "price": {
               "currency": "INR",
-              "value": "360.0"
+              "value": "240.0"
             }
           },
           {
-            "@ondc/org/item_id": "07888647-89a1-4a41-b3d2-2936471fc816",
+            "@ondc/org/item_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
             "@ondc/org/title_type": "packing",
             "title": "Packing Charges",
             "price": {
@@ -196,7 +203,7 @@
             }
           },
           {
-            "@ondc/org/item_id": "07888647-89a1-4a41-b3d2-2936471fc816",
+            "@ondc/org/item_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
             "@ondc/org/title_type": "delivery",
             "title": "Delivery Charges",
             "price": {
@@ -205,12 +212,48 @@
             }
           },
           {
-            "@ondc/org/item_id": "07888647-89a1-4a41-b3d2-2936471fc816",
+            "@ondc/org/item_id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "@ondc/org/title_type": "item",
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "120.0"
+              }
+            },
+            "title": "Walnuts",
+            "price": {
+              "currency": "INR",
+              "value": "240.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
+            "@ondc/org/title_type": "packing",
+            "title": "Packing Charges",
+            "price": {
+              "currency": "INR",
+              "value": "5.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
+            "@ondc/org/title_type": "delivery",
+            "title": "Delivery Charges",
+            "price": {
+              "currency": "INR",
+              "value": "100.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
             "@ondc/org/title_type": "misc",
             "title": "Convenience Fee",
             "price": {
               "currency": "INR",
-              "value": "49.62"
+              "value": "48.31"
             }
           }
         ],
@@ -240,8 +283,8 @@
           ]
         }
       ],
-      "created_at": "2025-01-18T04:24:10.828Z",
-      "updated_at": "2025-01-18T04:24:10.828Z"
+      "created_at": "2025-01-23T12:16:47.408Z",
+      "updated_at": "2025-01-23T12:16:47.408Z"
     }
   }
 }

--- a/Pirimid/SellerApp/Retail/RET-10/FLOW_2/init.json
+++ b/Pirimid/SellerApp/Retail/RET-10/FLOW_2/init.json
@@ -8,9 +8,9 @@
     "bap_id": "buyer-app-preprod-v2.ondc.org",
     "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
     "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-    "transaction_id": "4b210a13-f55d-4aca-8feb-815d4a383d81",
-    "message_id": "852634a0-4464-423a-a7c1-195185b28a65",
-    "timestamp": "2025-01-18T04:23:45.679Z",
+    "transaction_id": "b2f44b86-f815-40dc-8a59-1fae65fbd30c",
+    "message_id": "a64b57be-1fe3-4c60-a8ef-b5ecd23b1e12",
+    "timestamp": "2025-01-23T12:16:16.800Z",
     "bpp_id": "ondc.pirimidtech.com/v2/seller",
     "ttl": "PT30S"
   },
@@ -28,18 +28,26 @@
         {
           "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
           "quantity": {
-            "count": 3
+            "count": 2
           },
           "location_id": "39550822-c3bb-4918-bd25-2d19ef6a9aca",
-          "fulfillment_id": "07888647-89a1-4a41-b3d2-2936471fc816"
+          "fulfillment_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b"
         },
         {
           "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
           "quantity": {
-            "count": 3
+            "count": 2
           },
           "location_id": "39550822-c3bb-4918-bd25-2d19ef6a9aca",
-          "fulfillment_id": "07888647-89a1-4a41-b3d2-2936471fc816"
+          "fulfillment_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b"
+        },
+        {
+          "id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+          "quantity": {
+            "count": 2
+          },
+          "location_id": "39550822-c3bb-4918-bd25-2d19ef6a9aca",
+          "fulfillment_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b"
         }
       ],
       "billing": {
@@ -55,12 +63,12 @@
         "phone": "7202959020",
         "name": "Hemanshu Faldu",
         "email": "fhemanshu@gmail.com",
-        "created_at": "2025-01-18T04:23:45.679Z",
-        "updated_at": "2025-01-18T04:23:45.679Z"
+        "created_at": "2025-01-23T12:16:16.800Z",
+        "updated_at": "2025-01-23T12:16:16.800Z"
       },
       "fulfillments": [
         {
-          "id": "07888647-89a1-4a41-b3d2-2936471fc816",
+          "id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
           "type": "Delivery",
           "end": {
             "contact": {

--- a/Pirimid/SellerApp/Retail/RET-10/FLOW_2/log_validation_utility_request.json
+++ b/Pirimid/SellerApp/Retail/RET-10/FLOW_2/log_validation_utility_request.json
@@ -13,9 +13,9 @@
                 "core_version": "1.2.0",
                 "bap_id": "buyer-app-preprod-v2.ondc.org",
                 "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
-                "transaction_id": "e53a74c5-7ce6-4498-800c-e7d90db0f2fa",
-                "message_id": "45726578-5033-41e0-b35f-2fcbcebe8f82",
-                "timestamp": "2025-01-17T12:00:01.818Z",
+                "transaction_id": "2a274964-3eec-4793-888c-1d30ef845cd1",
+                "message_id": "c5c58f68-8483-4490-b318-a1436c6ee88b",
+                "timestamp": "2025-01-23T12:00:01.908Z",
                 "ttl": "PT30S"
             },
             "message": {
@@ -41,9 +41,9 @@
                 "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
                 "bpp_id": "ondc.pirimidtech.com/v2/seller",
                 "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-                "transaction_id": "e53a74c5-7ce6-4498-800c-e7d90db0f2fa",
-                "message_id": "45726578-5033-41e0-b35f-2fcbcebe8f82",
-                "timestamp": "2025-01-17T12:00:21.411Z",
+                "transaction_id": "2a274964-3eec-4793-888c-1d30ef845cd1",
+                "message_id": "c5c58f68-8483-4490-b318-a1436c6ee88b",
+                "timestamp": "2025-01-23T12:00:21.519Z",
                 "ttl": "PT30S"
             },
             "message": {
@@ -90,70 +90,8 @@
                             "@ondc/org/fssai_license_no": "12345678912345",
                             "time": {
                                 "label": "enable",
-                                "timestamp": "2025-01-17T12:00:21.411Z"
+                                "timestamp": "2025-01-23T12:00:21.519Z"
                             },
-                            "categories": [
-                                {
-                                    "id": "variant10000",
-                                    "descriptor": {
-                                        "name": "Variant for Nutraj-California-Almonds-1Kg"
-                                    },
-                                    "tags": [
-                                        {
-                                            "code": "type",
-                                            "list": [
-                                                {
-                                                    "code": "type",
-                                                    "value": "variant_group"
-                                                }
-                                            ]
-                                        },
-                                        {
-                                            "code": "attr",
-                                            "list": [
-                                                {
-                                                    "code": "name",
-                                                    "value": "item.quantity.unitized.measure"
-                                                },
-                                                {
-                                                    "code": "seq",
-                                                    "value": "1"
-                                                }
-                                            ]
-                                        }
-                                    ]
-                                },
-                                {
-                                    "id": "variant10001",
-                                    "descriptor": {
-                                        "name": "Variant for Cashews"
-                                    },
-                                    "tags": [
-                                        {
-                                            "code": "type",
-                                            "list": [
-                                                {
-                                                    "code": "type",
-                                                    "value": "variant_group"
-                                                }
-                                            ]
-                                        },
-                                        {
-                                            "code": "attr",
-                                            "list": [
-                                                {
-                                                    "code": "name",
-                                                    "value": "item.quantity.unitized.measure"
-                                                },
-                                                {
-                                                    "code": "seq",
-                                                    "value": "1"
-                                                }
-                                            ]
-                                        }
-                                    ]
-                                }
-                            ],
                             "fulfillments": [
                                 {
                                     "id": "1",
@@ -173,11 +111,11 @@
                                         "locality": "Ashok Vatika",
                                         "city": "Ahmedabad",
                                         "state": "Gujarat",
-                                        "area_code": "380058"
+                                        "area_code": "380054"
                                     },
                                     "time": {
                                         "label": "enable",
-                                        "timestamp": "2024-12-04T13:50:34.608Z",
+                                        "timestamp": "2025-01-22T07:34:34.534Z",
                                         "range": {
                                             "start": "0930",
                                             "end": "1930"
@@ -194,12 +132,85 @@
                             ],
                             "items": [
                                 {
+                                    "id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+                                    "descriptor": {
+                                        "name": "Walnuts",
+                                        "code": "1:12345678",
+                                        "symbol": "https://c8.alamy.com/comp/2HCTDG2/modern-design-walnut-leaf-nature-green-logo-design-2HCTDG2.jpg",
+                                        "short_desc": "WONDERLAND California Whole Walnut Walnuts (Akhrot)  (500 g)",
+                                        "long_desc": "WONDERLAND California Whole Walnut Walnuts (Akhrot)  (500 g)",
+                                        "images": [
+                                            "https://rukminim2.flixcart.com/image/416/416/xif0q/nut-dry-fruit/h/x/t/500-california-whole-walnut-1-pouch-wonderland-original-imagy632bnvk8fde.jpeg?q=70",
+                                            "https://rukminim2.flixcart.com/image/416/416/xif0q/nut-dry-fruit/q/r/t/500-california-whole-walnut-1-pouch-wonderland-original-imagy6326hdk68cd.jpeg?q=70"
+                                        ]
+                                    },
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "120.0",
+                                        "maximum_value": "200.0"
+                                    },
+                                    "quantity": {
+                                        "available": {
+                                            "count": "99"
+                                        },
+                                        "maximum": {
+                                            "count": "99"
+                                        },
+                                        "unitized": {
+                                            "measure": {
+                                                "value": "500",
+                                                "unit": "gram"
+                                            }
+                                        }
+                                    },
+                                    "category_id": "Snacks, Dry Fruits, Nuts",
+                                    "fulfillment_id": "1",
+                                    "location_id": "39550822-c3bb-4918-bd25-2d19ef6a9aca",
+                                    "time": {
+                                        "label": "enable",
+                                        "timestamp": "2025-01-23T12:00:21.519Z"
+                                    },
+                                    "@ondc/org/returnable": true,
+                                    "@ondc/org/seller_pickup_return": false,
+                                    "@ondc/org/return_window": "P7D",
+                                    "@ondc/org/cancellable": true,
+                                    "@ondc/org/time_to_ship": "PT3H",
+                                    "@ondc/org/available_on_cod": false,
+                                    "@ondc/org/contact_details_consumer_care": "PirimidFintech,user@gmail.com,7744774477",
+                                    "@ondc/org/statutory_reqs_prepackaged_food": {
+                                        "nutritional_info": "nutritional_info",
+                                        "additives_info": "additives_info",
+                                        "brand_owner_FSSAI_license_no": "12345678912345",
+                                        "other_FSSAI_license_no": "12345678912345",
+                                        "importer_FSSAI_license_no": "12345678912345"
+                                    },
+                                    "tags": [
+                                        {
+                                            "code": "origin",
+                                            "list": [
+                                                {
+                                                    "code": "Country",
+                                                    "value": "IND"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "veg_nonveg",
+                                            "list": [
+                                                {
+                                                    "code": "veg",
+                                                    "value": "yes"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                {
                                     "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
-                                    "parent_item_id": "variant10000",
                                     "descriptor": {
                                         "name": "Nutraj-California-Almonds-1Kg",
                                         "code": "1:12345678",
-                                        "symbol": "symbols.in/symbol.jpg",
+                                        "symbol": "https://img.freepik.com/premium-vector/almonds-nuts-nature-farm-vintage-logo-icon-symbol-vector-illustration-minimalist-design_889650-491.jpg?semt=ais_hybrid",
                                         "short_desc": "Nutraj California Almond kernels 1kg Pouch|Badam Giri|Dry Fruits and Nuts|Grocery",
                                         "long_desc": "Nutraj California Almond kernels 1kg Pouch|Badam Giri|Dry Fruits and Nuts|Grocery",
                                         "images": [
@@ -230,7 +241,7 @@
                                     "location_id": "39550822-c3bb-4918-bd25-2d19ef6a9aca",
                                     "time": {
                                         "label": "enable",
-                                        "timestamp": "2025-01-17T12:00:21.411Z"
+                                        "timestamp": "2025-01-23T12:00:21.519Z"
                                     },
                                     "@ondc/org/returnable": true,
                                     "@ondc/org/seller_pickup_return": false,
@@ -269,11 +280,10 @@
                                 },
                                 {
                                     "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
-                                    "parent_item_id": "variant10001",
                                     "descriptor": {
                                         "name": "Cashews",
                                         "code": "1:12345678",
-                                        "symbol": "symbols.in/symbol.jpg",
+                                        "symbol": "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTVlckKW1pwOvmkj9_s_rPbAvcsr_EdmIStMA&s",
                                         "short_desc": "Emart Brand - Vedaka Whole Cashews | 500 Gram | Kaju Nuts Grade W320 | Plant Based Protein | Gluten-Free | Nutty Flavor | Healthy Snack | Rich Delicious Taste",
                                         "long_desc": "Emart Brand - Vedaka Whole Cashews | 500 Gram | Kaju Nuts Grade W320 | Plant Based Protein | Gluten-Free | Nutty Flavor | Healthy Snack | Rich Delicious Taste",
                                         "images": [
@@ -283,7 +293,7 @@
                                     "price": {
                                         "currency": "INR",
                                         "value": "120.0",
-                                        "maximum_value": "258.0"
+                                        "maximum_value": "212.0"
                                     },
                                     "quantity": {
                                         "available": {
@@ -294,8 +304,8 @@
                                         },
                                         "unitized": {
                                             "measure": {
-                                                "value": "1",
-                                                "unit": "kilogram"
+                                                "value": "500",
+                                                "unit": "gram"
                                             }
                                         }
                                     },
@@ -304,7 +314,7 @@
                                     "location_id": "39550822-c3bb-4918-bd25-2d19ef6a9aca",
                                     "time": {
                                         "label": "enable",
-                                        "timestamp": "2025-01-17T12:00:21.411Z"
+                                        "timestamp": "2025-01-23T12:00:21.519Z"
                                     },
                                     "@ondc/org/returnable": true,
                                     "@ondc/org/seller_pickup_return": false,
@@ -374,36 +384,7 @@
                                     "list": [
                                         {
                                             "code": "type",
-                                            "value": "Order"
-                                        },
-                                        {
-                                            "code": "location",
-                                            "value": "39550822-c3bb-4918-bd25-2d19ef6a9aca"
-                                        },
-                                        {
-                                            "code": "day_from",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "day_to",
-                                            "value": "7"
-                                        },
-                                        {
-                                            "code": "time_from",
-                                            "value": "0930"
-                                        },
-                                        {
-                                            "code": "time_to",
-                                            "value": "1930"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "timing",
-                                    "list": [
-                                        {
-                                            "code": "type",
-                                            "value": "Delivery"
+                                            "value": "All"
                                         },
                                         {
                                             "code": "location",
@@ -443,9 +424,9 @@
                 "bap_id": "buyer-app-preprod-v2.ondc.org",
                 "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
                 "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-                "transaction_id": "4b210a13-f55d-4aca-8feb-815d4a383d81",
-                "message_id": "c7c389c3-419f-4d0f-805a-1252a387ec43",
-                "timestamp": "2025-01-18T04:23:29.944Z",
+                "transaction_id": "b2f44b86-f815-40dc-8a59-1fae65fbd30c",
+                "message_id": "2643345b-61c1-44ab-a4bd-b7f06f6f742c",
+                "timestamp": "2025-01-23T12:16:05.761Z",
                 "bpp_id": "ondc.pirimidtech.com/v2/seller",
                 "ttl": "PT30S"
             },
@@ -455,14 +436,21 @@
                         {
                             "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
                             "quantity": {
-                                "count": 3
+                                "count": 2
                             },
                             "location_id": "39550822-c3bb-4918-bd25-2d19ef6a9aca"
                         },
                         {
                             "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
                             "quantity": {
-                                "count": 3
+                                "count": 2
+                            },
+                            "location_id": "39550822-c3bb-4918-bd25-2d19ef6a9aca"
+                        },
+                        {
+                            "id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+                            "quantity": {
+                                "count": 2
                             },
                             "location_id": "39550822-c3bb-4918-bd25-2d19ef6a9aca"
                         }
@@ -501,9 +489,9 @@
                 "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
                 "bpp_id": "ondc.pirimidtech.com/v2/seller",
                 "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-                "transaction_id": "4b210a13-f55d-4aca-8feb-815d4a383d81",
-                "message_id": "c7c389c3-419f-4d0f-805a-1252a387ec43",
-                "timestamp": "2025-01-18T04:23:31.956Z"
+                "transaction_id": "b2f44b86-f815-40dc-8a59-1fae65fbd30c",
+                "message_id": "2643345b-61c1-44ab-a4bd-b7f06f6f742c",
+                "timestamp": "2025-01-23T12:16:07.500Z"
             },
             "message": {
                 "order": {
@@ -518,16 +506,20 @@
                     "items": [
                         {
                             "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
-                            "fulfillment_id": "07888647-89a1-4a41-b3d2-2936471fc816"
+                            "fulfillment_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b"
                         },
                         {
                             "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
-                            "fulfillment_id": "07888647-89a1-4a41-b3d2-2936471fc816"
+                            "fulfillment_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b"
+                        },
+                        {
+                            "id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+                            "fulfillment_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b"
                         }
                     ],
                     "fulfillments": [
                         {
-                            "id": "07888647-89a1-4a41-b3d2-2936471fc816",
+                            "id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
                             "type": "Delivery",
                             "@ondc/org/category": "Standard Delivery",
                             "@ondc/org/TAT": "PT99H",
@@ -543,13 +535,13 @@
                     "quote": {
                         "price": {
                             "currency": "INR",
-                            "value": "1401.72"
+                            "value": "1364.71"
                         },
                         "breakup": [
                             {
                                 "@ondc/org/item_id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
                                 "@ondc/org/item_quantity": {
-                                    "count": 3
+                                    "count": 2
                                 },
                                 "@ondc/org/title_type": "item",
                                 "item": {
@@ -569,11 +561,11 @@
                                 "title": "Nutraj-California-Almonds-1Kg",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "660.0"
+                                    "value": "440.0"
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "07888647-89a1-4a41-b3d2-2936471fc816",
+                                "@ondc/org/item_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
                                 "@ondc/org/title_type": "packing",
                                 "title": "Packing Charges",
                                 "price": {
@@ -582,7 +574,7 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "07888647-89a1-4a41-b3d2-2936471fc816",
+                                "@ondc/org/item_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
                                 "@ondc/org/title_type": "delivery",
                                 "title": "Delivery Charges",
                                 "price": {
@@ -596,13 +588,13 @@
                                 "title": "Tax",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "122.1"
+                                    "value": "81.4"
                                 }
                             },
                             {
                                 "@ondc/org/item_id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
                                 "@ondc/org/item_quantity": {
-                                    "count": 3
+                                    "count": 2
                                 },
                                 "@ondc/org/title_type": "item",
                                 "item": {
@@ -622,11 +614,11 @@
                                 "title": "Cashews",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "360.0"
+                                    "value": "240.0"
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "07888647-89a1-4a41-b3d2-2936471fc816",
+                                "@ondc/org/item_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
                                 "@ondc/org/title_type": "packing",
                                 "title": "Packing Charges",
                                 "price": {
@@ -635,7 +627,7 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "07888647-89a1-4a41-b3d2-2936471fc816",
+                                "@ondc/org/item_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
                                 "@ondc/org/title_type": "delivery",
                                 "title": "Delivery Charges",
                                 "price": {
@@ -644,12 +636,56 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "07888647-89a1-4a41-b3d2-2936471fc816",
+                                "@ondc/org/item_id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+                                "@ondc/org/item_quantity": {
+                                    "count": 2
+                                },
+                                "@ondc/org/title_type": "item",
+                                "item": {
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "120.0"
+                                    },
+                                    "quantity": {
+                                        "available": {
+                                            "count": "99"
+                                        },
+                                        "maximum": {
+                                            "count": "99"
+                                        }
+                                    }
+                                },
+                                "title": "Walnuts",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "240.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
+                                "@ondc/org/title_type": "packing",
+                                "title": "Packing Charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "5.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
+                                "@ondc/org/title_type": "delivery",
+                                "title": "Delivery Charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "100.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
                                 "@ondc/org/title_type": "misc",
                                 "title": "Convenience Fee",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "49.62"
+                                    "value": "48.31"
                                 }
                             }
                         ],
@@ -668,9 +704,9 @@
                 "bap_id": "buyer-app-preprod-v2.ondc.org",
                 "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
                 "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-                "transaction_id": "4b210a13-f55d-4aca-8feb-815d4a383d81",
-                "message_id": "852634a0-4464-423a-a7c1-195185b28a65",
-                "timestamp": "2025-01-18T04:23:45.679Z",
+                "transaction_id": "b2f44b86-f815-40dc-8a59-1fae65fbd30c",
+                "message_id": "a64b57be-1fe3-4c60-a8ef-b5ecd23b1e12",
+                "timestamp": "2025-01-23T12:16:16.800Z",
                 "bpp_id": "ondc.pirimidtech.com/v2/seller",
                 "ttl": "PT30S"
             },
@@ -688,18 +724,26 @@
                         {
                             "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
                             "quantity": {
-                                "count": 3
+                                "count": 2
                             },
                             "location_id": "39550822-c3bb-4918-bd25-2d19ef6a9aca",
-                            "fulfillment_id": "07888647-89a1-4a41-b3d2-2936471fc816"
+                            "fulfillment_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b"
                         },
                         {
                             "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
                             "quantity": {
-                                "count": 3
+                                "count": 2
                             },
                             "location_id": "39550822-c3bb-4918-bd25-2d19ef6a9aca",
-                            "fulfillment_id": "07888647-89a1-4a41-b3d2-2936471fc816"
+                            "fulfillment_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b"
+                        },
+                        {
+                            "id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+                            "quantity": {
+                                "count": 2
+                            },
+                            "location_id": "39550822-c3bb-4918-bd25-2d19ef6a9aca",
+                            "fulfillment_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b"
                         }
                     ],
                     "billing": {
@@ -715,12 +759,12 @@
                         "phone": "7202959020",
                         "name": "Hemanshu Faldu",
                         "email": "fhemanshu@gmail.com",
-                        "created_at": "2025-01-18T04:23:45.679Z",
-                        "updated_at": "2025-01-18T04:23:45.679Z"
+                        "created_at": "2025-01-23T12:16:16.800Z",
+                        "updated_at": "2025-01-23T12:16:16.800Z"
                     },
                     "fulfillments": [
                         {
-                            "id": "07888647-89a1-4a41-b3d2-2936471fc816",
+                            "id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
                             "type": "Delivery",
                             "end": {
                                 "contact": {
@@ -756,9 +800,9 @@
                 "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
                 "bpp_id": "ondc.pirimidtech.com/v2/seller",
                 "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-                "transaction_id": "4b210a13-f55d-4aca-8feb-815d4a383d81",
-                "message_id": "852634a0-4464-423a-a7c1-195185b28a65",
-                "timestamp": "2025-01-18T04:23:46.703Z",
+                "transaction_id": "b2f44b86-f815-40dc-8a59-1fae65fbd30c",
+                "message_id": "a64b57be-1fe3-4c60-a8ef-b5ecd23b1e12",
+                "timestamp": "2025-01-23T12:16:17.614Z",
                 "ttl": "PT30S"
             },
             "message": {
@@ -776,21 +820,31 @@
                             "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
                             "quantity": {
                                 "unitized": {
-                                    "count": "3"
+                                    "count": "2"
                                 },
-                                "count": 3
+                                "count": 2
                             },
-                            "fulfillment_id": "07888647-89a1-4a41-b3d2-2936471fc816"
+                            "fulfillment_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b"
                         },
                         {
                             "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
                             "quantity": {
                                 "unitized": {
-                                    "count": "3"
+                                    "count": "2"
                                 },
-                                "count": 3
+                                "count": 2
                             },
-                            "fulfillment_id": "07888647-89a1-4a41-b3d2-2936471fc816"
+                            "fulfillment_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b"
+                        },
+                        {
+                            "id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+                            "quantity": {
+                                "unitized": {
+                                    "count": "2"
+                                },
+                                "count": 2
+                            },
+                            "fulfillment_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b"
                         }
                     ],
                     "billing": {
@@ -806,19 +860,13 @@
                         },
                         "email": "fhemanshu@gmail.com",
                         "phone": "7202959020",
-                        "created_at": "2025-01-18T04:23:45.679Z",
-                        "updated_at": "2025-01-18T04:23:45.679Z"
+                        "created_at": "2025-01-23T12:16:16.800Z",
+                        "updated_at": "2025-01-23T12:16:16.800Z"
                     },
                     "fulfillments": [
                         {
-                            "id": "07888647-89a1-4a41-b3d2-2936471fc816",
+                            "id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
                             "type": "Delivery",
-                            "provider_id": "ondc.loadshare.com/ondc/18275",
-                            "state": {
-                                "descriptor": {
-                                    "code": "INITIALIZING"
-                                }
-                            },
                             "tracking": false,
                             "end": {
                                 "location": {
@@ -832,9 +880,6 @@
                                         "country": "IND",
                                         "area_code": "380015"
                                     }
-                                },
-                                "time": {
-                                    "range": {}
                                 },
                                 "instructions": {
                                     "name": "Status for pickup",
@@ -855,13 +900,13 @@
                     "quote": {
                         "price": {
                             "currency": "INR",
-                            "value": "1401.72"
+                            "value": "1364.71"
                         },
                         "breakup": [
                             {
                                 "@ondc/org/item_id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
                                 "@ondc/org/item_quantity": {
-                                    "count": 3
+                                    "count": 2
                                 },
                                 "@ondc/org/title_type": "item",
                                 "item": {
@@ -873,11 +918,11 @@
                                 "title": "Nutraj-California-Almonds-1Kg",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "660.0"
+                                    "value": "440.0"
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "07888647-89a1-4a41-b3d2-2936471fc816",
+                                "@ondc/org/item_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
                                 "@ondc/org/title_type": "packing",
                                 "title": "Packing Charges",
                                 "price": {
@@ -886,7 +931,7 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "07888647-89a1-4a41-b3d2-2936471fc816",
+                                "@ondc/org/item_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
                                 "@ondc/org/title_type": "delivery",
                                 "title": "Delivery Charges",
                                 "price": {
@@ -900,13 +945,13 @@
                                 "title": "Tax",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "122.1"
+                                    "value": "81.4"
                                 }
                             },
                             {
                                 "@ondc/org/item_id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
                                 "@ondc/org/item_quantity": {
-                                    "count": 3
+                                    "count": 2
                                 },
                                 "@ondc/org/title_type": "item",
                                 "item": {
@@ -918,11 +963,11 @@
                                 "title": "Cashews",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "360.0"
+                                    "value": "240.0"
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "07888647-89a1-4a41-b3d2-2936471fc816",
+                                "@ondc/org/item_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
                                 "@ondc/org/title_type": "packing",
                                 "title": "Packing Charges",
                                 "price": {
@@ -931,7 +976,7 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "07888647-89a1-4a41-b3d2-2936471fc816",
+                                "@ondc/org/item_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
                                 "@ondc/org/title_type": "delivery",
                                 "title": "Delivery Charges",
                                 "price": {
@@ -940,22 +985,58 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "07888647-89a1-4a41-b3d2-2936471fc816",
+                                "@ondc/org/item_id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+                                "@ondc/org/item_quantity": {
+                                    "count": 2
+                                },
+                                "@ondc/org/title_type": "item",
+                                "item": {
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "120.0"
+                                    }
+                                },
+                                "title": "Walnuts",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "240.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
+                                "@ondc/org/title_type": "packing",
+                                "title": "Packing Charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "5.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
+                                "@ondc/org/title_type": "delivery",
+                                "title": "Delivery Charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "100.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
                                 "@ondc/org/title_type": "misc",
                                 "title": "Convenience Fee",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "49.62"
+                                    "value": "48.31"
                                 }
                             }
                         ],
                         "ttl": "P1D"
                     },
                     "payment": {
-                        "uri": "https://ondc-pirimid-payment.netlify.app/payment/4b210a13-f55d-4aca-8feb-815d4a383d81",
+                        "uri": "https://ondc-pirimid-payment.netlify.app/payment/b2f44b86-f815-40dc-8a59-1fae65fbd30c",
                         "type": "ON-ORDER",
                         "status": "NOT-PAID",
-                        "collected_by": "BPP",
+                        "collected_by": "BAP",
                         "@ondc/org/buyer_app_finder_fee_type": "percent",
                         "@ondc/org/buyer_app_finder_fee_amount": "3.0",
                         "@ondc/org/withholding_amount": "0.0",
@@ -975,8 +1056,8 @@
                             }
                         ]
                     },
-                    "created_at": "2025-01-18T04:23:35.068Z",
-                    "updated_at": "2025-01-18T04:23:46.816Z",
+                    "created_at": "2025-01-23T12:16:07.540Z",
+                    "updated_at": "2025-01-23T12:16:17.646Z",
                     "tags": [
                         {
                             "code": "bpp_terms",
@@ -1005,15 +1086,15 @@
                 "bap_id": "buyer-app-preprod-v2.ondc.org",
                 "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
                 "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-                "transaction_id": "4b210a13-f55d-4aca-8feb-815d4a383d81",
-                "message_id": "730a42f5-eb45-4d0c-827c-e44b177a5d11",
-                "timestamp": "2025-01-18T04:24:10.828Z",
+                "transaction_id": "b2f44b86-f815-40dc-8a59-1fae65fbd30c",
+                "message_id": "da5dcdaf-006d-4269-a868-12ed29b258a1",
+                "timestamp": "2025-01-23T12:16:47.408Z",
                 "bpp_id": "ondc.pirimidtech.com/v2/seller",
                 "ttl": "PT30S"
             },
             "message": {
                 "order": {
-                    "id": "2025-01-18-851979",
+                    "id": "2025-01-23-232372",
                     "state": "Created",
                     "billing": {
                         "address": {
@@ -1028,23 +1109,30 @@
                         "phone": "7202959020",
                         "name": "Hemanshu Faldu",
                         "email": "fhemanshu@gmail.com",
-                        "created_at": "2025-01-18T04:23:45.679Z",
-                        "updated_at": "2025-01-18T04:23:45.679Z"
+                        "created_at": "2025-01-23T12:16:16.800Z",
+                        "updated_at": "2025-01-23T12:16:16.800Z"
                     },
                     "items": [
                         {
                             "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
                             "quantity": {
-                                "count": 3
+                                "count": 2
                             },
-                            "fulfillment_id": "07888647-89a1-4a41-b3d2-2936471fc816"
+                            "fulfillment_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b"
                         },
                         {
                             "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
                             "quantity": {
-                                "count": 3
+                                "count": 2
                             },
-                            "fulfillment_id": "07888647-89a1-4a41-b3d2-2936471fc816"
+                            "fulfillment_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b"
+                        },
+                        {
+                            "id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+                            "quantity": {
+                                "count": 2
+                            },
+                            "fulfillment_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b"
                         }
                     ],
                     "provider": {
@@ -1058,7 +1146,7 @@
                     "fulfillments": [
                         {
                             "@ondc/org/TAT": "PT99H",
-                            "id": "07888647-89a1-4a41-b3d2-2936471fc816",
+                            "id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
                             "tracking": false,
                             "end": {
                                 "contact": {
@@ -1088,9 +1176,9 @@
                         "uri": "https://razorpay.com/",
                         "tl_method": "http/get",
                         "params": {
-                            "amount": "1401.72",
+                            "amount": "1364.71",
                             "currency": "INR",
-                            "transaction_id": "order_PklzhEb4pJDTsN"
+                            "transaction_id": "order_PmsiPwsbCPBCII"
                         },
                         "status": "PAID",
                         "type": "ON-ORDER",
@@ -1117,13 +1205,13 @@
                     "quote": {
                         "price": {
                             "currency": "INR",
-                            "value": "1401.72"
+                            "value": "1364.71"
                         },
                         "breakup": [
                             {
                                 "@ondc/org/item_id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
                                 "@ondc/org/item_quantity": {
-                                    "count": 3
+                                    "count": 2
                                 },
                                 "@ondc/org/title_type": "item",
                                 "item": {
@@ -1135,11 +1223,11 @@
                                 "title": "Nutraj-California-Almonds-1Kg",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "660.0"
+                                    "value": "440.0"
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "07888647-89a1-4a41-b3d2-2936471fc816",
+                                "@ondc/org/item_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
                                 "@ondc/org/title_type": "packing",
                                 "title": "Packing Charges",
                                 "price": {
@@ -1148,7 +1236,7 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "07888647-89a1-4a41-b3d2-2936471fc816",
+                                "@ondc/org/item_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
                                 "@ondc/org/title_type": "delivery",
                                 "title": "Delivery Charges",
                                 "price": {
@@ -1162,13 +1250,13 @@
                                 "title": "Tax",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "122.1"
+                                    "value": "81.4"
                                 }
                             },
                             {
                                 "@ondc/org/item_id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
                                 "@ondc/org/item_quantity": {
-                                    "count": 3
+                                    "count": 2
                                 },
                                 "@ondc/org/title_type": "item",
                                 "item": {
@@ -1180,11 +1268,11 @@
                                 "title": "Cashews",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "360.0"
+                                    "value": "240.0"
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "07888647-89a1-4a41-b3d2-2936471fc816",
+                                "@ondc/org/item_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
                                 "@ondc/org/title_type": "packing",
                                 "title": "Packing Charges",
                                 "price": {
@@ -1193,7 +1281,7 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "07888647-89a1-4a41-b3d2-2936471fc816",
+                                "@ondc/org/item_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
                                 "@ondc/org/title_type": "delivery",
                                 "title": "Delivery Charges",
                                 "price": {
@@ -1202,12 +1290,48 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "07888647-89a1-4a41-b3d2-2936471fc816",
+                                "@ondc/org/item_id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+                                "@ondc/org/item_quantity": {
+                                    "count": 2
+                                },
+                                "@ondc/org/title_type": "item",
+                                "item": {
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "120.0"
+                                    }
+                                },
+                                "title": "Walnuts",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "240.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
+                                "@ondc/org/title_type": "packing",
+                                "title": "Packing Charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "5.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
+                                "@ondc/org/title_type": "delivery",
+                                "title": "Delivery Charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "100.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
                                 "@ondc/org/title_type": "misc",
                                 "title": "Convenience Fee",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "49.62"
+                                    "value": "48.31"
                                 }
                             }
                         ],
@@ -1237,8 +1361,8 @@
                             ]
                         }
                     ],
-                    "created_at": "2025-01-18T04:24:10.828Z",
-                    "updated_at": "2025-01-18T04:24:10.828Z"
+                    "created_at": "2025-01-23T12:16:47.408Z",
+                    "updated_at": "2025-01-23T12:16:47.408Z"
                 }
             }
         },
@@ -1253,13 +1377,13 @@
                 "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
                 "bpp_id": "ondc.pirimidtech.com/v2/seller",
                 "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-                "transaction_id": "4b210a13-f55d-4aca-8feb-815d4a383d81",
-                "message_id": "730a42f5-eb45-4d0c-827c-e44b177a5d11",
-                "timestamp": "2025-01-18T04:24:12.169Z"
+                "transaction_id": "b2f44b86-f815-40dc-8a59-1fae65fbd30c",
+                "message_id": "da5dcdaf-006d-4269-a868-12ed29b258a1",
+                "timestamp": "2025-01-23T12:16:48.296Z"
             },
             "message": {
                 "order": {
-                    "id": "2025-01-18-851979",
+                    "id": "2025-01-23-232372",
                     "state": "Created",
                     "provider": {
                         "id": "e2008459-7e90-493e-b02e-cae52ca53214",
@@ -1273,16 +1397,23 @@
                         {
                             "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
                             "quantity": {
-                                "count": 3
+                                "count": 2
                             },
-                            "fulfillment_id": "07888647-89a1-4a41-b3d2-2936471fc816"
+                            "fulfillment_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b"
                         },
                         {
                             "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
                             "quantity": {
-                                "count": 3
+                                "count": 2
                             },
-                            "fulfillment_id": "07888647-89a1-4a41-b3d2-2936471fc816"
+                            "fulfillment_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b"
+                        },
+                        {
+                            "id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+                            "quantity": {
+                                "count": 2
+                            },
+                            "fulfillment_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b"
                         }
                     ],
                     "billing": {
@@ -1298,12 +1429,12 @@
                         },
                         "email": "fhemanshu@gmail.com",
                         "phone": "7202959020",
-                        "created_at": "2025-01-18T04:23:45.679Z",
-                        "updated_at": "2025-01-18T04:23:45.679Z"
+                        "created_at": "2025-01-23T12:16:16.800Z",
+                        "updated_at": "2025-01-23T12:16:16.800Z"
                     },
                     "fulfillments": [
                         {
-                            "id": "07888647-89a1-4a41-b3d2-2936471fc816",
+                            "id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
                             "type": "Delivery",
                             "@ondc/org/TAT": "PT99H",
                             "@ondc/org/provider_name": "LoadShare",
@@ -1324,7 +1455,7 @@
                                         "locality": "Ashok Vatika",
                                         "city": "Ahmedabad",
                                         "state": "Gujarat",
-                                        "area_code": "380058"
+                                        "area_code": "380054"
                                     }
                                 },
                                 "contact": {
@@ -1358,13 +1489,13 @@
                     "quote": {
                         "price": {
                             "currency": "INR",
-                            "value": "1401.72"
+                            "value": "1364.71"
                         },
                         "breakup": [
                             {
                                 "@ondc/org/item_id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
                                 "@ondc/org/item_quantity": {
-                                    "count": 3
+                                    "count": 2
                                 },
                                 "@ondc/org/title_type": "item",
                                 "item": {
@@ -1376,11 +1507,11 @@
                                 "title": "Nutraj-California-Almonds-1Kg",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "660.0"
+                                    "value": "440.0"
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "07888647-89a1-4a41-b3d2-2936471fc816",
+                                "@ondc/org/item_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
                                 "@ondc/org/title_type": "packing",
                                 "title": "Packing Charges",
                                 "price": {
@@ -1389,7 +1520,7 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "07888647-89a1-4a41-b3d2-2936471fc816",
+                                "@ondc/org/item_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
                                 "@ondc/org/title_type": "delivery",
                                 "title": "Delivery Charges",
                                 "price": {
@@ -1403,13 +1534,13 @@
                                 "title": "Tax",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "122.1"
+                                    "value": "81.4"
                                 }
                             },
                             {
                                 "@ondc/org/item_id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
                                 "@ondc/org/item_quantity": {
-                                    "count": 3
+                                    "count": 2
                                 },
                                 "@ondc/org/title_type": "item",
                                 "item": {
@@ -1421,11 +1552,11 @@
                                 "title": "Cashews",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "360.0"
+                                    "value": "240.0"
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "07888647-89a1-4a41-b3d2-2936471fc816",
+                                "@ondc/org/item_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
                                 "@ondc/org/title_type": "packing",
                                 "title": "Packing Charges",
                                 "price": {
@@ -1434,7 +1565,7 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "07888647-89a1-4a41-b3d2-2936471fc816",
+                                "@ondc/org/item_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
                                 "@ondc/org/title_type": "delivery",
                                 "title": "Delivery Charges",
                                 "price": {
@@ -1443,12 +1574,48 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "07888647-89a1-4a41-b3d2-2936471fc816",
+                                "@ondc/org/item_id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+                                "@ondc/org/item_quantity": {
+                                    "count": 2
+                                },
+                                "@ondc/org/title_type": "item",
+                                "item": {
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "120.0"
+                                    }
+                                },
+                                "title": "Walnuts",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "240.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
+                                "@ondc/org/title_type": "packing",
+                                "title": "Packing Charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "5.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
+                                "@ondc/org/title_type": "delivery",
+                                "title": "Delivery Charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "100.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
                                 "@ondc/org/title_type": "misc",
                                 "title": "Convenience Fee",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "49.62"
+                                    "value": "48.31"
                                 }
                             }
                         ],
@@ -1458,8 +1625,8 @@
                         "uri": "https://razorpay.com/",
                         "tl_method": "http/get",
                         "params": {
-                            "transaction_id": "order_PklzhEb4pJDTsN",
-                            "amount": "1401.72",
+                            "transaction_id": "order_PmsiPwsbCPBCII",
+                            "amount": "1364.71",
                             "currency": "INR"
                         },
                         "type": "ON-ORDER",
@@ -1484,8 +1651,8 @@
                             }
                         ]
                     },
-                    "created_at": "2025-01-18T04:24:10.828Z",
-                    "updated_at": "2025-01-18T04:24:12.169Z",
+                    "created_at": "2025-01-23T12:16:47.408Z",
+                    "updated_at": "2025-01-23T12:16:48.296Z",
                     "tags": [
                         {
                             "code": "bpp_terms",
@@ -1528,14 +1695,14 @@
                 "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
                 "bpp_id": "ondc.pirimidtech.com/v2/seller",
                 "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-                "transaction_id": "4b210a13-f55d-4aca-8feb-815d4a383d81",
-                "message_id": "b740fcc8-161e-4539-8d87-7cc3e9eede11",
-                "timestamp": "2025-01-18T04:27:55.030Z",
+                "transaction_id": "b2f44b86-f815-40dc-8a59-1fae65fbd30c",
+                "message_id": "1f745cba-f199-4496-ba33-888815a428bc",
+                "timestamp": "2025-01-23T12:17:58.465Z",
                 "ttl": "PT30S"
             },
             "message": {
                 "order": {
-                    "id": "2025-01-18-851979",
+                    "id": "2025-01-23-232372",
                     "state": "Accepted",
                     "provider": {
                         "id": "e2008459-7e90-493e-b02e-cae52ca53214",
@@ -1549,16 +1716,23 @@
                         {
                             "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
                             "quantity": {
-                                "count": 3
+                                "count": 2
                             },
-                            "fulfillment_id": "07888647-89a1-4a41-b3d2-2936471fc816"
+                            "fulfillment_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b"
                         },
                         {
                             "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
                             "quantity": {
-                                "count": 3
+                                "count": 2
                             },
-                            "fulfillment_id": "07888647-89a1-4a41-b3d2-2936471fc816"
+                            "fulfillment_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b"
+                        },
+                        {
+                            "id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+                            "quantity": {
+                                "count": 2
+                            },
+                            "fulfillment_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b"
                         }
                     ],
                     "billing": {
@@ -1574,12 +1748,12 @@
                         },
                         "email": "fhemanshu@gmail.com",
                         "phone": "7202959020",
-                        "created_at": "2025-01-18T04:23:45.679Z",
-                        "updated_at": "2025-01-18T04:23:45.679Z"
+                        "created_at": "2025-01-23T12:16:16.800Z",
+                        "updated_at": "2025-01-23T12:16:16.800Z"
                     },
                     "fulfillments": [
                         {
-                            "id": "07888647-89a1-4a41-b3d2-2936471fc816",
+                            "id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
                             "type": "Delivery",
                             "@ondc/org/TAT": "PT99H",
                             "provider_id": "ondc.loadshare.com/ondc/18275",
@@ -1601,13 +1775,13 @@
                                         "locality": "Ashok Vatika",
                                         "city": "Ahmedabad",
                                         "state": "Gujarat",
-                                        "area_code": "380058"
+                                        "area_code": "380054"
                                     }
                                 },
                                 "time": {
                                     "range": {
-                                        "start": "2025-01-18T04:27:55.028Z",
-                                        "end": "2025-01-18T07:27:55.028Z"
+                                        "start": "2025-01-23T12:17:58.463Z",
+                                        "end": "2025-01-23T15:17:58.463Z"
                                     }
                                 },
                                 "instructions": {
@@ -1636,8 +1810,8 @@
                                 },
                                 "time": {
                                     "range": {
-                                        "start": "2025-01-18T07:27:55.028Z",
-                                        "end": "2025-01-22T07:27:55.028Z"
+                                        "start": "2025-01-23T15:17:58.463Z",
+                                        "end": "2025-01-27T15:17:58.463Z"
                                     }
                                 },
                                 "contact": {
@@ -1653,13 +1827,13 @@
                     "quote": {
                         "price": {
                             "currency": "INR",
-                            "value": "1401.72"
+                            "value": "1364.71"
                         },
                         "breakup": [
                             {
                                 "@ondc/org/item_id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
                                 "@ondc/org/item_quantity": {
-                                    "count": 3
+                                    "count": 2
                                 },
                                 "@ondc/org/title_type": "item",
                                 "item": {
@@ -1671,11 +1845,11 @@
                                 "title": "Nutraj-California-Almonds-1Kg",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "660.0"
+                                    "value": "440.0"
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "07888647-89a1-4a41-b3d2-2936471fc816",
+                                "@ondc/org/item_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
                                 "@ondc/org/title_type": "packing",
                                 "title": "Packing Charges",
                                 "price": {
@@ -1684,7 +1858,7 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "07888647-89a1-4a41-b3d2-2936471fc816",
+                                "@ondc/org/item_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
                                 "@ondc/org/title_type": "delivery",
                                 "title": "Delivery Charges",
                                 "price": {
@@ -1698,13 +1872,13 @@
                                 "title": "Tax",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "122.1"
+                                    "value": "81.4"
                                 }
                             },
                             {
                                 "@ondc/org/item_id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
                                 "@ondc/org/item_quantity": {
-                                    "count": 3
+                                    "count": 2
                                 },
                                 "@ondc/org/title_type": "item",
                                 "item": {
@@ -1716,11 +1890,11 @@
                                 "title": "Cashews",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "360.0"
+                                    "value": "240.0"
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "07888647-89a1-4a41-b3d2-2936471fc816",
+                                "@ondc/org/item_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
                                 "@ondc/org/title_type": "packing",
                                 "title": "Packing Charges",
                                 "price": {
@@ -1729,7 +1903,7 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "07888647-89a1-4a41-b3d2-2936471fc816",
+                                "@ondc/org/item_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
                                 "@ondc/org/title_type": "delivery",
                                 "title": "Delivery Charges",
                                 "price": {
@@ -1738,12 +1912,48 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "07888647-89a1-4a41-b3d2-2936471fc816",
+                                "@ondc/org/item_id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+                                "@ondc/org/item_quantity": {
+                                    "count": 2
+                                },
+                                "@ondc/org/title_type": "item",
+                                "item": {
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "120.0"
+                                    }
+                                },
+                                "title": "Walnuts",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "240.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
+                                "@ondc/org/title_type": "packing",
+                                "title": "Packing Charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "5.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
+                                "@ondc/org/title_type": "delivery",
+                                "title": "Delivery Charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "100.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
                                 "@ondc/org/title_type": "misc",
                                 "title": "Convenience Fee",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "49.62"
+                                    "value": "48.31"
                                 }
                             }
                         ],
@@ -1753,8 +1963,8 @@
                         "uri": "https://razorpay.com/",
                         "tl_method": "http/get",
                         "params": {
-                            "transaction_id": "order_PklzhEb4pJDTsN",
-                            "amount": "1401.72",
+                            "transaction_id": "order_PmsiPwsbCPBCII",
+                            "amount": "1364.71",
                             "currency": "INR"
                         },
                         "type": "ON-ORDER",
@@ -1779,8 +1989,8 @@
                             }
                         ]
                     },
-                    "created_at": "2025-01-18T04:24:10.828Z",
-                    "updated_at": "2025-01-18T04:27:55.030Z"
+                    "created_at": "2025-01-23T12:16:47.408Z",
+                    "updated_at": "2025-01-23T12:17:58.465Z"
                 }
             }
         },
@@ -1795,14 +2005,14 @@
                 "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
                 "bpp_id": "ondc.pirimidtech.com/v2/seller",
                 "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-                "transaction_id": "4b210a13-f55d-4aca-8feb-815d4a383d81",
-                "message_id": "e98e37f5-15fd-41f1-b2b4-7dd07c4dca0c",
-                "timestamp": "2025-01-18T04:27:59.179Z",
+                "transaction_id": "b2f44b86-f815-40dc-8a59-1fae65fbd30c",
+                "message_id": "069c0dc8-fec7-4ce7-88ce-70bec16a481d",
+                "timestamp": "2025-01-23T12:18:04.374Z",
                 "ttl": "PT30S"
             },
             "message": {
                 "order": {
-                    "id": "2025-01-18-851979",
+                    "id": "2025-01-23-232372",
                     "state": "In-progress",
                     "provider": {
                         "id": "e2008459-7e90-493e-b02e-cae52ca53214",
@@ -1816,16 +2026,23 @@
                         {
                             "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
                             "quantity": {
-                                "count": 3
+                                "count": 2
                             },
-                            "fulfillment_id": "07888647-89a1-4a41-b3d2-2936471fc816"
+                            "fulfillment_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b"
                         },
                         {
                             "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
                             "quantity": {
-                                "count": 3
+                                "count": 2
                             },
-                            "fulfillment_id": "07888647-89a1-4a41-b3d2-2936471fc816"
+                            "fulfillment_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b"
+                        },
+                        {
+                            "id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+                            "quantity": {
+                                "count": 2
+                            },
+                            "fulfillment_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b"
                         }
                     ],
                     "billing": {
@@ -1841,12 +2058,12 @@
                         },
                         "email": "fhemanshu@gmail.com",
                         "phone": "7202959020",
-                        "created_at": "2025-01-18T04:23:45.679Z",
-                        "updated_at": "2025-01-18T04:23:45.679Z"
+                        "created_at": "2025-01-23T12:16:16.800Z",
+                        "updated_at": "2025-01-23T12:16:16.800Z"
                     },
                     "fulfillments": [
                         {
-                            "id": "07888647-89a1-4a41-b3d2-2936471fc816",
+                            "id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
                             "type": "Delivery",
                             "@ondc/org/TAT": "PT99H",
                             "provider_id": "ondc.loadshare.com/ondc/18275",
@@ -1877,13 +2094,13 @@
                                         "locality": "Ashok Vatika",
                                         "city": "Ahmedabad",
                                         "state": "Gujarat",
-                                        "area_code": "380058"
+                                        "area_code": "380054"
                                     }
                                 },
                                 "time": {
                                     "range": {
-                                        "start": "2025-01-18T04:27:55.028Z",
-                                        "end": "2025-01-18T07:27:55.028Z"
+                                        "start": "2025-01-23T12:17:58.463Z",
+                                        "end": "2025-01-23T15:17:58.463Z"
                                     }
                                 },
                                 "instructions": {
@@ -1912,8 +2129,8 @@
                                 },
                                 "time": {
                                     "range": {
-                                        "start": "2025-01-18T07:27:55.028Z",
-                                        "end": "2025-01-22T07:27:55.028Z"
+                                        "start": "2025-01-23T15:17:58.463Z",
+                                        "end": "2025-01-27T15:17:58.463Z"
                                     }
                                 },
                                 "contact": {
@@ -1923,19 +2140,30 @@
                                 "person": {
                                     "name": "Hemanshu Faldu"
                                 }
-                            }
+                            },
+                            "tags": [
+                                {
+                                    "code": "routing",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "P2P"
+                                        }
+                                    ]
+                                }
+                            ]
                         }
                     ],
                     "quote": {
                         "price": {
                             "currency": "INR",
-                            "value": "1401.72"
+                            "value": "1364.71"
                         },
                         "breakup": [
                             {
                                 "@ondc/org/item_id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
                                 "@ondc/org/item_quantity": {
-                                    "count": 3
+                                    "count": 2
                                 },
                                 "@ondc/org/title_type": "item",
                                 "item": {
@@ -1947,11 +2175,11 @@
                                 "title": "Nutraj-California-Almonds-1Kg",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "660.0"
+                                    "value": "440.0"
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "07888647-89a1-4a41-b3d2-2936471fc816",
+                                "@ondc/org/item_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
                                 "@ondc/org/title_type": "packing",
                                 "title": "Packing Charges",
                                 "price": {
@@ -1960,7 +2188,7 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "07888647-89a1-4a41-b3d2-2936471fc816",
+                                "@ondc/org/item_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
                                 "@ondc/org/title_type": "delivery",
                                 "title": "Delivery Charges",
                                 "price": {
@@ -1974,13 +2202,13 @@
                                 "title": "Tax",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "122.1"
+                                    "value": "81.4"
                                 }
                             },
                             {
                                 "@ondc/org/item_id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
                                 "@ondc/org/item_quantity": {
-                                    "count": 3
+                                    "count": 2
                                 },
                                 "@ondc/org/title_type": "item",
                                 "item": {
@@ -1992,11 +2220,11 @@
                                 "title": "Cashews",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "360.0"
+                                    "value": "240.0"
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "07888647-89a1-4a41-b3d2-2936471fc816",
+                                "@ondc/org/item_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
                                 "@ondc/org/title_type": "packing",
                                 "title": "Packing Charges",
                                 "price": {
@@ -2005,7 +2233,7 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "07888647-89a1-4a41-b3d2-2936471fc816",
+                                "@ondc/org/item_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
                                 "@ondc/org/title_type": "delivery",
                                 "title": "Delivery Charges",
                                 "price": {
@@ -2014,12 +2242,48 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "07888647-89a1-4a41-b3d2-2936471fc816",
+                                "@ondc/org/item_id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+                                "@ondc/org/item_quantity": {
+                                    "count": 2
+                                },
+                                "@ondc/org/title_type": "item",
+                                "item": {
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "120.0"
+                                    }
+                                },
+                                "title": "Walnuts",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "240.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
+                                "@ondc/org/title_type": "packing",
+                                "title": "Packing Charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "5.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
+                                "@ondc/org/title_type": "delivery",
+                                "title": "Delivery Charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "100.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
                                 "@ondc/org/title_type": "misc",
                                 "title": "Convenience Fee",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "49.62"
+                                    "value": "48.31"
                                 }
                             }
                         ],
@@ -2029,8 +2293,8 @@
                         "uri": "https://razorpay.com/",
                         "tl_method": "http/get",
                         "params": {
-                            "transaction_id": "order_PklzhEb4pJDTsN",
-                            "amount": "1401.72",
+                            "transaction_id": "order_PmsiPwsbCPBCII",
+                            "amount": "1364.71",
                             "currency": "INR"
                         },
                         "type": "ON-ORDER",
@@ -2055,8 +2319,8 @@
                             }
                         ]
                     },
-                    "created_at": "2025-01-18T04:24:10.828Z",
-                    "updated_at": "2025-01-18T04:27:59.179Z"
+                    "created_at": "2025-01-23T12:16:47.408Z",
+                    "updated_at": "2025-01-23T12:18:04.374Z"
                 }
             }
         },
@@ -2071,14 +2335,14 @@
                 "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
                 "bpp_id": "ondc.pirimidtech.com/v2/seller",
                 "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-                "transaction_id": "4b210a13-f55d-4aca-8feb-815d4a383d81",
-                "message_id": "fbaba24c-452a-4700-bc5d-97f79631e753",
-                "timestamp": "2025-01-18T04:28:07.355Z",
+                "transaction_id": "b2f44b86-f815-40dc-8a59-1fae65fbd30c",
+                "message_id": "7a730f1b-13cf-435a-a0b8-626a58f20020",
+                "timestamp": "2025-01-23T12:18:14.171Z",
                 "ttl": "PT30S"
             },
             "message": {
                 "order": {
-                    "id": "2025-01-18-851979",
+                    "id": "2025-01-23-232372",
                     "state": "In-progress",
                     "provider": {
                         "id": "e2008459-7e90-493e-b02e-cae52ca53214",
@@ -2092,21 +2356,28 @@
                         {
                             "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
                             "quantity": {
-                                "count": 3
+                                "count": 2
                             },
-                            "fulfillment_id": "07888647-89a1-4a41-b3d2-2936471fc816"
+                            "fulfillment_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b"
                         },
                         {
                             "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
                             "quantity": {
-                                "count": 3
+                                "count": 2
                             },
-                            "fulfillment_id": "07888647-89a1-4a41-b3d2-2936471fc816"
+                            "fulfillment_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b"
+                        },
+                        {
+                            "id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+                            "quantity": {
+                                "count": 2
+                            },
+                            "fulfillment_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b"
                         }
                     ],
                     "documents": [
                         {
-                            "url": "https://ondc.pirimidtech.com/v2/seller/api/order/invoice/4983732a-d89b-4d70-af9b-3aab1f3fc9f7",
+                            "url": "https://ondc.pirimidtech.com/v2/seller/api/order/invoice/14b74007-121d-46fd-b57d-4b54121b50b7",
                             "label": "Invoice"
                         }
                     ],
@@ -2123,12 +2394,12 @@
                         },
                         "email": "fhemanshu@gmail.com",
                         "phone": "7202959020",
-                        "created_at": "2025-01-18T04:23:45.679Z",
-                        "updated_at": "2025-01-18T04:23:45.679Z"
+                        "created_at": "2025-01-23T12:16:16.800Z",
+                        "updated_at": "2025-01-23T12:16:16.800Z"
                     },
                     "fulfillments": [
                         {
-                            "id": "07888647-89a1-4a41-b3d2-2936471fc816",
+                            "id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
                             "type": "Delivery",
                             "@ondc/org/TAT": "PT99H",
                             "provider_id": "ondc.loadshare.com/ondc/18275",
@@ -2159,14 +2430,14 @@
                                         "locality": "Ashok Vatika",
                                         "city": "Ahmedabad",
                                         "state": "Gujarat",
-                                        "area_code": "380058"
+                                        "area_code": "380054"
                                     }
                                 },
                                 "time": {
-                                    "timestamp": "2025-01-18T04:28:07.353Z",
+                                    "timestamp": "2025-01-23T12:18:14.166Z",
                                     "range": {
-                                        "start": "2025-01-18T04:27:55.028Z",
-                                        "end": "2025-01-18T07:27:55.028Z"
+                                        "start": "2025-01-23T12:17:58.463Z",
+                                        "end": "2025-01-23T15:17:58.463Z"
                                     }
                                 },
                                 "instructions": {
@@ -2195,8 +2466,8 @@
                                 },
                                 "time": {
                                     "range": {
-                                        "start": "2025-01-18T07:27:55.028Z",
-                                        "end": "2025-01-22T07:27:55.028Z"
+                                        "start": "2025-01-23T15:17:58.463Z",
+                                        "end": "2025-01-27T15:17:58.463Z"
                                     }
                                 },
                                 "contact": {
@@ -2223,13 +2494,13 @@
                     "quote": {
                         "price": {
                             "currency": "INR",
-                            "value": "1401.72"
+                            "value": "1364.71"
                         },
                         "breakup": [
                             {
                                 "@ondc/org/item_id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
                                 "@ondc/org/item_quantity": {
-                                    "count": 3
+                                    "count": 2
                                 },
                                 "@ondc/org/title_type": "item",
                                 "item": {
@@ -2241,11 +2512,11 @@
                                 "title": "Nutraj-California-Almonds-1Kg",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "660.0"
+                                    "value": "440.0"
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "07888647-89a1-4a41-b3d2-2936471fc816",
+                                "@ondc/org/item_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
                                 "@ondc/org/title_type": "packing",
                                 "title": "Packing Charges",
                                 "price": {
@@ -2254,7 +2525,7 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "07888647-89a1-4a41-b3d2-2936471fc816",
+                                "@ondc/org/item_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
                                 "@ondc/org/title_type": "delivery",
                                 "title": "Delivery Charges",
                                 "price": {
@@ -2268,13 +2539,13 @@
                                 "title": "Tax",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "122.1"
+                                    "value": "81.4"
                                 }
                             },
                             {
                                 "@ondc/org/item_id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
                                 "@ondc/org/item_quantity": {
-                                    "count": 3
+                                    "count": 2
                                 },
                                 "@ondc/org/title_type": "item",
                                 "item": {
@@ -2286,11 +2557,11 @@
                                 "title": "Cashews",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "360.0"
+                                    "value": "240.0"
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "07888647-89a1-4a41-b3d2-2936471fc816",
+                                "@ondc/org/item_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
                                 "@ondc/org/title_type": "packing",
                                 "title": "Packing Charges",
                                 "price": {
@@ -2299,7 +2570,7 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "07888647-89a1-4a41-b3d2-2936471fc816",
+                                "@ondc/org/item_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
                                 "@ondc/org/title_type": "delivery",
                                 "title": "Delivery Charges",
                                 "price": {
@@ -2308,12 +2579,48 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "07888647-89a1-4a41-b3d2-2936471fc816",
+                                "@ondc/org/item_id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+                                "@ondc/org/item_quantity": {
+                                    "count": 2
+                                },
+                                "@ondc/org/title_type": "item",
+                                "item": {
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "120.0"
+                                    }
+                                },
+                                "title": "Walnuts",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "240.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
+                                "@ondc/org/title_type": "packing",
+                                "title": "Packing Charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "5.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
+                                "@ondc/org/title_type": "delivery",
+                                "title": "Delivery Charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "100.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
                                 "@ondc/org/title_type": "misc",
                                 "title": "Convenience Fee",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "49.62"
+                                    "value": "48.31"
                                 }
                             }
                         ],
@@ -2323,8 +2630,8 @@
                         "uri": "https://razorpay.com/",
                         "tl_method": "http/get",
                         "params": {
-                            "transaction_id": "order_PklzhEb4pJDTsN",
-                            "amount": "1401.72",
+                            "transaction_id": "order_PmsiPwsbCPBCII",
+                            "amount": "1364.71",
                             "currency": "INR"
                         },
                         "type": "ON-ORDER",
@@ -2349,8 +2656,8 @@
                             }
                         ]
                     },
-                    "created_at": "2025-01-18T04:24:10.828Z",
-                    "updated_at": "2025-01-18T04:28:07.355Z"
+                    "created_at": "2025-01-23T12:16:47.408Z",
+                    "updated_at": "2025-01-23T12:18:14.171Z"
                 }
             }
         },
@@ -2365,14 +2672,14 @@
                 "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
                 "bpp_id": "ondc.pirimidtech.com/v2/seller",
                 "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-                "transaction_id": "4b210a13-f55d-4aca-8feb-815d4a383d81",
-                "message_id": "bf7d4820-2d41-4ade-908b-7202277cda6a",
-                "timestamp": "2025-01-18T15:43:00.518Z",
+                "transaction_id": "b2f44b86-f815-40dc-8a59-1fae65fbd30c",
+                "message_id": "8cdce307-1542-4521-bdd3-19ccc7f6011c",
+                "timestamp": "2025-01-24T05:19:05.865Z",
                 "ttl": "PT30S"
             },
             "message": {
                 "order": {
-                    "id": "2025-01-18-851979",
+                    "id": "2025-01-23-232372",
                     "state": "In-progress",
                     "provider": {
                         "id": "e2008459-7e90-493e-b02e-cae52ca53214",
@@ -2386,21 +2693,28 @@
                         {
                             "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
                             "quantity": {
-                                "count": 3
+                                "count": 2
                             },
-                            "fulfillment_id": "07888647-89a1-4a41-b3d2-2936471fc816"
+                            "fulfillment_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b"
                         },
                         {
                             "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
                             "quantity": {
-                                "count": 3
+                                "count": 2
                             },
-                            "fulfillment_id": "07888647-89a1-4a41-b3d2-2936471fc816"
+                            "fulfillment_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b"
+                        },
+                        {
+                            "id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+                            "quantity": {
+                                "count": 2
+                            },
+                            "fulfillment_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b"
                         }
                     ],
                     "documents": [
                         {
-                            "url": "https://ondc.pirimidtech.com/v2/seller/api/order/invoice/4983732a-d89b-4d70-af9b-3aab1f3fc9f7",
+                            "url": "https://ondc.pirimidtech.com/v2/seller/api/order/invoice/14b74007-121d-46fd-b57d-4b54121b50b7",
                             "label": "Invoice"
                         }
                     ],
@@ -2417,12 +2731,12 @@
                         },
                         "email": "fhemanshu@gmail.com",
                         "phone": "7202959020",
-                        "created_at": "2025-01-18T04:23:45.679Z",
-                        "updated_at": "2025-01-18T04:23:45.679Z"
+                        "created_at": "2025-01-23T12:16:16.800Z",
+                        "updated_at": "2025-01-23T12:16:16.800Z"
                     },
                     "fulfillments": [
                         {
-                            "id": "07888647-89a1-4a41-b3d2-2936471fc816",
+                            "id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
                             "type": "Delivery",
                             "@ondc/org/TAT": "PT99H",
                             "provider_id": "ondc.loadshare.com/ondc/18275",
@@ -2453,14 +2767,14 @@
                                         "locality": "Ashok Vatika",
                                         "city": "Ahmedabad",
                                         "state": "Gujarat",
-                                        "area_code": "380058"
+                                        "area_code": "380054"
                                     }
                                 },
                                 "time": {
-                                    "timestamp": "2025-01-18T04:28:07.353Z",
+                                    "timestamp": "2025-01-23T12:18:14.166Z",
                                     "range": {
-                                        "start": "2025-01-18T04:27:55.028Z",
-                                        "end": "2025-01-18T07:27:55.028Z"
+                                        "start": "2025-01-23T12:17:58.463Z",
+                                        "end": "2025-01-23T15:17:58.463Z"
                                     }
                                 },
                                 "instructions": {
@@ -2489,8 +2803,8 @@
                                 },
                                 "time": {
                                     "range": {
-                                        "start": "2025-01-18T07:27:55.028Z",
-                                        "end": "2025-01-22T07:27:55.028Z"
+                                        "start": "2025-01-23T15:17:58.463Z",
+                                        "end": "2025-01-27T15:17:58.463Z"
                                     }
                                 },
                                 "contact": {
@@ -2517,13 +2831,13 @@
                     "quote": {
                         "price": {
                             "currency": "INR",
-                            "value": "1401.72"
+                            "value": "1364.71"
                         },
                         "breakup": [
                             {
                                 "@ondc/org/item_id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
                                 "@ondc/org/item_quantity": {
-                                    "count": 3
+                                    "count": 2
                                 },
                                 "@ondc/org/title_type": "item",
                                 "item": {
@@ -2535,11 +2849,11 @@
                                 "title": "Nutraj-California-Almonds-1Kg",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "660.0"
+                                    "value": "440.0"
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "07888647-89a1-4a41-b3d2-2936471fc816",
+                                "@ondc/org/item_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
                                 "@ondc/org/title_type": "packing",
                                 "title": "Packing Charges",
                                 "price": {
@@ -2548,7 +2862,7 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "07888647-89a1-4a41-b3d2-2936471fc816",
+                                "@ondc/org/item_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
                                 "@ondc/org/title_type": "delivery",
                                 "title": "Delivery Charges",
                                 "price": {
@@ -2562,13 +2876,13 @@
                                 "title": "Tax",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "122.1"
+                                    "value": "81.4"
                                 }
                             },
                             {
                                 "@ondc/org/item_id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
                                 "@ondc/org/item_quantity": {
-                                    "count": 3
+                                    "count": 2
                                 },
                                 "@ondc/org/title_type": "item",
                                 "item": {
@@ -2580,11 +2894,11 @@
                                 "title": "Cashews",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "360.0"
+                                    "value": "240.0"
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "07888647-89a1-4a41-b3d2-2936471fc816",
+                                "@ondc/org/item_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
                                 "@ondc/org/title_type": "packing",
                                 "title": "Packing Charges",
                                 "price": {
@@ -2593,7 +2907,7 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "07888647-89a1-4a41-b3d2-2936471fc816",
+                                "@ondc/org/item_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
                                 "@ondc/org/title_type": "delivery",
                                 "title": "Delivery Charges",
                                 "price": {
@@ -2602,12 +2916,48 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "07888647-89a1-4a41-b3d2-2936471fc816",
+                                "@ondc/org/item_id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+                                "@ondc/org/item_quantity": {
+                                    "count": 2
+                                },
+                                "@ondc/org/title_type": "item",
+                                "item": {
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "120.0"
+                                    }
+                                },
+                                "title": "Walnuts",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "240.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
+                                "@ondc/org/title_type": "packing",
+                                "title": "Packing Charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "5.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
+                                "@ondc/org/title_type": "delivery",
+                                "title": "Delivery Charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "100.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
                                 "@ondc/org/title_type": "misc",
                                 "title": "Convenience Fee",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "49.62"
+                                    "value": "48.31"
                                 }
                             }
                         ],
@@ -2617,8 +2967,8 @@
                         "uri": "https://razorpay.com/",
                         "tl_method": "http/get",
                         "params": {
-                            "transaction_id": "order_PklzhEb4pJDTsN",
-                            "amount": "1401.72",
+                            "transaction_id": "order_PmsiPwsbCPBCII",
+                            "amount": "1364.71",
                             "currency": "INR"
                         },
                         "type": "ON-ORDER",
@@ -2643,8 +2993,8 @@
                             }
                         ]
                     },
-                    "created_at": "2025-01-18T04:24:10.828Z",
-                    "updated_at": "2025-01-18T15:43:00.518Z"
+                    "created_at": "2025-01-23T12:16:47.408Z",
+                    "updated_at": "2025-01-24T05:19:05.865Z"
                 }
             }
         },
@@ -2659,14 +3009,14 @@
                 "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
                 "bpp_id": "ondc.pirimidtech.com/v2/seller",
                 "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-                "transaction_id": "4b210a13-f55d-4aca-8feb-815d4a383d81",
-                "message_id": "62bf4886-3725-4575-b67a-d9cc8ee5aceb",
-                "timestamp": "2025-01-18T15:43:10.323Z",
+                "transaction_id": "b2f44b86-f815-40dc-8a59-1fae65fbd30c",
+                "message_id": "bd55a88b-92df-4475-91bf-cd87a27fb77b",
+                "timestamp": "2025-01-24T05:19:12.322Z",
                 "ttl": "PT30S"
             },
             "message": {
                 "order": {
-                    "id": "2025-01-18-851979",
+                    "id": "2025-01-23-232372",
                     "state": "Completed",
                     "provider": {
                         "id": "e2008459-7e90-493e-b02e-cae52ca53214",
@@ -2680,21 +3030,28 @@
                         {
                             "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
                             "quantity": {
-                                "count": 3
+                                "count": 2
                             },
-                            "fulfillment_id": "07888647-89a1-4a41-b3d2-2936471fc816"
+                            "fulfillment_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b"
                         },
                         {
                             "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
                             "quantity": {
-                                "count": 3
+                                "count": 2
                             },
-                            "fulfillment_id": "07888647-89a1-4a41-b3d2-2936471fc816"
+                            "fulfillment_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b"
+                        },
+                        {
+                            "id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+                            "quantity": {
+                                "count": 2
+                            },
+                            "fulfillment_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b"
                         }
                     ],
                     "documents": [
                         {
-                            "url": "https://ondc.pirimidtech.com/v2/seller/api/order/invoice/4983732a-d89b-4d70-af9b-3aab1f3fc9f7",
+                            "url": "https://ondc.pirimidtech.com/v2/seller/api/order/invoice/14b74007-121d-46fd-b57d-4b54121b50b7",
                             "label": "Invoice"
                         }
                     ],
@@ -2711,12 +3068,12 @@
                         },
                         "email": "fhemanshu@gmail.com",
                         "phone": "7202959020",
-                        "created_at": "2025-01-18T04:23:45.679Z",
-                        "updated_at": "2025-01-18T04:23:45.679Z"
+                        "created_at": "2025-01-23T12:16:16.800Z",
+                        "updated_at": "2025-01-23T12:16:16.800Z"
                     },
                     "fulfillments": [
                         {
-                            "id": "07888647-89a1-4a41-b3d2-2936471fc816",
+                            "id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
                             "type": "Delivery",
                             "@ondc/org/TAT": "PT99H",
                             "provider_id": "ondc.loadshare.com/ondc/18275",
@@ -2747,14 +3104,14 @@
                                         "locality": "Ashok Vatika",
                                         "city": "Ahmedabad",
                                         "state": "Gujarat",
-                                        "area_code": "380058"
+                                        "area_code": "380054"
                                     }
                                 },
                                 "time": {
-                                    "timestamp": "2025-01-18T04:28:07.353Z",
+                                    "timestamp": "2025-01-23T12:18:14.166Z",
                                     "range": {
-                                        "start": "2025-01-18T04:27:55.028Z",
-                                        "end": "2025-01-18T07:27:55.028Z"
+                                        "start": "2025-01-23T12:17:58.463Z",
+                                        "end": "2025-01-23T15:17:58.463Z"
                                     }
                                 },
                                 "instructions": {
@@ -2782,10 +3139,10 @@
                                     }
                                 },
                                 "time": {
-                                    "timestamp": "2025-01-18T15:43:10.319Z",
+                                    "timestamp": "2025-01-24T05:19:12.320Z",
                                     "range": {
-                                        "start": "2025-01-18T07:27:55.028Z",
-                                        "end": "2025-01-22T07:27:55.028Z"
+                                        "start": "2025-01-23T15:17:58.463Z",
+                                        "end": "2025-01-27T15:17:58.463Z"
                                     }
                                 },
                                 "contact": {
@@ -2812,13 +3169,13 @@
                     "quote": {
                         "price": {
                             "currency": "INR",
-                            "value": "1401.72"
+                            "value": "1364.71"
                         },
                         "breakup": [
                             {
                                 "@ondc/org/item_id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
                                 "@ondc/org/item_quantity": {
-                                    "count": 3
+                                    "count": 2
                                 },
                                 "@ondc/org/title_type": "item",
                                 "item": {
@@ -2830,11 +3187,11 @@
                                 "title": "Nutraj-California-Almonds-1Kg",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "660.0"
+                                    "value": "440.0"
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "07888647-89a1-4a41-b3d2-2936471fc816",
+                                "@ondc/org/item_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
                                 "@ondc/org/title_type": "packing",
                                 "title": "Packing Charges",
                                 "price": {
@@ -2843,7 +3200,7 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "07888647-89a1-4a41-b3d2-2936471fc816",
+                                "@ondc/org/item_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
                                 "@ondc/org/title_type": "delivery",
                                 "title": "Delivery Charges",
                                 "price": {
@@ -2857,13 +3214,13 @@
                                 "title": "Tax",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "122.1"
+                                    "value": "81.4"
                                 }
                             },
                             {
                                 "@ondc/org/item_id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
                                 "@ondc/org/item_quantity": {
-                                    "count": 3
+                                    "count": 2
                                 },
                                 "@ondc/org/title_type": "item",
                                 "item": {
@@ -2875,11 +3232,11 @@
                                 "title": "Cashews",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "360.0"
+                                    "value": "240.0"
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "07888647-89a1-4a41-b3d2-2936471fc816",
+                                "@ondc/org/item_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
                                 "@ondc/org/title_type": "packing",
                                 "title": "Packing Charges",
                                 "price": {
@@ -2888,7 +3245,7 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "07888647-89a1-4a41-b3d2-2936471fc816",
+                                "@ondc/org/item_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
                                 "@ondc/org/title_type": "delivery",
                                 "title": "Delivery Charges",
                                 "price": {
@@ -2897,12 +3254,48 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "07888647-89a1-4a41-b3d2-2936471fc816",
+                                "@ondc/org/item_id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+                                "@ondc/org/item_quantity": {
+                                    "count": 2
+                                },
+                                "@ondc/org/title_type": "item",
+                                "item": {
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "120.0"
+                                    }
+                                },
+                                "title": "Walnuts",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "240.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
+                                "@ondc/org/title_type": "packing",
+                                "title": "Packing Charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "5.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
+                                "@ondc/org/title_type": "delivery",
+                                "title": "Delivery Charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "100.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
                                 "@ondc/org/title_type": "misc",
                                 "title": "Convenience Fee",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "49.62"
+                                    "value": "48.31"
                                 }
                             }
                         ],
@@ -2912,8 +3305,8 @@
                         "uri": "https://razorpay.com/",
                         "tl_method": "http/get",
                         "params": {
-                            "transaction_id": "order_PklzhEb4pJDTsN",
-                            "amount": "1401.72",
+                            "transaction_id": "order_PmsiPwsbCPBCII",
+                            "amount": "1364.71",
                             "currency": "INR"
                         },
                         "type": "ON-ORDER",
@@ -2938,8 +3331,8 @@
                             }
                         ]
                     },
-                    "created_at": "2025-01-18T04:24:10.828Z",
-                    "updated_at": "2025-01-18T15:43:10.323Z"
+                    "created_at": "2025-01-23T12:16:47.408Z",
+                    "updated_at": "2025-01-24T05:19:12.322Z"
                 }
             }
         }

--- a/Pirimid/SellerApp/Retail/RET-10/FLOW_2/log_validation_utitlity_response.json
+++ b/Pirimid/SellerApp/Retail/RET-10/FLOW_2/log_validation_utitlity_response.json
@@ -1,13 +1,17 @@
 {
-    "success": true,
+    "success": false,
     "response": {
-        "message": "Logs were verified successfully",
-        "report": {},
+        "message": "Logs were not verified successfully",
+        "report": {
+            "on_search_full_catalog_refresh": {
+                "prvdr0categories": "Support for variants is mandatory, categories must be present in bpp/providers[0]"
+            }
+        },
         "bpp_id": "ondc.pirimidtech.com/v2/seller",
         "bap_id": "buyer-app-preprod-v2.ondc.org",
         "domain": "ONDC:RET10",
-        "reportTimestamp": "2025-01-19T04:51:15.801Z"
+        "reportTimestamp": "2025-01-24T05:56:27.141Z"
     },
-    "signature": "xWj8SbPnIbDOZasf98MmQ6YkXyj1ZIrsJWl8sYSMYH77rVXCAdq5xzvVHRAIF29f4Eo9B4LU+k5fIHk07zGwCA==",
-    "signTimestamp": "2025-01-19T04:51:15.801Z"
+    "signature": "0GxR2dba8KBYnioL5F0s1ZBuH3GWNT9YNuDmkkvsAh9FzZ40tWWCDsK7RKAICoNnVUNcudcxVxKVW2cGyiLJCg==",
+    "signTimestamp": "2025-01-24T05:56:27.142Z"
 }

--- a/Pirimid/SellerApp/Retail/RET-10/FLOW_2/on_confirm.json
+++ b/Pirimid/SellerApp/Retail/RET-10/FLOW_2/on_confirm.json
@@ -9,13 +9,13 @@
     "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
     "bpp_id": "ondc.pirimidtech.com/v2/seller",
     "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-    "transaction_id": "4b210a13-f55d-4aca-8feb-815d4a383d81",
-    "message_id": "730a42f5-eb45-4d0c-827c-e44b177a5d11",
-    "timestamp": "2025-01-18T04:24:12.169Z"
+    "transaction_id": "b2f44b86-f815-40dc-8a59-1fae65fbd30c",
+    "message_id": "da5dcdaf-006d-4269-a868-12ed29b258a1",
+    "timestamp": "2025-01-23T12:16:48.296Z"
   },
   "message": {
     "order": {
-      "id": "2025-01-18-851979",
+      "id": "2025-01-23-232372",
       "state": "Created",
       "provider": {
         "id": "e2008459-7e90-493e-b02e-cae52ca53214",
@@ -29,16 +29,23 @@
         {
           "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
           "quantity": {
-            "count": 3
+            "count": 2
           },
-          "fulfillment_id": "07888647-89a1-4a41-b3d2-2936471fc816"
+          "fulfillment_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b"
         },
         {
           "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
           "quantity": {
-            "count": 3
+            "count": 2
           },
-          "fulfillment_id": "07888647-89a1-4a41-b3d2-2936471fc816"
+          "fulfillment_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b"
+        },
+        {
+          "id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b"
         }
       ],
       "billing": {
@@ -54,12 +61,12 @@
         },
         "email": "fhemanshu@gmail.com",
         "phone": "7202959020",
-        "created_at": "2025-01-18T04:23:45.679Z",
-        "updated_at": "2025-01-18T04:23:45.679Z"
+        "created_at": "2025-01-23T12:16:16.800Z",
+        "updated_at": "2025-01-23T12:16:16.800Z"
       },
       "fulfillments": [
         {
-          "id": "07888647-89a1-4a41-b3d2-2936471fc816",
+          "id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
           "type": "Delivery",
           "@ondc/org/TAT": "PT99H",
           "@ondc/org/provider_name": "LoadShare",
@@ -80,7 +87,7 @@
                 "locality": "Ashok Vatika",
                 "city": "Ahmedabad",
                 "state": "Gujarat",
-                "area_code": "380058"
+                "area_code": "380054"
               }
             },
             "contact": {
@@ -114,13 +121,13 @@
       "quote": {
         "price": {
           "currency": "INR",
-          "value": "1401.72"
+          "value": "1364.71"
         },
         "breakup": [
           {
             "@ondc/org/item_id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
             "@ondc/org/item_quantity": {
-              "count": 3
+              "count": 2
             },
             "@ondc/org/title_type": "item",
             "item": {
@@ -132,11 +139,11 @@
             "title": "Nutraj-California-Almonds-1Kg",
             "price": {
               "currency": "INR",
-              "value": "660.0"
+              "value": "440.0"
             }
           },
           {
-            "@ondc/org/item_id": "07888647-89a1-4a41-b3d2-2936471fc816",
+            "@ondc/org/item_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
             "@ondc/org/title_type": "packing",
             "title": "Packing Charges",
             "price": {
@@ -145,7 +152,7 @@
             }
           },
           {
-            "@ondc/org/item_id": "07888647-89a1-4a41-b3d2-2936471fc816",
+            "@ondc/org/item_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
             "@ondc/org/title_type": "delivery",
             "title": "Delivery Charges",
             "price": {
@@ -159,13 +166,13 @@
             "title": "Tax",
             "price": {
               "currency": "INR",
-              "value": "122.1"
+              "value": "81.4"
             }
           },
           {
             "@ondc/org/item_id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
             "@ondc/org/item_quantity": {
-              "count": 3
+              "count": 2
             },
             "@ondc/org/title_type": "item",
             "item": {
@@ -177,11 +184,11 @@
             "title": "Cashews",
             "price": {
               "currency": "INR",
-              "value": "360.0"
+              "value": "240.0"
             }
           },
           {
-            "@ondc/org/item_id": "07888647-89a1-4a41-b3d2-2936471fc816",
+            "@ondc/org/item_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
             "@ondc/org/title_type": "packing",
             "title": "Packing Charges",
             "price": {
@@ -190,7 +197,7 @@
             }
           },
           {
-            "@ondc/org/item_id": "07888647-89a1-4a41-b3d2-2936471fc816",
+            "@ondc/org/item_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
             "@ondc/org/title_type": "delivery",
             "title": "Delivery Charges",
             "price": {
@@ -199,12 +206,48 @@
             }
           },
           {
-            "@ondc/org/item_id": "07888647-89a1-4a41-b3d2-2936471fc816",
+            "@ondc/org/item_id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "@ondc/org/title_type": "item",
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "120.0"
+              }
+            },
+            "title": "Walnuts",
+            "price": {
+              "currency": "INR",
+              "value": "240.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
+            "@ondc/org/title_type": "packing",
+            "title": "Packing Charges",
+            "price": {
+              "currency": "INR",
+              "value": "5.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
+            "@ondc/org/title_type": "delivery",
+            "title": "Delivery Charges",
+            "price": {
+              "currency": "INR",
+              "value": "100.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
             "@ondc/org/title_type": "misc",
             "title": "Convenience Fee",
             "price": {
               "currency": "INR",
-              "value": "49.62"
+              "value": "48.31"
             }
           }
         ],
@@ -214,8 +257,8 @@
         "uri": "https://razorpay.com/",
         "tl_method": "http/get",
         "params": {
-          "transaction_id": "order_PklzhEb4pJDTsN",
-          "amount": "1401.72",
+          "transaction_id": "order_PmsiPwsbCPBCII",
+          "amount": "1364.71",
           "currency": "INR"
         },
         "type": "ON-ORDER",
@@ -240,8 +283,8 @@
           }
         ]
       },
-      "created_at": "2025-01-18T04:24:10.828Z",
-      "updated_at": "2025-01-18T04:24:12.169Z",
+      "created_at": "2025-01-23T12:16:47.408Z",
+      "updated_at": "2025-01-23T12:16:48.296Z",
       "tags": [
         {
           "code": "bpp_terms",

--- a/Pirimid/SellerApp/Retail/RET-10/FLOW_2/on_init.json
+++ b/Pirimid/SellerApp/Retail/RET-10/FLOW_2/on_init.json
@@ -9,9 +9,9 @@
     "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
     "bpp_id": "ondc.pirimidtech.com/v2/seller",
     "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-    "transaction_id": "4b210a13-f55d-4aca-8feb-815d4a383d81",
-    "message_id": "852634a0-4464-423a-a7c1-195185b28a65",
-    "timestamp": "2025-01-18T04:23:46.703Z",
+    "transaction_id": "b2f44b86-f815-40dc-8a59-1fae65fbd30c",
+    "message_id": "a64b57be-1fe3-4c60-a8ef-b5ecd23b1e12",
+    "timestamp": "2025-01-23T12:16:17.614Z",
     "ttl": "PT30S"
   },
   "message": {
@@ -29,21 +29,31 @@
           "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
           "quantity": {
             "unitized": {
-              "count": "3"
+              "count": "2"
             },
-            "count": 3
+            "count": 2
           },
-          "fulfillment_id": "07888647-89a1-4a41-b3d2-2936471fc816"
+          "fulfillment_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b"
         },
         {
           "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
           "quantity": {
             "unitized": {
-              "count": "3"
+              "count": "2"
             },
-            "count": 3
+            "count": 2
           },
-          "fulfillment_id": "07888647-89a1-4a41-b3d2-2936471fc816"
+          "fulfillment_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b"
+        },
+        {
+          "id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+          "quantity": {
+            "unitized": {
+              "count": "2"
+            },
+            "count": 2
+          },
+          "fulfillment_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b"
         }
       ],
       "billing": {
@@ -59,19 +69,13 @@
         },
         "email": "fhemanshu@gmail.com",
         "phone": "7202959020",
-        "created_at": "2025-01-18T04:23:45.679Z",
-        "updated_at": "2025-01-18T04:23:45.679Z"
+        "created_at": "2025-01-23T12:16:16.800Z",
+        "updated_at": "2025-01-23T12:16:16.800Z"
       },
       "fulfillments": [
         {
-          "id": "07888647-89a1-4a41-b3d2-2936471fc816",
+          "id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
           "type": "Delivery",
-          "provider_id": "ondc.loadshare.com/ondc/18275",
-          "state": {
-            "descriptor": {
-              "code": "INITIALIZING"
-            }
-          },
           "tracking": false,
           "end": {
             "location": {
@@ -85,9 +89,6 @@
                 "country": "IND",
                 "area_code": "380015"
               }
-            },
-            "time": {
-              "range": {}
             },
             "instructions": {
               "name": "Status for pickup",
@@ -108,13 +109,13 @@
       "quote": {
         "price": {
           "currency": "INR",
-          "value": "1401.72"
+          "value": "1364.71"
         },
         "breakup": [
           {
             "@ondc/org/item_id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
             "@ondc/org/item_quantity": {
-              "count": 3
+              "count": 2
             },
             "@ondc/org/title_type": "item",
             "item": {
@@ -126,11 +127,11 @@
             "title": "Nutraj-California-Almonds-1Kg",
             "price": {
               "currency": "INR",
-              "value": "660.0"
+              "value": "440.0"
             }
           },
           {
-            "@ondc/org/item_id": "07888647-89a1-4a41-b3d2-2936471fc816",
+            "@ondc/org/item_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
             "@ondc/org/title_type": "packing",
             "title": "Packing Charges",
             "price": {
@@ -139,7 +140,7 @@
             }
           },
           {
-            "@ondc/org/item_id": "07888647-89a1-4a41-b3d2-2936471fc816",
+            "@ondc/org/item_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
             "@ondc/org/title_type": "delivery",
             "title": "Delivery Charges",
             "price": {
@@ -153,13 +154,13 @@
             "title": "Tax",
             "price": {
               "currency": "INR",
-              "value": "122.1"
+              "value": "81.4"
             }
           },
           {
             "@ondc/org/item_id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
             "@ondc/org/item_quantity": {
-              "count": 3
+              "count": 2
             },
             "@ondc/org/title_type": "item",
             "item": {
@@ -171,11 +172,11 @@
             "title": "Cashews",
             "price": {
               "currency": "INR",
-              "value": "360.0"
+              "value": "240.0"
             }
           },
           {
-            "@ondc/org/item_id": "07888647-89a1-4a41-b3d2-2936471fc816",
+            "@ondc/org/item_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
             "@ondc/org/title_type": "packing",
             "title": "Packing Charges",
             "price": {
@@ -184,7 +185,7 @@
             }
           },
           {
-            "@ondc/org/item_id": "07888647-89a1-4a41-b3d2-2936471fc816",
+            "@ondc/org/item_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
             "@ondc/org/title_type": "delivery",
             "title": "Delivery Charges",
             "price": {
@@ -193,22 +194,58 @@
             }
           },
           {
-            "@ondc/org/item_id": "07888647-89a1-4a41-b3d2-2936471fc816",
+            "@ondc/org/item_id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "@ondc/org/title_type": "item",
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "120.0"
+              }
+            },
+            "title": "Walnuts",
+            "price": {
+              "currency": "INR",
+              "value": "240.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
+            "@ondc/org/title_type": "packing",
+            "title": "Packing Charges",
+            "price": {
+              "currency": "INR",
+              "value": "5.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
+            "@ondc/org/title_type": "delivery",
+            "title": "Delivery Charges",
+            "price": {
+              "currency": "INR",
+              "value": "100.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
             "@ondc/org/title_type": "misc",
             "title": "Convenience Fee",
             "price": {
               "currency": "INR",
-              "value": "49.62"
+              "value": "48.31"
             }
           }
         ],
         "ttl": "P1D"
       },
       "payment": {
-        "uri": "https://ondc-pirimid-payment.netlify.app/payment/4b210a13-f55d-4aca-8feb-815d4a383d81",
+        "uri": "https://ondc-pirimid-payment.netlify.app/payment/b2f44b86-f815-40dc-8a59-1fae65fbd30c",
         "type": "ON-ORDER",
         "status": "NOT-PAID",
-        "collected_by": "BPP",
+        "collected_by": "BAP",
         "@ondc/org/buyer_app_finder_fee_type": "percent",
         "@ondc/org/buyer_app_finder_fee_amount": "3.0",
         "@ondc/org/withholding_amount": "0.0",
@@ -228,8 +265,8 @@
           }
         ]
       },
-      "created_at": "2025-01-18T04:23:35.068Z",
-      "updated_at": "2025-01-18T04:23:46.816Z",
+      "created_at": "2025-01-23T12:16:07.540Z",
+      "updated_at": "2025-01-23T12:16:17.646Z",
       "tags": [
         {
           "code": "bpp_terms",

--- a/Pirimid/SellerApp/Retail/RET-10/FLOW_2/on_search_full_catalog_refresh.json
+++ b/Pirimid/SellerApp/Retail/RET-10/FLOW_2/on_search_full_catalog_refresh.json
@@ -9,9 +9,9 @@
     "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
     "bpp_id": "ondc.pirimidtech.com/v2/seller",
     "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-    "transaction_id": "e53a74c5-7ce6-4498-800c-e7d90db0f2fa",
-    "message_id": "45726578-5033-41e0-b35f-2fcbcebe8f82",
-    "timestamp": "2025-01-17T12:00:21.411Z",
+    "transaction_id": "2a274964-3eec-4793-888c-1d30ef845cd1",
+    "message_id": "c5c58f68-8483-4490-b318-a1436c6ee88b",
+    "timestamp": "2025-01-23T12:00:21.519Z",
     "ttl": "PT30S"
   },
   "message": {
@@ -58,70 +58,8 @@
           "@ondc/org/fssai_license_no": "12345678912345",
           "time": {
             "label": "enable",
-            "timestamp": "2025-01-17T12:00:21.411Z"
+            "timestamp": "2025-01-23T12:00:21.519Z"
           },
-          "categories": [
-            {
-              "id": "variant10000",
-              "descriptor": {
-                "name": "Variant for Nutraj-California-Almonds-1Kg"
-              },
-              "tags": [
-                {
-                  "code": "type",
-                  "list": [
-                    {
-                      "code": "type",
-                      "value": "variant_group"
-                    }
-                  ]
-                },
-                {
-                  "code": "attr",
-                  "list": [
-                    {
-                      "code": "name",
-                      "value": "item.quantity.unitized.measure"
-                    },
-                    {
-                      "code": "seq",
-                      "value": "1"
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "id": "variant10001",
-              "descriptor": {
-                "name": "Variant for Cashews"
-              },
-              "tags": [
-                {
-                  "code": "type",
-                  "list": [
-                    {
-                      "code": "type",
-                      "value": "variant_group"
-                    }
-                  ]
-                },
-                {
-                  "code": "attr",
-                  "list": [
-                    {
-                      "code": "name",
-                      "value": "item.quantity.unitized.measure"
-                    },
-                    {
-                      "code": "seq",
-                      "value": "1"
-                    }
-                  ]
-                }
-              ]
-            }
-          ],
           "fulfillments": [
             {
               "id": "1",
@@ -141,11 +79,11 @@
                 "locality": "Ashok Vatika",
                 "city": "Ahmedabad",
                 "state": "Gujarat",
-                "area_code": "380058"
+                "area_code": "380054"
               },
               "time": {
                 "label": "enable",
-                "timestamp": "2024-12-04T13:50:34.608Z",
+                "timestamp": "2025-01-22T07:34:34.534Z",
                 "range": {
                   "start": "0930",
                   "end": "1930"
@@ -162,12 +100,85 @@
           ],
           "items": [
             {
+              "id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+              "descriptor": {
+                "name": "Walnuts",
+                "code": "1:12345678",
+                "symbol": "https://c8.alamy.com/comp/2HCTDG2/modern-design-walnut-leaf-nature-green-logo-design-2HCTDG2.jpg",
+                "short_desc": "WONDERLAND California Whole Walnut Walnuts (Akhrot)  (500 g)",
+                "long_desc": "WONDERLAND California Whole Walnut Walnuts (Akhrot)  (500 g)",
+                "images": [
+                  "https://rukminim2.flixcart.com/image/416/416/xif0q/nut-dry-fruit/h/x/t/500-california-whole-walnut-1-pouch-wonderland-original-imagy632bnvk8fde.jpeg?q=70",
+                  "https://rukminim2.flixcart.com/image/416/416/xif0q/nut-dry-fruit/q/r/t/500-california-whole-walnut-1-pouch-wonderland-original-imagy6326hdk68cd.jpeg?q=70"
+                ]
+              },
+              "price": {
+                "currency": "INR",
+                "value": "120.0",
+                "maximum_value": "200.0"
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "value": "500",
+                    "unit": "gram"
+                  }
+                }
+              },
+              "category_id": "Snacks, Dry Fruits, Nuts",
+              "fulfillment_id": "1",
+              "location_id": "39550822-c3bb-4918-bd25-2d19ef6a9aca",
+              "time": {
+                "label": "enable",
+                "timestamp": "2025-01-23T12:00:21.519Z"
+              },
+              "@ondc/org/returnable": true,
+              "@ondc/org/seller_pickup_return": false,
+              "@ondc/org/return_window": "P7D",
+              "@ondc/org/cancellable": true,
+              "@ondc/org/time_to_ship": "PT3H",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "PirimidFintech,user@gmail.com,7744774477",
+              "@ondc/org/statutory_reqs_prepackaged_food": {
+                "nutritional_info": "nutritional_info",
+                "additives_info": "additives_info",
+                "brand_owner_FSSAI_license_no": "12345678912345",
+                "other_FSSAI_license_no": "12345678912345",
+                "importer_FSSAI_license_no": "12345678912345"
+              },
+              "tags": [
+                {
+                  "code": "origin",
+                  "list": [
+                    {
+                      "code": "Country",
+                      "value": "IND"
+                    }
+                  ]
+                },
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
               "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
-              "parent_item_id": "variant10000",
               "descriptor": {
                 "name": "Nutraj-California-Almonds-1Kg",
                 "code": "1:12345678",
-                "symbol": "symbols.in/symbol.jpg",
+                "symbol": "https://img.freepik.com/premium-vector/almonds-nuts-nature-farm-vintage-logo-icon-symbol-vector-illustration-minimalist-design_889650-491.jpg?semt=ais_hybrid",
                 "short_desc": "Nutraj California Almond kernels 1kg Pouch|Badam Giri|Dry Fruits and Nuts|Grocery",
                 "long_desc": "Nutraj California Almond kernels 1kg Pouch|Badam Giri|Dry Fruits and Nuts|Grocery",
                 "images": [
@@ -198,7 +209,7 @@
               "location_id": "39550822-c3bb-4918-bd25-2d19ef6a9aca",
               "time": {
                 "label": "enable",
-                "timestamp": "2025-01-17T12:00:21.411Z"
+                "timestamp": "2025-01-23T12:00:21.519Z"
               },
               "@ondc/org/returnable": true,
               "@ondc/org/seller_pickup_return": false,
@@ -237,11 +248,10 @@
             },
             {
               "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
-              "parent_item_id": "variant10001",
               "descriptor": {
                 "name": "Cashews",
                 "code": "1:12345678",
-                "symbol": "symbols.in/symbol.jpg",
+                "symbol": "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTVlckKW1pwOvmkj9_s_rPbAvcsr_EdmIStMA&s",
                 "short_desc": "Emart Brand - Vedaka Whole Cashews | 500 Gram | Kaju Nuts Grade W320 | Plant Based Protein | Gluten-Free | Nutty Flavor | Healthy Snack | Rich Delicious Taste",
                 "long_desc": "Emart Brand - Vedaka Whole Cashews | 500 Gram | Kaju Nuts Grade W320 | Plant Based Protein | Gluten-Free | Nutty Flavor | Healthy Snack | Rich Delicious Taste",
                 "images": [
@@ -251,7 +261,7 @@
               "price": {
                 "currency": "INR",
                 "value": "120.0",
-                "maximum_value": "258.0"
+                "maximum_value": "212.0"
               },
               "quantity": {
                 "available": {
@@ -262,8 +272,8 @@
                 },
                 "unitized": {
                   "measure": {
-                    "value": "1",
-                    "unit": "kilogram"
+                    "value": "500",
+                    "unit": "gram"
                   }
                 }
               },
@@ -272,7 +282,7 @@
               "location_id": "39550822-c3bb-4918-bd25-2d19ef6a9aca",
               "time": {
                 "label": "enable",
-                "timestamp": "2025-01-17T12:00:21.411Z"
+                "timestamp": "2025-01-23T12:00:21.519Z"
               },
               "@ondc/org/returnable": true,
               "@ondc/org/seller_pickup_return": false,
@@ -342,36 +352,7 @@
               "list": [
                 {
                   "code": "type",
-                  "value": "Order"
-                },
-                {
-                  "code": "location",
-                  "value": "39550822-c3bb-4918-bd25-2d19ef6a9aca"
-                },
-                {
-                  "code": "day_from",
-                  "value": "1"
-                },
-                {
-                  "code": "day_to",
-                  "value": "7"
-                },
-                {
-                  "code": "time_from",
-                  "value": "0930"
-                },
-                {
-                  "code": "time_to",
-                  "value": "1930"
-                }
-              ]
-            },
-            {
-              "code": "timing",
-              "list": [
-                {
-                  "code": "type",
-                  "value": "Delivery"
+                  "value": "All"
                 },
                 {
                   "code": "location",

--- a/Pirimid/SellerApp/Retail/RET-10/FLOW_2/on_select.json
+++ b/Pirimid/SellerApp/Retail/RET-10/FLOW_2/on_select.json
@@ -9,9 +9,9 @@
     "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
     "bpp_id": "ondc.pirimidtech.com/v2/seller",
     "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-    "transaction_id": "4b210a13-f55d-4aca-8feb-815d4a383d81",
-    "message_id": "c7c389c3-419f-4d0f-805a-1252a387ec43",
-    "timestamp": "2025-01-18T04:23:31.956Z"
+    "transaction_id": "b2f44b86-f815-40dc-8a59-1fae65fbd30c",
+    "message_id": "2643345b-61c1-44ab-a4bd-b7f06f6f742c",
+    "timestamp": "2025-01-23T12:16:07.500Z"
   },
   "message": {
     "order": {
@@ -26,16 +26,20 @@
       "items": [
         {
           "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
-          "fulfillment_id": "07888647-89a1-4a41-b3d2-2936471fc816"
+          "fulfillment_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b"
         },
         {
           "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
-          "fulfillment_id": "07888647-89a1-4a41-b3d2-2936471fc816"
+          "fulfillment_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b"
+        },
+        {
+          "id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+          "fulfillment_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b"
         }
       ],
       "fulfillments": [
         {
-          "id": "07888647-89a1-4a41-b3d2-2936471fc816",
+          "id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
           "type": "Delivery",
           "@ondc/org/category": "Standard Delivery",
           "@ondc/org/TAT": "PT99H",
@@ -51,13 +55,13 @@
       "quote": {
         "price": {
           "currency": "INR",
-          "value": "1401.72"
+          "value": "1364.71"
         },
         "breakup": [
           {
             "@ondc/org/item_id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
             "@ondc/org/item_quantity": {
-              "count": 3
+              "count": 2
             },
             "@ondc/org/title_type": "item",
             "item": {
@@ -77,11 +81,11 @@
             "title": "Nutraj-California-Almonds-1Kg",
             "price": {
               "currency": "INR",
-              "value": "660.0"
+              "value": "440.0"
             }
           },
           {
-            "@ondc/org/item_id": "07888647-89a1-4a41-b3d2-2936471fc816",
+            "@ondc/org/item_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
             "@ondc/org/title_type": "packing",
             "title": "Packing Charges",
             "price": {
@@ -90,7 +94,7 @@
             }
           },
           {
-            "@ondc/org/item_id": "07888647-89a1-4a41-b3d2-2936471fc816",
+            "@ondc/org/item_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
             "@ondc/org/title_type": "delivery",
             "title": "Delivery Charges",
             "price": {
@@ -104,13 +108,13 @@
             "title": "Tax",
             "price": {
               "currency": "INR",
-              "value": "122.1"
+              "value": "81.4"
             }
           },
           {
             "@ondc/org/item_id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
             "@ondc/org/item_quantity": {
-              "count": 3
+              "count": 2
             },
             "@ondc/org/title_type": "item",
             "item": {
@@ -130,11 +134,11 @@
             "title": "Cashews",
             "price": {
               "currency": "INR",
-              "value": "360.0"
+              "value": "240.0"
             }
           },
           {
-            "@ondc/org/item_id": "07888647-89a1-4a41-b3d2-2936471fc816",
+            "@ondc/org/item_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
             "@ondc/org/title_type": "packing",
             "title": "Packing Charges",
             "price": {
@@ -143,7 +147,7 @@
             }
           },
           {
-            "@ondc/org/item_id": "07888647-89a1-4a41-b3d2-2936471fc816",
+            "@ondc/org/item_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
             "@ondc/org/title_type": "delivery",
             "title": "Delivery Charges",
             "price": {
@@ -152,12 +156,56 @@
             }
           },
           {
-            "@ondc/org/item_id": "07888647-89a1-4a41-b3d2-2936471fc816",
+            "@ondc/org/item_id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "@ondc/org/title_type": "item",
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "120.0"
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                }
+              }
+            },
+            "title": "Walnuts",
+            "price": {
+              "currency": "INR",
+              "value": "240.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
+            "@ondc/org/title_type": "packing",
+            "title": "Packing Charges",
+            "price": {
+              "currency": "INR",
+              "value": "5.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
+            "@ondc/org/title_type": "delivery",
+            "title": "Delivery Charges",
+            "price": {
+              "currency": "INR",
+              "value": "100.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
             "@ondc/org/title_type": "misc",
             "title": "Convenience Fee",
             "price": {
               "currency": "INR",
-              "value": "49.62"
+              "value": "48.31"
             }
           }
         ],

--- a/Pirimid/SellerApp/Retail/RET-10/FLOW_2/on_status_delivered.json
+++ b/Pirimid/SellerApp/Retail/RET-10/FLOW_2/on_status_delivered.json
@@ -9,14 +9,14 @@
     "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
     "bpp_id": "ondc.pirimidtech.com/v2/seller",
     "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-    "transaction_id": "4b210a13-f55d-4aca-8feb-815d4a383d81",
-    "message_id": "62bf4886-3725-4575-b67a-d9cc8ee5aceb",
-    "timestamp": "2025-01-18T15:43:10.323Z",
+    "transaction_id": "b2f44b86-f815-40dc-8a59-1fae65fbd30c",
+    "message_id": "bd55a88b-92df-4475-91bf-cd87a27fb77b",
+    "timestamp": "2025-01-24T05:19:12.322Z",
     "ttl": "PT30S"
   },
   "message": {
     "order": {
-      "id": "2025-01-18-851979",
+      "id": "2025-01-23-232372",
       "state": "Completed",
       "provider": {
         "id": "e2008459-7e90-493e-b02e-cae52ca53214",
@@ -30,21 +30,28 @@
         {
           "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
           "quantity": {
-            "count": 3
+            "count": 2
           },
-          "fulfillment_id": "07888647-89a1-4a41-b3d2-2936471fc816"
+          "fulfillment_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b"
         },
         {
           "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
           "quantity": {
-            "count": 3
+            "count": 2
           },
-          "fulfillment_id": "07888647-89a1-4a41-b3d2-2936471fc816"
+          "fulfillment_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b"
+        },
+        {
+          "id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b"
         }
       ],
       "documents": [
         {
-          "url": "https://ondc.pirimidtech.com/v2/seller/api/order/invoice/4983732a-d89b-4d70-af9b-3aab1f3fc9f7",
+          "url": "https://ondc.pirimidtech.com/v2/seller/api/order/invoice/14b74007-121d-46fd-b57d-4b54121b50b7",
           "label": "Invoice"
         }
       ],
@@ -61,12 +68,12 @@
         },
         "email": "fhemanshu@gmail.com",
         "phone": "7202959020",
-        "created_at": "2025-01-18T04:23:45.679Z",
-        "updated_at": "2025-01-18T04:23:45.679Z"
+        "created_at": "2025-01-23T12:16:16.800Z",
+        "updated_at": "2025-01-23T12:16:16.800Z"
       },
       "fulfillments": [
         {
-          "id": "07888647-89a1-4a41-b3d2-2936471fc816",
+          "id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
           "type": "Delivery",
           "@ondc/org/TAT": "PT99H",
           "provider_id": "ondc.loadshare.com/ondc/18275",
@@ -97,14 +104,14 @@
                 "locality": "Ashok Vatika",
                 "city": "Ahmedabad",
                 "state": "Gujarat",
-                "area_code": "380058"
+                "area_code": "380054"
               }
             },
             "time": {
-              "timestamp": "2025-01-18T04:28:07.353Z",
+              "timestamp": "2025-01-23T12:18:14.166Z",
               "range": {
-                "start": "2025-01-18T04:27:55.028Z",
-                "end": "2025-01-18T07:27:55.028Z"
+                "start": "2025-01-23T12:17:58.463Z",
+                "end": "2025-01-23T15:17:58.463Z"
               }
             },
             "instructions": {
@@ -132,10 +139,10 @@
               }
             },
             "time": {
-              "timestamp": "2025-01-18T15:43:10.319Z",
+              "timestamp": "2025-01-24T05:19:12.320Z",
               "range": {
-                "start": "2025-01-18T07:27:55.028Z",
-                "end": "2025-01-22T07:27:55.028Z"
+                "start": "2025-01-23T15:17:58.463Z",
+                "end": "2025-01-27T15:17:58.463Z"
               }
             },
             "contact": {
@@ -162,13 +169,13 @@
       "quote": {
         "price": {
           "currency": "INR",
-          "value": "1401.72"
+          "value": "1364.71"
         },
         "breakup": [
           {
             "@ondc/org/item_id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
             "@ondc/org/item_quantity": {
-              "count": 3
+              "count": 2
             },
             "@ondc/org/title_type": "item",
             "item": {
@@ -180,11 +187,11 @@
             "title": "Nutraj-California-Almonds-1Kg",
             "price": {
               "currency": "INR",
-              "value": "660.0"
+              "value": "440.0"
             }
           },
           {
-            "@ondc/org/item_id": "07888647-89a1-4a41-b3d2-2936471fc816",
+            "@ondc/org/item_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
             "@ondc/org/title_type": "packing",
             "title": "Packing Charges",
             "price": {
@@ -193,7 +200,7 @@
             }
           },
           {
-            "@ondc/org/item_id": "07888647-89a1-4a41-b3d2-2936471fc816",
+            "@ondc/org/item_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
             "@ondc/org/title_type": "delivery",
             "title": "Delivery Charges",
             "price": {
@@ -207,13 +214,13 @@
             "title": "Tax",
             "price": {
               "currency": "INR",
-              "value": "122.1"
+              "value": "81.4"
             }
           },
           {
             "@ondc/org/item_id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
             "@ondc/org/item_quantity": {
-              "count": 3
+              "count": 2
             },
             "@ondc/org/title_type": "item",
             "item": {
@@ -225,11 +232,11 @@
             "title": "Cashews",
             "price": {
               "currency": "INR",
-              "value": "360.0"
+              "value": "240.0"
             }
           },
           {
-            "@ondc/org/item_id": "07888647-89a1-4a41-b3d2-2936471fc816",
+            "@ondc/org/item_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
             "@ondc/org/title_type": "packing",
             "title": "Packing Charges",
             "price": {
@@ -238,7 +245,7 @@
             }
           },
           {
-            "@ondc/org/item_id": "07888647-89a1-4a41-b3d2-2936471fc816",
+            "@ondc/org/item_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
             "@ondc/org/title_type": "delivery",
             "title": "Delivery Charges",
             "price": {
@@ -247,12 +254,48 @@
             }
           },
           {
-            "@ondc/org/item_id": "07888647-89a1-4a41-b3d2-2936471fc816",
+            "@ondc/org/item_id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "@ondc/org/title_type": "item",
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "120.0"
+              }
+            },
+            "title": "Walnuts",
+            "price": {
+              "currency": "INR",
+              "value": "240.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
+            "@ondc/org/title_type": "packing",
+            "title": "Packing Charges",
+            "price": {
+              "currency": "INR",
+              "value": "5.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
+            "@ondc/org/title_type": "delivery",
+            "title": "Delivery Charges",
+            "price": {
+              "currency": "INR",
+              "value": "100.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
             "@ondc/org/title_type": "misc",
             "title": "Convenience Fee",
             "price": {
               "currency": "INR",
-              "value": "49.62"
+              "value": "48.31"
             }
           }
         ],
@@ -262,8 +305,8 @@
         "uri": "https://razorpay.com/",
         "tl_method": "http/get",
         "params": {
-          "transaction_id": "order_PklzhEb4pJDTsN",
-          "amount": "1401.72",
+          "transaction_id": "order_PmsiPwsbCPBCII",
+          "amount": "1364.71",
           "currency": "INR"
         },
         "type": "ON-ORDER",
@@ -288,8 +331,8 @@
           }
         ]
       },
-      "created_at": "2025-01-18T04:24:10.828Z",
-      "updated_at": "2025-01-18T15:43:10.323Z"
+      "created_at": "2025-01-23T12:16:47.408Z",
+      "updated_at": "2025-01-24T05:19:12.322Z"
     }
   }
 }

--- a/Pirimid/SellerApp/Retail/RET-10/FLOW_2/on_status_out_for_delivery.json
+++ b/Pirimid/SellerApp/Retail/RET-10/FLOW_2/on_status_out_for_delivery.json
@@ -9,14 +9,14 @@
     "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
     "bpp_id": "ondc.pirimidtech.com/v2/seller",
     "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-    "transaction_id": "4b210a13-f55d-4aca-8feb-815d4a383d81",
-    "message_id": "bf7d4820-2d41-4ade-908b-7202277cda6a",
-    "timestamp": "2025-01-18T15:43:00.518Z",
+    "transaction_id": "b2f44b86-f815-40dc-8a59-1fae65fbd30c",
+    "message_id": "8cdce307-1542-4521-bdd3-19ccc7f6011c",
+    "timestamp": "2025-01-24T05:19:05.865Z",
     "ttl": "PT30S"
   },
   "message": {
     "order": {
-      "id": "2025-01-18-851979",
+      "id": "2025-01-23-232372",
       "state": "In-progress",
       "provider": {
         "id": "e2008459-7e90-493e-b02e-cae52ca53214",
@@ -30,21 +30,28 @@
         {
           "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
           "quantity": {
-            "count": 3
+            "count": 2
           },
-          "fulfillment_id": "07888647-89a1-4a41-b3d2-2936471fc816"
+          "fulfillment_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b"
         },
         {
           "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
           "quantity": {
-            "count": 3
+            "count": 2
           },
-          "fulfillment_id": "07888647-89a1-4a41-b3d2-2936471fc816"
+          "fulfillment_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b"
+        },
+        {
+          "id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b"
         }
       ],
       "documents": [
         {
-          "url": "https://ondc.pirimidtech.com/v2/seller/api/order/invoice/4983732a-d89b-4d70-af9b-3aab1f3fc9f7",
+          "url": "https://ondc.pirimidtech.com/v2/seller/api/order/invoice/14b74007-121d-46fd-b57d-4b54121b50b7",
           "label": "Invoice"
         }
       ],
@@ -61,12 +68,12 @@
         },
         "email": "fhemanshu@gmail.com",
         "phone": "7202959020",
-        "created_at": "2025-01-18T04:23:45.679Z",
-        "updated_at": "2025-01-18T04:23:45.679Z"
+        "created_at": "2025-01-23T12:16:16.800Z",
+        "updated_at": "2025-01-23T12:16:16.800Z"
       },
       "fulfillments": [
         {
-          "id": "07888647-89a1-4a41-b3d2-2936471fc816",
+          "id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
           "type": "Delivery",
           "@ondc/org/TAT": "PT99H",
           "provider_id": "ondc.loadshare.com/ondc/18275",
@@ -97,14 +104,14 @@
                 "locality": "Ashok Vatika",
                 "city": "Ahmedabad",
                 "state": "Gujarat",
-                "area_code": "380058"
+                "area_code": "380054"
               }
             },
             "time": {
-              "timestamp": "2025-01-18T04:28:07.353Z",
+              "timestamp": "2025-01-23T12:18:14.166Z",
               "range": {
-                "start": "2025-01-18T04:27:55.028Z",
-                "end": "2025-01-18T07:27:55.028Z"
+                "start": "2025-01-23T12:17:58.463Z",
+                "end": "2025-01-23T15:17:58.463Z"
               }
             },
             "instructions": {
@@ -133,8 +140,8 @@
             },
             "time": {
               "range": {
-                "start": "2025-01-18T07:27:55.028Z",
-                "end": "2025-01-22T07:27:55.028Z"
+                "start": "2025-01-23T15:17:58.463Z",
+                "end": "2025-01-27T15:17:58.463Z"
               }
             },
             "contact": {
@@ -161,13 +168,13 @@
       "quote": {
         "price": {
           "currency": "INR",
-          "value": "1401.72"
+          "value": "1364.71"
         },
         "breakup": [
           {
             "@ondc/org/item_id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
             "@ondc/org/item_quantity": {
-              "count": 3
+              "count": 2
             },
             "@ondc/org/title_type": "item",
             "item": {
@@ -179,11 +186,11 @@
             "title": "Nutraj-California-Almonds-1Kg",
             "price": {
               "currency": "INR",
-              "value": "660.0"
+              "value": "440.0"
             }
           },
           {
-            "@ondc/org/item_id": "07888647-89a1-4a41-b3d2-2936471fc816",
+            "@ondc/org/item_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
             "@ondc/org/title_type": "packing",
             "title": "Packing Charges",
             "price": {
@@ -192,7 +199,7 @@
             }
           },
           {
-            "@ondc/org/item_id": "07888647-89a1-4a41-b3d2-2936471fc816",
+            "@ondc/org/item_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
             "@ondc/org/title_type": "delivery",
             "title": "Delivery Charges",
             "price": {
@@ -206,13 +213,13 @@
             "title": "Tax",
             "price": {
               "currency": "INR",
-              "value": "122.1"
+              "value": "81.4"
             }
           },
           {
             "@ondc/org/item_id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
             "@ondc/org/item_quantity": {
-              "count": 3
+              "count": 2
             },
             "@ondc/org/title_type": "item",
             "item": {
@@ -224,11 +231,11 @@
             "title": "Cashews",
             "price": {
               "currency": "INR",
-              "value": "360.0"
+              "value": "240.0"
             }
           },
           {
-            "@ondc/org/item_id": "07888647-89a1-4a41-b3d2-2936471fc816",
+            "@ondc/org/item_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
             "@ondc/org/title_type": "packing",
             "title": "Packing Charges",
             "price": {
@@ -237,7 +244,7 @@
             }
           },
           {
-            "@ondc/org/item_id": "07888647-89a1-4a41-b3d2-2936471fc816",
+            "@ondc/org/item_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
             "@ondc/org/title_type": "delivery",
             "title": "Delivery Charges",
             "price": {
@@ -246,12 +253,48 @@
             }
           },
           {
-            "@ondc/org/item_id": "07888647-89a1-4a41-b3d2-2936471fc816",
+            "@ondc/org/item_id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "@ondc/org/title_type": "item",
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "120.0"
+              }
+            },
+            "title": "Walnuts",
+            "price": {
+              "currency": "INR",
+              "value": "240.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
+            "@ondc/org/title_type": "packing",
+            "title": "Packing Charges",
+            "price": {
+              "currency": "INR",
+              "value": "5.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
+            "@ondc/org/title_type": "delivery",
+            "title": "Delivery Charges",
+            "price": {
+              "currency": "INR",
+              "value": "100.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
             "@ondc/org/title_type": "misc",
             "title": "Convenience Fee",
             "price": {
               "currency": "INR",
-              "value": "49.62"
+              "value": "48.31"
             }
           }
         ],
@@ -261,8 +304,8 @@
         "uri": "https://razorpay.com/",
         "tl_method": "http/get",
         "params": {
-          "transaction_id": "order_PklzhEb4pJDTsN",
-          "amount": "1401.72",
+          "transaction_id": "order_PmsiPwsbCPBCII",
+          "amount": "1364.71",
           "currency": "INR"
         },
         "type": "ON-ORDER",
@@ -287,8 +330,8 @@
           }
         ]
       },
-      "created_at": "2025-01-18T04:24:10.828Z",
-      "updated_at": "2025-01-18T15:43:00.518Z"
+      "created_at": "2025-01-23T12:16:47.408Z",
+      "updated_at": "2025-01-24T05:19:05.865Z"
     }
   }
 }

--- a/Pirimid/SellerApp/Retail/RET-10/FLOW_2/on_status_packed.json
+++ b/Pirimid/SellerApp/Retail/RET-10/FLOW_2/on_status_packed.json
@@ -9,14 +9,14 @@
     "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
     "bpp_id": "ondc.pirimidtech.com/v2/seller",
     "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-    "transaction_id": "4b210a13-f55d-4aca-8feb-815d4a383d81",
-    "message_id": "e98e37f5-15fd-41f1-b2b4-7dd07c4dca0c",
-    "timestamp": "2025-01-18T04:27:59.179Z",
+    "transaction_id": "b2f44b86-f815-40dc-8a59-1fae65fbd30c",
+    "message_id": "069c0dc8-fec7-4ce7-88ce-70bec16a481d",
+    "timestamp": "2025-01-23T12:18:04.374Z",
     "ttl": "PT30S"
   },
   "message": {
     "order": {
-      "id": "2025-01-18-851979",
+      "id": "2025-01-23-232372",
       "state": "In-progress",
       "provider": {
         "id": "e2008459-7e90-493e-b02e-cae52ca53214",
@@ -30,16 +30,23 @@
         {
           "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
           "quantity": {
-            "count": 3
+            "count": 2
           },
-          "fulfillment_id": "07888647-89a1-4a41-b3d2-2936471fc816"
+          "fulfillment_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b"
         },
         {
           "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
           "quantity": {
-            "count": 3
+            "count": 2
           },
-          "fulfillment_id": "07888647-89a1-4a41-b3d2-2936471fc816"
+          "fulfillment_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b"
+        },
+        {
+          "id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b"
         }
       ],
       "billing": {
@@ -55,12 +62,12 @@
         },
         "email": "fhemanshu@gmail.com",
         "phone": "7202959020",
-        "created_at": "2025-01-18T04:23:45.679Z",
-        "updated_at": "2025-01-18T04:23:45.679Z"
+        "created_at": "2025-01-23T12:16:16.800Z",
+        "updated_at": "2025-01-23T12:16:16.800Z"
       },
       "fulfillments": [
         {
-          "id": "07888647-89a1-4a41-b3d2-2936471fc816",
+          "id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
           "type": "Delivery",
           "@ondc/org/TAT": "PT99H",
           "provider_id": "ondc.loadshare.com/ondc/18275",
@@ -91,13 +98,13 @@
                 "locality": "Ashok Vatika",
                 "city": "Ahmedabad",
                 "state": "Gujarat",
-                "area_code": "380058"
+                "area_code": "380054"
               }
             },
             "time": {
               "range": {
-                "start": "2025-01-18T04:27:55.028Z",
-                "end": "2025-01-18T07:27:55.028Z"
+                "start": "2025-01-23T12:17:58.463Z",
+                "end": "2025-01-23T15:17:58.463Z"
               }
             },
             "instructions": {
@@ -126,8 +133,8 @@
             },
             "time": {
               "range": {
-                "start": "2025-01-18T07:27:55.028Z",
-                "end": "2025-01-22T07:27:55.028Z"
+                "start": "2025-01-23T15:17:58.463Z",
+                "end": "2025-01-27T15:17:58.463Z"
               }
             },
             "contact": {
@@ -137,19 +144,30 @@
             "person": {
               "name": "Hemanshu Faldu"
             }
-          }
+          },
+          "tags": [
+            {
+              "code": "routing",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "P2P"
+                }
+              ]
+            }
+          ]
         }
       ],
       "quote": {
         "price": {
           "currency": "INR",
-          "value": "1401.72"
+          "value": "1364.71"
         },
         "breakup": [
           {
             "@ondc/org/item_id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
             "@ondc/org/item_quantity": {
-              "count": 3
+              "count": 2
             },
             "@ondc/org/title_type": "item",
             "item": {
@@ -161,11 +179,11 @@
             "title": "Nutraj-California-Almonds-1Kg",
             "price": {
               "currency": "INR",
-              "value": "660.0"
+              "value": "440.0"
             }
           },
           {
-            "@ondc/org/item_id": "07888647-89a1-4a41-b3d2-2936471fc816",
+            "@ondc/org/item_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
             "@ondc/org/title_type": "packing",
             "title": "Packing Charges",
             "price": {
@@ -174,7 +192,7 @@
             }
           },
           {
-            "@ondc/org/item_id": "07888647-89a1-4a41-b3d2-2936471fc816",
+            "@ondc/org/item_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
             "@ondc/org/title_type": "delivery",
             "title": "Delivery Charges",
             "price": {
@@ -188,13 +206,13 @@
             "title": "Tax",
             "price": {
               "currency": "INR",
-              "value": "122.1"
+              "value": "81.4"
             }
           },
           {
             "@ondc/org/item_id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
             "@ondc/org/item_quantity": {
-              "count": 3
+              "count": 2
             },
             "@ondc/org/title_type": "item",
             "item": {
@@ -206,11 +224,11 @@
             "title": "Cashews",
             "price": {
               "currency": "INR",
-              "value": "360.0"
+              "value": "240.0"
             }
           },
           {
-            "@ondc/org/item_id": "07888647-89a1-4a41-b3d2-2936471fc816",
+            "@ondc/org/item_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
             "@ondc/org/title_type": "packing",
             "title": "Packing Charges",
             "price": {
@@ -219,7 +237,7 @@
             }
           },
           {
-            "@ondc/org/item_id": "07888647-89a1-4a41-b3d2-2936471fc816",
+            "@ondc/org/item_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
             "@ondc/org/title_type": "delivery",
             "title": "Delivery Charges",
             "price": {
@@ -228,12 +246,48 @@
             }
           },
           {
-            "@ondc/org/item_id": "07888647-89a1-4a41-b3d2-2936471fc816",
+            "@ondc/org/item_id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "@ondc/org/title_type": "item",
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "120.0"
+              }
+            },
+            "title": "Walnuts",
+            "price": {
+              "currency": "INR",
+              "value": "240.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
+            "@ondc/org/title_type": "packing",
+            "title": "Packing Charges",
+            "price": {
+              "currency": "INR",
+              "value": "5.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
+            "@ondc/org/title_type": "delivery",
+            "title": "Delivery Charges",
+            "price": {
+              "currency": "INR",
+              "value": "100.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
             "@ondc/org/title_type": "misc",
             "title": "Convenience Fee",
             "price": {
               "currency": "INR",
-              "value": "49.62"
+              "value": "48.31"
             }
           }
         ],
@@ -243,8 +297,8 @@
         "uri": "https://razorpay.com/",
         "tl_method": "http/get",
         "params": {
-          "transaction_id": "order_PklzhEb4pJDTsN",
-          "amount": "1401.72",
+          "transaction_id": "order_PmsiPwsbCPBCII",
+          "amount": "1364.71",
           "currency": "INR"
         },
         "type": "ON-ORDER",
@@ -269,8 +323,8 @@
           }
         ]
       },
-      "created_at": "2025-01-18T04:24:10.828Z",
-      "updated_at": "2025-01-18T04:27:59.179Z"
+      "created_at": "2025-01-23T12:16:47.408Z",
+      "updated_at": "2025-01-23T12:18:04.374Z"
     }
   }
 }

--- a/Pirimid/SellerApp/Retail/RET-10/FLOW_2/on_status_pending.json
+++ b/Pirimid/SellerApp/Retail/RET-10/FLOW_2/on_status_pending.json
@@ -9,14 +9,14 @@
     "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
     "bpp_id": "ondc.pirimidtech.com/v2/seller",
     "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-    "transaction_id": "4b210a13-f55d-4aca-8feb-815d4a383d81",
-    "message_id": "b740fcc8-161e-4539-8d87-7cc3e9eede11",
-    "timestamp": "2025-01-18T04:27:55.030Z",
+    "transaction_id": "b2f44b86-f815-40dc-8a59-1fae65fbd30c",
+    "message_id": "1f745cba-f199-4496-ba33-888815a428bc",
+    "timestamp": "2025-01-23T12:17:58.465Z",
     "ttl": "PT30S"
   },
   "message": {
     "order": {
-      "id": "2025-01-18-851979",
+      "id": "2025-01-23-232372",
       "state": "Accepted",
       "provider": {
         "id": "e2008459-7e90-493e-b02e-cae52ca53214",
@@ -30,16 +30,23 @@
         {
           "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
           "quantity": {
-            "count": 3
+            "count": 2
           },
-          "fulfillment_id": "07888647-89a1-4a41-b3d2-2936471fc816"
+          "fulfillment_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b"
         },
         {
           "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
           "quantity": {
-            "count": 3
+            "count": 2
           },
-          "fulfillment_id": "07888647-89a1-4a41-b3d2-2936471fc816"
+          "fulfillment_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b"
+        },
+        {
+          "id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b"
         }
       ],
       "billing": {
@@ -55,12 +62,12 @@
         },
         "email": "fhemanshu@gmail.com",
         "phone": "7202959020",
-        "created_at": "2025-01-18T04:23:45.679Z",
-        "updated_at": "2025-01-18T04:23:45.679Z"
+        "created_at": "2025-01-23T12:16:16.800Z",
+        "updated_at": "2025-01-23T12:16:16.800Z"
       },
       "fulfillments": [
         {
-          "id": "07888647-89a1-4a41-b3d2-2936471fc816",
+          "id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
           "type": "Delivery",
           "@ondc/org/TAT": "PT99H",
           "provider_id": "ondc.loadshare.com/ondc/18275",
@@ -82,13 +89,13 @@
                 "locality": "Ashok Vatika",
                 "city": "Ahmedabad",
                 "state": "Gujarat",
-                "area_code": "380058"
+                "area_code": "380054"
               }
             },
             "time": {
               "range": {
-                "start": "2025-01-18T04:27:55.028Z",
-                "end": "2025-01-18T07:27:55.028Z"
+                "start": "2025-01-23T12:17:58.463Z",
+                "end": "2025-01-23T15:17:58.463Z"
               }
             },
             "instructions": {
@@ -117,8 +124,8 @@
             },
             "time": {
               "range": {
-                "start": "2025-01-18T07:27:55.028Z",
-                "end": "2025-01-22T07:27:55.028Z"
+                "start": "2025-01-23T15:17:58.463Z",
+                "end": "2025-01-27T15:17:58.463Z"
               }
             },
             "contact": {
@@ -134,13 +141,13 @@
       "quote": {
         "price": {
           "currency": "INR",
-          "value": "1401.72"
+          "value": "1364.71"
         },
         "breakup": [
           {
             "@ondc/org/item_id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
             "@ondc/org/item_quantity": {
-              "count": 3
+              "count": 2
             },
             "@ondc/org/title_type": "item",
             "item": {
@@ -152,11 +159,11 @@
             "title": "Nutraj-California-Almonds-1Kg",
             "price": {
               "currency": "INR",
-              "value": "660.0"
+              "value": "440.0"
             }
           },
           {
-            "@ondc/org/item_id": "07888647-89a1-4a41-b3d2-2936471fc816",
+            "@ondc/org/item_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
             "@ondc/org/title_type": "packing",
             "title": "Packing Charges",
             "price": {
@@ -165,7 +172,7 @@
             }
           },
           {
-            "@ondc/org/item_id": "07888647-89a1-4a41-b3d2-2936471fc816",
+            "@ondc/org/item_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
             "@ondc/org/title_type": "delivery",
             "title": "Delivery Charges",
             "price": {
@@ -179,13 +186,13 @@
             "title": "Tax",
             "price": {
               "currency": "INR",
-              "value": "122.1"
+              "value": "81.4"
             }
           },
           {
             "@ondc/org/item_id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
             "@ondc/org/item_quantity": {
-              "count": 3
+              "count": 2
             },
             "@ondc/org/title_type": "item",
             "item": {
@@ -197,11 +204,11 @@
             "title": "Cashews",
             "price": {
               "currency": "INR",
-              "value": "360.0"
+              "value": "240.0"
             }
           },
           {
-            "@ondc/org/item_id": "07888647-89a1-4a41-b3d2-2936471fc816",
+            "@ondc/org/item_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
             "@ondc/org/title_type": "packing",
             "title": "Packing Charges",
             "price": {
@@ -210,7 +217,7 @@
             }
           },
           {
-            "@ondc/org/item_id": "07888647-89a1-4a41-b3d2-2936471fc816",
+            "@ondc/org/item_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
             "@ondc/org/title_type": "delivery",
             "title": "Delivery Charges",
             "price": {
@@ -219,12 +226,48 @@
             }
           },
           {
-            "@ondc/org/item_id": "07888647-89a1-4a41-b3d2-2936471fc816",
+            "@ondc/org/item_id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "@ondc/org/title_type": "item",
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "120.0"
+              }
+            },
+            "title": "Walnuts",
+            "price": {
+              "currency": "INR",
+              "value": "240.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
+            "@ondc/org/title_type": "packing",
+            "title": "Packing Charges",
+            "price": {
+              "currency": "INR",
+              "value": "5.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
+            "@ondc/org/title_type": "delivery",
+            "title": "Delivery Charges",
+            "price": {
+              "currency": "INR",
+              "value": "100.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
             "@ondc/org/title_type": "misc",
             "title": "Convenience Fee",
             "price": {
               "currency": "INR",
-              "value": "49.62"
+              "value": "48.31"
             }
           }
         ],
@@ -234,8 +277,8 @@
         "uri": "https://razorpay.com/",
         "tl_method": "http/get",
         "params": {
-          "transaction_id": "order_PklzhEb4pJDTsN",
-          "amount": "1401.72",
+          "transaction_id": "order_PmsiPwsbCPBCII",
+          "amount": "1364.71",
           "currency": "INR"
         },
         "type": "ON-ORDER",
@@ -260,8 +303,8 @@
           }
         ]
       },
-      "created_at": "2025-01-18T04:24:10.828Z",
-      "updated_at": "2025-01-18T04:27:55.030Z"
+      "created_at": "2025-01-23T12:16:47.408Z",
+      "updated_at": "2025-01-23T12:17:58.465Z"
     }
   }
 }

--- a/Pirimid/SellerApp/Retail/RET-10/FLOW_2/on_status_picked.json
+++ b/Pirimid/SellerApp/Retail/RET-10/FLOW_2/on_status_picked.json
@@ -9,14 +9,14 @@
     "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
     "bpp_id": "ondc.pirimidtech.com/v2/seller",
     "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-    "transaction_id": "4b210a13-f55d-4aca-8feb-815d4a383d81",
-    "message_id": "fbaba24c-452a-4700-bc5d-97f79631e753",
-    "timestamp": "2025-01-18T04:28:07.355Z",
+    "transaction_id": "b2f44b86-f815-40dc-8a59-1fae65fbd30c",
+    "message_id": "7a730f1b-13cf-435a-a0b8-626a58f20020",
+    "timestamp": "2025-01-23T12:18:14.171Z",
     "ttl": "PT30S"
   },
   "message": {
     "order": {
-      "id": "2025-01-18-851979",
+      "id": "2025-01-23-232372",
       "state": "In-progress",
       "provider": {
         "id": "e2008459-7e90-493e-b02e-cae52ca53214",
@@ -30,21 +30,28 @@
         {
           "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
           "quantity": {
-            "count": 3
+            "count": 2
           },
-          "fulfillment_id": "07888647-89a1-4a41-b3d2-2936471fc816"
+          "fulfillment_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b"
         },
         {
           "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
           "quantity": {
-            "count": 3
+            "count": 2
           },
-          "fulfillment_id": "07888647-89a1-4a41-b3d2-2936471fc816"
+          "fulfillment_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b"
+        },
+        {
+          "id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b"
         }
       ],
       "documents": [
         {
-          "url": "https://ondc.pirimidtech.com/v2/seller/api/order/invoice/4983732a-d89b-4d70-af9b-3aab1f3fc9f7",
+          "url": "https://ondc.pirimidtech.com/v2/seller/api/order/invoice/14b74007-121d-46fd-b57d-4b54121b50b7",
           "label": "Invoice"
         }
       ],
@@ -61,12 +68,12 @@
         },
         "email": "fhemanshu@gmail.com",
         "phone": "7202959020",
-        "created_at": "2025-01-18T04:23:45.679Z",
-        "updated_at": "2025-01-18T04:23:45.679Z"
+        "created_at": "2025-01-23T12:16:16.800Z",
+        "updated_at": "2025-01-23T12:16:16.800Z"
       },
       "fulfillments": [
         {
-          "id": "07888647-89a1-4a41-b3d2-2936471fc816",
+          "id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
           "type": "Delivery",
           "@ondc/org/TAT": "PT99H",
           "provider_id": "ondc.loadshare.com/ondc/18275",
@@ -97,14 +104,14 @@
                 "locality": "Ashok Vatika",
                 "city": "Ahmedabad",
                 "state": "Gujarat",
-                "area_code": "380058"
+                "area_code": "380054"
               }
             },
             "time": {
-              "timestamp": "2025-01-18T04:28:07.353Z",
+              "timestamp": "2025-01-23T12:18:14.166Z",
               "range": {
-                "start": "2025-01-18T04:27:55.028Z",
-                "end": "2025-01-18T07:27:55.028Z"
+                "start": "2025-01-23T12:17:58.463Z",
+                "end": "2025-01-23T15:17:58.463Z"
               }
             },
             "instructions": {
@@ -133,8 +140,8 @@
             },
             "time": {
               "range": {
-                "start": "2025-01-18T07:27:55.028Z",
-                "end": "2025-01-22T07:27:55.028Z"
+                "start": "2025-01-23T15:17:58.463Z",
+                "end": "2025-01-27T15:17:58.463Z"
               }
             },
             "contact": {
@@ -161,13 +168,13 @@
       "quote": {
         "price": {
           "currency": "INR",
-          "value": "1401.72"
+          "value": "1364.71"
         },
         "breakup": [
           {
             "@ondc/org/item_id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
             "@ondc/org/item_quantity": {
-              "count": 3
+              "count": 2
             },
             "@ondc/org/title_type": "item",
             "item": {
@@ -179,11 +186,11 @@
             "title": "Nutraj-California-Almonds-1Kg",
             "price": {
               "currency": "INR",
-              "value": "660.0"
+              "value": "440.0"
             }
           },
           {
-            "@ondc/org/item_id": "07888647-89a1-4a41-b3d2-2936471fc816",
+            "@ondc/org/item_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
             "@ondc/org/title_type": "packing",
             "title": "Packing Charges",
             "price": {
@@ -192,7 +199,7 @@
             }
           },
           {
-            "@ondc/org/item_id": "07888647-89a1-4a41-b3d2-2936471fc816",
+            "@ondc/org/item_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
             "@ondc/org/title_type": "delivery",
             "title": "Delivery Charges",
             "price": {
@@ -206,13 +213,13 @@
             "title": "Tax",
             "price": {
               "currency": "INR",
-              "value": "122.1"
+              "value": "81.4"
             }
           },
           {
             "@ondc/org/item_id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
             "@ondc/org/item_quantity": {
-              "count": 3
+              "count": 2
             },
             "@ondc/org/title_type": "item",
             "item": {
@@ -224,11 +231,11 @@
             "title": "Cashews",
             "price": {
               "currency": "INR",
-              "value": "360.0"
+              "value": "240.0"
             }
           },
           {
-            "@ondc/org/item_id": "07888647-89a1-4a41-b3d2-2936471fc816",
+            "@ondc/org/item_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
             "@ondc/org/title_type": "packing",
             "title": "Packing Charges",
             "price": {
@@ -237,7 +244,7 @@
             }
           },
           {
-            "@ondc/org/item_id": "07888647-89a1-4a41-b3d2-2936471fc816",
+            "@ondc/org/item_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
             "@ondc/org/title_type": "delivery",
             "title": "Delivery Charges",
             "price": {
@@ -246,12 +253,48 @@
             }
           },
           {
-            "@ondc/org/item_id": "07888647-89a1-4a41-b3d2-2936471fc816",
+            "@ondc/org/item_id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "@ondc/org/title_type": "item",
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "120.0"
+              }
+            },
+            "title": "Walnuts",
+            "price": {
+              "currency": "INR",
+              "value": "240.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
+            "@ondc/org/title_type": "packing",
+            "title": "Packing Charges",
+            "price": {
+              "currency": "INR",
+              "value": "5.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
+            "@ondc/org/title_type": "delivery",
+            "title": "Delivery Charges",
+            "price": {
+              "currency": "INR",
+              "value": "100.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "15c187c1-468b-420e-a1a4-aa0305ccc14b",
             "@ondc/org/title_type": "misc",
             "title": "Convenience Fee",
             "price": {
               "currency": "INR",
-              "value": "49.62"
+              "value": "48.31"
             }
           }
         ],
@@ -261,8 +304,8 @@
         "uri": "https://razorpay.com/",
         "tl_method": "http/get",
         "params": {
-          "transaction_id": "order_PklzhEb4pJDTsN",
-          "amount": "1401.72",
+          "transaction_id": "order_PmsiPwsbCPBCII",
+          "amount": "1364.71",
           "currency": "INR"
         },
         "type": "ON-ORDER",
@@ -287,8 +330,8 @@
           }
         ]
       },
-      "created_at": "2025-01-18T04:24:10.828Z",
-      "updated_at": "2025-01-18T04:28:07.355Z"
+      "created_at": "2025-01-23T12:16:47.408Z",
+      "updated_at": "2025-01-23T12:18:14.171Z"
     }
   }
 }

--- a/Pirimid/SellerApp/Retail/RET-10/FLOW_2/search_full_catalog_refresh.json
+++ b/Pirimid/SellerApp/Retail/RET-10/FLOW_2/search_full_catalog_refresh.json
@@ -7,9 +7,9 @@
     "core_version": "1.2.0",
     "bap_id": "buyer-app-preprod-v2.ondc.org",
     "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
-    "transaction_id": "e53a74c5-7ce6-4498-800c-e7d90db0f2fa",
-    "message_id": "45726578-5033-41e0-b35f-2fcbcebe8f82",
-    "timestamp": "2025-01-17T12:00:01.818Z",
+    "transaction_id": "2a274964-3eec-4793-888c-1d30ef845cd1",
+    "message_id": "c5c58f68-8483-4490-b318-a1436c6ee88b",
+    "timestamp": "2025-01-23T12:00:01.908Z",
     "ttl": "PT30S"
   },
   "message": {

--- a/Pirimid/SellerApp/Retail/RET-10/FLOW_2/select.json
+++ b/Pirimid/SellerApp/Retail/RET-10/FLOW_2/select.json
@@ -8,9 +8,9 @@
     "bap_id": "buyer-app-preprod-v2.ondc.org",
     "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
     "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-    "transaction_id": "4b210a13-f55d-4aca-8feb-815d4a383d81",
-    "message_id": "c7c389c3-419f-4d0f-805a-1252a387ec43",
-    "timestamp": "2025-01-18T04:23:29.944Z",
+    "transaction_id": "b2f44b86-f815-40dc-8a59-1fae65fbd30c",
+    "message_id": "2643345b-61c1-44ab-a4bd-b7f06f6f742c",
+    "timestamp": "2025-01-23T12:16:05.761Z",
     "bpp_id": "ondc.pirimidtech.com/v2/seller",
     "ttl": "PT30S"
   },
@@ -20,14 +20,21 @@
         {
           "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
           "quantity": {
-            "count": 3
+            "count": 2
           },
           "location_id": "39550822-c3bb-4918-bd25-2d19ef6a9aca"
         },
         {
           "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
           "quantity": {
-            "count": 3
+            "count": 2
+          },
+          "location_id": "39550822-c3bb-4918-bd25-2d19ef6a9aca"
+        },
+        {
+          "id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+          "quantity": {
+            "count": 2
           },
           "location_id": "39550822-c3bb-4918-bd25-2d19ef6a9aca"
         }

--- a/Pirimid/SellerApp/Retail/RET-10/FLOW_3/confirm.json
+++ b/Pirimid/SellerApp/Retail/RET-10/FLOW_3/confirm.json
@@ -8,15 +8,15 @@
     "bap_id": "buyer-app-preprod-v2.ondc.org",
     "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
     "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-    "transaction_id": "2765f026-17e3-4a3f-a6bb-0b83046ff2c7",
-    "message_id": "02d13e63-f067-4678-b26d-a7d118ae73d2",
-    "timestamp": "2025-01-18T04:32:26.191Z",
+    "transaction_id": "2d4259ff-d365-4419-b86e-eada579d06e7",
+    "message_id": "228f4f99-723d-4b19-ac1f-035da1c19acd",
+    "timestamp": "2025-01-23T12:20:38.886Z",
     "bpp_id": "ondc.pirimidtech.com/v2/seller",
     "ttl": "PT30S"
   },
   "message": {
     "order": {
-      "id": "2025-01-18-499387",
+      "id": "2025-01-23-190156",
       "state": "Created",
       "billing": {
         "address": {
@@ -31,16 +31,23 @@
         "phone": "7202959020",
         "name": "Hemanshu Faldu",
         "email": "fhemanshu@gmail.com",
-        "created_at": "2025-01-18T04:32:04.795Z",
-        "updated_at": "2025-01-18T04:32:04.795Z"
+        "created_at": "2025-01-23T12:20:17.208Z",
+        "updated_at": "2025-01-23T12:20:17.208Z"
       },
       "items": [
         {
           "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
           "quantity": {
-            "count": 4
+            "count": 2
           },
-          "fulfillment_id": "6c14ebdb-6cb6-4b5c-ab85-4c2acb747973"
+          "fulfillment_id": "18653ff5-041f-4391-a6f6-91a1f5c09695"
+        },
+        {
+          "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "18653ff5-041f-4391-a6f6-91a1f5c09695"
         }
       ],
       "provider": {
@@ -53,8 +60,8 @@
       },
       "fulfillments": [
         {
-          "@ondc/org/TAT": "PT74H",
-          "id": "6c14ebdb-6cb6-4b5c-ab85-4c2acb747973",
+          "@ondc/org/TAT": "PT99H",
+          "id": "18653ff5-041f-4391-a6f6-91a1f5c09695",
           "tracking": false,
           "end": {
             "contact": {
@@ -84,9 +91,9 @@
         "uri": "https://razorpay.com/",
         "tl_method": "http/get",
         "params": {
-          "amount": "1189.92",
+          "amount": "1007.05",
           "currency": "INR",
-          "transaction_id": "order_Pkm8SsI9aoMbkW"
+          "transaction_id": "order_Pmsmecg6gruGAW"
         },
         "status": "PAID",
         "type": "ON-ORDER",
@@ -113,13 +120,13 @@
       "quote": {
         "price": {
           "currency": "INR",
-          "value": "1189.92"
+          "value": "1007.05"
         },
         "breakup": [
           {
             "@ondc/org/item_id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
             "@ondc/org/item_quantity": {
-              "count": 4
+              "count": 2
             },
             "@ondc/org/title_type": "item",
             "item": {
@@ -131,11 +138,11 @@
             "title": "Nutraj-California-Almonds-1Kg",
             "price": {
               "currency": "INR",
-              "value": "880.0"
+              "value": "440.0"
             }
           },
           {
-            "@ondc/org/item_id": "6c14ebdb-6cb6-4b5c-ab85-4c2acb747973",
+            "@ondc/org/item_id": "18653ff5-041f-4391-a6f6-91a1f5c09695",
             "@ondc/org/title_type": "packing",
             "title": "Packing Charges",
             "price": {
@@ -144,7 +151,7 @@
             }
           },
           {
-            "@ondc/org/item_id": "6c14ebdb-6cb6-4b5c-ab85-4c2acb747973",
+            "@ondc/org/item_id": "18653ff5-041f-4391-a6f6-91a1f5c09695",
             "@ondc/org/title_type": "delivery",
             "title": "Delivery Charges",
             "price": {
@@ -158,16 +165,52 @@
             "title": "Tax",
             "price": {
               "currency": "INR",
-              "value": "162.8"
+              "value": "81.4"
             }
           },
           {
-            "@ondc/org/item_id": "6c14ebdb-6cb6-4b5c-ab85-4c2acb747973",
+            "@ondc/org/item_id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "@ondc/org/title_type": "item",
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "120.0"
+              }
+            },
+            "title": "Cashews",
+            "price": {
+              "currency": "INR",
+              "value": "240.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "18653ff5-041f-4391-a6f6-91a1f5c09695",
+            "@ondc/org/title_type": "packing",
+            "title": "Packing Charges",
+            "price": {
+              "currency": "INR",
+              "value": "5.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "18653ff5-041f-4391-a6f6-91a1f5c09695",
+            "@ondc/org/title_type": "delivery",
+            "title": "Delivery Charges",
+            "price": {
+              "currency": "INR",
+              "value": "100.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "18653ff5-041f-4391-a6f6-91a1f5c09695",
             "@ondc/org/title_type": "misc",
             "title": "Convenience Fee",
             "price": {
               "currency": "INR",
-              "value": "42.12"
+              "value": "35.65"
             }
           }
         ],
@@ -197,8 +240,8 @@
           ]
         }
       ],
-      "created_at": "2025-01-18T04:32:26.191Z",
-      "updated_at": "2025-01-18T04:32:26.191Z"
+      "created_at": "2025-01-23T12:20:38.886Z",
+      "updated_at": "2025-01-23T12:20:38.886Z"
     }
   }
 }

--- a/Pirimid/SellerApp/Retail/RET-10/FLOW_3/init.json
+++ b/Pirimid/SellerApp/Retail/RET-10/FLOW_3/init.json
@@ -8,9 +8,9 @@
     "bap_id": "buyer-app-preprod-v2.ondc.org",
     "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
     "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-    "transaction_id": "2765f026-17e3-4a3f-a6bb-0b83046ff2c7",
-    "message_id": "c8144888-5c10-4764-84db-4a03c063489c",
-    "timestamp": "2025-01-18T04:32:04.795Z",
+    "transaction_id": "2d4259ff-d365-4419-b86e-eada579d06e7",
+    "message_id": "973a1d1f-fe0f-4c95-a84d-0239065c7f34",
+    "timestamp": "2025-01-23T12:20:17.208Z",
     "bpp_id": "ondc.pirimidtech.com/v2/seller",
     "ttl": "PT30S"
   },
@@ -28,10 +28,18 @@
         {
           "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
           "quantity": {
-            "count": 4
+            "count": 2
           },
           "location_id": "39550822-c3bb-4918-bd25-2d19ef6a9aca",
-          "fulfillment_id": "6c14ebdb-6cb6-4b5c-ab85-4c2acb747973"
+          "fulfillment_id": "18653ff5-041f-4391-a6f6-91a1f5c09695"
+        },
+        {
+          "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
+          "quantity": {
+            "count": 2
+          },
+          "location_id": "39550822-c3bb-4918-bd25-2d19ef6a9aca",
+          "fulfillment_id": "18653ff5-041f-4391-a6f6-91a1f5c09695"
         }
       ],
       "billing": {
@@ -47,12 +55,12 @@
         "phone": "7202959020",
         "name": "Hemanshu Faldu",
         "email": "fhemanshu@gmail.com",
-        "created_at": "2025-01-18T04:32:04.795Z",
-        "updated_at": "2025-01-18T04:32:04.795Z"
+        "created_at": "2025-01-23T12:20:17.208Z",
+        "updated_at": "2025-01-23T12:20:17.208Z"
       },
       "fulfillments": [
         {
-          "id": "6c14ebdb-6cb6-4b5c-ab85-4c2acb747973",
+          "id": "18653ff5-041f-4391-a6f6-91a1f5c09695",
           "type": "Delivery",
           "end": {
             "contact": {

--- a/Pirimid/SellerApp/Retail/RET-10/FLOW_3/log_validation_utility_request.json
+++ b/Pirimid/SellerApp/Retail/RET-10/FLOW_3/log_validation_utility_request.json
@@ -13,9 +13,9 @@
                 "core_version": "1.2.0",
                 "bap_id": "buyer-app-preprod-v2.ondc.org",
                 "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
-                "transaction_id": "e53a74c5-7ce6-4498-800c-e7d90db0f2fa",
-                "message_id": "45726578-5033-41e0-b35f-2fcbcebe8f82",
-                "timestamp": "2025-01-17T12:00:01.818Z",
+                "transaction_id": "2a274964-3eec-4793-888c-1d30ef845cd1",
+                "message_id": "c5c58f68-8483-4490-b318-a1436c6ee88b",
+                "timestamp": "2025-01-23T12:00:01.908Z",
                 "ttl": "PT30S"
             },
             "message": {
@@ -41,9 +41,9 @@
                 "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
                 "bpp_id": "ondc.pirimidtech.com/v2/seller",
                 "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-                "transaction_id": "e53a74c5-7ce6-4498-800c-e7d90db0f2fa",
-                "message_id": "45726578-5033-41e0-b35f-2fcbcebe8f82",
-                "timestamp": "2025-01-17T12:00:21.411Z",
+                "transaction_id": "2a274964-3eec-4793-888c-1d30ef845cd1",
+                "message_id": "c5c58f68-8483-4490-b318-a1436c6ee88b",
+                "timestamp": "2025-01-23T12:00:21.519Z",
                 "ttl": "PT30S"
             },
             "message": {
@@ -90,70 +90,8 @@
                             "@ondc/org/fssai_license_no": "12345678912345",
                             "time": {
                                 "label": "enable",
-                                "timestamp": "2025-01-17T12:00:21.411Z"
+                                "timestamp": "2025-01-23T12:00:21.519Z"
                             },
-                            "categories": [
-                                {
-                                    "id": "variant10000",
-                                    "descriptor": {
-                                        "name": "Variant for Nutraj-California-Almonds-1Kg"
-                                    },
-                                    "tags": [
-                                        {
-                                            "code": "type",
-                                            "list": [
-                                                {
-                                                    "code": "type",
-                                                    "value": "variant_group"
-                                                }
-                                            ]
-                                        },
-                                        {
-                                            "code": "attr",
-                                            "list": [
-                                                {
-                                                    "code": "name",
-                                                    "value": "item.quantity.unitized.measure"
-                                                },
-                                                {
-                                                    "code": "seq",
-                                                    "value": "1"
-                                                }
-                                            ]
-                                        }
-                                    ]
-                                },
-                                {
-                                    "id": "variant10001",
-                                    "descriptor": {
-                                        "name": "Variant for Cashews"
-                                    },
-                                    "tags": [
-                                        {
-                                            "code": "type",
-                                            "list": [
-                                                {
-                                                    "code": "type",
-                                                    "value": "variant_group"
-                                                }
-                                            ]
-                                        },
-                                        {
-                                            "code": "attr",
-                                            "list": [
-                                                {
-                                                    "code": "name",
-                                                    "value": "item.quantity.unitized.measure"
-                                                },
-                                                {
-                                                    "code": "seq",
-                                                    "value": "1"
-                                                }
-                                            ]
-                                        }
-                                    ]
-                                }
-                            ],
                             "fulfillments": [
                                 {
                                     "id": "1",
@@ -173,11 +111,11 @@
                                         "locality": "Ashok Vatika",
                                         "city": "Ahmedabad",
                                         "state": "Gujarat",
-                                        "area_code": "380058"
+                                        "area_code": "380054"
                                     },
                                     "time": {
                                         "label": "enable",
-                                        "timestamp": "2024-12-04T13:50:34.608Z",
+                                        "timestamp": "2025-01-22T07:34:34.534Z",
                                         "range": {
                                             "start": "0930",
                                             "end": "1930"
@@ -194,12 +132,85 @@
                             ],
                             "items": [
                                 {
+                                    "id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+                                    "descriptor": {
+                                        "name": "Walnuts",
+                                        "code": "1:12345678",
+                                        "symbol": "https://c8.alamy.com/comp/2HCTDG2/modern-design-walnut-leaf-nature-green-logo-design-2HCTDG2.jpg",
+                                        "short_desc": "WONDERLAND California Whole Walnut Walnuts (Akhrot)  (500 g)",
+                                        "long_desc": "WONDERLAND California Whole Walnut Walnuts (Akhrot)  (500 g)",
+                                        "images": [
+                                            "https://rukminim2.flixcart.com/image/416/416/xif0q/nut-dry-fruit/h/x/t/500-california-whole-walnut-1-pouch-wonderland-original-imagy632bnvk8fde.jpeg?q=70",
+                                            "https://rukminim2.flixcart.com/image/416/416/xif0q/nut-dry-fruit/q/r/t/500-california-whole-walnut-1-pouch-wonderland-original-imagy6326hdk68cd.jpeg?q=70"
+                                        ]
+                                    },
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "120.0",
+                                        "maximum_value": "200.0"
+                                    },
+                                    "quantity": {
+                                        "available": {
+                                            "count": "99"
+                                        },
+                                        "maximum": {
+                                            "count": "99"
+                                        },
+                                        "unitized": {
+                                            "measure": {
+                                                "value": "500",
+                                                "unit": "gram"
+                                            }
+                                        }
+                                    },
+                                    "category_id": "Snacks, Dry Fruits, Nuts",
+                                    "fulfillment_id": "1",
+                                    "location_id": "39550822-c3bb-4918-bd25-2d19ef6a9aca",
+                                    "time": {
+                                        "label": "enable",
+                                        "timestamp": "2025-01-23T12:00:21.519Z"
+                                    },
+                                    "@ondc/org/returnable": true,
+                                    "@ondc/org/seller_pickup_return": false,
+                                    "@ondc/org/return_window": "P7D",
+                                    "@ondc/org/cancellable": true,
+                                    "@ondc/org/time_to_ship": "PT3H",
+                                    "@ondc/org/available_on_cod": false,
+                                    "@ondc/org/contact_details_consumer_care": "PirimidFintech,user@gmail.com,7744774477",
+                                    "@ondc/org/statutory_reqs_prepackaged_food": {
+                                        "nutritional_info": "nutritional_info",
+                                        "additives_info": "additives_info",
+                                        "brand_owner_FSSAI_license_no": "12345678912345",
+                                        "other_FSSAI_license_no": "12345678912345",
+                                        "importer_FSSAI_license_no": "12345678912345"
+                                    },
+                                    "tags": [
+                                        {
+                                            "code": "origin",
+                                            "list": [
+                                                {
+                                                    "code": "Country",
+                                                    "value": "IND"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "veg_nonveg",
+                                            "list": [
+                                                {
+                                                    "code": "veg",
+                                                    "value": "yes"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                {
                                     "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
-                                    "parent_item_id": "variant10000",
                                     "descriptor": {
                                         "name": "Nutraj-California-Almonds-1Kg",
                                         "code": "1:12345678",
-                                        "symbol": "symbols.in/symbol.jpg",
+                                        "symbol": "https://img.freepik.com/premium-vector/almonds-nuts-nature-farm-vintage-logo-icon-symbol-vector-illustration-minimalist-design_889650-491.jpg?semt=ais_hybrid",
                                         "short_desc": "Nutraj California Almond kernels 1kg Pouch|Badam Giri|Dry Fruits and Nuts|Grocery",
                                         "long_desc": "Nutraj California Almond kernels 1kg Pouch|Badam Giri|Dry Fruits and Nuts|Grocery",
                                         "images": [
@@ -230,7 +241,7 @@
                                     "location_id": "39550822-c3bb-4918-bd25-2d19ef6a9aca",
                                     "time": {
                                         "label": "enable",
-                                        "timestamp": "2025-01-17T12:00:21.411Z"
+                                        "timestamp": "2025-01-23T12:00:21.519Z"
                                     },
                                     "@ondc/org/returnable": true,
                                     "@ondc/org/seller_pickup_return": false,
@@ -269,11 +280,10 @@
                                 },
                                 {
                                     "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
-                                    "parent_item_id": "variant10001",
                                     "descriptor": {
                                         "name": "Cashews",
                                         "code": "1:12345678",
-                                        "symbol": "symbols.in/symbol.jpg",
+                                        "symbol": "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTVlckKW1pwOvmkj9_s_rPbAvcsr_EdmIStMA&s",
                                         "short_desc": "Emart Brand - Vedaka Whole Cashews | 500 Gram | Kaju Nuts Grade W320 | Plant Based Protein | Gluten-Free | Nutty Flavor | Healthy Snack | Rich Delicious Taste",
                                         "long_desc": "Emart Brand - Vedaka Whole Cashews | 500 Gram | Kaju Nuts Grade W320 | Plant Based Protein | Gluten-Free | Nutty Flavor | Healthy Snack | Rich Delicious Taste",
                                         "images": [
@@ -283,7 +293,7 @@
                                     "price": {
                                         "currency": "INR",
                                         "value": "120.0",
-                                        "maximum_value": "258.0"
+                                        "maximum_value": "212.0"
                                     },
                                     "quantity": {
                                         "available": {
@@ -294,8 +304,8 @@
                                         },
                                         "unitized": {
                                             "measure": {
-                                                "value": "1",
-                                                "unit": "kilogram"
+                                                "value": "500",
+                                                "unit": "gram"
                                             }
                                         }
                                     },
@@ -304,7 +314,7 @@
                                     "location_id": "39550822-c3bb-4918-bd25-2d19ef6a9aca",
                                     "time": {
                                         "label": "enable",
-                                        "timestamp": "2025-01-17T12:00:21.411Z"
+                                        "timestamp": "2025-01-23T12:00:21.519Z"
                                     },
                                     "@ondc/org/returnable": true,
                                     "@ondc/org/seller_pickup_return": false,
@@ -374,36 +384,7 @@
                                     "list": [
                                         {
                                             "code": "type",
-                                            "value": "Order"
-                                        },
-                                        {
-                                            "code": "location",
-                                            "value": "39550822-c3bb-4918-bd25-2d19ef6a9aca"
-                                        },
-                                        {
-                                            "code": "day_from",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "day_to",
-                                            "value": "7"
-                                        },
-                                        {
-                                            "code": "time_from",
-                                            "value": "0930"
-                                        },
-                                        {
-                                            "code": "time_to",
-                                            "value": "1930"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "timing",
-                                    "list": [
-                                        {
-                                            "code": "type",
-                                            "value": "Delivery"
+                                            "value": "All"
                                         },
                                         {
                                             "code": "location",
@@ -443,9 +424,9 @@
                 "bap_id": "buyer-app-preprod-v2.ondc.org",
                 "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
                 "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-                "transaction_id": "2765f026-17e3-4a3f-a6bb-0b83046ff2c7",
-                "message_id": "08530f56-219f-4612-bf6e-99ad6d68cb1d",
-                "timestamp": "2025-01-18T04:31:38.213Z",
+                "transaction_id": "2d4259ff-d365-4419-b86e-eada579d06e7",
+                "message_id": "9e4cdbf9-cc86-4a8e-a05b-b163cbcf0b9b",
+                "timestamp": "2025-01-23T12:19:55.257Z",
                 "bpp_id": "ondc.pirimidtech.com/v2/seller",
                 "ttl": "PT30S"
             },
@@ -455,14 +436,21 @@
                         {
                             "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
                             "quantity": {
-                                "count": 4
+                                "count": 2
                             },
                             "location_id": "39550822-c3bb-4918-bd25-2d19ef6a9aca"
                         },
                         {
                             "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
                             "quantity": {
-                                "count": 3
+                                "count": 2
+                            },
+                            "location_id": "39550822-c3bb-4918-bd25-2d19ef6a9aca"
+                        },
+                        {
+                            "id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+                            "quantity": {
+                                "count": 2
                             },
                             "location_id": "39550822-c3bb-4918-bd25-2d19ef6a9aca"
                         }
@@ -501,9 +489,9 @@
                 "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
                 "bpp_id": "ondc.pirimidtech.com/v2/seller",
                 "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-                "transaction_id": "2765f026-17e3-4a3f-a6bb-0b83046ff2c7",
-                "message_id": "08530f56-219f-4612-bf6e-99ad6d68cb1d",
-                "timestamp": "2025-01-18T04:31:39.702Z"
+                "transaction_id": "2d4259ff-d365-4419-b86e-eada579d06e7",
+                "message_id": "9e4cdbf9-cc86-4a8e-a05b-b163cbcf0b9b",
+                "timestamp": "2025-01-23T12:19:57.186Z"
             },
             "message": {
                 "order": {
@@ -518,16 +506,20 @@
                     "items": [
                         {
                             "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
-                            "fulfillment_id": "b461394b-97f4-4eb0-a43c-72729c30344e"
+                            "fulfillment_id": "1ec0398b-10ea-4a2b-8acd-37bd0a405ece"
                         },
                         {
                             "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
-                            "fulfillment_id": "b461394b-97f4-4eb0-a43c-72729c30344e"
+                            "fulfillment_id": "1ec0398b-10ea-4a2b-8acd-37bd0a405ece"
+                        },
+                        {
+                            "id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+                            "fulfillment_id": "1ec0398b-10ea-4a2b-8acd-37bd0a405ece"
                         }
                     ],
                     "fulfillments": [
                         {
-                            "id": "b461394b-97f4-4eb0-a43c-72729c30344e",
+                            "id": "1ec0398b-10ea-4a2b-8acd-37bd0a405ece",
                             "type": "Delivery",
                             "@ondc/org/category": "Standard Delivery",
                             "@ondc/org/TAT": "PT99H",
@@ -543,13 +535,13 @@
                     "quote": {
                         "price": {
                             "currency": "INR",
-                            "value": "1189.92"
+                            "value": "1007.05"
                         },
                         "breakup": [
                             {
                                 "@ondc/org/item_id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
                                 "@ondc/org/item_quantity": {
-                                    "count": 4
+                                    "count": 2
                                 },
                                 "@ondc/org/title_type": "item",
                                 "item": {
@@ -569,11 +561,11 @@
                                 "title": "Nutraj-California-Almonds-1Kg",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "880.0"
+                                    "value": "440.0"
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "b461394b-97f4-4eb0-a43c-72729c30344e",
+                                "@ondc/org/item_id": "1ec0398b-10ea-4a2b-8acd-37bd0a405ece",
                                 "@ondc/org/title_type": "packing",
                                 "title": "Packing Charges",
                                 "price": {
@@ -582,7 +574,7 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "b461394b-97f4-4eb0-a43c-72729c30344e",
+                                "@ondc/org/item_id": "1ec0398b-10ea-4a2b-8acd-37bd0a405ece",
                                 "@ondc/org/title_type": "delivery",
                                 "title": "Delivery Charges",
                                 "price": {
@@ -596,11 +588,55 @@
                                 "title": "Tax",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "162.8"
+                                    "value": "81.4"
                                 }
                             },
                             {
                                 "@ondc/org/item_id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
+                                "@ondc/org/item_quantity": {
+                                    "count": 2
+                                },
+                                "@ondc/org/title_type": "item",
+                                "item": {
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "120.0"
+                                    },
+                                    "quantity": {
+                                        "available": {
+                                            "count": "99"
+                                        },
+                                        "maximum": {
+                                            "count": "99"
+                                        }
+                                    }
+                                },
+                                "title": "Cashews",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "240.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "1ec0398b-10ea-4a2b-8acd-37bd0a405ece",
+                                "@ondc/org/title_type": "packing",
+                                "title": "Packing Charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "5.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "1ec0398b-10ea-4a2b-8acd-37bd0a405ece",
+                                "@ondc/org/title_type": "delivery",
+                                "title": "Delivery Charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "100.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
                                 "@ondc/org/item_quantity": {
                                     "count": 0
                                 },
@@ -619,14 +655,14 @@
                                         }
                                     }
                                 },
-                                "title": "Cashews",
+                                "title": "Walnuts",
                                 "price": {
                                     "currency": "INR",
                                     "value": "0.0"
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "b461394b-97f4-4eb0-a43c-72729c30344e",
+                                "@ondc/org/item_id": "1ec0398b-10ea-4a2b-8acd-37bd0a405ece",
                                 "@ondc/org/title_type": "packing",
                                 "title": "Packing Charges",
                                 "price": {
@@ -635,7 +671,7 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "b461394b-97f4-4eb0-a43c-72729c30344e",
+                                "@ondc/org/item_id": "1ec0398b-10ea-4a2b-8acd-37bd0a405ece",
                                 "@ondc/org/title_type": "delivery",
                                 "title": "Delivery Charges",
                                 "price": {
@@ -644,12 +680,12 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "b461394b-97f4-4eb0-a43c-72729c30344e",
+                                "@ondc/org/item_id": "1ec0398b-10ea-4a2b-8acd-37bd0a405ece",
                                 "@ondc/org/title_type": "misc",
                                 "title": "Convenience Fee",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "42.12"
+                                    "value": "35.65"
                                 }
                             }
                         ],
@@ -660,7 +696,7 @@
             "error": {
                 "type": "DOMAIN-ERROR",
                 "code": "40002",
-                "message": "[{\"item_id\":\"0984d1dd-b5ea-417f-9104-68a2ec40dbd4\",\"error\":\"40002\"}]"
+                "message": "[{\"item_id\":\"1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7\",\"error\":\"40002\"}]"
             }
         },
         "select": {
@@ -673,9 +709,9 @@
                 "bap_id": "buyer-app-preprod-v2.ondc.org",
                 "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
                 "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-                "transaction_id": "2765f026-17e3-4a3f-a6bb-0b83046ff2c7",
-                "message_id": "5a59a9e8-6a51-40b6-a213-1174fd5fa1e6",
-                "timestamp": "2025-01-18T04:31:55.082Z",
+                "transaction_id": "2d4259ff-d365-4419-b86e-eada579d06e7",
+                "message_id": "070acea7-6306-47a0-a43a-9c4af2ee2f95",
+                "timestamp": "2025-01-23T12:20:07.850Z",
                 "bpp_id": "ondc.pirimidtech.com/v2/seller",
                 "ttl": "PT30S"
             },
@@ -685,7 +721,14 @@
                         {
                             "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
                             "quantity": {
-                                "count": 4
+                                "count": 2
+                            },
+                            "location_id": "39550822-c3bb-4918-bd25-2d19ef6a9aca"
+                        },
+                        {
+                            "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
+                            "quantity": {
+                                "count": 2
                             },
                             "location_id": "39550822-c3bb-4918-bd25-2d19ef6a9aca"
                         }
@@ -724,9 +767,9 @@
                 "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
                 "bpp_id": "ondc.pirimidtech.com/v2/seller",
                 "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-                "transaction_id": "2765f026-17e3-4a3f-a6bb-0b83046ff2c7",
-                "message_id": "5a59a9e8-6a51-40b6-a213-1174fd5fa1e6",
-                "timestamp": "2025-01-18T04:31:55.833Z"
+                "transaction_id": "2d4259ff-d365-4419-b86e-eada579d06e7",
+                "message_id": "070acea7-6306-47a0-a43a-9c4af2ee2f95",
+                "timestamp": "2025-01-23T12:20:08.741Z"
             },
             "message": {
                 "order": {
@@ -741,15 +784,19 @@
                     "items": [
                         {
                             "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
-                            "fulfillment_id": "6c14ebdb-6cb6-4b5c-ab85-4c2acb747973"
+                            "fulfillment_id": "18653ff5-041f-4391-a6f6-91a1f5c09695"
+                        },
+                        {
+                            "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
+                            "fulfillment_id": "18653ff5-041f-4391-a6f6-91a1f5c09695"
                         }
                     ],
                     "fulfillments": [
                         {
-                            "id": "6c14ebdb-6cb6-4b5c-ab85-4c2acb747973",
+                            "id": "18653ff5-041f-4391-a6f6-91a1f5c09695",
                             "type": "Delivery",
                             "@ondc/org/category": "Standard Delivery",
-                            "@ondc/org/TAT": "PT74H",
+                            "@ondc/org/TAT": "PT99H",
                             "@ondc/org/provider_name": "LoadShare",
                             "state": {
                                 "descriptor": {
@@ -762,13 +809,13 @@
                     "quote": {
                         "price": {
                             "currency": "INR",
-                            "value": "1189.92"
+                            "value": "1007.05"
                         },
                         "breakup": [
                             {
                                 "@ondc/org/item_id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
                                 "@ondc/org/item_quantity": {
-                                    "count": 4
+                                    "count": 2
                                 },
                                 "@ondc/org/title_type": "item",
                                 "item": {
@@ -788,11 +835,11 @@
                                 "title": "Nutraj-California-Almonds-1Kg",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "880.0"
+                                    "value": "440.0"
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "6c14ebdb-6cb6-4b5c-ab85-4c2acb747973",
+                                "@ondc/org/item_id": "18653ff5-041f-4391-a6f6-91a1f5c09695",
                                 "@ondc/org/title_type": "packing",
                                 "title": "Packing Charges",
                                 "price": {
@@ -801,7 +848,7 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "6c14ebdb-6cb6-4b5c-ab85-4c2acb747973",
+                                "@ondc/org/item_id": "18653ff5-041f-4391-a6f6-91a1f5c09695",
                                 "@ondc/org/title_type": "delivery",
                                 "title": "Delivery Charges",
                                 "price": {
@@ -815,16 +862,60 @@
                                 "title": "Tax",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "162.8"
+                                    "value": "81.4"
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "6c14ebdb-6cb6-4b5c-ab85-4c2acb747973",
+                                "@ondc/org/item_id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
+                                "@ondc/org/item_quantity": {
+                                    "count": 2
+                                },
+                                "@ondc/org/title_type": "item",
+                                "item": {
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "120.0"
+                                    },
+                                    "quantity": {
+                                        "available": {
+                                            "count": "99"
+                                        },
+                                        "maximum": {
+                                            "count": "99"
+                                        }
+                                    }
+                                },
+                                "title": "Cashews",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "240.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "18653ff5-041f-4391-a6f6-91a1f5c09695",
+                                "@ondc/org/title_type": "packing",
+                                "title": "Packing Charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "5.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "18653ff5-041f-4391-a6f6-91a1f5c09695",
+                                "@ondc/org/title_type": "delivery",
+                                "title": "Delivery Charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "100.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "18653ff5-041f-4391-a6f6-91a1f5c09695",
                                 "@ondc/org/title_type": "misc",
                                 "title": "Convenience Fee",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "42.12"
+                                    "value": "35.65"
                                 }
                             }
                         ],
@@ -843,9 +934,9 @@
                 "bap_id": "buyer-app-preprod-v2.ondc.org",
                 "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
                 "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-                "transaction_id": "2765f026-17e3-4a3f-a6bb-0b83046ff2c7",
-                "message_id": "c8144888-5c10-4764-84db-4a03c063489c",
-                "timestamp": "2025-01-18T04:32:04.795Z",
+                "transaction_id": "2d4259ff-d365-4419-b86e-eada579d06e7",
+                "message_id": "973a1d1f-fe0f-4c95-a84d-0239065c7f34",
+                "timestamp": "2025-01-23T12:20:17.208Z",
                 "bpp_id": "ondc.pirimidtech.com/v2/seller",
                 "ttl": "PT30S"
             },
@@ -863,10 +954,18 @@
                         {
                             "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
                             "quantity": {
-                                "count": 4
+                                "count": 2
                             },
                             "location_id": "39550822-c3bb-4918-bd25-2d19ef6a9aca",
-                            "fulfillment_id": "6c14ebdb-6cb6-4b5c-ab85-4c2acb747973"
+                            "fulfillment_id": "18653ff5-041f-4391-a6f6-91a1f5c09695"
+                        },
+                        {
+                            "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
+                            "quantity": {
+                                "count": 2
+                            },
+                            "location_id": "39550822-c3bb-4918-bd25-2d19ef6a9aca",
+                            "fulfillment_id": "18653ff5-041f-4391-a6f6-91a1f5c09695"
                         }
                     ],
                     "billing": {
@@ -882,12 +981,12 @@
                         "phone": "7202959020",
                         "name": "Hemanshu Faldu",
                         "email": "fhemanshu@gmail.com",
-                        "created_at": "2025-01-18T04:32:04.795Z",
-                        "updated_at": "2025-01-18T04:32:04.795Z"
+                        "created_at": "2025-01-23T12:20:17.208Z",
+                        "updated_at": "2025-01-23T12:20:17.208Z"
                     },
                     "fulfillments": [
                         {
-                            "id": "6c14ebdb-6cb6-4b5c-ab85-4c2acb747973",
+                            "id": "18653ff5-041f-4391-a6f6-91a1f5c09695",
                             "type": "Delivery",
                             "end": {
                                 "contact": {
@@ -923,9 +1022,9 @@
                 "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
                 "bpp_id": "ondc.pirimidtech.com/v2/seller",
                 "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-                "transaction_id": "2765f026-17e3-4a3f-a6bb-0b83046ff2c7",
-                "message_id": "c8144888-5c10-4764-84db-4a03c063489c",
-                "timestamp": "2025-01-18T04:32:05.577Z",
+                "transaction_id": "2d4259ff-d365-4419-b86e-eada579d06e7",
+                "message_id": "973a1d1f-fe0f-4c95-a84d-0239065c7f34",
+                "timestamp": "2025-01-23T12:20:18.033Z",
                 "ttl": "PT30S"
             },
             "message": {
@@ -943,11 +1042,21 @@
                             "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
                             "quantity": {
                                 "unitized": {
-                                    "count": "4"
+                                    "count": "2"
                                 },
-                                "count": 4
+                                "count": 2
                             },
-                            "fulfillment_id": "6c14ebdb-6cb6-4b5c-ab85-4c2acb747973"
+                            "fulfillment_id": "18653ff5-041f-4391-a6f6-91a1f5c09695"
+                        },
+                        {
+                            "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
+                            "quantity": {
+                                "unitized": {
+                                    "count": "2"
+                                },
+                                "count": 2
+                            },
+                            "fulfillment_id": "18653ff5-041f-4391-a6f6-91a1f5c09695"
                         }
                     ],
                     "billing": {
@@ -963,19 +1072,13 @@
                         },
                         "email": "fhemanshu@gmail.com",
                         "phone": "7202959020",
-                        "created_at": "2025-01-18T04:32:04.795Z",
-                        "updated_at": "2025-01-18T04:32:04.795Z"
+                        "created_at": "2025-01-23T12:20:17.208Z",
+                        "updated_at": "2025-01-23T12:20:17.208Z"
                     },
                     "fulfillments": [
                         {
-                            "id": "6c14ebdb-6cb6-4b5c-ab85-4c2acb747973",
+                            "id": "18653ff5-041f-4391-a6f6-91a1f5c09695",
                             "type": "Delivery",
-                            "provider_id": "ondc.loadshare.com/ondc/18275",
-                            "state": {
-                                "descriptor": {
-                                    "code": "INITIALIZING"
-                                }
-                            },
                             "tracking": false,
                             "end": {
                                 "location": {
@@ -989,9 +1092,6 @@
                                         "country": "IND",
                                         "area_code": "380015"
                                     }
-                                },
-                                "time": {
-                                    "range": {}
                                 },
                                 "instructions": {
                                     "name": "Status for pickup",
@@ -1012,13 +1112,13 @@
                     "quote": {
                         "price": {
                             "currency": "INR",
-                            "value": "1189.92"
+                            "value": "1007.05"
                         },
                         "breakup": [
                             {
                                 "@ondc/org/item_id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
                                 "@ondc/org/item_quantity": {
-                                    "count": 4
+                                    "count": 2
                                 },
                                 "@ondc/org/title_type": "item",
                                 "item": {
@@ -1030,11 +1130,11 @@
                                 "title": "Nutraj-California-Almonds-1Kg",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "880.0"
+                                    "value": "440.0"
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "6c14ebdb-6cb6-4b5c-ab85-4c2acb747973",
+                                "@ondc/org/item_id": "18653ff5-041f-4391-a6f6-91a1f5c09695",
                                 "@ondc/org/title_type": "packing",
                                 "title": "Packing Charges",
                                 "price": {
@@ -1043,7 +1143,7 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "6c14ebdb-6cb6-4b5c-ab85-4c2acb747973",
+                                "@ondc/org/item_id": "18653ff5-041f-4391-a6f6-91a1f5c09695",
                                 "@ondc/org/title_type": "delivery",
                                 "title": "Delivery Charges",
                                 "price": {
@@ -1057,26 +1157,62 @@
                                 "title": "Tax",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "162.8"
+                                    "value": "81.4"
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "6c14ebdb-6cb6-4b5c-ab85-4c2acb747973",
+                                "@ondc/org/item_id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
+                                "@ondc/org/item_quantity": {
+                                    "count": 2
+                                },
+                                "@ondc/org/title_type": "item",
+                                "item": {
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "120.0"
+                                    }
+                                },
+                                "title": "Cashews",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "240.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "18653ff5-041f-4391-a6f6-91a1f5c09695",
+                                "@ondc/org/title_type": "packing",
+                                "title": "Packing Charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "5.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "18653ff5-041f-4391-a6f6-91a1f5c09695",
+                                "@ondc/org/title_type": "delivery",
+                                "title": "Delivery Charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "100.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "18653ff5-041f-4391-a6f6-91a1f5c09695",
                                 "@ondc/org/title_type": "misc",
                                 "title": "Convenience Fee",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "42.12"
+                                    "value": "35.65"
                                 }
                             }
                         ],
                         "ttl": "P1D"
                     },
                     "payment": {
-                        "uri": "https://ondc-pirimid-payment.netlify.app/payment/2765f026-17e3-4a3f-a6bb-0b83046ff2c7",
+                        "uri": "https://ondc-pirimid-payment.netlify.app/payment/2d4259ff-d365-4419-b86e-eada579d06e7",
                         "type": "ON-ORDER",
                         "status": "NOT-PAID",
-                        "collected_by": "BPP",
+                        "collected_by": "BAP",
                         "@ondc/org/buyer_app_finder_fee_type": "percent",
                         "@ondc/org/buyer_app_finder_fee_amount": "3.0",
                         "@ondc/org/withholding_amount": "0.0",
@@ -1096,8 +1232,8 @@
                             }
                         ]
                     },
-                    "created_at": "2025-01-18T04:31:39.713Z",
-                    "updated_at": "2025-01-18T04:32:05.587Z",
+                    "created_at": "2025-01-23T12:19:57.201Z",
+                    "updated_at": "2025-01-23T12:20:18.048Z",
                     "tags": [
                         {
                             "code": "bpp_terms",
@@ -1126,15 +1262,15 @@
                 "bap_id": "buyer-app-preprod-v2.ondc.org",
                 "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
                 "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-                "transaction_id": "2765f026-17e3-4a3f-a6bb-0b83046ff2c7",
-                "message_id": "02d13e63-f067-4678-b26d-a7d118ae73d2",
-                "timestamp": "2025-01-18T04:32:26.191Z",
+                "transaction_id": "2d4259ff-d365-4419-b86e-eada579d06e7",
+                "message_id": "228f4f99-723d-4b19-ac1f-035da1c19acd",
+                "timestamp": "2025-01-23T12:20:38.886Z",
                 "bpp_id": "ondc.pirimidtech.com/v2/seller",
                 "ttl": "PT30S"
             },
             "message": {
                 "order": {
-                    "id": "2025-01-18-499387",
+                    "id": "2025-01-23-190156",
                     "state": "Created",
                     "billing": {
                         "address": {
@@ -1149,16 +1285,23 @@
                         "phone": "7202959020",
                         "name": "Hemanshu Faldu",
                         "email": "fhemanshu@gmail.com",
-                        "created_at": "2025-01-18T04:32:04.795Z",
-                        "updated_at": "2025-01-18T04:32:04.795Z"
+                        "created_at": "2025-01-23T12:20:17.208Z",
+                        "updated_at": "2025-01-23T12:20:17.208Z"
                     },
                     "items": [
                         {
                             "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
                             "quantity": {
-                                "count": 4
+                                "count": 2
                             },
-                            "fulfillment_id": "6c14ebdb-6cb6-4b5c-ab85-4c2acb747973"
+                            "fulfillment_id": "18653ff5-041f-4391-a6f6-91a1f5c09695"
+                        },
+                        {
+                            "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
+                            "quantity": {
+                                "count": 2
+                            },
+                            "fulfillment_id": "18653ff5-041f-4391-a6f6-91a1f5c09695"
                         }
                     ],
                     "provider": {
@@ -1171,8 +1314,8 @@
                     },
                     "fulfillments": [
                         {
-                            "@ondc/org/TAT": "PT74H",
-                            "id": "6c14ebdb-6cb6-4b5c-ab85-4c2acb747973",
+                            "@ondc/org/TAT": "PT99H",
+                            "id": "18653ff5-041f-4391-a6f6-91a1f5c09695",
                             "tracking": false,
                             "end": {
                                 "contact": {
@@ -1202,9 +1345,9 @@
                         "uri": "https://razorpay.com/",
                         "tl_method": "http/get",
                         "params": {
-                            "amount": "1189.92",
+                            "amount": "1007.05",
                             "currency": "INR",
-                            "transaction_id": "order_Pkm8SsI9aoMbkW"
+                            "transaction_id": "order_Pmsmecg6gruGAW"
                         },
                         "status": "PAID",
                         "type": "ON-ORDER",
@@ -1231,13 +1374,13 @@
                     "quote": {
                         "price": {
                             "currency": "INR",
-                            "value": "1189.92"
+                            "value": "1007.05"
                         },
                         "breakup": [
                             {
                                 "@ondc/org/item_id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
                                 "@ondc/org/item_quantity": {
-                                    "count": 4
+                                    "count": 2
                                 },
                                 "@ondc/org/title_type": "item",
                                 "item": {
@@ -1249,11 +1392,11 @@
                                 "title": "Nutraj-California-Almonds-1Kg",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "880.0"
+                                    "value": "440.0"
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "6c14ebdb-6cb6-4b5c-ab85-4c2acb747973",
+                                "@ondc/org/item_id": "18653ff5-041f-4391-a6f6-91a1f5c09695",
                                 "@ondc/org/title_type": "packing",
                                 "title": "Packing Charges",
                                 "price": {
@@ -1262,7 +1405,7 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "6c14ebdb-6cb6-4b5c-ab85-4c2acb747973",
+                                "@ondc/org/item_id": "18653ff5-041f-4391-a6f6-91a1f5c09695",
                                 "@ondc/org/title_type": "delivery",
                                 "title": "Delivery Charges",
                                 "price": {
@@ -1276,16 +1419,52 @@
                                 "title": "Tax",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "162.8"
+                                    "value": "81.4"
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "6c14ebdb-6cb6-4b5c-ab85-4c2acb747973",
+                                "@ondc/org/item_id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
+                                "@ondc/org/item_quantity": {
+                                    "count": 2
+                                },
+                                "@ondc/org/title_type": "item",
+                                "item": {
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "120.0"
+                                    }
+                                },
+                                "title": "Cashews",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "240.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "18653ff5-041f-4391-a6f6-91a1f5c09695",
+                                "@ondc/org/title_type": "packing",
+                                "title": "Packing Charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "5.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "18653ff5-041f-4391-a6f6-91a1f5c09695",
+                                "@ondc/org/title_type": "delivery",
+                                "title": "Delivery Charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "100.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "18653ff5-041f-4391-a6f6-91a1f5c09695",
                                 "@ondc/org/title_type": "misc",
                                 "title": "Convenience Fee",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "42.12"
+                                    "value": "35.65"
                                 }
                             }
                         ],
@@ -1315,8 +1494,8 @@
                             ]
                         }
                     ],
-                    "created_at": "2025-01-18T04:32:26.191Z",
-                    "updated_at": "2025-01-18T04:32:26.191Z"
+                    "created_at": "2025-01-23T12:20:38.886Z",
+                    "updated_at": "2025-01-23T12:20:38.886Z"
                 }
             }
         },
@@ -1331,13 +1510,13 @@
                 "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
                 "bpp_id": "ondc.pirimidtech.com/v2/seller",
                 "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-                "transaction_id": "2765f026-17e3-4a3f-a6bb-0b83046ff2c7",
-                "message_id": "02d13e63-f067-4678-b26d-a7d118ae73d2",
-                "timestamp": "2025-01-18T04:32:27.039Z"
+                "transaction_id": "2d4259ff-d365-4419-b86e-eada579d06e7",
+                "message_id": "228f4f99-723d-4b19-ac1f-035da1c19acd",
+                "timestamp": "2025-01-23T12:20:39.826Z"
             },
             "message": {
                 "order": {
-                    "id": "2025-01-18-499387",
+                    "id": "2025-01-23-190156",
                     "state": "Created",
                     "provider": {
                         "id": "e2008459-7e90-493e-b02e-cae52ca53214",
@@ -1351,9 +1530,16 @@
                         {
                             "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
                             "quantity": {
-                                "count": 4
+                                "count": 2
                             },
-                            "fulfillment_id": "6c14ebdb-6cb6-4b5c-ab85-4c2acb747973"
+                            "fulfillment_id": "18653ff5-041f-4391-a6f6-91a1f5c09695"
+                        },
+                        {
+                            "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
+                            "quantity": {
+                                "count": 2
+                            },
+                            "fulfillment_id": "18653ff5-041f-4391-a6f6-91a1f5c09695"
                         }
                     ],
                     "billing": {
@@ -1369,14 +1555,14 @@
                         },
                         "email": "fhemanshu@gmail.com",
                         "phone": "7202959020",
-                        "created_at": "2025-01-18T04:32:04.795Z",
-                        "updated_at": "2025-01-18T04:32:04.795Z"
+                        "created_at": "2025-01-23T12:20:17.208Z",
+                        "updated_at": "2025-01-23T12:20:17.208Z"
                     },
                     "fulfillments": [
                         {
-                            "id": "6c14ebdb-6cb6-4b5c-ab85-4c2acb747973",
+                            "id": "18653ff5-041f-4391-a6f6-91a1f5c09695",
                             "type": "Delivery",
-                            "@ondc/org/TAT": "PT74H",
+                            "@ondc/org/TAT": "PT99H",
                             "@ondc/org/provider_name": "LoadShare",
                             "state": {
                                 "descriptor": {
@@ -1395,7 +1581,7 @@
                                         "locality": "Ashok Vatika",
                                         "city": "Ahmedabad",
                                         "state": "Gujarat",
-                                        "area_code": "380058"
+                                        "area_code": "380054"
                                     }
                                 },
                                 "contact": {
@@ -1429,13 +1615,13 @@
                     "quote": {
                         "price": {
                             "currency": "INR",
-                            "value": "1189.92"
+                            "value": "1007.05"
                         },
                         "breakup": [
                             {
                                 "@ondc/org/item_id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
                                 "@ondc/org/item_quantity": {
-                                    "count": 4
+                                    "count": 2
                                 },
                                 "@ondc/org/title_type": "item",
                                 "item": {
@@ -1447,11 +1633,11 @@
                                 "title": "Nutraj-California-Almonds-1Kg",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "880.0"
+                                    "value": "440.0"
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "6c14ebdb-6cb6-4b5c-ab85-4c2acb747973",
+                                "@ondc/org/item_id": "18653ff5-041f-4391-a6f6-91a1f5c09695",
                                 "@ondc/org/title_type": "packing",
                                 "title": "Packing Charges",
                                 "price": {
@@ -1460,7 +1646,7 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "6c14ebdb-6cb6-4b5c-ab85-4c2acb747973",
+                                "@ondc/org/item_id": "18653ff5-041f-4391-a6f6-91a1f5c09695",
                                 "@ondc/org/title_type": "delivery",
                                 "title": "Delivery Charges",
                                 "price": {
@@ -1474,16 +1660,52 @@
                                 "title": "Tax",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "162.8"
+                                    "value": "81.4"
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "6c14ebdb-6cb6-4b5c-ab85-4c2acb747973",
+                                "@ondc/org/item_id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
+                                "@ondc/org/item_quantity": {
+                                    "count": 2
+                                },
+                                "@ondc/org/title_type": "item",
+                                "item": {
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "120.0"
+                                    }
+                                },
+                                "title": "Cashews",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "240.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "18653ff5-041f-4391-a6f6-91a1f5c09695",
+                                "@ondc/org/title_type": "packing",
+                                "title": "Packing Charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "5.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "18653ff5-041f-4391-a6f6-91a1f5c09695",
+                                "@ondc/org/title_type": "delivery",
+                                "title": "Delivery Charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "100.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "18653ff5-041f-4391-a6f6-91a1f5c09695",
                                 "@ondc/org/title_type": "misc",
                                 "title": "Convenience Fee",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "42.12"
+                                    "value": "35.65"
                                 }
                             }
                         ],
@@ -1493,8 +1715,8 @@
                         "uri": "https://razorpay.com/",
                         "tl_method": "http/get",
                         "params": {
-                            "transaction_id": "order_Pkm8SsI9aoMbkW",
-                            "amount": "1189.92",
+                            "transaction_id": "order_Pmsmecg6gruGAW",
+                            "amount": "1007.05",
                             "currency": "INR"
                         },
                         "type": "ON-ORDER",
@@ -1519,8 +1741,8 @@
                             }
                         ]
                     },
-                    "created_at": "2025-01-18T04:32:26.191Z",
-                    "updated_at": "2025-01-18T04:32:27.039Z",
+                    "created_at": "2025-01-23T12:20:38.886Z",
+                    "updated_at": "2025-01-23T12:20:39.826Z",
                     "tags": [
                         {
                             "code": "bpp_terms",
@@ -1563,14 +1785,14 @@
                 "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
                 "bpp_id": "ondc.pirimidtech.com/v2/seller",
                 "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-                "transaction_id": "2765f026-17e3-4a3f-a6bb-0b83046ff2c7",
-                "message_id": "31c7ad9f-0468-48b1-a66c-fd4a600d1c3b",
-                "timestamp": "2025-01-18T04:32:58.890Z",
+                "transaction_id": "2d4259ff-d365-4419-b86e-eada579d06e7",
+                "message_id": "74efe074-21ce-40d4-b502-5f044c481043",
+                "timestamp": "2025-01-23T12:21:25.260Z",
                 "ttl": "PT30S"
             },
             "message": {
                 "order": {
-                    "id": "2025-01-18-499387",
+                    "id": "2025-01-23-190156",
                     "state": "Accepted",
                     "provider": {
                         "id": "e2008459-7e90-493e-b02e-cae52ca53214",
@@ -1584,9 +1806,16 @@
                         {
                             "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
                             "quantity": {
-                                "count": 4
+                                "count": 2
                             },
-                            "fulfillment_id": "6c14ebdb-6cb6-4b5c-ab85-4c2acb747973"
+                            "fulfillment_id": "18653ff5-041f-4391-a6f6-91a1f5c09695"
+                        },
+                        {
+                            "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
+                            "quantity": {
+                                "count": 2
+                            },
+                            "fulfillment_id": "18653ff5-041f-4391-a6f6-91a1f5c09695"
                         }
                     ],
                     "billing": {
@@ -1602,14 +1831,14 @@
                         },
                         "email": "fhemanshu@gmail.com",
                         "phone": "7202959020",
-                        "created_at": "2025-01-18T04:32:04.795Z",
-                        "updated_at": "2025-01-18T04:32:04.795Z"
+                        "created_at": "2025-01-23T12:20:17.208Z",
+                        "updated_at": "2025-01-23T12:20:17.208Z"
                     },
                     "fulfillments": [
                         {
-                            "id": "6c14ebdb-6cb6-4b5c-ab85-4c2acb747973",
+                            "id": "18653ff5-041f-4391-a6f6-91a1f5c09695",
                             "type": "Delivery",
-                            "@ondc/org/TAT": "PT74H",
+                            "@ondc/org/TAT": "PT99H",
                             "provider_id": "ondc.loadshare.com/ondc/18275",
                             "@ondc/org/provider_name": "LoadShare",
                             "state": {
@@ -1629,13 +1858,13 @@
                                         "locality": "Ashok Vatika",
                                         "city": "Ahmedabad",
                                         "state": "Gujarat",
-                                        "area_code": "380058"
+                                        "area_code": "380054"
                                     }
                                 },
                                 "time": {
                                     "range": {
-                                        "start": "2025-01-18T04:32:58.888Z",
-                                        "end": "2025-01-18T06:32:58.888Z"
+                                        "start": "2025-01-23T12:21:25.258Z",
+                                        "end": "2025-01-23T15:21:25.258Z"
                                     }
                                 },
                                 "instructions": {
@@ -1664,8 +1893,8 @@
                                 },
                                 "time": {
                                     "range": {
-                                        "start": "2025-01-18T06:32:58.888Z",
-                                        "end": "2025-01-21T06:32:58.888Z"
+                                        "start": "2025-01-23T15:21:25.258Z",
+                                        "end": "2025-01-27T15:21:25.258Z"
                                     }
                                 },
                                 "contact": {
@@ -1681,13 +1910,13 @@
                     "quote": {
                         "price": {
                             "currency": "INR",
-                            "value": "1189.92"
+                            "value": "1007.05"
                         },
                         "breakup": [
                             {
                                 "@ondc/org/item_id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
                                 "@ondc/org/item_quantity": {
-                                    "count": 4
+                                    "count": 2
                                 },
                                 "@ondc/org/title_type": "item",
                                 "item": {
@@ -1699,11 +1928,11 @@
                                 "title": "Nutraj-California-Almonds-1Kg",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "880.0"
+                                    "value": "440.0"
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "6c14ebdb-6cb6-4b5c-ab85-4c2acb747973",
+                                "@ondc/org/item_id": "18653ff5-041f-4391-a6f6-91a1f5c09695",
                                 "@ondc/org/title_type": "packing",
                                 "title": "Packing Charges",
                                 "price": {
@@ -1712,7 +1941,7 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "6c14ebdb-6cb6-4b5c-ab85-4c2acb747973",
+                                "@ondc/org/item_id": "18653ff5-041f-4391-a6f6-91a1f5c09695",
                                 "@ondc/org/title_type": "delivery",
                                 "title": "Delivery Charges",
                                 "price": {
@@ -1726,16 +1955,52 @@
                                 "title": "Tax",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "162.8"
+                                    "value": "81.4"
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "6c14ebdb-6cb6-4b5c-ab85-4c2acb747973",
+                                "@ondc/org/item_id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
+                                "@ondc/org/item_quantity": {
+                                    "count": 2
+                                },
+                                "@ondc/org/title_type": "item",
+                                "item": {
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "120.0"
+                                    }
+                                },
+                                "title": "Cashews",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "240.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "18653ff5-041f-4391-a6f6-91a1f5c09695",
+                                "@ondc/org/title_type": "packing",
+                                "title": "Packing Charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "5.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "18653ff5-041f-4391-a6f6-91a1f5c09695",
+                                "@ondc/org/title_type": "delivery",
+                                "title": "Delivery Charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "100.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "18653ff5-041f-4391-a6f6-91a1f5c09695",
                                 "@ondc/org/title_type": "misc",
                                 "title": "Convenience Fee",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "42.12"
+                                    "value": "35.65"
                                 }
                             }
                         ],
@@ -1745,8 +2010,8 @@
                         "uri": "https://razorpay.com/",
                         "tl_method": "http/get",
                         "params": {
-                            "transaction_id": "order_Pkm8SsI9aoMbkW",
-                            "amount": "1189.92",
+                            "transaction_id": "order_Pmsmecg6gruGAW",
+                            "amount": "1007.05",
                             "currency": "INR"
                         },
                         "type": "ON-ORDER",
@@ -1771,8 +2036,8 @@
                             }
                         ]
                     },
-                    "created_at": "2025-01-18T04:32:26.191Z",
-                    "updated_at": "2025-01-18T04:32:58.890Z"
+                    "created_at": "2025-01-23T12:20:38.886Z",
+                    "updated_at": "2025-01-23T12:21:25.260Z"
                 }
             }
         },
@@ -1787,14 +2052,14 @@
                 "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
                 "bpp_id": "ondc.pirimidtech.com/v2/seller",
                 "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-                "transaction_id": "2765f026-17e3-4a3f-a6bb-0b83046ff2c7",
-                "message_id": "6abe664c-a170-41d2-b293-3435556e595f",
-                "timestamp": "2025-01-18T04:33:05.146Z",
+                "transaction_id": "2d4259ff-d365-4419-b86e-eada579d06e7",
+                "message_id": "c6b773bf-c154-4ab1-92d5-6f6072dcc320",
+                "timestamp": "2025-01-23T12:21:30.767Z",
                 "ttl": "PT30S"
             },
             "message": {
                 "order": {
-                    "id": "2025-01-18-499387",
+                    "id": "2025-01-23-190156",
                     "state": "In-progress",
                     "provider": {
                         "id": "e2008459-7e90-493e-b02e-cae52ca53214",
@@ -1808,9 +2073,16 @@
                         {
                             "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
                             "quantity": {
-                                "count": 4
+                                "count": 2
                             },
-                            "fulfillment_id": "6c14ebdb-6cb6-4b5c-ab85-4c2acb747973"
+                            "fulfillment_id": "18653ff5-041f-4391-a6f6-91a1f5c09695"
+                        },
+                        {
+                            "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
+                            "quantity": {
+                                "count": 2
+                            },
+                            "fulfillment_id": "18653ff5-041f-4391-a6f6-91a1f5c09695"
                         }
                     ],
                     "billing": {
@@ -1826,14 +2098,14 @@
                         },
                         "email": "fhemanshu@gmail.com",
                         "phone": "7202959020",
-                        "created_at": "2025-01-18T04:32:04.795Z",
-                        "updated_at": "2025-01-18T04:32:04.795Z"
+                        "created_at": "2025-01-23T12:20:17.208Z",
+                        "updated_at": "2025-01-23T12:20:17.208Z"
                     },
                     "fulfillments": [
                         {
-                            "id": "6c14ebdb-6cb6-4b5c-ab85-4c2acb747973",
+                            "id": "18653ff5-041f-4391-a6f6-91a1f5c09695",
                             "type": "Delivery",
-                            "@ondc/org/TAT": "PT74H",
+                            "@ondc/org/TAT": "PT99H",
                             "provider_id": "ondc.loadshare.com/ondc/18275",
                             "@ondc/org/provider_name": "LoadShare",
                             "state": {
@@ -1862,13 +2134,13 @@
                                         "locality": "Ashok Vatika",
                                         "city": "Ahmedabad",
                                         "state": "Gujarat",
-                                        "area_code": "380058"
+                                        "area_code": "380054"
                                     }
                                 },
                                 "time": {
                                     "range": {
-                                        "start": "2025-01-18T04:32:58.888Z",
-                                        "end": "2025-01-18T06:32:58.888Z"
+                                        "start": "2025-01-23T12:21:25.258Z",
+                                        "end": "2025-01-23T15:21:25.258Z"
                                     }
                                 },
                                 "instructions": {
@@ -1897,8 +2169,8 @@
                                 },
                                 "time": {
                                     "range": {
-                                        "start": "2025-01-18T06:32:58.888Z",
-                                        "end": "2025-01-21T06:32:58.888Z"
+                                        "start": "2025-01-23T15:21:25.258Z",
+                                        "end": "2025-01-27T15:21:25.258Z"
                                     }
                                 },
                                 "contact": {
@@ -1908,19 +2180,30 @@
                                 "person": {
                                     "name": "Hemanshu Faldu"
                                 }
-                            }
+                            },
+                            "tags": [
+                                {
+                                    "code": "routing",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "P2P"
+                                        }
+                                    ]
+                                }
+                            ]
                         }
                     ],
                     "quote": {
                         "price": {
                             "currency": "INR",
-                            "value": "1189.92"
+                            "value": "1007.05"
                         },
                         "breakup": [
                             {
                                 "@ondc/org/item_id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
                                 "@ondc/org/item_quantity": {
-                                    "count": 4
+                                    "count": 2
                                 },
                                 "@ondc/org/title_type": "item",
                                 "item": {
@@ -1932,11 +2215,11 @@
                                 "title": "Nutraj-California-Almonds-1Kg",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "880.0"
+                                    "value": "440.0"
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "6c14ebdb-6cb6-4b5c-ab85-4c2acb747973",
+                                "@ondc/org/item_id": "18653ff5-041f-4391-a6f6-91a1f5c09695",
                                 "@ondc/org/title_type": "packing",
                                 "title": "Packing Charges",
                                 "price": {
@@ -1945,7 +2228,7 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "6c14ebdb-6cb6-4b5c-ab85-4c2acb747973",
+                                "@ondc/org/item_id": "18653ff5-041f-4391-a6f6-91a1f5c09695",
                                 "@ondc/org/title_type": "delivery",
                                 "title": "Delivery Charges",
                                 "price": {
@@ -1959,16 +2242,52 @@
                                 "title": "Tax",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "162.8"
+                                    "value": "81.4"
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "6c14ebdb-6cb6-4b5c-ab85-4c2acb747973",
+                                "@ondc/org/item_id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
+                                "@ondc/org/item_quantity": {
+                                    "count": 2
+                                },
+                                "@ondc/org/title_type": "item",
+                                "item": {
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "120.0"
+                                    }
+                                },
+                                "title": "Cashews",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "240.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "18653ff5-041f-4391-a6f6-91a1f5c09695",
+                                "@ondc/org/title_type": "packing",
+                                "title": "Packing Charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "5.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "18653ff5-041f-4391-a6f6-91a1f5c09695",
+                                "@ondc/org/title_type": "delivery",
+                                "title": "Delivery Charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "100.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "18653ff5-041f-4391-a6f6-91a1f5c09695",
                                 "@ondc/org/title_type": "misc",
                                 "title": "Convenience Fee",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "42.12"
+                                    "value": "35.65"
                                 }
                             }
                         ],
@@ -1978,8 +2297,8 @@
                         "uri": "https://razorpay.com/",
                         "tl_method": "http/get",
                         "params": {
-                            "transaction_id": "order_Pkm8SsI9aoMbkW",
-                            "amount": "1189.92",
+                            "transaction_id": "order_Pmsmecg6gruGAW",
+                            "amount": "1007.05",
                             "currency": "INR"
                         },
                         "type": "ON-ORDER",
@@ -2004,8 +2323,8 @@
                             }
                         ]
                     },
-                    "created_at": "2025-01-18T04:32:26.191Z",
-                    "updated_at": "2025-01-18T04:33:05.146Z"
+                    "created_at": "2025-01-23T12:20:38.886Z",
+                    "updated_at": "2025-01-23T12:21:30.767Z"
                 }
             }
         },
@@ -2020,14 +2339,14 @@
                 "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
                 "bpp_id": "ondc.pirimidtech.com/v2/seller",
                 "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-                "transaction_id": "2765f026-17e3-4a3f-a6bb-0b83046ff2c7",
-                "message_id": "d04c03d0-4a90-4795-95ec-027370d65cc3",
-                "timestamp": "2025-01-18T04:33:14.163Z",
+                "transaction_id": "2d4259ff-d365-4419-b86e-eada579d06e7",
+                "message_id": "1dbe014b-386c-4fe4-99cf-f2e733cdd05c",
+                "timestamp": "2025-01-23T12:21:38.217Z",
                 "ttl": "PT30S"
             },
             "message": {
                 "order": {
-                    "id": "2025-01-18-499387",
+                    "id": "2025-01-23-190156",
                     "state": "In-progress",
                     "provider": {
                         "id": "e2008459-7e90-493e-b02e-cae52ca53214",
@@ -2041,14 +2360,21 @@
                         {
                             "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
                             "quantity": {
-                                "count": 4
+                                "count": 2
                             },
-                            "fulfillment_id": "6c14ebdb-6cb6-4b5c-ab85-4c2acb747973"
+                            "fulfillment_id": "18653ff5-041f-4391-a6f6-91a1f5c09695"
+                        },
+                        {
+                            "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
+                            "quantity": {
+                                "count": 2
+                            },
+                            "fulfillment_id": "18653ff5-041f-4391-a6f6-91a1f5c09695"
                         }
                     ],
                     "documents": [
                         {
-                            "url": "https://ondc.pirimidtech.com/v2/seller/api/order/invoice/409628fc-59ec-4ca7-9fd1-90f31cd45533",
+                            "url": "https://ondc.pirimidtech.com/v2/seller/api/order/invoice/391cc4a0-61a4-49ca-aee6-ed28e308d8c2",
                             "label": "Invoice"
                         }
                     ],
@@ -2065,14 +2391,14 @@
                         },
                         "email": "fhemanshu@gmail.com",
                         "phone": "7202959020",
-                        "created_at": "2025-01-18T04:32:04.795Z",
-                        "updated_at": "2025-01-18T04:32:04.795Z"
+                        "created_at": "2025-01-23T12:20:17.208Z",
+                        "updated_at": "2025-01-23T12:20:17.208Z"
                     },
                     "fulfillments": [
                         {
-                            "id": "6c14ebdb-6cb6-4b5c-ab85-4c2acb747973",
+                            "id": "18653ff5-041f-4391-a6f6-91a1f5c09695",
                             "type": "Delivery",
-                            "@ondc/org/TAT": "PT74H",
+                            "@ondc/org/TAT": "PT99H",
                             "provider_id": "ondc.loadshare.com/ondc/18275",
                             "@ondc/org/provider_name": "LoadShare",
                             "state": {
@@ -2101,14 +2427,14 @@
                                         "locality": "Ashok Vatika",
                                         "city": "Ahmedabad",
                                         "state": "Gujarat",
-                                        "area_code": "380058"
+                                        "area_code": "380054"
                                     }
                                 },
                                 "time": {
-                                    "timestamp": "2025-01-18T04:33:14.159Z",
+                                    "timestamp": "2025-01-23T12:21:38.215Z",
                                     "range": {
-                                        "start": "2025-01-18T04:32:58.888Z",
-                                        "end": "2025-01-18T06:32:58.888Z"
+                                        "start": "2025-01-23T12:21:25.258Z",
+                                        "end": "2025-01-23T15:21:25.258Z"
                                     }
                                 },
                                 "instructions": {
@@ -2137,8 +2463,8 @@
                                 },
                                 "time": {
                                     "range": {
-                                        "start": "2025-01-18T06:32:58.888Z",
-                                        "end": "2025-01-21T06:32:58.888Z"
+                                        "start": "2025-01-23T15:21:25.258Z",
+                                        "end": "2025-01-27T15:21:25.258Z"
                                     }
                                 },
                                 "contact": {
@@ -2165,13 +2491,13 @@
                     "quote": {
                         "price": {
                             "currency": "INR",
-                            "value": "1189.92"
+                            "value": "1007.05"
                         },
                         "breakup": [
                             {
                                 "@ondc/org/item_id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
                                 "@ondc/org/item_quantity": {
-                                    "count": 4
+                                    "count": 2
                                 },
                                 "@ondc/org/title_type": "item",
                                 "item": {
@@ -2183,11 +2509,11 @@
                                 "title": "Nutraj-California-Almonds-1Kg",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "880.0"
+                                    "value": "440.0"
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "6c14ebdb-6cb6-4b5c-ab85-4c2acb747973",
+                                "@ondc/org/item_id": "18653ff5-041f-4391-a6f6-91a1f5c09695",
                                 "@ondc/org/title_type": "packing",
                                 "title": "Packing Charges",
                                 "price": {
@@ -2196,7 +2522,7 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "6c14ebdb-6cb6-4b5c-ab85-4c2acb747973",
+                                "@ondc/org/item_id": "18653ff5-041f-4391-a6f6-91a1f5c09695",
                                 "@ondc/org/title_type": "delivery",
                                 "title": "Delivery Charges",
                                 "price": {
@@ -2210,16 +2536,52 @@
                                 "title": "Tax",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "162.8"
+                                    "value": "81.4"
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "6c14ebdb-6cb6-4b5c-ab85-4c2acb747973",
+                                "@ondc/org/item_id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
+                                "@ondc/org/item_quantity": {
+                                    "count": 2
+                                },
+                                "@ondc/org/title_type": "item",
+                                "item": {
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "120.0"
+                                    }
+                                },
+                                "title": "Cashews",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "240.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "18653ff5-041f-4391-a6f6-91a1f5c09695",
+                                "@ondc/org/title_type": "packing",
+                                "title": "Packing Charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "5.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "18653ff5-041f-4391-a6f6-91a1f5c09695",
+                                "@ondc/org/title_type": "delivery",
+                                "title": "Delivery Charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "100.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "18653ff5-041f-4391-a6f6-91a1f5c09695",
                                 "@ondc/org/title_type": "misc",
                                 "title": "Convenience Fee",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "42.12"
+                                    "value": "35.65"
                                 }
                             }
                         ],
@@ -2229,8 +2591,8 @@
                         "uri": "https://razorpay.com/",
                         "tl_method": "http/get",
                         "params": {
-                            "transaction_id": "order_Pkm8SsI9aoMbkW",
-                            "amount": "1189.92",
+                            "transaction_id": "order_Pmsmecg6gruGAW",
+                            "amount": "1007.05",
                             "currency": "INR"
                         },
                         "type": "ON-ORDER",
@@ -2255,8 +2617,8 @@
                             }
                         ]
                     },
-                    "created_at": "2025-01-18T04:32:26.191Z",
-                    "updated_at": "2025-01-18T04:33:14.163Z"
+                    "created_at": "2025-01-23T12:20:38.886Z",
+                    "updated_at": "2025-01-23T12:21:38.217Z"
                 }
             }
         },
@@ -2271,14 +2633,14 @@
                 "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
                 "bpp_id": "ondc.pirimidtech.com/v2/seller",
                 "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-                "transaction_id": "2765f026-17e3-4a3f-a6bb-0b83046ff2c7",
-                "message_id": "352d1d14-7ce1-45de-8283-ec3070f95552",
-                "timestamp": "2025-01-18T15:47:04.830Z",
+                "transaction_id": "2d4259ff-d365-4419-b86e-eada579d06e7",
+                "message_id": "c5245e24-05b7-432e-899f-55a036b6b0b0",
+                "timestamp": "2025-01-24T05:24:49.021Z",
                 "ttl": "PT30S"
             },
             "message": {
                 "order": {
-                    "id": "2025-01-18-499387",
+                    "id": "2025-01-23-190156",
                     "state": "In-progress",
                     "provider": {
                         "id": "e2008459-7e90-493e-b02e-cae52ca53214",
@@ -2292,14 +2654,21 @@
                         {
                             "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
                             "quantity": {
-                                "count": 4
+                                "count": 2
                             },
-                            "fulfillment_id": "6c14ebdb-6cb6-4b5c-ab85-4c2acb747973"
+                            "fulfillment_id": "18653ff5-041f-4391-a6f6-91a1f5c09695"
+                        },
+                        {
+                            "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
+                            "quantity": {
+                                "count": 2
+                            },
+                            "fulfillment_id": "18653ff5-041f-4391-a6f6-91a1f5c09695"
                         }
                     ],
                     "documents": [
                         {
-                            "url": "https://ondc.pirimidtech.com/v2/seller/api/order/invoice/409628fc-59ec-4ca7-9fd1-90f31cd45533",
+                            "url": "https://ondc.pirimidtech.com/v2/seller/api/order/invoice/391cc4a0-61a4-49ca-aee6-ed28e308d8c2",
                             "label": "Invoice"
                         }
                     ],
@@ -2316,14 +2685,14 @@
                         },
                         "email": "fhemanshu@gmail.com",
                         "phone": "7202959020",
-                        "created_at": "2025-01-18T04:32:04.795Z",
-                        "updated_at": "2025-01-18T04:32:04.795Z"
+                        "created_at": "2025-01-23T12:20:17.208Z",
+                        "updated_at": "2025-01-23T12:20:17.208Z"
                     },
                     "fulfillments": [
                         {
-                            "id": "6c14ebdb-6cb6-4b5c-ab85-4c2acb747973",
+                            "id": "18653ff5-041f-4391-a6f6-91a1f5c09695",
                             "type": "Delivery",
-                            "@ondc/org/TAT": "PT74H",
+                            "@ondc/org/TAT": "PT99H",
                             "provider_id": "ondc.loadshare.com/ondc/18275",
                             "@ondc/org/provider_name": "LoadShare",
                             "state": {
@@ -2352,14 +2721,14 @@
                                         "locality": "Ashok Vatika",
                                         "city": "Ahmedabad",
                                         "state": "Gujarat",
-                                        "area_code": "380058"
+                                        "area_code": "380054"
                                     }
                                 },
                                 "time": {
-                                    "timestamp": "2025-01-18T04:33:14.159Z",
+                                    "timestamp": "2025-01-23T12:21:38.215Z",
                                     "range": {
-                                        "start": "2025-01-18T04:32:58.888Z",
-                                        "end": "2025-01-18T06:32:58.888Z"
+                                        "start": "2025-01-23T12:21:25.258Z",
+                                        "end": "2025-01-23T15:21:25.258Z"
                                     }
                                 },
                                 "instructions": {
@@ -2388,8 +2757,8 @@
                                 },
                                 "time": {
                                     "range": {
-                                        "start": "2025-01-18T06:32:58.888Z",
-                                        "end": "2025-01-21T06:32:58.888Z"
+                                        "start": "2025-01-23T15:21:25.258Z",
+                                        "end": "2025-01-27T15:21:25.258Z"
                                     }
                                 },
                                 "contact": {
@@ -2416,13 +2785,13 @@
                     "quote": {
                         "price": {
                             "currency": "INR",
-                            "value": "1189.92"
+                            "value": "1007.05"
                         },
                         "breakup": [
                             {
                                 "@ondc/org/item_id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
                                 "@ondc/org/item_quantity": {
-                                    "count": 4
+                                    "count": 2
                                 },
                                 "@ondc/org/title_type": "item",
                                 "item": {
@@ -2434,11 +2803,11 @@
                                 "title": "Nutraj-California-Almonds-1Kg",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "880.0"
+                                    "value": "440.0"
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "6c14ebdb-6cb6-4b5c-ab85-4c2acb747973",
+                                "@ondc/org/item_id": "18653ff5-041f-4391-a6f6-91a1f5c09695",
                                 "@ondc/org/title_type": "packing",
                                 "title": "Packing Charges",
                                 "price": {
@@ -2447,7 +2816,7 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "6c14ebdb-6cb6-4b5c-ab85-4c2acb747973",
+                                "@ondc/org/item_id": "18653ff5-041f-4391-a6f6-91a1f5c09695",
                                 "@ondc/org/title_type": "delivery",
                                 "title": "Delivery Charges",
                                 "price": {
@@ -2461,16 +2830,52 @@
                                 "title": "Tax",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "162.8"
+                                    "value": "81.4"
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "6c14ebdb-6cb6-4b5c-ab85-4c2acb747973",
+                                "@ondc/org/item_id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
+                                "@ondc/org/item_quantity": {
+                                    "count": 2
+                                },
+                                "@ondc/org/title_type": "item",
+                                "item": {
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "120.0"
+                                    }
+                                },
+                                "title": "Cashews",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "240.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "18653ff5-041f-4391-a6f6-91a1f5c09695",
+                                "@ondc/org/title_type": "packing",
+                                "title": "Packing Charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "5.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "18653ff5-041f-4391-a6f6-91a1f5c09695",
+                                "@ondc/org/title_type": "delivery",
+                                "title": "Delivery Charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "100.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "18653ff5-041f-4391-a6f6-91a1f5c09695",
                                 "@ondc/org/title_type": "misc",
                                 "title": "Convenience Fee",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "42.12"
+                                    "value": "35.65"
                                 }
                             }
                         ],
@@ -2480,8 +2885,8 @@
                         "uri": "https://razorpay.com/",
                         "tl_method": "http/get",
                         "params": {
-                            "transaction_id": "order_Pkm8SsI9aoMbkW",
-                            "amount": "1189.92",
+                            "transaction_id": "order_Pmsmecg6gruGAW",
+                            "amount": "1007.05",
                             "currency": "INR"
                         },
                         "type": "ON-ORDER",
@@ -2506,8 +2911,8 @@
                             }
                         ]
                     },
-                    "created_at": "2025-01-18T04:32:26.191Z",
-                    "updated_at": "2025-01-18T15:47:04.830Z"
+                    "created_at": "2025-01-23T12:20:38.886Z",
+                    "updated_at": "2025-01-24T05:24:49.021Z"
                 }
             }
         },
@@ -2522,14 +2927,14 @@
                 "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
                 "bpp_id": "ondc.pirimidtech.com/v2/seller",
                 "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-                "transaction_id": "2765f026-17e3-4a3f-a6bb-0b83046ff2c7",
-                "message_id": "20860cd7-2e4d-4e97-b9f9-5ea076f77c72",
-                "timestamp": "2025-01-18T15:47:09.666Z",
+                "transaction_id": "2d4259ff-d365-4419-b86e-eada579d06e7",
+                "message_id": "f0a18eee-c60a-4ed9-a562-c9d5ed903fab",
+                "timestamp": "2025-01-24T05:25:03.958Z",
                 "ttl": "PT30S"
             },
             "message": {
                 "order": {
-                    "id": "2025-01-18-499387",
+                    "id": "2025-01-23-190156",
                     "state": "Completed",
                     "provider": {
                         "id": "e2008459-7e90-493e-b02e-cae52ca53214",
@@ -2543,14 +2948,21 @@
                         {
                             "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
                             "quantity": {
-                                "count": 4
+                                "count": 2
                             },
-                            "fulfillment_id": "6c14ebdb-6cb6-4b5c-ab85-4c2acb747973"
+                            "fulfillment_id": "18653ff5-041f-4391-a6f6-91a1f5c09695"
+                        },
+                        {
+                            "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
+                            "quantity": {
+                                "count": 2
+                            },
+                            "fulfillment_id": "18653ff5-041f-4391-a6f6-91a1f5c09695"
                         }
                     ],
                     "documents": [
                         {
-                            "url": "https://ondc.pirimidtech.com/v2/seller/api/order/invoice/409628fc-59ec-4ca7-9fd1-90f31cd45533",
+                            "url": "https://ondc.pirimidtech.com/v2/seller/api/order/invoice/391cc4a0-61a4-49ca-aee6-ed28e308d8c2",
                             "label": "Invoice"
                         }
                     ],
@@ -2567,14 +2979,14 @@
                         },
                         "email": "fhemanshu@gmail.com",
                         "phone": "7202959020",
-                        "created_at": "2025-01-18T04:32:04.795Z",
-                        "updated_at": "2025-01-18T04:32:04.795Z"
+                        "created_at": "2025-01-23T12:20:17.208Z",
+                        "updated_at": "2025-01-23T12:20:17.208Z"
                     },
                     "fulfillments": [
                         {
-                            "id": "6c14ebdb-6cb6-4b5c-ab85-4c2acb747973",
+                            "id": "18653ff5-041f-4391-a6f6-91a1f5c09695",
                             "type": "Delivery",
-                            "@ondc/org/TAT": "PT74H",
+                            "@ondc/org/TAT": "PT99H",
                             "provider_id": "ondc.loadshare.com/ondc/18275",
                             "@ondc/org/provider_name": "LoadShare",
                             "state": {
@@ -2603,14 +3015,14 @@
                                         "locality": "Ashok Vatika",
                                         "city": "Ahmedabad",
                                         "state": "Gujarat",
-                                        "area_code": "380058"
+                                        "area_code": "380054"
                                     }
                                 },
                                 "time": {
-                                    "timestamp": "2025-01-18T04:33:14.159Z",
+                                    "timestamp": "2025-01-23T12:21:38.215Z",
                                     "range": {
-                                        "start": "2025-01-18T04:32:58.888Z",
-                                        "end": "2025-01-18T06:32:58.888Z"
+                                        "start": "2025-01-23T12:21:25.258Z",
+                                        "end": "2025-01-23T15:21:25.258Z"
                                     }
                                 },
                                 "instructions": {
@@ -2638,10 +3050,10 @@
                                     }
                                 },
                                 "time": {
-                                    "timestamp": "2025-01-18T15:47:09.664Z",
+                                    "timestamp": "2025-01-24T05:25:03.956Z",
                                     "range": {
-                                        "start": "2025-01-18T06:32:58.888Z",
-                                        "end": "2025-01-21T06:32:58.888Z"
+                                        "start": "2025-01-23T15:21:25.258Z",
+                                        "end": "2025-01-27T15:21:25.258Z"
                                     }
                                 },
                                 "contact": {
@@ -2668,13 +3080,13 @@
                     "quote": {
                         "price": {
                             "currency": "INR",
-                            "value": "1189.92"
+                            "value": "1007.05"
                         },
                         "breakup": [
                             {
                                 "@ondc/org/item_id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
                                 "@ondc/org/item_quantity": {
-                                    "count": 4
+                                    "count": 2
                                 },
                                 "@ondc/org/title_type": "item",
                                 "item": {
@@ -2686,11 +3098,11 @@
                                 "title": "Nutraj-California-Almonds-1Kg",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "880.0"
+                                    "value": "440.0"
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "6c14ebdb-6cb6-4b5c-ab85-4c2acb747973",
+                                "@ondc/org/item_id": "18653ff5-041f-4391-a6f6-91a1f5c09695",
                                 "@ondc/org/title_type": "packing",
                                 "title": "Packing Charges",
                                 "price": {
@@ -2699,7 +3111,7 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "6c14ebdb-6cb6-4b5c-ab85-4c2acb747973",
+                                "@ondc/org/item_id": "18653ff5-041f-4391-a6f6-91a1f5c09695",
                                 "@ondc/org/title_type": "delivery",
                                 "title": "Delivery Charges",
                                 "price": {
@@ -2713,16 +3125,52 @@
                                 "title": "Tax",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "162.8"
+                                    "value": "81.4"
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "6c14ebdb-6cb6-4b5c-ab85-4c2acb747973",
+                                "@ondc/org/item_id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
+                                "@ondc/org/item_quantity": {
+                                    "count": 2
+                                },
+                                "@ondc/org/title_type": "item",
+                                "item": {
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "120.0"
+                                    }
+                                },
+                                "title": "Cashews",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "240.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "18653ff5-041f-4391-a6f6-91a1f5c09695",
+                                "@ondc/org/title_type": "packing",
+                                "title": "Packing Charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "5.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "18653ff5-041f-4391-a6f6-91a1f5c09695",
+                                "@ondc/org/title_type": "delivery",
+                                "title": "Delivery Charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "100.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "18653ff5-041f-4391-a6f6-91a1f5c09695",
                                 "@ondc/org/title_type": "misc",
                                 "title": "Convenience Fee",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "42.12"
+                                    "value": "35.65"
                                 }
                             }
                         ],
@@ -2732,8 +3180,8 @@
                         "uri": "https://razorpay.com/",
                         "tl_method": "http/get",
                         "params": {
-                            "transaction_id": "order_Pkm8SsI9aoMbkW",
-                            "amount": "1189.92",
+                            "transaction_id": "order_Pmsmecg6gruGAW",
+                            "amount": "1007.05",
                             "currency": "INR"
                         },
                         "type": "ON-ORDER",
@@ -2758,8 +3206,8 @@
                             }
                         ]
                     },
-                    "created_at": "2025-01-18T04:32:26.191Z",
-                    "updated_at": "2025-01-18T15:47:09.666Z"
+                    "created_at": "2025-01-23T12:20:38.886Z",
+                    "updated_at": "2025-01-24T05:25:03.958Z"
                 }
             }
         }

--- a/Pirimid/SellerApp/Retail/RET-10/FLOW_3/log_validation_utitlity_response.json
+++ b/Pirimid/SellerApp/Retail/RET-10/FLOW_3/log_validation_utitlity_response.json
@@ -1,13 +1,17 @@
 {
-    "success": true,
+    "success": false,
     "response": {
-        "message": "Logs were verified successfully",
-        "report": {},
+        "message": "Logs were not verified successfully",
+        "report": {
+            "on_search_full_catalog_refresh": {
+                "prvdr0categories": "Support for variants is mandatory, categories must be present in bpp/providers[0]"
+            }
+        },
         "bpp_id": "ondc.pirimidtech.com/v2/seller",
         "bap_id": "buyer-app-preprod-v2.ondc.org",
         "domain": "ONDC:RET10",
-        "reportTimestamp": "2025-01-19T04:51:43.485Z"
+        "reportTimestamp": "2025-01-24T05:56:11.349Z"
     },
-    "signature": "ua14nxBS1cmPUGgSu9ktARxroDfICzxPLkBPgeTzJAweCECgK1noWip0RRivbk4FN1gJVz+MSK/jjsCVgJqqAA==",
-    "signTimestamp": "2025-01-19T04:51:43.485Z"
+    "signature": "XC0nTtyHqRayiVdJ8P6jEt4Dw3iOPcBscncFE1WCMML3MX/oUWZFWYwykBYJ74zOrOEmJWk1I6ODnYopAny8Bg==",
+    "signTimestamp": "2025-01-24T05:56:11.349Z"
 }

--- a/Pirimid/SellerApp/Retail/RET-10/FLOW_3/on_confirm.json
+++ b/Pirimid/SellerApp/Retail/RET-10/FLOW_3/on_confirm.json
@@ -9,13 +9,13 @@
     "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
     "bpp_id": "ondc.pirimidtech.com/v2/seller",
     "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-    "transaction_id": "2765f026-17e3-4a3f-a6bb-0b83046ff2c7",
-    "message_id": "02d13e63-f067-4678-b26d-a7d118ae73d2",
-    "timestamp": "2025-01-18T04:32:27.039Z"
+    "transaction_id": "2d4259ff-d365-4419-b86e-eada579d06e7",
+    "message_id": "228f4f99-723d-4b19-ac1f-035da1c19acd",
+    "timestamp": "2025-01-23T12:20:39.826Z"
   },
   "message": {
     "order": {
-      "id": "2025-01-18-499387",
+      "id": "2025-01-23-190156",
       "state": "Created",
       "provider": {
         "id": "e2008459-7e90-493e-b02e-cae52ca53214",
@@ -29,9 +29,16 @@
         {
           "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
           "quantity": {
-            "count": 4
+            "count": 2
           },
-          "fulfillment_id": "6c14ebdb-6cb6-4b5c-ab85-4c2acb747973"
+          "fulfillment_id": "18653ff5-041f-4391-a6f6-91a1f5c09695"
+        },
+        {
+          "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "18653ff5-041f-4391-a6f6-91a1f5c09695"
         }
       ],
       "billing": {
@@ -47,14 +54,14 @@
         },
         "email": "fhemanshu@gmail.com",
         "phone": "7202959020",
-        "created_at": "2025-01-18T04:32:04.795Z",
-        "updated_at": "2025-01-18T04:32:04.795Z"
+        "created_at": "2025-01-23T12:20:17.208Z",
+        "updated_at": "2025-01-23T12:20:17.208Z"
       },
       "fulfillments": [
         {
-          "id": "6c14ebdb-6cb6-4b5c-ab85-4c2acb747973",
+          "id": "18653ff5-041f-4391-a6f6-91a1f5c09695",
           "type": "Delivery",
-          "@ondc/org/TAT": "PT74H",
+          "@ondc/org/TAT": "PT99H",
           "@ondc/org/provider_name": "LoadShare",
           "state": {
             "descriptor": {
@@ -73,7 +80,7 @@
                 "locality": "Ashok Vatika",
                 "city": "Ahmedabad",
                 "state": "Gujarat",
-                "area_code": "380058"
+                "area_code": "380054"
               }
             },
             "contact": {
@@ -107,13 +114,13 @@
       "quote": {
         "price": {
           "currency": "INR",
-          "value": "1189.92"
+          "value": "1007.05"
         },
         "breakup": [
           {
             "@ondc/org/item_id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
             "@ondc/org/item_quantity": {
-              "count": 4
+              "count": 2
             },
             "@ondc/org/title_type": "item",
             "item": {
@@ -125,11 +132,11 @@
             "title": "Nutraj-California-Almonds-1Kg",
             "price": {
               "currency": "INR",
-              "value": "880.0"
+              "value": "440.0"
             }
           },
           {
-            "@ondc/org/item_id": "6c14ebdb-6cb6-4b5c-ab85-4c2acb747973",
+            "@ondc/org/item_id": "18653ff5-041f-4391-a6f6-91a1f5c09695",
             "@ondc/org/title_type": "packing",
             "title": "Packing Charges",
             "price": {
@@ -138,7 +145,7 @@
             }
           },
           {
-            "@ondc/org/item_id": "6c14ebdb-6cb6-4b5c-ab85-4c2acb747973",
+            "@ondc/org/item_id": "18653ff5-041f-4391-a6f6-91a1f5c09695",
             "@ondc/org/title_type": "delivery",
             "title": "Delivery Charges",
             "price": {
@@ -152,16 +159,52 @@
             "title": "Tax",
             "price": {
               "currency": "INR",
-              "value": "162.8"
+              "value": "81.4"
             }
           },
           {
-            "@ondc/org/item_id": "6c14ebdb-6cb6-4b5c-ab85-4c2acb747973",
+            "@ondc/org/item_id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "@ondc/org/title_type": "item",
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "120.0"
+              }
+            },
+            "title": "Cashews",
+            "price": {
+              "currency": "INR",
+              "value": "240.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "18653ff5-041f-4391-a6f6-91a1f5c09695",
+            "@ondc/org/title_type": "packing",
+            "title": "Packing Charges",
+            "price": {
+              "currency": "INR",
+              "value": "5.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "18653ff5-041f-4391-a6f6-91a1f5c09695",
+            "@ondc/org/title_type": "delivery",
+            "title": "Delivery Charges",
+            "price": {
+              "currency": "INR",
+              "value": "100.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "18653ff5-041f-4391-a6f6-91a1f5c09695",
             "@ondc/org/title_type": "misc",
             "title": "Convenience Fee",
             "price": {
               "currency": "INR",
-              "value": "42.12"
+              "value": "35.65"
             }
           }
         ],
@@ -171,8 +214,8 @@
         "uri": "https://razorpay.com/",
         "tl_method": "http/get",
         "params": {
-          "transaction_id": "order_Pkm8SsI9aoMbkW",
-          "amount": "1189.92",
+          "transaction_id": "order_Pmsmecg6gruGAW",
+          "amount": "1007.05",
           "currency": "INR"
         },
         "type": "ON-ORDER",
@@ -197,8 +240,8 @@
           }
         ]
       },
-      "created_at": "2025-01-18T04:32:26.191Z",
-      "updated_at": "2025-01-18T04:32:27.039Z",
+      "created_at": "2025-01-23T12:20:38.886Z",
+      "updated_at": "2025-01-23T12:20:39.826Z",
       "tags": [
         {
           "code": "bpp_terms",

--- a/Pirimid/SellerApp/Retail/RET-10/FLOW_3/on_init.json
+++ b/Pirimid/SellerApp/Retail/RET-10/FLOW_3/on_init.json
@@ -9,9 +9,9 @@
     "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
     "bpp_id": "ondc.pirimidtech.com/v2/seller",
     "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-    "transaction_id": "2765f026-17e3-4a3f-a6bb-0b83046ff2c7",
-    "message_id": "c8144888-5c10-4764-84db-4a03c063489c",
-    "timestamp": "2025-01-18T04:32:05.577Z",
+    "transaction_id": "2d4259ff-d365-4419-b86e-eada579d06e7",
+    "message_id": "973a1d1f-fe0f-4c95-a84d-0239065c7f34",
+    "timestamp": "2025-01-23T12:20:18.033Z",
     "ttl": "PT30S"
   },
   "message": {
@@ -29,11 +29,21 @@
           "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
           "quantity": {
             "unitized": {
-              "count": "4"
+              "count": "2"
             },
-            "count": 4
+            "count": 2
           },
-          "fulfillment_id": "6c14ebdb-6cb6-4b5c-ab85-4c2acb747973"
+          "fulfillment_id": "18653ff5-041f-4391-a6f6-91a1f5c09695"
+        },
+        {
+          "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
+          "quantity": {
+            "unitized": {
+              "count": "2"
+            },
+            "count": 2
+          },
+          "fulfillment_id": "18653ff5-041f-4391-a6f6-91a1f5c09695"
         }
       ],
       "billing": {
@@ -49,19 +59,13 @@
         },
         "email": "fhemanshu@gmail.com",
         "phone": "7202959020",
-        "created_at": "2025-01-18T04:32:04.795Z",
-        "updated_at": "2025-01-18T04:32:04.795Z"
+        "created_at": "2025-01-23T12:20:17.208Z",
+        "updated_at": "2025-01-23T12:20:17.208Z"
       },
       "fulfillments": [
         {
-          "id": "6c14ebdb-6cb6-4b5c-ab85-4c2acb747973",
+          "id": "18653ff5-041f-4391-a6f6-91a1f5c09695",
           "type": "Delivery",
-          "provider_id": "ondc.loadshare.com/ondc/18275",
-          "state": {
-            "descriptor": {
-              "code": "INITIALIZING"
-            }
-          },
           "tracking": false,
           "end": {
             "location": {
@@ -75,9 +79,6 @@
                 "country": "IND",
                 "area_code": "380015"
               }
-            },
-            "time": {
-              "range": {}
             },
             "instructions": {
               "name": "Status for pickup",
@@ -98,13 +99,13 @@
       "quote": {
         "price": {
           "currency": "INR",
-          "value": "1189.92"
+          "value": "1007.05"
         },
         "breakup": [
           {
             "@ondc/org/item_id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
             "@ondc/org/item_quantity": {
-              "count": 4
+              "count": 2
             },
             "@ondc/org/title_type": "item",
             "item": {
@@ -116,11 +117,11 @@
             "title": "Nutraj-California-Almonds-1Kg",
             "price": {
               "currency": "INR",
-              "value": "880.0"
+              "value": "440.0"
             }
           },
           {
-            "@ondc/org/item_id": "6c14ebdb-6cb6-4b5c-ab85-4c2acb747973",
+            "@ondc/org/item_id": "18653ff5-041f-4391-a6f6-91a1f5c09695",
             "@ondc/org/title_type": "packing",
             "title": "Packing Charges",
             "price": {
@@ -129,7 +130,7 @@
             }
           },
           {
-            "@ondc/org/item_id": "6c14ebdb-6cb6-4b5c-ab85-4c2acb747973",
+            "@ondc/org/item_id": "18653ff5-041f-4391-a6f6-91a1f5c09695",
             "@ondc/org/title_type": "delivery",
             "title": "Delivery Charges",
             "price": {
@@ -143,26 +144,62 @@
             "title": "Tax",
             "price": {
               "currency": "INR",
-              "value": "162.8"
+              "value": "81.4"
             }
           },
           {
-            "@ondc/org/item_id": "6c14ebdb-6cb6-4b5c-ab85-4c2acb747973",
+            "@ondc/org/item_id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "@ondc/org/title_type": "item",
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "120.0"
+              }
+            },
+            "title": "Cashews",
+            "price": {
+              "currency": "INR",
+              "value": "240.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "18653ff5-041f-4391-a6f6-91a1f5c09695",
+            "@ondc/org/title_type": "packing",
+            "title": "Packing Charges",
+            "price": {
+              "currency": "INR",
+              "value": "5.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "18653ff5-041f-4391-a6f6-91a1f5c09695",
+            "@ondc/org/title_type": "delivery",
+            "title": "Delivery Charges",
+            "price": {
+              "currency": "INR",
+              "value": "100.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "18653ff5-041f-4391-a6f6-91a1f5c09695",
             "@ondc/org/title_type": "misc",
             "title": "Convenience Fee",
             "price": {
               "currency": "INR",
-              "value": "42.12"
+              "value": "35.65"
             }
           }
         ],
         "ttl": "P1D"
       },
       "payment": {
-        "uri": "https://ondc-pirimid-payment.netlify.app/payment/2765f026-17e3-4a3f-a6bb-0b83046ff2c7",
+        "uri": "https://ondc-pirimid-payment.netlify.app/payment/2d4259ff-d365-4419-b86e-eada579d06e7",
         "type": "ON-ORDER",
         "status": "NOT-PAID",
-        "collected_by": "BPP",
+        "collected_by": "BAP",
         "@ondc/org/buyer_app_finder_fee_type": "percent",
         "@ondc/org/buyer_app_finder_fee_amount": "3.0",
         "@ondc/org/withholding_amount": "0.0",
@@ -182,8 +219,8 @@
           }
         ]
       },
-      "created_at": "2025-01-18T04:31:39.713Z",
-      "updated_at": "2025-01-18T04:32:05.587Z",
+      "created_at": "2025-01-23T12:19:57.201Z",
+      "updated_at": "2025-01-23T12:20:18.048Z",
       "tags": [
         {
           "code": "bpp_terms",

--- a/Pirimid/SellerApp/Retail/RET-10/FLOW_3/on_search_full_catalog_refresh.json
+++ b/Pirimid/SellerApp/Retail/RET-10/FLOW_3/on_search_full_catalog_refresh.json
@@ -9,9 +9,9 @@
     "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
     "bpp_id": "ondc.pirimidtech.com/v2/seller",
     "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-    "transaction_id": "e53a74c5-7ce6-4498-800c-e7d90db0f2fa",
-    "message_id": "45726578-5033-41e0-b35f-2fcbcebe8f82",
-    "timestamp": "2025-01-17T12:00:21.411Z",
+    "transaction_id": "2a274964-3eec-4793-888c-1d30ef845cd1",
+    "message_id": "c5c58f68-8483-4490-b318-a1436c6ee88b",
+    "timestamp": "2025-01-23T12:00:21.519Z",
     "ttl": "PT30S"
   },
   "message": {
@@ -58,70 +58,8 @@
           "@ondc/org/fssai_license_no": "12345678912345",
           "time": {
             "label": "enable",
-            "timestamp": "2025-01-17T12:00:21.411Z"
+            "timestamp": "2025-01-23T12:00:21.519Z"
           },
-          "categories": [
-            {
-              "id": "variant10000",
-              "descriptor": {
-                "name": "Variant for Nutraj-California-Almonds-1Kg"
-              },
-              "tags": [
-                {
-                  "code": "type",
-                  "list": [
-                    {
-                      "code": "type",
-                      "value": "variant_group"
-                    }
-                  ]
-                },
-                {
-                  "code": "attr",
-                  "list": [
-                    {
-                      "code": "name",
-                      "value": "item.quantity.unitized.measure"
-                    },
-                    {
-                      "code": "seq",
-                      "value": "1"
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "id": "variant10001",
-              "descriptor": {
-                "name": "Variant for Cashews"
-              },
-              "tags": [
-                {
-                  "code": "type",
-                  "list": [
-                    {
-                      "code": "type",
-                      "value": "variant_group"
-                    }
-                  ]
-                },
-                {
-                  "code": "attr",
-                  "list": [
-                    {
-                      "code": "name",
-                      "value": "item.quantity.unitized.measure"
-                    },
-                    {
-                      "code": "seq",
-                      "value": "1"
-                    }
-                  ]
-                }
-              ]
-            }
-          ],
           "fulfillments": [
             {
               "id": "1",
@@ -141,11 +79,11 @@
                 "locality": "Ashok Vatika",
                 "city": "Ahmedabad",
                 "state": "Gujarat",
-                "area_code": "380058"
+                "area_code": "380054"
               },
               "time": {
                 "label": "enable",
-                "timestamp": "2024-12-04T13:50:34.608Z",
+                "timestamp": "2025-01-22T07:34:34.534Z",
                 "range": {
                   "start": "0930",
                   "end": "1930"
@@ -162,12 +100,85 @@
           ],
           "items": [
             {
+              "id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+              "descriptor": {
+                "name": "Walnuts",
+                "code": "1:12345678",
+                "symbol": "https://c8.alamy.com/comp/2HCTDG2/modern-design-walnut-leaf-nature-green-logo-design-2HCTDG2.jpg",
+                "short_desc": "WONDERLAND California Whole Walnut Walnuts (Akhrot)  (500 g)",
+                "long_desc": "WONDERLAND California Whole Walnut Walnuts (Akhrot)  (500 g)",
+                "images": [
+                  "https://rukminim2.flixcart.com/image/416/416/xif0q/nut-dry-fruit/h/x/t/500-california-whole-walnut-1-pouch-wonderland-original-imagy632bnvk8fde.jpeg?q=70",
+                  "https://rukminim2.flixcart.com/image/416/416/xif0q/nut-dry-fruit/q/r/t/500-california-whole-walnut-1-pouch-wonderland-original-imagy6326hdk68cd.jpeg?q=70"
+                ]
+              },
+              "price": {
+                "currency": "INR",
+                "value": "120.0",
+                "maximum_value": "200.0"
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "value": "500",
+                    "unit": "gram"
+                  }
+                }
+              },
+              "category_id": "Snacks, Dry Fruits, Nuts",
+              "fulfillment_id": "1",
+              "location_id": "39550822-c3bb-4918-bd25-2d19ef6a9aca",
+              "time": {
+                "label": "enable",
+                "timestamp": "2025-01-23T12:00:21.519Z"
+              },
+              "@ondc/org/returnable": true,
+              "@ondc/org/seller_pickup_return": false,
+              "@ondc/org/return_window": "P7D",
+              "@ondc/org/cancellable": true,
+              "@ondc/org/time_to_ship": "PT3H",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "PirimidFintech,user@gmail.com,7744774477",
+              "@ondc/org/statutory_reqs_prepackaged_food": {
+                "nutritional_info": "nutritional_info",
+                "additives_info": "additives_info",
+                "brand_owner_FSSAI_license_no": "12345678912345",
+                "other_FSSAI_license_no": "12345678912345",
+                "importer_FSSAI_license_no": "12345678912345"
+              },
+              "tags": [
+                {
+                  "code": "origin",
+                  "list": [
+                    {
+                      "code": "Country",
+                      "value": "IND"
+                    }
+                  ]
+                },
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
               "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
-              "parent_item_id": "variant10000",
               "descriptor": {
                 "name": "Nutraj-California-Almonds-1Kg",
                 "code": "1:12345678",
-                "symbol": "symbols.in/symbol.jpg",
+                "symbol": "https://img.freepik.com/premium-vector/almonds-nuts-nature-farm-vintage-logo-icon-symbol-vector-illustration-minimalist-design_889650-491.jpg?semt=ais_hybrid",
                 "short_desc": "Nutraj California Almond kernels 1kg Pouch|Badam Giri|Dry Fruits and Nuts|Grocery",
                 "long_desc": "Nutraj California Almond kernels 1kg Pouch|Badam Giri|Dry Fruits and Nuts|Grocery",
                 "images": [
@@ -198,7 +209,7 @@
               "location_id": "39550822-c3bb-4918-bd25-2d19ef6a9aca",
               "time": {
                 "label": "enable",
-                "timestamp": "2025-01-17T12:00:21.411Z"
+                "timestamp": "2025-01-23T12:00:21.519Z"
               },
               "@ondc/org/returnable": true,
               "@ondc/org/seller_pickup_return": false,
@@ -237,11 +248,10 @@
             },
             {
               "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
-              "parent_item_id": "variant10001",
               "descriptor": {
                 "name": "Cashews",
                 "code": "1:12345678",
-                "symbol": "symbols.in/symbol.jpg",
+                "symbol": "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTVlckKW1pwOvmkj9_s_rPbAvcsr_EdmIStMA&s",
                 "short_desc": "Emart Brand - Vedaka Whole Cashews | 500 Gram | Kaju Nuts Grade W320 | Plant Based Protein | Gluten-Free | Nutty Flavor | Healthy Snack | Rich Delicious Taste",
                 "long_desc": "Emart Brand - Vedaka Whole Cashews | 500 Gram | Kaju Nuts Grade W320 | Plant Based Protein | Gluten-Free | Nutty Flavor | Healthy Snack | Rich Delicious Taste",
                 "images": [
@@ -251,7 +261,7 @@
               "price": {
                 "currency": "INR",
                 "value": "120.0",
-                "maximum_value": "258.0"
+                "maximum_value": "212.0"
               },
               "quantity": {
                 "available": {
@@ -262,8 +272,8 @@
                 },
                 "unitized": {
                   "measure": {
-                    "value": "1",
-                    "unit": "kilogram"
+                    "value": "500",
+                    "unit": "gram"
                   }
                 }
               },
@@ -272,7 +282,7 @@
               "location_id": "39550822-c3bb-4918-bd25-2d19ef6a9aca",
               "time": {
                 "label": "enable",
-                "timestamp": "2025-01-17T12:00:21.411Z"
+                "timestamp": "2025-01-23T12:00:21.519Z"
               },
               "@ondc/org/returnable": true,
               "@ondc/org/seller_pickup_return": false,
@@ -342,36 +352,7 @@
               "list": [
                 {
                   "code": "type",
-                  "value": "Order"
-                },
-                {
-                  "code": "location",
-                  "value": "39550822-c3bb-4918-bd25-2d19ef6a9aca"
-                },
-                {
-                  "code": "day_from",
-                  "value": "1"
-                },
-                {
-                  "code": "day_to",
-                  "value": "7"
-                },
-                {
-                  "code": "time_from",
-                  "value": "0930"
-                },
-                {
-                  "code": "time_to",
-                  "value": "1930"
-                }
-              ]
-            },
-            {
-              "code": "timing",
-              "list": [
-                {
-                  "code": "type",
-                  "value": "Delivery"
+                  "value": "All"
                 },
                 {
                   "code": "location",

--- a/Pirimid/SellerApp/Retail/RET-10/FLOW_3/on_select.json
+++ b/Pirimid/SellerApp/Retail/RET-10/FLOW_3/on_select.json
@@ -9,9 +9,9 @@
     "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
     "bpp_id": "ondc.pirimidtech.com/v2/seller",
     "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-    "transaction_id": "2765f026-17e3-4a3f-a6bb-0b83046ff2c7",
-    "message_id": "5a59a9e8-6a51-40b6-a213-1174fd5fa1e6",
-    "timestamp": "2025-01-18T04:31:55.833Z"
+    "transaction_id": "2d4259ff-d365-4419-b86e-eada579d06e7",
+    "message_id": "070acea7-6306-47a0-a43a-9c4af2ee2f95",
+    "timestamp": "2025-01-23T12:20:08.741Z"
   },
   "message": {
     "order": {
@@ -26,15 +26,19 @@
       "items": [
         {
           "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
-          "fulfillment_id": "6c14ebdb-6cb6-4b5c-ab85-4c2acb747973"
+          "fulfillment_id": "18653ff5-041f-4391-a6f6-91a1f5c09695"
+        },
+        {
+          "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
+          "fulfillment_id": "18653ff5-041f-4391-a6f6-91a1f5c09695"
         }
       ],
       "fulfillments": [
         {
-          "id": "6c14ebdb-6cb6-4b5c-ab85-4c2acb747973",
+          "id": "18653ff5-041f-4391-a6f6-91a1f5c09695",
           "type": "Delivery",
           "@ondc/org/category": "Standard Delivery",
-          "@ondc/org/TAT": "PT74H",
+          "@ondc/org/TAT": "PT99H",
           "@ondc/org/provider_name": "LoadShare",
           "state": {
             "descriptor": {
@@ -47,13 +51,13 @@
       "quote": {
         "price": {
           "currency": "INR",
-          "value": "1189.92"
+          "value": "1007.05"
         },
         "breakup": [
           {
             "@ondc/org/item_id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
             "@ondc/org/item_quantity": {
-              "count": 4
+              "count": 2
             },
             "@ondc/org/title_type": "item",
             "item": {
@@ -73,11 +77,11 @@
             "title": "Nutraj-California-Almonds-1Kg",
             "price": {
               "currency": "INR",
-              "value": "880.0"
+              "value": "440.0"
             }
           },
           {
-            "@ondc/org/item_id": "6c14ebdb-6cb6-4b5c-ab85-4c2acb747973",
+            "@ondc/org/item_id": "18653ff5-041f-4391-a6f6-91a1f5c09695",
             "@ondc/org/title_type": "packing",
             "title": "Packing Charges",
             "price": {
@@ -86,7 +90,7 @@
             }
           },
           {
-            "@ondc/org/item_id": "6c14ebdb-6cb6-4b5c-ab85-4c2acb747973",
+            "@ondc/org/item_id": "18653ff5-041f-4391-a6f6-91a1f5c09695",
             "@ondc/org/title_type": "delivery",
             "title": "Delivery Charges",
             "price": {
@@ -100,16 +104,60 @@
             "title": "Tax",
             "price": {
               "currency": "INR",
-              "value": "162.8"
+              "value": "81.4"
             }
           },
           {
-            "@ondc/org/item_id": "6c14ebdb-6cb6-4b5c-ab85-4c2acb747973",
+            "@ondc/org/item_id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "@ondc/org/title_type": "item",
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "120.0"
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                }
+              }
+            },
+            "title": "Cashews",
+            "price": {
+              "currency": "INR",
+              "value": "240.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "18653ff5-041f-4391-a6f6-91a1f5c09695",
+            "@ondc/org/title_type": "packing",
+            "title": "Packing Charges",
+            "price": {
+              "currency": "INR",
+              "value": "5.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "18653ff5-041f-4391-a6f6-91a1f5c09695",
+            "@ondc/org/title_type": "delivery",
+            "title": "Delivery Charges",
+            "price": {
+              "currency": "INR",
+              "value": "100.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "18653ff5-041f-4391-a6f6-91a1f5c09695",
             "@ondc/org/title_type": "misc",
             "title": "Convenience Fee",
             "price": {
               "currency": "INR",
-              "value": "42.12"
+              "value": "35.65"
             }
           }
         ],

--- a/Pirimid/SellerApp/Retail/RET-10/FLOW_3/on_select_out_of_stock.json
+++ b/Pirimid/SellerApp/Retail/RET-10/FLOW_3/on_select_out_of_stock.json
@@ -9,9 +9,9 @@
     "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
     "bpp_id": "ondc.pirimidtech.com/v2/seller",
     "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-    "transaction_id": "2765f026-17e3-4a3f-a6bb-0b83046ff2c7",
-    "message_id": "08530f56-219f-4612-bf6e-99ad6d68cb1d",
-    "timestamp": "2025-01-18T04:31:39.702Z"
+    "transaction_id": "2d4259ff-d365-4419-b86e-eada579d06e7",
+    "message_id": "9e4cdbf9-cc86-4a8e-a05b-b163cbcf0b9b",
+    "timestamp": "2025-01-23T12:19:57.186Z"
   },
   "message": {
     "order": {
@@ -26,16 +26,20 @@
       "items": [
         {
           "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
-          "fulfillment_id": "b461394b-97f4-4eb0-a43c-72729c30344e"
+          "fulfillment_id": "1ec0398b-10ea-4a2b-8acd-37bd0a405ece"
         },
         {
           "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
-          "fulfillment_id": "b461394b-97f4-4eb0-a43c-72729c30344e"
+          "fulfillment_id": "1ec0398b-10ea-4a2b-8acd-37bd0a405ece"
+        },
+        {
+          "id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+          "fulfillment_id": "1ec0398b-10ea-4a2b-8acd-37bd0a405ece"
         }
       ],
       "fulfillments": [
         {
-          "id": "b461394b-97f4-4eb0-a43c-72729c30344e",
+          "id": "1ec0398b-10ea-4a2b-8acd-37bd0a405ece",
           "type": "Delivery",
           "@ondc/org/category": "Standard Delivery",
           "@ondc/org/TAT": "PT99H",
@@ -51,13 +55,13 @@
       "quote": {
         "price": {
           "currency": "INR",
-          "value": "1189.92"
+          "value": "1007.05"
         },
         "breakup": [
           {
             "@ondc/org/item_id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
             "@ondc/org/item_quantity": {
-              "count": 4
+              "count": 2
             },
             "@ondc/org/title_type": "item",
             "item": {
@@ -77,11 +81,11 @@
             "title": "Nutraj-California-Almonds-1Kg",
             "price": {
               "currency": "INR",
-              "value": "880.0"
+              "value": "440.0"
             }
           },
           {
-            "@ondc/org/item_id": "b461394b-97f4-4eb0-a43c-72729c30344e",
+            "@ondc/org/item_id": "1ec0398b-10ea-4a2b-8acd-37bd0a405ece",
             "@ondc/org/title_type": "packing",
             "title": "Packing Charges",
             "price": {
@@ -90,7 +94,7 @@
             }
           },
           {
-            "@ondc/org/item_id": "b461394b-97f4-4eb0-a43c-72729c30344e",
+            "@ondc/org/item_id": "1ec0398b-10ea-4a2b-8acd-37bd0a405ece",
             "@ondc/org/title_type": "delivery",
             "title": "Delivery Charges",
             "price": {
@@ -104,11 +108,55 @@
             "title": "Tax",
             "price": {
               "currency": "INR",
-              "value": "162.8"
+              "value": "81.4"
             }
           },
           {
             "@ondc/org/item_id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "@ondc/org/title_type": "item",
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "120.0"
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                }
+              }
+            },
+            "title": "Cashews",
+            "price": {
+              "currency": "INR",
+              "value": "240.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "1ec0398b-10ea-4a2b-8acd-37bd0a405ece",
+            "@ondc/org/title_type": "packing",
+            "title": "Packing Charges",
+            "price": {
+              "currency": "INR",
+              "value": "5.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "1ec0398b-10ea-4a2b-8acd-37bd0a405ece",
+            "@ondc/org/title_type": "delivery",
+            "title": "Delivery Charges",
+            "price": {
+              "currency": "INR",
+              "value": "100.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
             "@ondc/org/item_quantity": {
               "count": 0
             },
@@ -127,14 +175,14 @@
                 }
               }
             },
-            "title": "Cashews",
+            "title": "Walnuts",
             "price": {
               "currency": "INR",
               "value": "0.0"
             }
           },
           {
-            "@ondc/org/item_id": "b461394b-97f4-4eb0-a43c-72729c30344e",
+            "@ondc/org/item_id": "1ec0398b-10ea-4a2b-8acd-37bd0a405ece",
             "@ondc/org/title_type": "packing",
             "title": "Packing Charges",
             "price": {
@@ -143,7 +191,7 @@
             }
           },
           {
-            "@ondc/org/item_id": "b461394b-97f4-4eb0-a43c-72729c30344e",
+            "@ondc/org/item_id": "1ec0398b-10ea-4a2b-8acd-37bd0a405ece",
             "@ondc/org/title_type": "delivery",
             "title": "Delivery Charges",
             "price": {
@@ -152,12 +200,12 @@
             }
           },
           {
-            "@ondc/org/item_id": "b461394b-97f4-4eb0-a43c-72729c30344e",
+            "@ondc/org/item_id": "1ec0398b-10ea-4a2b-8acd-37bd0a405ece",
             "@ondc/org/title_type": "misc",
             "title": "Convenience Fee",
             "price": {
               "currency": "INR",
-              "value": "42.12"
+              "value": "35.65"
             }
           }
         ],
@@ -168,6 +216,6 @@
   "error": {
     "type": "DOMAIN-ERROR",
     "code": "40002",
-    "message": "[{\"item_id\":\"0984d1dd-b5ea-417f-9104-68a2ec40dbd4\",\"error\":\"40002\"}]"
+    "message": "[{\"item_id\":\"1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7\",\"error\":\"40002\"}]"
   }
 }

--- a/Pirimid/SellerApp/Retail/RET-10/FLOW_3/on_status_delivered.json
+++ b/Pirimid/SellerApp/Retail/RET-10/FLOW_3/on_status_delivered.json
@@ -9,14 +9,14 @@
     "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
     "bpp_id": "ondc.pirimidtech.com/v2/seller",
     "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-    "transaction_id": "2765f026-17e3-4a3f-a6bb-0b83046ff2c7",
-    "message_id": "20860cd7-2e4d-4e97-b9f9-5ea076f77c72",
-    "timestamp": "2025-01-18T15:47:09.666Z",
+    "transaction_id": "2d4259ff-d365-4419-b86e-eada579d06e7",
+    "message_id": "f0a18eee-c60a-4ed9-a562-c9d5ed903fab",
+    "timestamp": "2025-01-24T05:25:03.958Z",
     "ttl": "PT30S"
   },
   "message": {
     "order": {
-      "id": "2025-01-18-499387",
+      "id": "2025-01-23-190156",
       "state": "Completed",
       "provider": {
         "id": "e2008459-7e90-493e-b02e-cae52ca53214",
@@ -30,14 +30,21 @@
         {
           "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
           "quantity": {
-            "count": 4
+            "count": 2
           },
-          "fulfillment_id": "6c14ebdb-6cb6-4b5c-ab85-4c2acb747973"
+          "fulfillment_id": "18653ff5-041f-4391-a6f6-91a1f5c09695"
+        },
+        {
+          "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "18653ff5-041f-4391-a6f6-91a1f5c09695"
         }
       ],
       "documents": [
         {
-          "url": "https://ondc.pirimidtech.com/v2/seller/api/order/invoice/409628fc-59ec-4ca7-9fd1-90f31cd45533",
+          "url": "https://ondc.pirimidtech.com/v2/seller/api/order/invoice/391cc4a0-61a4-49ca-aee6-ed28e308d8c2",
           "label": "Invoice"
         }
       ],
@@ -54,14 +61,14 @@
         },
         "email": "fhemanshu@gmail.com",
         "phone": "7202959020",
-        "created_at": "2025-01-18T04:32:04.795Z",
-        "updated_at": "2025-01-18T04:32:04.795Z"
+        "created_at": "2025-01-23T12:20:17.208Z",
+        "updated_at": "2025-01-23T12:20:17.208Z"
       },
       "fulfillments": [
         {
-          "id": "6c14ebdb-6cb6-4b5c-ab85-4c2acb747973",
+          "id": "18653ff5-041f-4391-a6f6-91a1f5c09695",
           "type": "Delivery",
-          "@ondc/org/TAT": "PT74H",
+          "@ondc/org/TAT": "PT99H",
           "provider_id": "ondc.loadshare.com/ondc/18275",
           "@ondc/org/provider_name": "LoadShare",
           "state": {
@@ -90,14 +97,14 @@
                 "locality": "Ashok Vatika",
                 "city": "Ahmedabad",
                 "state": "Gujarat",
-                "area_code": "380058"
+                "area_code": "380054"
               }
             },
             "time": {
-              "timestamp": "2025-01-18T04:33:14.159Z",
+              "timestamp": "2025-01-23T12:21:38.215Z",
               "range": {
-                "start": "2025-01-18T04:32:58.888Z",
-                "end": "2025-01-18T06:32:58.888Z"
+                "start": "2025-01-23T12:21:25.258Z",
+                "end": "2025-01-23T15:21:25.258Z"
               }
             },
             "instructions": {
@@ -125,10 +132,10 @@
               }
             },
             "time": {
-              "timestamp": "2025-01-18T15:47:09.664Z",
+              "timestamp": "2025-01-24T05:25:03.956Z",
               "range": {
-                "start": "2025-01-18T06:32:58.888Z",
-                "end": "2025-01-21T06:32:58.888Z"
+                "start": "2025-01-23T15:21:25.258Z",
+                "end": "2025-01-27T15:21:25.258Z"
               }
             },
             "contact": {
@@ -155,13 +162,13 @@
       "quote": {
         "price": {
           "currency": "INR",
-          "value": "1189.92"
+          "value": "1007.05"
         },
         "breakup": [
           {
             "@ondc/org/item_id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
             "@ondc/org/item_quantity": {
-              "count": 4
+              "count": 2
             },
             "@ondc/org/title_type": "item",
             "item": {
@@ -173,11 +180,11 @@
             "title": "Nutraj-California-Almonds-1Kg",
             "price": {
               "currency": "INR",
-              "value": "880.0"
+              "value": "440.0"
             }
           },
           {
-            "@ondc/org/item_id": "6c14ebdb-6cb6-4b5c-ab85-4c2acb747973",
+            "@ondc/org/item_id": "18653ff5-041f-4391-a6f6-91a1f5c09695",
             "@ondc/org/title_type": "packing",
             "title": "Packing Charges",
             "price": {
@@ -186,7 +193,7 @@
             }
           },
           {
-            "@ondc/org/item_id": "6c14ebdb-6cb6-4b5c-ab85-4c2acb747973",
+            "@ondc/org/item_id": "18653ff5-041f-4391-a6f6-91a1f5c09695",
             "@ondc/org/title_type": "delivery",
             "title": "Delivery Charges",
             "price": {
@@ -200,16 +207,52 @@
             "title": "Tax",
             "price": {
               "currency": "INR",
-              "value": "162.8"
+              "value": "81.4"
             }
           },
           {
-            "@ondc/org/item_id": "6c14ebdb-6cb6-4b5c-ab85-4c2acb747973",
+            "@ondc/org/item_id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "@ondc/org/title_type": "item",
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "120.0"
+              }
+            },
+            "title": "Cashews",
+            "price": {
+              "currency": "INR",
+              "value": "240.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "18653ff5-041f-4391-a6f6-91a1f5c09695",
+            "@ondc/org/title_type": "packing",
+            "title": "Packing Charges",
+            "price": {
+              "currency": "INR",
+              "value": "5.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "18653ff5-041f-4391-a6f6-91a1f5c09695",
+            "@ondc/org/title_type": "delivery",
+            "title": "Delivery Charges",
+            "price": {
+              "currency": "INR",
+              "value": "100.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "18653ff5-041f-4391-a6f6-91a1f5c09695",
             "@ondc/org/title_type": "misc",
             "title": "Convenience Fee",
             "price": {
               "currency": "INR",
-              "value": "42.12"
+              "value": "35.65"
             }
           }
         ],
@@ -219,8 +262,8 @@
         "uri": "https://razorpay.com/",
         "tl_method": "http/get",
         "params": {
-          "transaction_id": "order_Pkm8SsI9aoMbkW",
-          "amount": "1189.92",
+          "transaction_id": "order_Pmsmecg6gruGAW",
+          "amount": "1007.05",
           "currency": "INR"
         },
         "type": "ON-ORDER",
@@ -245,8 +288,8 @@
           }
         ]
       },
-      "created_at": "2025-01-18T04:32:26.191Z",
-      "updated_at": "2025-01-18T15:47:09.666Z"
+      "created_at": "2025-01-23T12:20:38.886Z",
+      "updated_at": "2025-01-24T05:25:03.958Z"
     }
   }
 }

--- a/Pirimid/SellerApp/Retail/RET-10/FLOW_3/on_status_out_for_delivery.json
+++ b/Pirimid/SellerApp/Retail/RET-10/FLOW_3/on_status_out_for_delivery.json
@@ -9,14 +9,14 @@
     "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
     "bpp_id": "ondc.pirimidtech.com/v2/seller",
     "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-    "transaction_id": "2765f026-17e3-4a3f-a6bb-0b83046ff2c7",
-    "message_id": "352d1d14-7ce1-45de-8283-ec3070f95552",
-    "timestamp": "2025-01-18T15:47:04.830Z",
+    "transaction_id": "2d4259ff-d365-4419-b86e-eada579d06e7",
+    "message_id": "c5245e24-05b7-432e-899f-55a036b6b0b0",
+    "timestamp": "2025-01-24T05:24:49.021Z",
     "ttl": "PT30S"
   },
   "message": {
     "order": {
-      "id": "2025-01-18-499387",
+      "id": "2025-01-23-190156",
       "state": "In-progress",
       "provider": {
         "id": "e2008459-7e90-493e-b02e-cae52ca53214",
@@ -30,14 +30,21 @@
         {
           "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
           "quantity": {
-            "count": 4
+            "count": 2
           },
-          "fulfillment_id": "6c14ebdb-6cb6-4b5c-ab85-4c2acb747973"
+          "fulfillment_id": "18653ff5-041f-4391-a6f6-91a1f5c09695"
+        },
+        {
+          "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "18653ff5-041f-4391-a6f6-91a1f5c09695"
         }
       ],
       "documents": [
         {
-          "url": "https://ondc.pirimidtech.com/v2/seller/api/order/invoice/409628fc-59ec-4ca7-9fd1-90f31cd45533",
+          "url": "https://ondc.pirimidtech.com/v2/seller/api/order/invoice/391cc4a0-61a4-49ca-aee6-ed28e308d8c2",
           "label": "Invoice"
         }
       ],
@@ -54,14 +61,14 @@
         },
         "email": "fhemanshu@gmail.com",
         "phone": "7202959020",
-        "created_at": "2025-01-18T04:32:04.795Z",
-        "updated_at": "2025-01-18T04:32:04.795Z"
+        "created_at": "2025-01-23T12:20:17.208Z",
+        "updated_at": "2025-01-23T12:20:17.208Z"
       },
       "fulfillments": [
         {
-          "id": "6c14ebdb-6cb6-4b5c-ab85-4c2acb747973",
+          "id": "18653ff5-041f-4391-a6f6-91a1f5c09695",
           "type": "Delivery",
-          "@ondc/org/TAT": "PT74H",
+          "@ondc/org/TAT": "PT99H",
           "provider_id": "ondc.loadshare.com/ondc/18275",
           "@ondc/org/provider_name": "LoadShare",
           "state": {
@@ -90,14 +97,14 @@
                 "locality": "Ashok Vatika",
                 "city": "Ahmedabad",
                 "state": "Gujarat",
-                "area_code": "380058"
+                "area_code": "380054"
               }
             },
             "time": {
-              "timestamp": "2025-01-18T04:33:14.159Z",
+              "timestamp": "2025-01-23T12:21:38.215Z",
               "range": {
-                "start": "2025-01-18T04:32:58.888Z",
-                "end": "2025-01-18T06:32:58.888Z"
+                "start": "2025-01-23T12:21:25.258Z",
+                "end": "2025-01-23T15:21:25.258Z"
               }
             },
             "instructions": {
@@ -126,8 +133,8 @@
             },
             "time": {
               "range": {
-                "start": "2025-01-18T06:32:58.888Z",
-                "end": "2025-01-21T06:32:58.888Z"
+                "start": "2025-01-23T15:21:25.258Z",
+                "end": "2025-01-27T15:21:25.258Z"
               }
             },
             "contact": {
@@ -154,13 +161,13 @@
       "quote": {
         "price": {
           "currency": "INR",
-          "value": "1189.92"
+          "value": "1007.05"
         },
         "breakup": [
           {
             "@ondc/org/item_id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
             "@ondc/org/item_quantity": {
-              "count": 4
+              "count": 2
             },
             "@ondc/org/title_type": "item",
             "item": {
@@ -172,11 +179,11 @@
             "title": "Nutraj-California-Almonds-1Kg",
             "price": {
               "currency": "INR",
-              "value": "880.0"
+              "value": "440.0"
             }
           },
           {
-            "@ondc/org/item_id": "6c14ebdb-6cb6-4b5c-ab85-4c2acb747973",
+            "@ondc/org/item_id": "18653ff5-041f-4391-a6f6-91a1f5c09695",
             "@ondc/org/title_type": "packing",
             "title": "Packing Charges",
             "price": {
@@ -185,7 +192,7 @@
             }
           },
           {
-            "@ondc/org/item_id": "6c14ebdb-6cb6-4b5c-ab85-4c2acb747973",
+            "@ondc/org/item_id": "18653ff5-041f-4391-a6f6-91a1f5c09695",
             "@ondc/org/title_type": "delivery",
             "title": "Delivery Charges",
             "price": {
@@ -199,16 +206,52 @@
             "title": "Tax",
             "price": {
               "currency": "INR",
-              "value": "162.8"
+              "value": "81.4"
             }
           },
           {
-            "@ondc/org/item_id": "6c14ebdb-6cb6-4b5c-ab85-4c2acb747973",
+            "@ondc/org/item_id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "@ondc/org/title_type": "item",
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "120.0"
+              }
+            },
+            "title": "Cashews",
+            "price": {
+              "currency": "INR",
+              "value": "240.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "18653ff5-041f-4391-a6f6-91a1f5c09695",
+            "@ondc/org/title_type": "packing",
+            "title": "Packing Charges",
+            "price": {
+              "currency": "INR",
+              "value": "5.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "18653ff5-041f-4391-a6f6-91a1f5c09695",
+            "@ondc/org/title_type": "delivery",
+            "title": "Delivery Charges",
+            "price": {
+              "currency": "INR",
+              "value": "100.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "18653ff5-041f-4391-a6f6-91a1f5c09695",
             "@ondc/org/title_type": "misc",
             "title": "Convenience Fee",
             "price": {
               "currency": "INR",
-              "value": "42.12"
+              "value": "35.65"
             }
           }
         ],
@@ -218,8 +261,8 @@
         "uri": "https://razorpay.com/",
         "tl_method": "http/get",
         "params": {
-          "transaction_id": "order_Pkm8SsI9aoMbkW",
-          "amount": "1189.92",
+          "transaction_id": "order_Pmsmecg6gruGAW",
+          "amount": "1007.05",
           "currency": "INR"
         },
         "type": "ON-ORDER",
@@ -244,8 +287,8 @@
           }
         ]
       },
-      "created_at": "2025-01-18T04:32:26.191Z",
-      "updated_at": "2025-01-18T15:47:04.830Z"
+      "created_at": "2025-01-23T12:20:38.886Z",
+      "updated_at": "2025-01-24T05:24:49.021Z"
     }
   }
 }

--- a/Pirimid/SellerApp/Retail/RET-10/FLOW_3/on_status_packed.json
+++ b/Pirimid/SellerApp/Retail/RET-10/FLOW_3/on_status_packed.json
@@ -9,14 +9,14 @@
     "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
     "bpp_id": "ondc.pirimidtech.com/v2/seller",
     "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-    "transaction_id": "2765f026-17e3-4a3f-a6bb-0b83046ff2c7",
-    "message_id": "6abe664c-a170-41d2-b293-3435556e595f",
-    "timestamp": "2025-01-18T04:33:05.146Z",
+    "transaction_id": "2d4259ff-d365-4419-b86e-eada579d06e7",
+    "message_id": "c6b773bf-c154-4ab1-92d5-6f6072dcc320",
+    "timestamp": "2025-01-23T12:21:30.767Z",
     "ttl": "PT30S"
   },
   "message": {
     "order": {
-      "id": "2025-01-18-499387",
+      "id": "2025-01-23-190156",
       "state": "In-progress",
       "provider": {
         "id": "e2008459-7e90-493e-b02e-cae52ca53214",
@@ -30,9 +30,16 @@
         {
           "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
           "quantity": {
-            "count": 4
+            "count": 2
           },
-          "fulfillment_id": "6c14ebdb-6cb6-4b5c-ab85-4c2acb747973"
+          "fulfillment_id": "18653ff5-041f-4391-a6f6-91a1f5c09695"
+        },
+        {
+          "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "18653ff5-041f-4391-a6f6-91a1f5c09695"
         }
       ],
       "billing": {
@@ -48,14 +55,14 @@
         },
         "email": "fhemanshu@gmail.com",
         "phone": "7202959020",
-        "created_at": "2025-01-18T04:32:04.795Z",
-        "updated_at": "2025-01-18T04:32:04.795Z"
+        "created_at": "2025-01-23T12:20:17.208Z",
+        "updated_at": "2025-01-23T12:20:17.208Z"
       },
       "fulfillments": [
         {
-          "id": "6c14ebdb-6cb6-4b5c-ab85-4c2acb747973",
+          "id": "18653ff5-041f-4391-a6f6-91a1f5c09695",
           "type": "Delivery",
-          "@ondc/org/TAT": "PT74H",
+          "@ondc/org/TAT": "PT99H",
           "provider_id": "ondc.loadshare.com/ondc/18275",
           "@ondc/org/provider_name": "LoadShare",
           "state": {
@@ -84,13 +91,13 @@
                 "locality": "Ashok Vatika",
                 "city": "Ahmedabad",
                 "state": "Gujarat",
-                "area_code": "380058"
+                "area_code": "380054"
               }
             },
             "time": {
               "range": {
-                "start": "2025-01-18T04:32:58.888Z",
-                "end": "2025-01-18T06:32:58.888Z"
+                "start": "2025-01-23T12:21:25.258Z",
+                "end": "2025-01-23T15:21:25.258Z"
               }
             },
             "instructions": {
@@ -119,8 +126,8 @@
             },
             "time": {
               "range": {
-                "start": "2025-01-18T06:32:58.888Z",
-                "end": "2025-01-21T06:32:58.888Z"
+                "start": "2025-01-23T15:21:25.258Z",
+                "end": "2025-01-27T15:21:25.258Z"
               }
             },
             "contact": {
@@ -130,19 +137,30 @@
             "person": {
               "name": "Hemanshu Faldu"
             }
-          }
+          },
+          "tags": [
+            {
+              "code": "routing",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "P2P"
+                }
+              ]
+            }
+          ]
         }
       ],
       "quote": {
         "price": {
           "currency": "INR",
-          "value": "1189.92"
+          "value": "1007.05"
         },
         "breakup": [
           {
             "@ondc/org/item_id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
             "@ondc/org/item_quantity": {
-              "count": 4
+              "count": 2
             },
             "@ondc/org/title_type": "item",
             "item": {
@@ -154,11 +172,11 @@
             "title": "Nutraj-California-Almonds-1Kg",
             "price": {
               "currency": "INR",
-              "value": "880.0"
+              "value": "440.0"
             }
           },
           {
-            "@ondc/org/item_id": "6c14ebdb-6cb6-4b5c-ab85-4c2acb747973",
+            "@ondc/org/item_id": "18653ff5-041f-4391-a6f6-91a1f5c09695",
             "@ondc/org/title_type": "packing",
             "title": "Packing Charges",
             "price": {
@@ -167,7 +185,7 @@
             }
           },
           {
-            "@ondc/org/item_id": "6c14ebdb-6cb6-4b5c-ab85-4c2acb747973",
+            "@ondc/org/item_id": "18653ff5-041f-4391-a6f6-91a1f5c09695",
             "@ondc/org/title_type": "delivery",
             "title": "Delivery Charges",
             "price": {
@@ -181,16 +199,52 @@
             "title": "Tax",
             "price": {
               "currency": "INR",
-              "value": "162.8"
+              "value": "81.4"
             }
           },
           {
-            "@ondc/org/item_id": "6c14ebdb-6cb6-4b5c-ab85-4c2acb747973",
+            "@ondc/org/item_id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "@ondc/org/title_type": "item",
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "120.0"
+              }
+            },
+            "title": "Cashews",
+            "price": {
+              "currency": "INR",
+              "value": "240.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "18653ff5-041f-4391-a6f6-91a1f5c09695",
+            "@ondc/org/title_type": "packing",
+            "title": "Packing Charges",
+            "price": {
+              "currency": "INR",
+              "value": "5.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "18653ff5-041f-4391-a6f6-91a1f5c09695",
+            "@ondc/org/title_type": "delivery",
+            "title": "Delivery Charges",
+            "price": {
+              "currency": "INR",
+              "value": "100.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "18653ff5-041f-4391-a6f6-91a1f5c09695",
             "@ondc/org/title_type": "misc",
             "title": "Convenience Fee",
             "price": {
               "currency": "INR",
-              "value": "42.12"
+              "value": "35.65"
             }
           }
         ],
@@ -200,8 +254,8 @@
         "uri": "https://razorpay.com/",
         "tl_method": "http/get",
         "params": {
-          "transaction_id": "order_Pkm8SsI9aoMbkW",
-          "amount": "1189.92",
+          "transaction_id": "order_Pmsmecg6gruGAW",
+          "amount": "1007.05",
           "currency": "INR"
         },
         "type": "ON-ORDER",
@@ -226,8 +280,8 @@
           }
         ]
       },
-      "created_at": "2025-01-18T04:32:26.191Z",
-      "updated_at": "2025-01-18T04:33:05.146Z"
+      "created_at": "2025-01-23T12:20:38.886Z",
+      "updated_at": "2025-01-23T12:21:30.767Z"
     }
   }
 }

--- a/Pirimid/SellerApp/Retail/RET-10/FLOW_3/on_status_pending.json
+++ b/Pirimid/SellerApp/Retail/RET-10/FLOW_3/on_status_pending.json
@@ -9,14 +9,14 @@
     "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
     "bpp_id": "ondc.pirimidtech.com/v2/seller",
     "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-    "transaction_id": "2765f026-17e3-4a3f-a6bb-0b83046ff2c7",
-    "message_id": "31c7ad9f-0468-48b1-a66c-fd4a600d1c3b",
-    "timestamp": "2025-01-18T04:32:58.890Z",
+    "transaction_id": "2d4259ff-d365-4419-b86e-eada579d06e7",
+    "message_id": "74efe074-21ce-40d4-b502-5f044c481043",
+    "timestamp": "2025-01-23T12:21:25.260Z",
     "ttl": "PT30S"
   },
   "message": {
     "order": {
-      "id": "2025-01-18-499387",
+      "id": "2025-01-23-190156",
       "state": "Accepted",
       "provider": {
         "id": "e2008459-7e90-493e-b02e-cae52ca53214",
@@ -30,9 +30,16 @@
         {
           "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
           "quantity": {
-            "count": 4
+            "count": 2
           },
-          "fulfillment_id": "6c14ebdb-6cb6-4b5c-ab85-4c2acb747973"
+          "fulfillment_id": "18653ff5-041f-4391-a6f6-91a1f5c09695"
+        },
+        {
+          "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "18653ff5-041f-4391-a6f6-91a1f5c09695"
         }
       ],
       "billing": {
@@ -48,14 +55,14 @@
         },
         "email": "fhemanshu@gmail.com",
         "phone": "7202959020",
-        "created_at": "2025-01-18T04:32:04.795Z",
-        "updated_at": "2025-01-18T04:32:04.795Z"
+        "created_at": "2025-01-23T12:20:17.208Z",
+        "updated_at": "2025-01-23T12:20:17.208Z"
       },
       "fulfillments": [
         {
-          "id": "6c14ebdb-6cb6-4b5c-ab85-4c2acb747973",
+          "id": "18653ff5-041f-4391-a6f6-91a1f5c09695",
           "type": "Delivery",
-          "@ondc/org/TAT": "PT74H",
+          "@ondc/org/TAT": "PT99H",
           "provider_id": "ondc.loadshare.com/ondc/18275",
           "@ondc/org/provider_name": "LoadShare",
           "state": {
@@ -75,13 +82,13 @@
                 "locality": "Ashok Vatika",
                 "city": "Ahmedabad",
                 "state": "Gujarat",
-                "area_code": "380058"
+                "area_code": "380054"
               }
             },
             "time": {
               "range": {
-                "start": "2025-01-18T04:32:58.888Z",
-                "end": "2025-01-18T06:32:58.888Z"
+                "start": "2025-01-23T12:21:25.258Z",
+                "end": "2025-01-23T15:21:25.258Z"
               }
             },
             "instructions": {
@@ -110,8 +117,8 @@
             },
             "time": {
               "range": {
-                "start": "2025-01-18T06:32:58.888Z",
-                "end": "2025-01-21T06:32:58.888Z"
+                "start": "2025-01-23T15:21:25.258Z",
+                "end": "2025-01-27T15:21:25.258Z"
               }
             },
             "contact": {
@@ -127,13 +134,13 @@
       "quote": {
         "price": {
           "currency": "INR",
-          "value": "1189.92"
+          "value": "1007.05"
         },
         "breakup": [
           {
             "@ondc/org/item_id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
             "@ondc/org/item_quantity": {
-              "count": 4
+              "count": 2
             },
             "@ondc/org/title_type": "item",
             "item": {
@@ -145,11 +152,11 @@
             "title": "Nutraj-California-Almonds-1Kg",
             "price": {
               "currency": "INR",
-              "value": "880.0"
+              "value": "440.0"
             }
           },
           {
-            "@ondc/org/item_id": "6c14ebdb-6cb6-4b5c-ab85-4c2acb747973",
+            "@ondc/org/item_id": "18653ff5-041f-4391-a6f6-91a1f5c09695",
             "@ondc/org/title_type": "packing",
             "title": "Packing Charges",
             "price": {
@@ -158,7 +165,7 @@
             }
           },
           {
-            "@ondc/org/item_id": "6c14ebdb-6cb6-4b5c-ab85-4c2acb747973",
+            "@ondc/org/item_id": "18653ff5-041f-4391-a6f6-91a1f5c09695",
             "@ondc/org/title_type": "delivery",
             "title": "Delivery Charges",
             "price": {
@@ -172,16 +179,52 @@
             "title": "Tax",
             "price": {
               "currency": "INR",
-              "value": "162.8"
+              "value": "81.4"
             }
           },
           {
-            "@ondc/org/item_id": "6c14ebdb-6cb6-4b5c-ab85-4c2acb747973",
+            "@ondc/org/item_id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "@ondc/org/title_type": "item",
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "120.0"
+              }
+            },
+            "title": "Cashews",
+            "price": {
+              "currency": "INR",
+              "value": "240.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "18653ff5-041f-4391-a6f6-91a1f5c09695",
+            "@ondc/org/title_type": "packing",
+            "title": "Packing Charges",
+            "price": {
+              "currency": "INR",
+              "value": "5.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "18653ff5-041f-4391-a6f6-91a1f5c09695",
+            "@ondc/org/title_type": "delivery",
+            "title": "Delivery Charges",
+            "price": {
+              "currency": "INR",
+              "value": "100.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "18653ff5-041f-4391-a6f6-91a1f5c09695",
             "@ondc/org/title_type": "misc",
             "title": "Convenience Fee",
             "price": {
               "currency": "INR",
-              "value": "42.12"
+              "value": "35.65"
             }
           }
         ],
@@ -191,8 +234,8 @@
         "uri": "https://razorpay.com/",
         "tl_method": "http/get",
         "params": {
-          "transaction_id": "order_Pkm8SsI9aoMbkW",
-          "amount": "1189.92",
+          "transaction_id": "order_Pmsmecg6gruGAW",
+          "amount": "1007.05",
           "currency": "INR"
         },
         "type": "ON-ORDER",
@@ -217,8 +260,8 @@
           }
         ]
       },
-      "created_at": "2025-01-18T04:32:26.191Z",
-      "updated_at": "2025-01-18T04:32:58.890Z"
+      "created_at": "2025-01-23T12:20:38.886Z",
+      "updated_at": "2025-01-23T12:21:25.260Z"
     }
   }
 }

--- a/Pirimid/SellerApp/Retail/RET-10/FLOW_3/on_status_picked.json
+++ b/Pirimid/SellerApp/Retail/RET-10/FLOW_3/on_status_picked.json
@@ -9,14 +9,14 @@
     "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
     "bpp_id": "ondc.pirimidtech.com/v2/seller",
     "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-    "transaction_id": "2765f026-17e3-4a3f-a6bb-0b83046ff2c7",
-    "message_id": "d04c03d0-4a90-4795-95ec-027370d65cc3",
-    "timestamp": "2025-01-18T04:33:14.163Z",
+    "transaction_id": "2d4259ff-d365-4419-b86e-eada579d06e7",
+    "message_id": "1dbe014b-386c-4fe4-99cf-f2e733cdd05c",
+    "timestamp": "2025-01-23T12:21:38.217Z",
     "ttl": "PT30S"
   },
   "message": {
     "order": {
-      "id": "2025-01-18-499387",
+      "id": "2025-01-23-190156",
       "state": "In-progress",
       "provider": {
         "id": "e2008459-7e90-493e-b02e-cae52ca53214",
@@ -30,14 +30,21 @@
         {
           "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
           "quantity": {
-            "count": 4
+            "count": 2
           },
-          "fulfillment_id": "6c14ebdb-6cb6-4b5c-ab85-4c2acb747973"
+          "fulfillment_id": "18653ff5-041f-4391-a6f6-91a1f5c09695"
+        },
+        {
+          "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "18653ff5-041f-4391-a6f6-91a1f5c09695"
         }
       ],
       "documents": [
         {
-          "url": "https://ondc.pirimidtech.com/v2/seller/api/order/invoice/409628fc-59ec-4ca7-9fd1-90f31cd45533",
+          "url": "https://ondc.pirimidtech.com/v2/seller/api/order/invoice/391cc4a0-61a4-49ca-aee6-ed28e308d8c2",
           "label": "Invoice"
         }
       ],
@@ -54,14 +61,14 @@
         },
         "email": "fhemanshu@gmail.com",
         "phone": "7202959020",
-        "created_at": "2025-01-18T04:32:04.795Z",
-        "updated_at": "2025-01-18T04:32:04.795Z"
+        "created_at": "2025-01-23T12:20:17.208Z",
+        "updated_at": "2025-01-23T12:20:17.208Z"
       },
       "fulfillments": [
         {
-          "id": "6c14ebdb-6cb6-4b5c-ab85-4c2acb747973",
+          "id": "18653ff5-041f-4391-a6f6-91a1f5c09695",
           "type": "Delivery",
-          "@ondc/org/TAT": "PT74H",
+          "@ondc/org/TAT": "PT99H",
           "provider_id": "ondc.loadshare.com/ondc/18275",
           "@ondc/org/provider_name": "LoadShare",
           "state": {
@@ -90,14 +97,14 @@
                 "locality": "Ashok Vatika",
                 "city": "Ahmedabad",
                 "state": "Gujarat",
-                "area_code": "380058"
+                "area_code": "380054"
               }
             },
             "time": {
-              "timestamp": "2025-01-18T04:33:14.159Z",
+              "timestamp": "2025-01-23T12:21:38.215Z",
               "range": {
-                "start": "2025-01-18T04:32:58.888Z",
-                "end": "2025-01-18T06:32:58.888Z"
+                "start": "2025-01-23T12:21:25.258Z",
+                "end": "2025-01-23T15:21:25.258Z"
               }
             },
             "instructions": {
@@ -126,8 +133,8 @@
             },
             "time": {
               "range": {
-                "start": "2025-01-18T06:32:58.888Z",
-                "end": "2025-01-21T06:32:58.888Z"
+                "start": "2025-01-23T15:21:25.258Z",
+                "end": "2025-01-27T15:21:25.258Z"
               }
             },
             "contact": {
@@ -154,13 +161,13 @@
       "quote": {
         "price": {
           "currency": "INR",
-          "value": "1189.92"
+          "value": "1007.05"
         },
         "breakup": [
           {
             "@ondc/org/item_id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
             "@ondc/org/item_quantity": {
-              "count": 4
+              "count": 2
             },
             "@ondc/org/title_type": "item",
             "item": {
@@ -172,11 +179,11 @@
             "title": "Nutraj-California-Almonds-1Kg",
             "price": {
               "currency": "INR",
-              "value": "880.0"
+              "value": "440.0"
             }
           },
           {
-            "@ondc/org/item_id": "6c14ebdb-6cb6-4b5c-ab85-4c2acb747973",
+            "@ondc/org/item_id": "18653ff5-041f-4391-a6f6-91a1f5c09695",
             "@ondc/org/title_type": "packing",
             "title": "Packing Charges",
             "price": {
@@ -185,7 +192,7 @@
             }
           },
           {
-            "@ondc/org/item_id": "6c14ebdb-6cb6-4b5c-ab85-4c2acb747973",
+            "@ondc/org/item_id": "18653ff5-041f-4391-a6f6-91a1f5c09695",
             "@ondc/org/title_type": "delivery",
             "title": "Delivery Charges",
             "price": {
@@ -199,16 +206,52 @@
             "title": "Tax",
             "price": {
               "currency": "INR",
-              "value": "162.8"
+              "value": "81.4"
             }
           },
           {
-            "@ondc/org/item_id": "6c14ebdb-6cb6-4b5c-ab85-4c2acb747973",
+            "@ondc/org/item_id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "@ondc/org/title_type": "item",
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "120.0"
+              }
+            },
+            "title": "Cashews",
+            "price": {
+              "currency": "INR",
+              "value": "240.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "18653ff5-041f-4391-a6f6-91a1f5c09695",
+            "@ondc/org/title_type": "packing",
+            "title": "Packing Charges",
+            "price": {
+              "currency": "INR",
+              "value": "5.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "18653ff5-041f-4391-a6f6-91a1f5c09695",
+            "@ondc/org/title_type": "delivery",
+            "title": "Delivery Charges",
+            "price": {
+              "currency": "INR",
+              "value": "100.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "18653ff5-041f-4391-a6f6-91a1f5c09695",
             "@ondc/org/title_type": "misc",
             "title": "Convenience Fee",
             "price": {
               "currency": "INR",
-              "value": "42.12"
+              "value": "35.65"
             }
           }
         ],
@@ -218,8 +261,8 @@
         "uri": "https://razorpay.com/",
         "tl_method": "http/get",
         "params": {
-          "transaction_id": "order_Pkm8SsI9aoMbkW",
-          "amount": "1189.92",
+          "transaction_id": "order_Pmsmecg6gruGAW",
+          "amount": "1007.05",
           "currency": "INR"
         },
         "type": "ON-ORDER",
@@ -244,8 +287,8 @@
           }
         ]
       },
-      "created_at": "2025-01-18T04:32:26.191Z",
-      "updated_at": "2025-01-18T04:33:14.163Z"
+      "created_at": "2025-01-23T12:20:38.886Z",
+      "updated_at": "2025-01-23T12:21:38.217Z"
     }
   }
 }

--- a/Pirimid/SellerApp/Retail/RET-10/FLOW_3/search_full_catalog_refresh.json
+++ b/Pirimid/SellerApp/Retail/RET-10/FLOW_3/search_full_catalog_refresh.json
@@ -7,9 +7,9 @@
     "core_version": "1.2.0",
     "bap_id": "buyer-app-preprod-v2.ondc.org",
     "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
-    "transaction_id": "e53a74c5-7ce6-4498-800c-e7d90db0f2fa",
-    "message_id": "45726578-5033-41e0-b35f-2fcbcebe8f82",
-    "timestamp": "2025-01-17T12:00:01.818Z",
+    "transaction_id": "2a274964-3eec-4793-888c-1d30ef845cd1",
+    "message_id": "c5c58f68-8483-4490-b318-a1436c6ee88b",
+    "timestamp": "2025-01-23T12:00:01.908Z",
     "ttl": "PT30S"
   },
   "message": {

--- a/Pirimid/SellerApp/Retail/RET-10/FLOW_3/select.json
+++ b/Pirimid/SellerApp/Retail/RET-10/FLOW_3/select.json
@@ -8,9 +8,9 @@
     "bap_id": "buyer-app-preprod-v2.ondc.org",
     "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
     "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-    "transaction_id": "2765f026-17e3-4a3f-a6bb-0b83046ff2c7",
-    "message_id": "5a59a9e8-6a51-40b6-a213-1174fd5fa1e6",
-    "timestamp": "2025-01-18T04:31:55.082Z",
+    "transaction_id": "2d4259ff-d365-4419-b86e-eada579d06e7",
+    "message_id": "070acea7-6306-47a0-a43a-9c4af2ee2f95",
+    "timestamp": "2025-01-23T12:20:07.850Z",
     "bpp_id": "ondc.pirimidtech.com/v2/seller",
     "ttl": "PT30S"
   },
@@ -20,7 +20,14 @@
         {
           "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
           "quantity": {
-            "count": 4
+            "count": 2
+          },
+          "location_id": "39550822-c3bb-4918-bd25-2d19ef6a9aca"
+        },
+        {
+          "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
+          "quantity": {
+            "count": 2
           },
           "location_id": "39550822-c3bb-4918-bd25-2d19ef6a9aca"
         }

--- a/Pirimid/SellerApp/Retail/RET-10/FLOW_3/select_out_of_stock.json
+++ b/Pirimid/SellerApp/Retail/RET-10/FLOW_3/select_out_of_stock.json
@@ -8,9 +8,9 @@
     "bap_id": "buyer-app-preprod-v2.ondc.org",
     "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
     "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-    "transaction_id": "2765f026-17e3-4a3f-a6bb-0b83046ff2c7",
-    "message_id": "08530f56-219f-4612-bf6e-99ad6d68cb1d",
-    "timestamp": "2025-01-18T04:31:38.213Z",
+    "transaction_id": "2d4259ff-d365-4419-b86e-eada579d06e7",
+    "message_id": "9e4cdbf9-cc86-4a8e-a05b-b163cbcf0b9b",
+    "timestamp": "2025-01-23T12:19:55.257Z",
     "bpp_id": "ondc.pirimidtech.com/v2/seller",
     "ttl": "PT30S"
   },
@@ -20,14 +20,21 @@
         {
           "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
           "quantity": {
-            "count": 4
+            "count": 2
           },
           "location_id": "39550822-c3bb-4918-bd25-2d19ef6a9aca"
         },
         {
           "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
           "quantity": {
-            "count": 3
+            "count": 2
+          },
+          "location_id": "39550822-c3bb-4918-bd25-2d19ef6a9aca"
+        },
+        {
+          "id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+          "quantity": {
+            "count": 2
           },
           "location_id": "39550822-c3bb-4918-bd25-2d19ef6a9aca"
         }

--- a/Pirimid/SellerApp/Retail/RET-10/FLOW_4/cancel.json
+++ b/Pirimid/SellerApp/Retail/RET-10/FLOW_4/cancel.json
@@ -8,14 +8,14 @@
     "bap_id": "buyer-app-preprod-v2.ondc.org",
     "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
     "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-    "transaction_id": "d02d4bc1-becf-4f37-a3b8-ff14d24144ab",
-    "message_id": "476e1aa4-7f51-4291-9158-0f67c35c1568",
-    "timestamp": "2025-01-17T12:11:19.783Z",
+    "transaction_id": "9ed41e8f-56cf-437a-ae53-d7d64409ef2e",
+    "message_id": "a2779ebb-32e8-4328-8529-b26e53f0be53",
+    "timestamp": "2025-01-23T12:05:09.282Z",
     "bpp_id": "ondc.pirimidtech.com/v2/seller",
     "ttl": "PT30S"
   },
   "message": {
-    "order_id": "2025-01-17-558256",
+    "order_id": "2025-01-23-702967",
     "cancellation_reason_id": "001"
   }
 }

--- a/Pirimid/SellerApp/Retail/RET-10/FLOW_4/confirm.json
+++ b/Pirimid/SellerApp/Retail/RET-10/FLOW_4/confirm.json
@@ -8,15 +8,15 @@
     "bap_id": "buyer-app-preprod-v2.ondc.org",
     "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
     "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-    "transaction_id": "d02d4bc1-becf-4f37-a3b8-ff14d24144ab",
-    "message_id": "d069b641-459f-44cb-92b3-98fa9f552750",
-    "timestamp": "2025-01-17T12:11:07.597Z",
+    "transaction_id": "9ed41e8f-56cf-437a-ae53-d7d64409ef2e",
+    "message_id": "d4efb134-bd4a-4ee7-b2cc-9a56273abc08",
+    "timestamp": "2025-01-23T12:04:56.020Z",
     "bpp_id": "ondc.pirimidtech.com/v2/seller",
     "ttl": "PT30S"
   },
   "message": {
     "order": {
-      "id": "2025-01-17-558256",
+      "id": "2025-01-23-702967",
       "state": "Created",
       "billing": {
         "address": {
@@ -31,23 +31,30 @@
         "phone": "7202959020",
         "name": "Hemanshu Faldu",
         "email": "fhemanshu@gmail.com",
-        "created_at": "2025-01-17T12:10:45.183Z",
-        "updated_at": "2025-01-17T12:10:45.183Z"
+        "created_at": "2025-01-23T12:04:27.137Z",
+        "updated_at": "2025-01-23T12:04:27.137Z"
       },
       "items": [
         {
-          "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
-          "quantity": {
-            "count": 3
-          },
-          "fulfillment_id": "ce0e2d9c-7db0-403e-a30a-3491d390931e"
-        },
-        {
           "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
           "quantity": {
-            "count": 3
+            "count": 2
           },
-          "fulfillment_id": "ce0e2d9c-7db0-403e-a30a-3491d390931e"
+          "fulfillment_id": "0f1fca5b-8a66-41f9-ab45-2afa92dcb5c1"
+        },
+        {
+          "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "0f1fca5b-8a66-41f9-ab45-2afa92dcb5c1"
+        },
+        {
+          "id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "0f1fca5b-8a66-41f9-ab45-2afa92dcb5c1"
         }
       ],
       "provider": {
@@ -61,7 +68,7 @@
       "fulfillments": [
         {
           "@ondc/org/TAT": "PT99H",
-          "id": "ce0e2d9c-7db0-403e-a30a-3491d390931e",
+          "id": "0f1fca5b-8a66-41f9-ab45-2afa92dcb5c1",
           "tracking": false,
           "end": {
             "contact": {
@@ -91,9 +98,9 @@
         "uri": "https://razorpay.com/",
         "tl_method": "http/get",
         "params": {
-          "amount": "1401.72",
+          "amount": "1364.71",
           "currency": "INR",
-          "transaction_id": "order_PkVPrEniq5bWbv"
+          "transaction_id": "order_PmsVwseRIRk2FE"
         },
         "status": "PAID",
         "type": "ON-ORDER",
@@ -120,49 +127,13 @@
       "quote": {
         "price": {
           "currency": "INR",
-          "value": "1401.72"
+          "value": "1364.71"
         },
         "breakup": [
           {
-            "@ondc/org/item_id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
-            "@ondc/org/item_quantity": {
-              "count": 3
-            },
-            "@ondc/org/title_type": "item",
-            "item": {
-              "price": {
-                "currency": "INR",
-                "value": "120.0"
-              }
-            },
-            "title": "Cashews",
-            "price": {
-              "currency": "INR",
-              "value": "360.0"
-            }
-          },
-          {
-            "@ondc/org/item_id": "ce0e2d9c-7db0-403e-a30a-3491d390931e",
-            "@ondc/org/title_type": "packing",
-            "title": "Packing Charges",
-            "price": {
-              "currency": "INR",
-              "value": "5.0"
-            }
-          },
-          {
-            "@ondc/org/item_id": "ce0e2d9c-7db0-403e-a30a-3491d390931e",
-            "@ondc/org/title_type": "delivery",
-            "title": "Delivery Charges",
-            "price": {
-              "currency": "INR",
-              "value": "100.0"
-            }
-          },
-          {
             "@ondc/org/item_id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
             "@ondc/org/item_quantity": {
-              "count": 3
+              "count": 2
             },
             "@ondc/org/title_type": "item",
             "item": {
@@ -174,11 +145,11 @@
             "title": "Nutraj-California-Almonds-1Kg",
             "price": {
               "currency": "INR",
-              "value": "660.0"
+              "value": "440.0"
             }
           },
           {
-            "@ondc/org/item_id": "ce0e2d9c-7db0-403e-a30a-3491d390931e",
+            "@ondc/org/item_id": "0f1fca5b-8a66-41f9-ab45-2afa92dcb5c1",
             "@ondc/org/title_type": "packing",
             "title": "Packing Charges",
             "price": {
@@ -187,7 +158,7 @@
             }
           },
           {
-            "@ondc/org/item_id": "ce0e2d9c-7db0-403e-a30a-3491d390931e",
+            "@ondc/org/item_id": "0f1fca5b-8a66-41f9-ab45-2afa92dcb5c1",
             "@ondc/org/title_type": "delivery",
             "title": "Delivery Charges",
             "price": {
@@ -201,16 +172,88 @@
             "title": "Tax",
             "price": {
               "currency": "INR",
-              "value": "122.1"
+              "value": "81.4"
             }
           },
           {
-            "@ondc/org/item_id": "ce0e2d9c-7db0-403e-a30a-3491d390931e",
+            "@ondc/org/item_id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "@ondc/org/title_type": "item",
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "120.0"
+              }
+            },
+            "title": "Cashews",
+            "price": {
+              "currency": "INR",
+              "value": "240.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "0f1fca5b-8a66-41f9-ab45-2afa92dcb5c1",
+            "@ondc/org/title_type": "packing",
+            "title": "Packing Charges",
+            "price": {
+              "currency": "INR",
+              "value": "5.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "0f1fca5b-8a66-41f9-ab45-2afa92dcb5c1",
+            "@ondc/org/title_type": "delivery",
+            "title": "Delivery Charges",
+            "price": {
+              "currency": "INR",
+              "value": "100.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "@ondc/org/title_type": "item",
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "120.0"
+              }
+            },
+            "title": "Walnuts",
+            "price": {
+              "currency": "INR",
+              "value": "240.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "0f1fca5b-8a66-41f9-ab45-2afa92dcb5c1",
+            "@ondc/org/title_type": "packing",
+            "title": "Packing Charges",
+            "price": {
+              "currency": "INR",
+              "value": "5.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "0f1fca5b-8a66-41f9-ab45-2afa92dcb5c1",
+            "@ondc/org/title_type": "delivery",
+            "title": "Delivery Charges",
+            "price": {
+              "currency": "INR",
+              "value": "100.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "0f1fca5b-8a66-41f9-ab45-2afa92dcb5c1",
             "@ondc/org/title_type": "misc",
             "title": "Convenience Fee",
             "price": {
               "currency": "INR",
-              "value": "49.62"
+              "value": "48.31"
             }
           }
         ],
@@ -240,8 +283,8 @@
           ]
         }
       ],
-      "created_at": "2025-01-17T12:11:07.597Z",
-      "updated_at": "2025-01-17T12:11:07.597Z"
+      "created_at": "2025-01-23T12:04:56.020Z",
+      "updated_at": "2025-01-23T12:04:56.020Z"
     }
   }
 }

--- a/Pirimid/SellerApp/Retail/RET-10/FLOW_4/init.json
+++ b/Pirimid/SellerApp/Retail/RET-10/FLOW_4/init.json
@@ -8,9 +8,9 @@
     "bap_id": "buyer-app-preprod-v2.ondc.org",
     "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
     "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-    "transaction_id": "d02d4bc1-becf-4f37-a3b8-ff14d24144ab",
-    "message_id": "299cbae8-b8e5-4f29-aed5-f34887462e64",
-    "timestamp": "2025-01-17T12:10:45.183Z",
+    "transaction_id": "9ed41e8f-56cf-437a-ae53-d7d64409ef2e",
+    "message_id": "997ce9d7-5c7a-413d-9d3b-fb6836e05e0d",
+    "timestamp": "2025-01-23T12:04:27.137Z",
     "bpp_id": "ondc.pirimidtech.com/v2/seller",
     "ttl": "PT30S"
   },
@@ -26,20 +26,28 @@
       },
       "items": [
         {
-          "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
-          "quantity": {
-            "count": 3
-          },
-          "location_id": "39550822-c3bb-4918-bd25-2d19ef6a9aca",
-          "fulfillment_id": "ce0e2d9c-7db0-403e-a30a-3491d390931e"
-        },
-        {
           "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
           "quantity": {
-            "count": 3
+            "count": 2
           },
           "location_id": "39550822-c3bb-4918-bd25-2d19ef6a9aca",
-          "fulfillment_id": "ce0e2d9c-7db0-403e-a30a-3491d390931e"
+          "fulfillment_id": "0f1fca5b-8a66-41f9-ab45-2afa92dcb5c1"
+        },
+        {
+          "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
+          "quantity": {
+            "count": 2
+          },
+          "location_id": "39550822-c3bb-4918-bd25-2d19ef6a9aca",
+          "fulfillment_id": "0f1fca5b-8a66-41f9-ab45-2afa92dcb5c1"
+        },
+        {
+          "id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+          "quantity": {
+            "count": 2
+          },
+          "location_id": "39550822-c3bb-4918-bd25-2d19ef6a9aca",
+          "fulfillment_id": "0f1fca5b-8a66-41f9-ab45-2afa92dcb5c1"
         }
       ],
       "billing": {
@@ -55,12 +63,12 @@
         "phone": "7202959020",
         "name": "Hemanshu Faldu",
         "email": "fhemanshu@gmail.com",
-        "created_at": "2025-01-17T12:10:45.183Z",
-        "updated_at": "2025-01-17T12:10:45.183Z"
+        "created_at": "2025-01-23T12:04:27.137Z",
+        "updated_at": "2025-01-23T12:04:27.137Z"
       },
       "fulfillments": [
         {
-          "id": "ce0e2d9c-7db0-403e-a30a-3491d390931e",
+          "id": "0f1fca5b-8a66-41f9-ab45-2afa92dcb5c1",
           "type": "Delivery",
           "end": {
             "contact": {

--- a/Pirimid/SellerApp/Retail/RET-10/FLOW_4/log_validation_utility_request.json
+++ b/Pirimid/SellerApp/Retail/RET-10/FLOW_4/log_validation_utility_request.json
@@ -13,9 +13,9 @@
                 "core_version": "1.2.0",
                 "bap_id": "buyer-app-preprod-v2.ondc.org",
                 "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
-                "transaction_id": "e53a74c5-7ce6-4498-800c-e7d90db0f2fa",
-                "message_id": "45726578-5033-41e0-b35f-2fcbcebe8f82",
-                "timestamp": "2025-01-17T12:00:01.818Z",
+                "transaction_id": "2a274964-3eec-4793-888c-1d30ef845cd1",
+                "message_id": "c5c58f68-8483-4490-b318-a1436c6ee88b",
+                "timestamp": "2025-01-23T12:00:01.908Z",
                 "ttl": "PT30S"
             },
             "message": {
@@ -41,9 +41,9 @@
                 "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
                 "bpp_id": "ondc.pirimidtech.com/v2/seller",
                 "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-                "transaction_id": "e53a74c5-7ce6-4498-800c-e7d90db0f2fa",
-                "message_id": "45726578-5033-41e0-b35f-2fcbcebe8f82",
-                "timestamp": "2025-01-17T12:00:21.411Z",
+                "transaction_id": "2a274964-3eec-4793-888c-1d30ef845cd1",
+                "message_id": "c5c58f68-8483-4490-b318-a1436c6ee88b",
+                "timestamp": "2025-01-23T12:00:21.519Z",
                 "ttl": "PT30S"
             },
             "message": {
@@ -90,70 +90,8 @@
                             "@ondc/org/fssai_license_no": "12345678912345",
                             "time": {
                                 "label": "enable",
-                                "timestamp": "2025-01-17T12:00:21.411Z"
+                                "timestamp": "2025-01-23T12:00:21.519Z"
                             },
-                            "categories": [
-                                {
-                                    "id": "variant10000",
-                                    "descriptor": {
-                                        "name": "Variant for Nutraj-California-Almonds-1Kg"
-                                    },
-                                    "tags": [
-                                        {
-                                            "code": "type",
-                                            "list": [
-                                                {
-                                                    "code": "type",
-                                                    "value": "variant_group"
-                                                }
-                                            ]
-                                        },
-                                        {
-                                            "code": "attr",
-                                            "list": [
-                                                {
-                                                    "code": "name",
-                                                    "value": "item.quantity.unitized.measure"
-                                                },
-                                                {
-                                                    "code": "seq",
-                                                    "value": "1"
-                                                }
-                                            ]
-                                        }
-                                    ]
-                                },
-                                {
-                                    "id": "variant10001",
-                                    "descriptor": {
-                                        "name": "Variant for Cashews"
-                                    },
-                                    "tags": [
-                                        {
-                                            "code": "type",
-                                            "list": [
-                                                {
-                                                    "code": "type",
-                                                    "value": "variant_group"
-                                                }
-                                            ]
-                                        },
-                                        {
-                                            "code": "attr",
-                                            "list": [
-                                                {
-                                                    "code": "name",
-                                                    "value": "item.quantity.unitized.measure"
-                                                },
-                                                {
-                                                    "code": "seq",
-                                                    "value": "1"
-                                                }
-                                            ]
-                                        }
-                                    ]
-                                }
-                            ],
                             "fulfillments": [
                                 {
                                     "id": "1",
@@ -173,11 +111,11 @@
                                         "locality": "Ashok Vatika",
                                         "city": "Ahmedabad",
                                         "state": "Gujarat",
-                                        "area_code": "380058"
+                                        "area_code": "380054"
                                     },
                                     "time": {
                                         "label": "enable",
-                                        "timestamp": "2024-12-04T13:50:34.608Z",
+                                        "timestamp": "2025-01-22T07:34:34.534Z",
                                         "range": {
                                             "start": "0930",
                                             "end": "1930"
@@ -194,12 +132,85 @@
                             ],
                             "items": [
                                 {
+                                    "id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+                                    "descriptor": {
+                                        "name": "Walnuts",
+                                        "code": "1:12345678",
+                                        "symbol": "https://c8.alamy.com/comp/2HCTDG2/modern-design-walnut-leaf-nature-green-logo-design-2HCTDG2.jpg",
+                                        "short_desc": "WONDERLAND California Whole Walnut Walnuts (Akhrot)  (500 g)",
+                                        "long_desc": "WONDERLAND California Whole Walnut Walnuts (Akhrot)  (500 g)",
+                                        "images": [
+                                            "https://rukminim2.flixcart.com/image/416/416/xif0q/nut-dry-fruit/h/x/t/500-california-whole-walnut-1-pouch-wonderland-original-imagy632bnvk8fde.jpeg?q=70",
+                                            "https://rukminim2.flixcart.com/image/416/416/xif0q/nut-dry-fruit/q/r/t/500-california-whole-walnut-1-pouch-wonderland-original-imagy6326hdk68cd.jpeg?q=70"
+                                        ]
+                                    },
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "120.0",
+                                        "maximum_value": "200.0"
+                                    },
+                                    "quantity": {
+                                        "available": {
+                                            "count": "99"
+                                        },
+                                        "maximum": {
+                                            "count": "99"
+                                        },
+                                        "unitized": {
+                                            "measure": {
+                                                "value": "500",
+                                                "unit": "gram"
+                                            }
+                                        }
+                                    },
+                                    "category_id": "Snacks, Dry Fruits, Nuts",
+                                    "fulfillment_id": "1",
+                                    "location_id": "39550822-c3bb-4918-bd25-2d19ef6a9aca",
+                                    "time": {
+                                        "label": "enable",
+                                        "timestamp": "2025-01-23T12:00:21.519Z"
+                                    },
+                                    "@ondc/org/returnable": true,
+                                    "@ondc/org/seller_pickup_return": false,
+                                    "@ondc/org/return_window": "P7D",
+                                    "@ondc/org/cancellable": true,
+                                    "@ondc/org/time_to_ship": "PT3H",
+                                    "@ondc/org/available_on_cod": false,
+                                    "@ondc/org/contact_details_consumer_care": "PirimidFintech,user@gmail.com,7744774477",
+                                    "@ondc/org/statutory_reqs_prepackaged_food": {
+                                        "nutritional_info": "nutritional_info",
+                                        "additives_info": "additives_info",
+                                        "brand_owner_FSSAI_license_no": "12345678912345",
+                                        "other_FSSAI_license_no": "12345678912345",
+                                        "importer_FSSAI_license_no": "12345678912345"
+                                    },
+                                    "tags": [
+                                        {
+                                            "code": "origin",
+                                            "list": [
+                                                {
+                                                    "code": "Country",
+                                                    "value": "IND"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "veg_nonveg",
+                                            "list": [
+                                                {
+                                                    "code": "veg",
+                                                    "value": "yes"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                {
                                     "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
-                                    "parent_item_id": "variant10000",
                                     "descriptor": {
                                         "name": "Nutraj-California-Almonds-1Kg",
                                         "code": "1:12345678",
-                                        "symbol": "symbols.in/symbol.jpg",
+                                        "symbol": "https://img.freepik.com/premium-vector/almonds-nuts-nature-farm-vintage-logo-icon-symbol-vector-illustration-minimalist-design_889650-491.jpg?semt=ais_hybrid",
                                         "short_desc": "Nutraj California Almond kernels 1kg Pouch|Badam Giri|Dry Fruits and Nuts|Grocery",
                                         "long_desc": "Nutraj California Almond kernels 1kg Pouch|Badam Giri|Dry Fruits and Nuts|Grocery",
                                         "images": [
@@ -230,7 +241,7 @@
                                     "location_id": "39550822-c3bb-4918-bd25-2d19ef6a9aca",
                                     "time": {
                                         "label": "enable",
-                                        "timestamp": "2025-01-17T12:00:21.411Z"
+                                        "timestamp": "2025-01-23T12:00:21.519Z"
                                     },
                                     "@ondc/org/returnable": true,
                                     "@ondc/org/seller_pickup_return": false,
@@ -269,11 +280,10 @@
                                 },
                                 {
                                     "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
-                                    "parent_item_id": "variant10001",
                                     "descriptor": {
                                         "name": "Cashews",
                                         "code": "1:12345678",
-                                        "symbol": "symbols.in/symbol.jpg",
+                                        "symbol": "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTVlckKW1pwOvmkj9_s_rPbAvcsr_EdmIStMA&s",
                                         "short_desc": "Emart Brand - Vedaka Whole Cashews | 500 Gram | Kaju Nuts Grade W320 | Plant Based Protein | Gluten-Free | Nutty Flavor | Healthy Snack | Rich Delicious Taste",
                                         "long_desc": "Emart Brand - Vedaka Whole Cashews | 500 Gram | Kaju Nuts Grade W320 | Plant Based Protein | Gluten-Free | Nutty Flavor | Healthy Snack | Rich Delicious Taste",
                                         "images": [
@@ -283,7 +293,7 @@
                                     "price": {
                                         "currency": "INR",
                                         "value": "120.0",
-                                        "maximum_value": "258.0"
+                                        "maximum_value": "212.0"
                                     },
                                     "quantity": {
                                         "available": {
@@ -294,8 +304,8 @@
                                         },
                                         "unitized": {
                                             "measure": {
-                                                "value": "1",
-                                                "unit": "kilogram"
+                                                "value": "500",
+                                                "unit": "gram"
                                             }
                                         }
                                     },
@@ -304,7 +314,7 @@
                                     "location_id": "39550822-c3bb-4918-bd25-2d19ef6a9aca",
                                     "time": {
                                         "label": "enable",
-                                        "timestamp": "2025-01-17T12:00:21.411Z"
+                                        "timestamp": "2025-01-23T12:00:21.519Z"
                                     },
                                     "@ondc/org/returnable": true,
                                     "@ondc/org/seller_pickup_return": false,
@@ -374,36 +384,7 @@
                                     "list": [
                                         {
                                             "code": "type",
-                                            "value": "Order"
-                                        },
-                                        {
-                                            "code": "location",
-                                            "value": "39550822-c3bb-4918-bd25-2d19ef6a9aca"
-                                        },
-                                        {
-                                            "code": "day_from",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "day_to",
-                                            "value": "7"
-                                        },
-                                        {
-                                            "code": "time_from",
-                                            "value": "0930"
-                                        },
-                                        {
-                                            "code": "time_to",
-                                            "value": "1930"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "timing",
-                                    "list": [
-                                        {
-                                            "code": "type",
-                                            "value": "Delivery"
+                                            "value": "All"
                                         },
                                         {
                                             "code": "location",
@@ -443,9 +424,9 @@
                 "bap_id": "buyer-app-preprod-v2.ondc.org",
                 "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
                 "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-                "transaction_id": "d02d4bc1-becf-4f37-a3b8-ff14d24144ab",
-                "message_id": "37a3a6bd-2c33-4f68-ae84-67f20100fa77",
-                "timestamp": "2025-01-17T12:10:36.382Z",
+                "transaction_id": "9ed41e8f-56cf-437a-ae53-d7d64409ef2e",
+                "message_id": "d49c48c4-7b76-4dd7-a294-98860891daed",
+                "timestamp": "2025-01-23T12:04:10.851Z",
                 "bpp_id": "ondc.pirimidtech.com/v2/seller",
                 "ttl": "PT30S"
             },
@@ -453,16 +434,23 @@
                 "order": {
                     "items": [
                         {
-                            "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
+                            "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
                             "quantity": {
-                                "count": 3
+                                "count": 2
                             },
                             "location_id": "39550822-c3bb-4918-bd25-2d19ef6a9aca"
                         },
                         {
-                            "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
+                            "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
                             "quantity": {
-                                "count": 3
+                                "count": 2
+                            },
+                            "location_id": "39550822-c3bb-4918-bd25-2d19ef6a9aca"
+                        },
+                        {
+                            "id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+                            "quantity": {
+                                "count": 2
                             },
                             "location_id": "39550822-c3bb-4918-bd25-2d19ef6a9aca"
                         }
@@ -501,9 +489,9 @@
                 "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
                 "bpp_id": "ondc.pirimidtech.com/v2/seller",
                 "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-                "transaction_id": "d02d4bc1-becf-4f37-a3b8-ff14d24144ab",
-                "message_id": "37a3a6bd-2c33-4f68-ae84-67f20100fa77",
-                "timestamp": "2025-01-17T12:10:37.825Z"
+                "transaction_id": "9ed41e8f-56cf-437a-ae53-d7d64409ef2e",
+                "message_id": "d49c48c4-7b76-4dd7-a294-98860891daed",
+                "timestamp": "2025-01-23T12:04:13.304Z"
             },
             "message": {
                 "order": {
@@ -517,17 +505,21 @@
                     },
                     "items": [
                         {
-                            "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
-                            "fulfillment_id": "ce0e2d9c-7db0-403e-a30a-3491d390931e"
+                            "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
+                            "fulfillment_id": "0f1fca5b-8a66-41f9-ab45-2afa92dcb5c1"
                         },
                         {
-                            "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
-                            "fulfillment_id": "ce0e2d9c-7db0-403e-a30a-3491d390931e"
+                            "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
+                            "fulfillment_id": "0f1fca5b-8a66-41f9-ab45-2afa92dcb5c1"
+                        },
+                        {
+                            "id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+                            "fulfillment_id": "0f1fca5b-8a66-41f9-ab45-2afa92dcb5c1"
                         }
                     ],
                     "fulfillments": [
                         {
-                            "id": "ce0e2d9c-7db0-403e-a30a-3491d390931e",
+                            "id": "0f1fca5b-8a66-41f9-ab45-2afa92dcb5c1",
                             "type": "Delivery",
                             "@ondc/org/category": "Standard Delivery",
                             "@ondc/org/TAT": "PT99H",
@@ -543,57 +535,13 @@
                     "quote": {
                         "price": {
                             "currency": "INR",
-                            "value": "1401.72"
+                            "value": "1364.71"
                         },
                         "breakup": [
                             {
-                                "@ondc/org/item_id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
-                                "@ondc/org/item_quantity": {
-                                    "count": 3
-                                },
-                                "@ondc/org/title_type": "item",
-                                "item": {
-                                    "price": {
-                                        "currency": "INR",
-                                        "value": "120.0"
-                                    },
-                                    "quantity": {
-                                        "available": {
-                                            "count": "99"
-                                        },
-                                        "maximum": {
-                                            "count": "99"
-                                        }
-                                    }
-                                },
-                                "title": "Cashews",
-                                "price": {
-                                    "currency": "INR",
-                                    "value": "360.0"
-                                }
-                            },
-                            {
-                                "@ondc/org/item_id": "ce0e2d9c-7db0-403e-a30a-3491d390931e",
-                                "@ondc/org/title_type": "packing",
-                                "title": "Packing Charges",
-                                "price": {
-                                    "currency": "INR",
-                                    "value": "5.0"
-                                }
-                            },
-                            {
-                                "@ondc/org/item_id": "ce0e2d9c-7db0-403e-a30a-3491d390931e",
-                                "@ondc/org/title_type": "delivery",
-                                "title": "Delivery Charges",
-                                "price": {
-                                    "currency": "INR",
-                                    "value": "100.0"
-                                }
-                            },
-                            {
                                 "@ondc/org/item_id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
                                 "@ondc/org/item_quantity": {
-                                    "count": 3
+                                    "count": 2
                                 },
                                 "@ondc/org/title_type": "item",
                                 "item": {
@@ -613,11 +561,11 @@
                                 "title": "Nutraj-California-Almonds-1Kg",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "660.0"
+                                    "value": "440.0"
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "ce0e2d9c-7db0-403e-a30a-3491d390931e",
+                                "@ondc/org/item_id": "0f1fca5b-8a66-41f9-ab45-2afa92dcb5c1",
                                 "@ondc/org/title_type": "packing",
                                 "title": "Packing Charges",
                                 "price": {
@@ -626,7 +574,7 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "ce0e2d9c-7db0-403e-a30a-3491d390931e",
+                                "@ondc/org/item_id": "0f1fca5b-8a66-41f9-ab45-2afa92dcb5c1",
                                 "@ondc/org/title_type": "delivery",
                                 "title": "Delivery Charges",
                                 "price": {
@@ -640,16 +588,104 @@
                                 "title": "Tax",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "122.1"
+                                    "value": "81.4"
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "ce0e2d9c-7db0-403e-a30a-3491d390931e",
+                                "@ondc/org/item_id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
+                                "@ondc/org/item_quantity": {
+                                    "count": 2
+                                },
+                                "@ondc/org/title_type": "item",
+                                "item": {
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "120.0"
+                                    },
+                                    "quantity": {
+                                        "available": {
+                                            "count": "99"
+                                        },
+                                        "maximum": {
+                                            "count": "99"
+                                        }
+                                    }
+                                },
+                                "title": "Cashews",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "240.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "0f1fca5b-8a66-41f9-ab45-2afa92dcb5c1",
+                                "@ondc/org/title_type": "packing",
+                                "title": "Packing Charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "5.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "0f1fca5b-8a66-41f9-ab45-2afa92dcb5c1",
+                                "@ondc/org/title_type": "delivery",
+                                "title": "Delivery Charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "100.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+                                "@ondc/org/item_quantity": {
+                                    "count": 2
+                                },
+                                "@ondc/org/title_type": "item",
+                                "item": {
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "120.0"
+                                    },
+                                    "quantity": {
+                                        "available": {
+                                            "count": "99"
+                                        },
+                                        "maximum": {
+                                            "count": "99"
+                                        }
+                                    }
+                                },
+                                "title": "Walnuts",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "240.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "0f1fca5b-8a66-41f9-ab45-2afa92dcb5c1",
+                                "@ondc/org/title_type": "packing",
+                                "title": "Packing Charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "5.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "0f1fca5b-8a66-41f9-ab45-2afa92dcb5c1",
+                                "@ondc/org/title_type": "delivery",
+                                "title": "Delivery Charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "100.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "0f1fca5b-8a66-41f9-ab45-2afa92dcb5c1",
                                 "@ondc/org/title_type": "misc",
                                 "title": "Convenience Fee",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "49.62"
+                                    "value": "48.31"
                                 }
                             }
                         ],
@@ -668,9 +704,9 @@
                 "bap_id": "buyer-app-preprod-v2.ondc.org",
                 "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
                 "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-                "transaction_id": "d02d4bc1-becf-4f37-a3b8-ff14d24144ab",
-                "message_id": "299cbae8-b8e5-4f29-aed5-f34887462e64",
-                "timestamp": "2025-01-17T12:10:45.183Z",
+                "transaction_id": "9ed41e8f-56cf-437a-ae53-d7d64409ef2e",
+                "message_id": "997ce9d7-5c7a-413d-9d3b-fb6836e05e0d",
+                "timestamp": "2025-01-23T12:04:27.137Z",
                 "bpp_id": "ondc.pirimidtech.com/v2/seller",
                 "ttl": "PT30S"
             },
@@ -686,20 +722,28 @@
                     },
                     "items": [
                         {
-                            "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
-                            "quantity": {
-                                "count": 3
-                            },
-                            "location_id": "39550822-c3bb-4918-bd25-2d19ef6a9aca",
-                            "fulfillment_id": "ce0e2d9c-7db0-403e-a30a-3491d390931e"
-                        },
-                        {
                             "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
                             "quantity": {
-                                "count": 3
+                                "count": 2
                             },
                             "location_id": "39550822-c3bb-4918-bd25-2d19ef6a9aca",
-                            "fulfillment_id": "ce0e2d9c-7db0-403e-a30a-3491d390931e"
+                            "fulfillment_id": "0f1fca5b-8a66-41f9-ab45-2afa92dcb5c1"
+                        },
+                        {
+                            "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
+                            "quantity": {
+                                "count": 2
+                            },
+                            "location_id": "39550822-c3bb-4918-bd25-2d19ef6a9aca",
+                            "fulfillment_id": "0f1fca5b-8a66-41f9-ab45-2afa92dcb5c1"
+                        },
+                        {
+                            "id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+                            "quantity": {
+                                "count": 2
+                            },
+                            "location_id": "39550822-c3bb-4918-bd25-2d19ef6a9aca",
+                            "fulfillment_id": "0f1fca5b-8a66-41f9-ab45-2afa92dcb5c1"
                         }
                     ],
                     "billing": {
@@ -715,12 +759,12 @@
                         "phone": "7202959020",
                         "name": "Hemanshu Faldu",
                         "email": "fhemanshu@gmail.com",
-                        "created_at": "2025-01-17T12:10:45.183Z",
-                        "updated_at": "2025-01-17T12:10:45.183Z"
+                        "created_at": "2025-01-23T12:04:27.137Z",
+                        "updated_at": "2025-01-23T12:04:27.137Z"
                     },
                     "fulfillments": [
                         {
-                            "id": "ce0e2d9c-7db0-403e-a30a-3491d390931e",
+                            "id": "0f1fca5b-8a66-41f9-ab45-2afa92dcb5c1",
                             "type": "Delivery",
                             "end": {
                                 "contact": {
@@ -756,9 +800,9 @@
                 "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
                 "bpp_id": "ondc.pirimidtech.com/v2/seller",
                 "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-                "transaction_id": "d02d4bc1-becf-4f37-a3b8-ff14d24144ab",
-                "message_id": "299cbae8-b8e5-4f29-aed5-f34887462e64",
-                "timestamp": "2025-01-17T12:10:46.154Z",
+                "transaction_id": "9ed41e8f-56cf-437a-ae53-d7d64409ef2e",
+                "message_id": "997ce9d7-5c7a-413d-9d3b-fb6836e05e0d",
+                "timestamp": "2025-01-23T12:04:28.046Z",
                 "ttl": "PT30S"
             },
             "message": {
@@ -773,24 +817,34 @@
                     },
                     "items": [
                         {
-                            "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
-                            "quantity": {
-                                "unitized": {
-                                    "count": "3"
-                                },
-                                "count": 3
-                            },
-                            "fulfillment_id": "ce0e2d9c-7db0-403e-a30a-3491d390931e"
-                        },
-                        {
                             "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
                             "quantity": {
                                 "unitized": {
-                                    "count": "3"
+                                    "count": "2"
                                 },
-                                "count": 3
+                                "count": 2
                             },
-                            "fulfillment_id": "ce0e2d9c-7db0-403e-a30a-3491d390931e"
+                            "fulfillment_id": "0f1fca5b-8a66-41f9-ab45-2afa92dcb5c1"
+                        },
+                        {
+                            "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
+                            "quantity": {
+                                "unitized": {
+                                    "count": "2"
+                                },
+                                "count": 2
+                            },
+                            "fulfillment_id": "0f1fca5b-8a66-41f9-ab45-2afa92dcb5c1"
+                        },
+                        {
+                            "id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+                            "quantity": {
+                                "unitized": {
+                                    "count": "2"
+                                },
+                                "count": 2
+                            },
+                            "fulfillment_id": "0f1fca5b-8a66-41f9-ab45-2afa92dcb5c1"
                         }
                     ],
                     "billing": {
@@ -806,19 +860,13 @@
                         },
                         "email": "fhemanshu@gmail.com",
                         "phone": "7202959020",
-                        "created_at": "2025-01-17T12:10:45.183Z",
-                        "updated_at": "2025-01-17T12:10:45.183Z"
+                        "created_at": "2025-01-23T12:04:27.137Z",
+                        "updated_at": "2025-01-23T12:04:27.137Z"
                     },
                     "fulfillments": [
                         {
-                            "id": "ce0e2d9c-7db0-403e-a30a-3491d390931e",
+                            "id": "0f1fca5b-8a66-41f9-ab45-2afa92dcb5c1",
                             "type": "Delivery",
-                            "provider_id": "ondc.loadshare.com/ondc/18275",
-                            "state": {
-                                "descriptor": {
-                                    "code": "INITIALIZING"
-                                }
-                            },
                             "tracking": false,
                             "end": {
                                 "location": {
@@ -832,9 +880,6 @@
                                         "country": "IND",
                                         "area_code": "380015"
                                     }
-                                },
-                                "time": {
-                                    "range": {}
                                 },
                                 "instructions": {
                                     "name": "Status for pickup",
@@ -855,49 +900,13 @@
                     "quote": {
                         "price": {
                             "currency": "INR",
-                            "value": "1401.72"
+                            "value": "1364.71"
                         },
                         "breakup": [
                             {
-                                "@ondc/org/item_id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
-                                "@ondc/org/item_quantity": {
-                                    "count": 3
-                                },
-                                "@ondc/org/title_type": "item",
-                                "item": {
-                                    "price": {
-                                        "currency": "INR",
-                                        "value": "120.0"
-                                    }
-                                },
-                                "title": "Cashews",
-                                "price": {
-                                    "currency": "INR",
-                                    "value": "360.0"
-                                }
-                            },
-                            {
-                                "@ondc/org/item_id": "ce0e2d9c-7db0-403e-a30a-3491d390931e",
-                                "@ondc/org/title_type": "packing",
-                                "title": "Packing Charges",
-                                "price": {
-                                    "currency": "INR",
-                                    "value": "5.0"
-                                }
-                            },
-                            {
-                                "@ondc/org/item_id": "ce0e2d9c-7db0-403e-a30a-3491d390931e",
-                                "@ondc/org/title_type": "delivery",
-                                "title": "Delivery Charges",
-                                "price": {
-                                    "currency": "INR",
-                                    "value": "100.0"
-                                }
-                            },
-                            {
                                 "@ondc/org/item_id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
                                 "@ondc/org/item_quantity": {
-                                    "count": 3
+                                    "count": 2
                                 },
                                 "@ondc/org/title_type": "item",
                                 "item": {
@@ -909,11 +918,11 @@
                                 "title": "Nutraj-California-Almonds-1Kg",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "660.0"
+                                    "value": "440.0"
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "ce0e2d9c-7db0-403e-a30a-3491d390931e",
+                                "@ondc/org/item_id": "0f1fca5b-8a66-41f9-ab45-2afa92dcb5c1",
                                 "@ondc/org/title_type": "packing",
                                 "title": "Packing Charges",
                                 "price": {
@@ -922,7 +931,7 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "ce0e2d9c-7db0-403e-a30a-3491d390931e",
+                                "@ondc/org/item_id": "0f1fca5b-8a66-41f9-ab45-2afa92dcb5c1",
                                 "@ondc/org/title_type": "delivery",
                                 "title": "Delivery Charges",
                                 "price": {
@@ -936,26 +945,98 @@
                                 "title": "Tax",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "122.1"
+                                    "value": "81.4"
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "ce0e2d9c-7db0-403e-a30a-3491d390931e",
+                                "@ondc/org/item_id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
+                                "@ondc/org/item_quantity": {
+                                    "count": 2
+                                },
+                                "@ondc/org/title_type": "item",
+                                "item": {
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "120.0"
+                                    }
+                                },
+                                "title": "Cashews",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "240.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "0f1fca5b-8a66-41f9-ab45-2afa92dcb5c1",
+                                "@ondc/org/title_type": "packing",
+                                "title": "Packing Charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "5.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "0f1fca5b-8a66-41f9-ab45-2afa92dcb5c1",
+                                "@ondc/org/title_type": "delivery",
+                                "title": "Delivery Charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "100.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+                                "@ondc/org/item_quantity": {
+                                    "count": 2
+                                },
+                                "@ondc/org/title_type": "item",
+                                "item": {
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "120.0"
+                                    }
+                                },
+                                "title": "Walnuts",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "240.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "0f1fca5b-8a66-41f9-ab45-2afa92dcb5c1",
+                                "@ondc/org/title_type": "packing",
+                                "title": "Packing Charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "5.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "0f1fca5b-8a66-41f9-ab45-2afa92dcb5c1",
+                                "@ondc/org/title_type": "delivery",
+                                "title": "Delivery Charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "100.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "0f1fca5b-8a66-41f9-ab45-2afa92dcb5c1",
                                 "@ondc/org/title_type": "misc",
                                 "title": "Convenience Fee",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "49.62"
+                                    "value": "48.31"
                                 }
                             }
                         ],
                         "ttl": "P1D"
                     },
                     "payment": {
-                        "uri": "https://ondc-pirimid-payment.netlify.app/payment/d02d4bc1-becf-4f37-a3b8-ff14d24144ab",
+                        "uri": "https://ondc-pirimid-payment.netlify.app/payment/9ed41e8f-56cf-437a-ae53-d7d64409ef2e",
                         "type": "ON-ORDER",
                         "status": "NOT-PAID",
-                        "collected_by": "BPP",
+                        "collected_by": "BAP",
                         "@ondc/org/buyer_app_finder_fee_type": "percent",
                         "@ondc/org/buyer_app_finder_fee_amount": "3.0",
                         "@ondc/org/withholding_amount": "0.0",
@@ -975,8 +1056,8 @@
                             }
                         ]
                     },
-                    "created_at": "2025-01-17T12:10:37.837Z",
-                    "updated_at": "2025-01-17T12:10:46.169Z",
+                    "created_at": "2025-01-23T12:04:13.417Z",
+                    "updated_at": "2025-01-23T12:04:28.071Z",
                     "tags": [
                         {
                             "code": "bpp_terms",
@@ -1005,15 +1086,15 @@
                 "bap_id": "buyer-app-preprod-v2.ondc.org",
                 "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
                 "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-                "transaction_id": "d02d4bc1-becf-4f37-a3b8-ff14d24144ab",
-                "message_id": "d069b641-459f-44cb-92b3-98fa9f552750",
-                "timestamp": "2025-01-17T12:11:07.597Z",
+                "transaction_id": "9ed41e8f-56cf-437a-ae53-d7d64409ef2e",
+                "message_id": "d4efb134-bd4a-4ee7-b2cc-9a56273abc08",
+                "timestamp": "2025-01-23T12:04:56.020Z",
                 "bpp_id": "ondc.pirimidtech.com/v2/seller",
                 "ttl": "PT30S"
             },
             "message": {
                 "order": {
-                    "id": "2025-01-17-558256",
+                    "id": "2025-01-23-702967",
                     "state": "Created",
                     "billing": {
                         "address": {
@@ -1028,23 +1109,30 @@
                         "phone": "7202959020",
                         "name": "Hemanshu Faldu",
                         "email": "fhemanshu@gmail.com",
-                        "created_at": "2025-01-17T12:10:45.183Z",
-                        "updated_at": "2025-01-17T12:10:45.183Z"
+                        "created_at": "2025-01-23T12:04:27.137Z",
+                        "updated_at": "2025-01-23T12:04:27.137Z"
                     },
                     "items": [
                         {
-                            "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
-                            "quantity": {
-                                "count": 3
-                            },
-                            "fulfillment_id": "ce0e2d9c-7db0-403e-a30a-3491d390931e"
-                        },
-                        {
                             "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
                             "quantity": {
-                                "count": 3
+                                "count": 2
                             },
-                            "fulfillment_id": "ce0e2d9c-7db0-403e-a30a-3491d390931e"
+                            "fulfillment_id": "0f1fca5b-8a66-41f9-ab45-2afa92dcb5c1"
+                        },
+                        {
+                            "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
+                            "quantity": {
+                                "count": 2
+                            },
+                            "fulfillment_id": "0f1fca5b-8a66-41f9-ab45-2afa92dcb5c1"
+                        },
+                        {
+                            "id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+                            "quantity": {
+                                "count": 2
+                            },
+                            "fulfillment_id": "0f1fca5b-8a66-41f9-ab45-2afa92dcb5c1"
                         }
                     ],
                     "provider": {
@@ -1058,7 +1146,7 @@
                     "fulfillments": [
                         {
                             "@ondc/org/TAT": "PT99H",
-                            "id": "ce0e2d9c-7db0-403e-a30a-3491d390931e",
+                            "id": "0f1fca5b-8a66-41f9-ab45-2afa92dcb5c1",
                             "tracking": false,
                             "end": {
                                 "contact": {
@@ -1088,9 +1176,9 @@
                         "uri": "https://razorpay.com/",
                         "tl_method": "http/get",
                         "params": {
-                            "amount": "1401.72",
+                            "amount": "1364.71",
                             "currency": "INR",
-                            "transaction_id": "order_PkVPrEniq5bWbv"
+                            "transaction_id": "order_PmsVwseRIRk2FE"
                         },
                         "status": "PAID",
                         "type": "ON-ORDER",
@@ -1117,49 +1205,13 @@
                     "quote": {
                         "price": {
                             "currency": "INR",
-                            "value": "1401.72"
+                            "value": "1364.71"
                         },
                         "breakup": [
                             {
-                                "@ondc/org/item_id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
-                                "@ondc/org/item_quantity": {
-                                    "count": 3
-                                },
-                                "@ondc/org/title_type": "item",
-                                "item": {
-                                    "price": {
-                                        "currency": "INR",
-                                        "value": "120.0"
-                                    }
-                                },
-                                "title": "Cashews",
-                                "price": {
-                                    "currency": "INR",
-                                    "value": "360.0"
-                                }
-                            },
-                            {
-                                "@ondc/org/item_id": "ce0e2d9c-7db0-403e-a30a-3491d390931e",
-                                "@ondc/org/title_type": "packing",
-                                "title": "Packing Charges",
-                                "price": {
-                                    "currency": "INR",
-                                    "value": "5.0"
-                                }
-                            },
-                            {
-                                "@ondc/org/item_id": "ce0e2d9c-7db0-403e-a30a-3491d390931e",
-                                "@ondc/org/title_type": "delivery",
-                                "title": "Delivery Charges",
-                                "price": {
-                                    "currency": "INR",
-                                    "value": "100.0"
-                                }
-                            },
-                            {
                                 "@ondc/org/item_id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
                                 "@ondc/org/item_quantity": {
-                                    "count": 3
+                                    "count": 2
                                 },
                                 "@ondc/org/title_type": "item",
                                 "item": {
@@ -1171,11 +1223,11 @@
                                 "title": "Nutraj-California-Almonds-1Kg",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "660.0"
+                                    "value": "440.0"
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "ce0e2d9c-7db0-403e-a30a-3491d390931e",
+                                "@ondc/org/item_id": "0f1fca5b-8a66-41f9-ab45-2afa92dcb5c1",
                                 "@ondc/org/title_type": "packing",
                                 "title": "Packing Charges",
                                 "price": {
@@ -1184,7 +1236,7 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "ce0e2d9c-7db0-403e-a30a-3491d390931e",
+                                "@ondc/org/item_id": "0f1fca5b-8a66-41f9-ab45-2afa92dcb5c1",
                                 "@ondc/org/title_type": "delivery",
                                 "title": "Delivery Charges",
                                 "price": {
@@ -1198,16 +1250,88 @@
                                 "title": "Tax",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "122.1"
+                                    "value": "81.4"
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "ce0e2d9c-7db0-403e-a30a-3491d390931e",
+                                "@ondc/org/item_id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
+                                "@ondc/org/item_quantity": {
+                                    "count": 2
+                                },
+                                "@ondc/org/title_type": "item",
+                                "item": {
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "120.0"
+                                    }
+                                },
+                                "title": "Cashews",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "240.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "0f1fca5b-8a66-41f9-ab45-2afa92dcb5c1",
+                                "@ondc/org/title_type": "packing",
+                                "title": "Packing Charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "5.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "0f1fca5b-8a66-41f9-ab45-2afa92dcb5c1",
+                                "@ondc/org/title_type": "delivery",
+                                "title": "Delivery Charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "100.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+                                "@ondc/org/item_quantity": {
+                                    "count": 2
+                                },
+                                "@ondc/org/title_type": "item",
+                                "item": {
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "120.0"
+                                    }
+                                },
+                                "title": "Walnuts",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "240.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "0f1fca5b-8a66-41f9-ab45-2afa92dcb5c1",
+                                "@ondc/org/title_type": "packing",
+                                "title": "Packing Charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "5.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "0f1fca5b-8a66-41f9-ab45-2afa92dcb5c1",
+                                "@ondc/org/title_type": "delivery",
+                                "title": "Delivery Charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "100.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "0f1fca5b-8a66-41f9-ab45-2afa92dcb5c1",
                                 "@ondc/org/title_type": "misc",
                                 "title": "Convenience Fee",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "49.62"
+                                    "value": "48.31"
                                 }
                             }
                         ],
@@ -1237,8 +1361,8 @@
                             ]
                         }
                     ],
-                    "created_at": "2025-01-17T12:11:07.597Z",
-                    "updated_at": "2025-01-17T12:11:07.597Z"
+                    "created_at": "2025-01-23T12:04:56.020Z",
+                    "updated_at": "2025-01-23T12:04:56.020Z"
                 }
             }
         },
@@ -1253,13 +1377,13 @@
                 "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
                 "bpp_id": "ondc.pirimidtech.com/v2/seller",
                 "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-                "transaction_id": "d02d4bc1-becf-4f37-a3b8-ff14d24144ab",
-                "message_id": "d069b641-459f-44cb-92b3-98fa9f552750",
-                "timestamp": "2025-01-17T12:11:08.422Z"
+                "transaction_id": "9ed41e8f-56cf-437a-ae53-d7d64409ef2e",
+                "message_id": "d4efb134-bd4a-4ee7-b2cc-9a56273abc08",
+                "timestamp": "2025-01-23T12:04:57.317Z"
             },
             "message": {
                 "order": {
-                    "id": "2025-01-17-558256",
+                    "id": "2025-01-23-702967",
                     "state": "Created",
                     "provider": {
                         "id": "e2008459-7e90-493e-b02e-cae52ca53214",
@@ -1271,18 +1395,25 @@
                     },
                     "items": [
                         {
-                            "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
-                            "quantity": {
-                                "count": 3
-                            },
-                            "fulfillment_id": "ce0e2d9c-7db0-403e-a30a-3491d390931e"
-                        },
-                        {
                             "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
                             "quantity": {
-                                "count": 3
+                                "count": 2
                             },
-                            "fulfillment_id": "ce0e2d9c-7db0-403e-a30a-3491d390931e"
+                            "fulfillment_id": "0f1fca5b-8a66-41f9-ab45-2afa92dcb5c1"
+                        },
+                        {
+                            "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
+                            "quantity": {
+                                "count": 2
+                            },
+                            "fulfillment_id": "0f1fca5b-8a66-41f9-ab45-2afa92dcb5c1"
+                        },
+                        {
+                            "id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+                            "quantity": {
+                                "count": 2
+                            },
+                            "fulfillment_id": "0f1fca5b-8a66-41f9-ab45-2afa92dcb5c1"
                         }
                     ],
                     "billing": {
@@ -1298,12 +1429,12 @@
                         },
                         "email": "fhemanshu@gmail.com",
                         "phone": "7202959020",
-                        "created_at": "2025-01-17T12:10:45.183Z",
-                        "updated_at": "2025-01-17T12:10:45.183Z"
+                        "created_at": "2025-01-23T12:04:27.137Z",
+                        "updated_at": "2025-01-23T12:04:27.137Z"
                     },
                     "fulfillments": [
                         {
-                            "id": "ce0e2d9c-7db0-403e-a30a-3491d390931e",
+                            "id": "0f1fca5b-8a66-41f9-ab45-2afa92dcb5c1",
                             "type": "Delivery",
                             "@ondc/org/TAT": "PT99H",
                             "@ondc/org/provider_name": "LoadShare",
@@ -1324,7 +1455,7 @@
                                         "locality": "Ashok Vatika",
                                         "city": "Ahmedabad",
                                         "state": "Gujarat",
-                                        "area_code": "380058"
+                                        "area_code": "380054"
                                     }
                                 },
                                 "contact": {
@@ -1358,49 +1489,13 @@
                     "quote": {
                         "price": {
                             "currency": "INR",
-                            "value": "1401.72"
+                            "value": "1364.71"
                         },
                         "breakup": [
                             {
-                                "@ondc/org/item_id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
-                                "@ondc/org/item_quantity": {
-                                    "count": 3
-                                },
-                                "@ondc/org/title_type": "item",
-                                "item": {
-                                    "price": {
-                                        "currency": "INR",
-                                        "value": "120.0"
-                                    }
-                                },
-                                "title": "Cashews",
-                                "price": {
-                                    "currency": "INR",
-                                    "value": "360.0"
-                                }
-                            },
-                            {
-                                "@ondc/org/item_id": "ce0e2d9c-7db0-403e-a30a-3491d390931e",
-                                "@ondc/org/title_type": "packing",
-                                "title": "Packing Charges",
-                                "price": {
-                                    "currency": "INR",
-                                    "value": "5.0"
-                                }
-                            },
-                            {
-                                "@ondc/org/item_id": "ce0e2d9c-7db0-403e-a30a-3491d390931e",
-                                "@ondc/org/title_type": "delivery",
-                                "title": "Delivery Charges",
-                                "price": {
-                                    "currency": "INR",
-                                    "value": "100.0"
-                                }
-                            },
-                            {
                                 "@ondc/org/item_id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
                                 "@ondc/org/item_quantity": {
-                                    "count": 3
+                                    "count": 2
                                 },
                                 "@ondc/org/title_type": "item",
                                 "item": {
@@ -1412,11 +1507,11 @@
                                 "title": "Nutraj-California-Almonds-1Kg",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "660.0"
+                                    "value": "440.0"
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "ce0e2d9c-7db0-403e-a30a-3491d390931e",
+                                "@ondc/org/item_id": "0f1fca5b-8a66-41f9-ab45-2afa92dcb5c1",
                                 "@ondc/org/title_type": "packing",
                                 "title": "Packing Charges",
                                 "price": {
@@ -1425,7 +1520,7 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "ce0e2d9c-7db0-403e-a30a-3491d390931e",
+                                "@ondc/org/item_id": "0f1fca5b-8a66-41f9-ab45-2afa92dcb5c1",
                                 "@ondc/org/title_type": "delivery",
                                 "title": "Delivery Charges",
                                 "price": {
@@ -1439,16 +1534,88 @@
                                 "title": "Tax",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "122.1"
+                                    "value": "81.4"
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "ce0e2d9c-7db0-403e-a30a-3491d390931e",
+                                "@ondc/org/item_id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
+                                "@ondc/org/item_quantity": {
+                                    "count": 2
+                                },
+                                "@ondc/org/title_type": "item",
+                                "item": {
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "120.0"
+                                    }
+                                },
+                                "title": "Cashews",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "240.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "0f1fca5b-8a66-41f9-ab45-2afa92dcb5c1",
+                                "@ondc/org/title_type": "packing",
+                                "title": "Packing Charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "5.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "0f1fca5b-8a66-41f9-ab45-2afa92dcb5c1",
+                                "@ondc/org/title_type": "delivery",
+                                "title": "Delivery Charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "100.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+                                "@ondc/org/item_quantity": {
+                                    "count": 2
+                                },
+                                "@ondc/org/title_type": "item",
+                                "item": {
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "120.0"
+                                    }
+                                },
+                                "title": "Walnuts",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "240.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "0f1fca5b-8a66-41f9-ab45-2afa92dcb5c1",
+                                "@ondc/org/title_type": "packing",
+                                "title": "Packing Charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "5.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "0f1fca5b-8a66-41f9-ab45-2afa92dcb5c1",
+                                "@ondc/org/title_type": "delivery",
+                                "title": "Delivery Charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "100.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "0f1fca5b-8a66-41f9-ab45-2afa92dcb5c1",
                                 "@ondc/org/title_type": "misc",
                                 "title": "Convenience Fee",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "49.62"
+                                    "value": "48.31"
                                 }
                             }
                         ],
@@ -1458,8 +1625,8 @@
                         "uri": "https://razorpay.com/",
                         "tl_method": "http/get",
                         "params": {
-                            "transaction_id": "order_PkVPrEniq5bWbv",
-                            "amount": "1401.72",
+                            "transaction_id": "order_PmsVwseRIRk2FE",
+                            "amount": "1364.71",
                             "currency": "INR"
                         },
                         "type": "ON-ORDER",
@@ -1484,8 +1651,8 @@
                             }
                         ]
                     },
-                    "created_at": "2025-01-17T12:11:07.597Z",
-                    "updated_at": "2025-01-17T12:11:08.422Z",
+                    "created_at": "2025-01-23T12:04:56.020Z",
+                    "updated_at": "2025-01-23T12:04:57.317Z",
                     "tags": [
                         {
                             "code": "bpp_terms",
@@ -1527,14 +1694,14 @@
                 "bap_id": "buyer-app-preprod-v2.ondc.org",
                 "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
                 "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-                "transaction_id": "d02d4bc1-becf-4f37-a3b8-ff14d24144ab",
-                "message_id": "476e1aa4-7f51-4291-9158-0f67c35c1568",
-                "timestamp": "2025-01-17T12:11:19.783Z",
+                "transaction_id": "9ed41e8f-56cf-437a-ae53-d7d64409ef2e",
+                "message_id": "a2779ebb-32e8-4328-8529-b26e53f0be53",
+                "timestamp": "2025-01-23T12:05:09.282Z",
                 "bpp_id": "ondc.pirimidtech.com/v2/seller",
                 "ttl": "PT30S"
             },
             "message": {
-                "order_id": "2025-01-17-558256",
+                "order_id": "2025-01-23-702967",
                 "cancellation_reason_id": "001"
             }
         },
@@ -1549,14 +1716,14 @@
                 "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
                 "bpp_id": "ondc.pirimidtech.com/v2/seller",
                 "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-                "transaction_id": "d02d4bc1-becf-4f37-a3b8-ff14d24144ab",
-                "message_id": "476e1aa4-7f51-4291-9158-0f67c35c1568",
-                "timestamp": "2025-01-17T12:11:20.568Z",
+                "transaction_id": "9ed41e8f-56cf-437a-ae53-d7d64409ef2e",
+                "message_id": "a2779ebb-32e8-4328-8529-b26e53f0be53",
+                "timestamp": "2025-01-23T12:05:10.224Z",
                 "ttl": "PT30S"
             },
             "message": {
                 "order": {
-                    "id": "2025-01-17-558256",
+                    "id": "2025-01-23-702967",
                     "state": "Cancelled",
                     "provider": {
                         "id": "e2008459-7e90-493e-b02e-cae52ca53214",
@@ -1568,32 +1735,46 @@
                     },
                     "items": [
                         {
+                            "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
+                            "quantity": {
+                                "count": 2
+                            },
+                            "fulfillment_id": "fc86e6b2-4f77-4f04-a537-810c1ebe8b13"
+                        },
+                        {
                             "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
                             "quantity": {
-                                "count": 0
+                                "count": 2
                             },
-                            "fulfillment_id": "ce0e2d9c-7db0-403e-a30a-3491d390931e"
+                            "fulfillment_id": "fc86e6b2-4f77-4f04-a537-810c1ebe8b13"
+                        },
+                        {
+                            "id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+                            "quantity": {
+                                "count": 2
+                            },
+                            "fulfillment_id": "fc86e6b2-4f77-4f04-a537-810c1ebe8b13"
                         },
                         {
                             "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
                             "quantity": {
                                 "count": 0
                             },
-                            "fulfillment_id": "ce0e2d9c-7db0-403e-a30a-3491d390931e"
+                            "fulfillment_id": "0f1fca5b-8a66-41f9-ab45-2afa92dcb5c1"
                         },
                         {
                             "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
                             "quantity": {
-                                "count": 3
+                                "count": 0
                             },
-                            "fulfillment_id": "59a05842-2207-4e41-a869-27f934a489a2"
+                            "fulfillment_id": "0f1fca5b-8a66-41f9-ab45-2afa92dcb5c1"
                         },
                         {
-                            "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
+                            "id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
                             "quantity": {
-                                "count": 3
+                                "count": 0
                             },
-                            "fulfillment_id": "59a05842-2207-4e41-a869-27f934a489a2"
+                            "fulfillment_id": "0f1fca5b-8a66-41f9-ab45-2afa92dcb5c1"
                         }
                     ],
                     "billing": {
@@ -1609,12 +1790,12 @@
                         },
                         "email": "fhemanshu@gmail.com",
                         "phone": "7202959020",
-                        "created_at": "2025-01-17T12:10:45.183Z",
-                        "updated_at": "2025-01-17T12:10:45.183Z"
+                        "created_at": "2025-01-23T12:04:27.137Z",
+                        "updated_at": "2025-01-23T12:04:27.137Z"
                     },
                     "fulfillments": [
                         {
-                            "id": "59a05842-2207-4e41-a869-27f934a489a2",
+                            "id": "fc86e6b2-4f77-4f04-a537-810c1ebe8b13",
                             "type": "Cancel",
                             "state": {
                                 "descriptor": {
@@ -1631,7 +1812,7 @@
                                         },
                                         {
                                             "code": "id",
-                                            "value": "ce0e2d9c-7db0-403e-a30a-3491d390931e"
+                                            "value": "0f1fca5b-8a66-41f9-ab45-2afa92dcb5c1"
                                         },
                                         {
                                             "code": "currency",
@@ -1639,70 +1820,7 @@
                                         },
                                         {
                                             "code": "value",
-                                            "value": "-49.62"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "quote_trail",
-                                    "list": [
-                                        {
-                                            "code": "type",
-                                            "value": "item"
-                                        },
-                                        {
-                                            "code": "id",
-                                            "value": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4"
-                                        },
-                                        {
-                                            "code": "currency",
-                                            "value": "INR"
-                                        },
-                                        {
-                                            "code": "value",
-                                            "value": "-360.0"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "quote_trail",
-                                    "list": [
-                                        {
-                                            "code": "type",
-                                            "value": "packing"
-                                        },
-                                        {
-                                            "code": "id",
-                                            "value": "59a05842-2207-4e41-a869-27f934a489a2"
-                                        },
-                                        {
-                                            "code": "currency",
-                                            "value": "INR"
-                                        },
-                                        {
-                                            "code": "value",
-                                            "value": "-5.0"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "quote_trail",
-                                    "list": [
-                                        {
-                                            "code": "type",
-                                            "value": "delivery"
-                                        },
-                                        {
-                                            "code": "id",
-                                            "value": "59a05842-2207-4e41-a869-27f934a489a2"
-                                        },
-                                        {
-                                            "code": "currency",
-                                            "value": "INR"
-                                        },
-                                        {
-                                            "code": "value",
-                                            "value": "-100.0"
+                                            "value": "-48.31"
                                         }
                                     ]
                                 },
@@ -1723,7 +1841,7 @@
                                         },
                                         {
                                             "code": "value",
-                                            "value": "-660.0"
+                                            "value": "-440.0"
                                         }
                                     ]
                                 },
@@ -1736,7 +1854,7 @@
                                         },
                                         {
                                             "code": "id",
-                                            "value": "59a05842-2207-4e41-a869-27f934a489a2"
+                                            "value": "fc86e6b2-4f77-4f04-a537-810c1ebe8b13"
                                         },
                                         {
                                             "code": "currency",
@@ -1757,7 +1875,7 @@
                                         },
                                         {
                                             "code": "id",
-                                            "value": "59a05842-2207-4e41-a869-27f934a489a2"
+                                            "value": "fc86e6b2-4f77-4f04-a537-810c1ebe8b13"
                                         },
                                         {
                                             "code": "currency",
@@ -1778,7 +1896,7 @@
                                         },
                                         {
                                             "code": "id",
-                                            "value": "59a05842-2207-4e41-a869-27f934a489a2"
+                                            "value": "fc86e6b2-4f77-4f04-a537-810c1ebe8b13"
                                         },
                                         {
                                             "code": "currency",
@@ -1786,14 +1904,140 @@
                                         },
                                         {
                                             "code": "value",
-                                            "value": "-122.1"
+                                            "value": "-81.4"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "quote_trail",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "item"
+                                        },
+                                        {
+                                            "code": "id",
+                                            "value": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4"
+                                        },
+                                        {
+                                            "code": "currency",
+                                            "value": "INR"
+                                        },
+                                        {
+                                            "code": "value",
+                                            "value": "-240.0"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "quote_trail",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "packing"
+                                        },
+                                        {
+                                            "code": "id",
+                                            "value": "fc86e6b2-4f77-4f04-a537-810c1ebe8b13"
+                                        },
+                                        {
+                                            "code": "currency",
+                                            "value": "INR"
+                                        },
+                                        {
+                                            "code": "value",
+                                            "value": "-5.0"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "quote_trail",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "delivery"
+                                        },
+                                        {
+                                            "code": "id",
+                                            "value": "fc86e6b2-4f77-4f04-a537-810c1ebe8b13"
+                                        },
+                                        {
+                                            "code": "currency",
+                                            "value": "INR"
+                                        },
+                                        {
+                                            "code": "value",
+                                            "value": "-100.0"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "quote_trail",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "item"
+                                        },
+                                        {
+                                            "code": "id",
+                                            "value": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7"
+                                        },
+                                        {
+                                            "code": "currency",
+                                            "value": "INR"
+                                        },
+                                        {
+                                            "code": "value",
+                                            "value": "-240.0"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "quote_trail",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "packing"
+                                        },
+                                        {
+                                            "code": "id",
+                                            "value": "fc86e6b2-4f77-4f04-a537-810c1ebe8b13"
+                                        },
+                                        {
+                                            "code": "currency",
+                                            "value": "INR"
+                                        },
+                                        {
+                                            "code": "value",
+                                            "value": "-5.0"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "quote_trail",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "delivery"
+                                        },
+                                        {
+                                            "code": "id",
+                                            "value": "fc86e6b2-4f77-4f04-a537-810c1ebe8b13"
+                                        },
+                                        {
+                                            "code": "currency",
+                                            "value": "INR"
+                                        },
+                                        {
+                                            "code": "value",
+                                            "value": "-100.0"
                                         }
                                     ]
                                 }
                             ]
                         },
                         {
-                            "id": "ce0e2d9c-7db0-403e-a30a-3491d390931e",
+                            "id": "0f1fca5b-8a66-41f9-ab45-2afa92dcb5c1",
                             "type": "Delivery",
                             "@ondc/org/TAT": "PT99H",
                             "provider_id": "ondc.loadshare.com/ondc/18275",
@@ -1824,13 +2068,13 @@
                                         "locality": "Ashok Vatika",
                                         "city": "Ahmedabad",
                                         "state": "Gujarat",
-                                        "area_code": "380058"
+                                        "area_code": "380054"
                                     }
                                 },
                                 "time": {
                                     "range": {
-                                        "start": "2025-01-17T12:11:20.531Z",
-                                        "end": "2025-01-17T15:11:20.531Z"
+                                        "start": "2025-01-23T12:05:10.126Z",
+                                        "end": "2025-01-23T15:05:10.126Z"
                                     }
                                 },
                                 "instructions": {
@@ -1859,8 +2103,8 @@
                                 },
                                 "time": {
                                     "range": {
-                                        "start": "2025-01-17T15:11:20.531Z",
-                                        "end": "2025-01-21T15:11:20.531Z"
+                                        "start": "2025-01-23T15:05:10.126Z",
+                                        "end": "2025-01-27T15:05:10.126Z"
                                     }
                                 },
                                 "contact": {
@@ -1894,7 +2138,7 @@
                                         },
                                         {
                                             "code": "updated_at",
-                                            "value": "2025-01-17T12:11:08.422Z"
+                                            "value": "2025-01-23T12:04:57.317Z"
                                         }
                                     ]
                                 }
@@ -1907,42 +2151,6 @@
                             "value": "0.0"
                         },
                         "breakup": [
-                            {
-                                "@ondc/org/item_id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
-                                "@ondc/org/item_quantity": {
-                                    "count": 0
-                                },
-                                "@ondc/org/title_type": "item",
-                                "item": {
-                                    "price": {
-                                        "currency": "INR",
-                                        "value": "120.0"
-                                    }
-                                },
-                                "title": "Cashews",
-                                "price": {
-                                    "currency": "INR",
-                                    "value": "0.0"
-                                }
-                            },
-                            {
-                                "@ondc/org/item_id": "59a05842-2207-4e41-a869-27f934a489a2",
-                                "@ondc/org/title_type": "packing",
-                                "title": "Packing Charges",
-                                "price": {
-                                    "currency": "INR",
-                                    "value": "0.0"
-                                }
-                            },
-                            {
-                                "@ondc/org/item_id": "59a05842-2207-4e41-a869-27f934a489a2",
-                                "@ondc/org/title_type": "delivery",
-                                "title": "Delivery Charges",
-                                "price": {
-                                    "currency": "INR",
-                                    "value": "0.0"
-                                }
-                            },
                             {
                                 "@ondc/org/item_id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
                                 "@ondc/org/item_quantity": {
@@ -1962,7 +2170,7 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "59a05842-2207-4e41-a869-27f934a489a2",
+                                "@ondc/org/item_id": "fc86e6b2-4f77-4f04-a537-810c1ebe8b13",
                                 "@ondc/org/title_type": "packing",
                                 "title": "Packing Charges",
                                 "price": {
@@ -1971,7 +2179,7 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "59a05842-2207-4e41-a869-27f934a489a2",
+                                "@ondc/org/item_id": "fc86e6b2-4f77-4f04-a537-810c1ebe8b13",
                                 "@ondc/org/title_type": "delivery",
                                 "title": "Delivery Charges",
                                 "price": {
@@ -1989,7 +2197,79 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "59a05842-2207-4e41-a869-27f934a489a2",
+                                "@ondc/org/item_id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
+                                "@ondc/org/item_quantity": {
+                                    "count": 0
+                                },
+                                "@ondc/org/title_type": "item",
+                                "item": {
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "120.0"
+                                    }
+                                },
+                                "title": "Cashews",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "0.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "fc86e6b2-4f77-4f04-a537-810c1ebe8b13",
+                                "@ondc/org/title_type": "packing",
+                                "title": "Packing Charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "0.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "fc86e6b2-4f77-4f04-a537-810c1ebe8b13",
+                                "@ondc/org/title_type": "delivery",
+                                "title": "Delivery Charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "0.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+                                "@ondc/org/item_quantity": {
+                                    "count": 0
+                                },
+                                "@ondc/org/title_type": "item",
+                                "item": {
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "120.0"
+                                    }
+                                },
+                                "title": "Walnuts",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "0.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "fc86e6b2-4f77-4f04-a537-810c1ebe8b13",
+                                "@ondc/org/title_type": "packing",
+                                "title": "Packing Charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "0.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "fc86e6b2-4f77-4f04-a537-810c1ebe8b13",
+                                "@ondc/org/title_type": "delivery",
+                                "title": "Delivery Charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "0.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "fc86e6b2-4f77-4f04-a537-810c1ebe8b13",
                                 "@ondc/org/title_type": "misc",
                                 "title": "Convenience Fee",
                                 "price": {
@@ -2004,8 +2284,8 @@
                         "uri": "https://razorpay.com/",
                         "tl_method": "http/get",
                         "params": {
-                            "transaction_id": "order_PkVPrEniq5bWbv",
-                            "amount": "1401.72",
+                            "transaction_id": "order_PmsVwseRIRk2FE",
+                            "amount": "1364.71",
                             "currency": "INR"
                         },
                         "type": "ON-ORDER",
@@ -2036,8 +2316,8 @@
                             "id": "001"
                         }
                     },
-                    "created_at": "2025-01-17T12:10:37.837Z",
-                    "updated_at": "2025-01-17T12:11:20.550Z"
+                    "created_at": "2025-01-23T12:04:13.417Z",
+                    "updated_at": "2025-01-23T12:05:10.200Z"
                 }
             }
         }

--- a/Pirimid/SellerApp/Retail/RET-10/FLOW_4/log_validation_utitlity_response.json
+++ b/Pirimid/SellerApp/Retail/RET-10/FLOW_4/log_validation_utitlity_response.json
@@ -1,13 +1,17 @@
 {
-    "success": true,
+    "success": false,
     "response": {
-        "message": "Logs were verified successfully",
-        "report": {},
+        "message": "Logs were not verified successfully",
+        "report": {
+            "on_search_full_catalog_refresh": {
+                "prvdr0categories": "Support for variants is mandatory, categories must be present in bpp/providers[0]"
+            }
+        },
         "bpp_id": "ondc.pirimidtech.com/v2/seller",
         "bap_id": "buyer-app-preprod-v2.ondc.org",
         "domain": "ONDC:RET10",
-        "reportTimestamp": "2025-01-19T04:52:14.091Z"
+        "reportTimestamp": "2025-01-24T05:55:54.597Z"
     },
-    "signature": "UnBCj5jWB6FpuOqo3AtBmioKhg9XbU4DjKtHH3WAsrNpvrPX9z11zCUh1h3otDo6nSgK1bn8MqfVDG+WaKNEBA==",
-    "signTimestamp": "2025-01-19T04:52:14.091Z"
+    "signature": "vEufUT/rWdss2QfVk4/2/LjgvC59EnrfirASKrGgAk7jCiVicM+whjf7+7TjylcY/Qw2d+jg+MhUMmx6Ku6PCg==",
+    "signTimestamp": "2025-01-24T05:55:54.597Z"
 }

--- a/Pirimid/SellerApp/Retail/RET-10/FLOW_4/on_cancel.json
+++ b/Pirimid/SellerApp/Retail/RET-10/FLOW_4/on_cancel.json
@@ -9,14 +9,14 @@
     "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
     "bpp_id": "ondc.pirimidtech.com/v2/seller",
     "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-    "transaction_id": "d02d4bc1-becf-4f37-a3b8-ff14d24144ab",
-    "message_id": "476e1aa4-7f51-4291-9158-0f67c35c1568",
-    "timestamp": "2025-01-17T12:11:20.568Z",
+    "transaction_id": "9ed41e8f-56cf-437a-ae53-d7d64409ef2e",
+    "message_id": "a2779ebb-32e8-4328-8529-b26e53f0be53",
+    "timestamp": "2025-01-23T12:05:10.224Z",
     "ttl": "PT30S"
   },
   "message": {
     "order": {
-      "id": "2025-01-17-558256",
+      "id": "2025-01-23-702967",
       "state": "Cancelled",
       "provider": {
         "id": "e2008459-7e90-493e-b02e-cae52ca53214",
@@ -28,32 +28,46 @@
       },
       "items": [
         {
+          "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "fc86e6b2-4f77-4f04-a537-810c1ebe8b13"
+        },
+        {
           "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
           "quantity": {
-            "count": 0
+            "count": 2
           },
-          "fulfillment_id": "ce0e2d9c-7db0-403e-a30a-3491d390931e"
+          "fulfillment_id": "fc86e6b2-4f77-4f04-a537-810c1ebe8b13"
+        },
+        {
+          "id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "fc86e6b2-4f77-4f04-a537-810c1ebe8b13"
         },
         {
           "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
           "quantity": {
             "count": 0
           },
-          "fulfillment_id": "ce0e2d9c-7db0-403e-a30a-3491d390931e"
+          "fulfillment_id": "0f1fca5b-8a66-41f9-ab45-2afa92dcb5c1"
         },
         {
           "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
           "quantity": {
-            "count": 3
+            "count": 0
           },
-          "fulfillment_id": "59a05842-2207-4e41-a869-27f934a489a2"
+          "fulfillment_id": "0f1fca5b-8a66-41f9-ab45-2afa92dcb5c1"
         },
         {
-          "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
+          "id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
           "quantity": {
-            "count": 3
+            "count": 0
           },
-          "fulfillment_id": "59a05842-2207-4e41-a869-27f934a489a2"
+          "fulfillment_id": "0f1fca5b-8a66-41f9-ab45-2afa92dcb5c1"
         }
       ],
       "billing": {
@@ -69,12 +83,12 @@
         },
         "email": "fhemanshu@gmail.com",
         "phone": "7202959020",
-        "created_at": "2025-01-17T12:10:45.183Z",
-        "updated_at": "2025-01-17T12:10:45.183Z"
+        "created_at": "2025-01-23T12:04:27.137Z",
+        "updated_at": "2025-01-23T12:04:27.137Z"
       },
       "fulfillments": [
         {
-          "id": "59a05842-2207-4e41-a869-27f934a489a2",
+          "id": "fc86e6b2-4f77-4f04-a537-810c1ebe8b13",
           "type": "Cancel",
           "state": {
             "descriptor": {
@@ -91,7 +105,7 @@
                 },
                 {
                   "code": "id",
-                  "value": "ce0e2d9c-7db0-403e-a30a-3491d390931e"
+                  "value": "0f1fca5b-8a66-41f9-ab45-2afa92dcb5c1"
                 },
                 {
                   "code": "currency",
@@ -99,70 +113,7 @@
                 },
                 {
                   "code": "value",
-                  "value": "-49.62"
-                }
-              ]
-            },
-            {
-              "code": "quote_trail",
-              "list": [
-                {
-                  "code": "type",
-                  "value": "item"
-                },
-                {
-                  "code": "id",
-                  "value": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4"
-                },
-                {
-                  "code": "currency",
-                  "value": "INR"
-                },
-                {
-                  "code": "value",
-                  "value": "-360.0"
-                }
-              ]
-            },
-            {
-              "code": "quote_trail",
-              "list": [
-                {
-                  "code": "type",
-                  "value": "packing"
-                },
-                {
-                  "code": "id",
-                  "value": "59a05842-2207-4e41-a869-27f934a489a2"
-                },
-                {
-                  "code": "currency",
-                  "value": "INR"
-                },
-                {
-                  "code": "value",
-                  "value": "-5.0"
-                }
-              ]
-            },
-            {
-              "code": "quote_trail",
-              "list": [
-                {
-                  "code": "type",
-                  "value": "delivery"
-                },
-                {
-                  "code": "id",
-                  "value": "59a05842-2207-4e41-a869-27f934a489a2"
-                },
-                {
-                  "code": "currency",
-                  "value": "INR"
-                },
-                {
-                  "code": "value",
-                  "value": "-100.0"
+                  "value": "-48.31"
                 }
               ]
             },
@@ -183,7 +134,7 @@
                 },
                 {
                   "code": "value",
-                  "value": "-660.0"
+                  "value": "-440.0"
                 }
               ]
             },
@@ -196,7 +147,7 @@
                 },
                 {
                   "code": "id",
-                  "value": "59a05842-2207-4e41-a869-27f934a489a2"
+                  "value": "fc86e6b2-4f77-4f04-a537-810c1ebe8b13"
                 },
                 {
                   "code": "currency",
@@ -217,7 +168,7 @@
                 },
                 {
                   "code": "id",
-                  "value": "59a05842-2207-4e41-a869-27f934a489a2"
+                  "value": "fc86e6b2-4f77-4f04-a537-810c1ebe8b13"
                 },
                 {
                   "code": "currency",
@@ -238,7 +189,7 @@
                 },
                 {
                   "code": "id",
-                  "value": "59a05842-2207-4e41-a869-27f934a489a2"
+                  "value": "fc86e6b2-4f77-4f04-a537-810c1ebe8b13"
                 },
                 {
                   "code": "currency",
@@ -246,14 +197,140 @@
                 },
                 {
                   "code": "value",
-                  "value": "-122.1"
+                  "value": "-81.4"
+                }
+              ]
+            },
+            {
+              "code": "quote_trail",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "item"
+                },
+                {
+                  "code": "id",
+                  "value": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4"
+                },
+                {
+                  "code": "currency",
+                  "value": "INR"
+                },
+                {
+                  "code": "value",
+                  "value": "-240.0"
+                }
+              ]
+            },
+            {
+              "code": "quote_trail",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "packing"
+                },
+                {
+                  "code": "id",
+                  "value": "fc86e6b2-4f77-4f04-a537-810c1ebe8b13"
+                },
+                {
+                  "code": "currency",
+                  "value": "INR"
+                },
+                {
+                  "code": "value",
+                  "value": "-5.0"
+                }
+              ]
+            },
+            {
+              "code": "quote_trail",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "delivery"
+                },
+                {
+                  "code": "id",
+                  "value": "fc86e6b2-4f77-4f04-a537-810c1ebe8b13"
+                },
+                {
+                  "code": "currency",
+                  "value": "INR"
+                },
+                {
+                  "code": "value",
+                  "value": "-100.0"
+                }
+              ]
+            },
+            {
+              "code": "quote_trail",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "item"
+                },
+                {
+                  "code": "id",
+                  "value": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7"
+                },
+                {
+                  "code": "currency",
+                  "value": "INR"
+                },
+                {
+                  "code": "value",
+                  "value": "-240.0"
+                }
+              ]
+            },
+            {
+              "code": "quote_trail",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "packing"
+                },
+                {
+                  "code": "id",
+                  "value": "fc86e6b2-4f77-4f04-a537-810c1ebe8b13"
+                },
+                {
+                  "code": "currency",
+                  "value": "INR"
+                },
+                {
+                  "code": "value",
+                  "value": "-5.0"
+                }
+              ]
+            },
+            {
+              "code": "quote_trail",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "delivery"
+                },
+                {
+                  "code": "id",
+                  "value": "fc86e6b2-4f77-4f04-a537-810c1ebe8b13"
+                },
+                {
+                  "code": "currency",
+                  "value": "INR"
+                },
+                {
+                  "code": "value",
+                  "value": "-100.0"
                 }
               ]
             }
           ]
         },
         {
-          "id": "ce0e2d9c-7db0-403e-a30a-3491d390931e",
+          "id": "0f1fca5b-8a66-41f9-ab45-2afa92dcb5c1",
           "type": "Delivery",
           "@ondc/org/TAT": "PT99H",
           "provider_id": "ondc.loadshare.com/ondc/18275",
@@ -284,13 +361,13 @@
                 "locality": "Ashok Vatika",
                 "city": "Ahmedabad",
                 "state": "Gujarat",
-                "area_code": "380058"
+                "area_code": "380054"
               }
             },
             "time": {
               "range": {
-                "start": "2025-01-17T12:11:20.531Z",
-                "end": "2025-01-17T15:11:20.531Z"
+                "start": "2025-01-23T12:05:10.126Z",
+                "end": "2025-01-23T15:05:10.126Z"
               }
             },
             "instructions": {
@@ -319,8 +396,8 @@
             },
             "time": {
               "range": {
-                "start": "2025-01-17T15:11:20.531Z",
-                "end": "2025-01-21T15:11:20.531Z"
+                "start": "2025-01-23T15:05:10.126Z",
+                "end": "2025-01-27T15:05:10.126Z"
               }
             },
             "contact": {
@@ -354,7 +431,7 @@
                 },
                 {
                   "code": "updated_at",
-                  "value": "2025-01-17T12:11:08.422Z"
+                  "value": "2025-01-23T12:04:57.317Z"
                 }
               ]
             }
@@ -367,42 +444,6 @@
           "value": "0.0"
         },
         "breakup": [
-          {
-            "@ondc/org/item_id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
-            "@ondc/org/item_quantity": {
-              "count": 0
-            },
-            "@ondc/org/title_type": "item",
-            "item": {
-              "price": {
-                "currency": "INR",
-                "value": "120.0"
-              }
-            },
-            "title": "Cashews",
-            "price": {
-              "currency": "INR",
-              "value": "0.0"
-            }
-          },
-          {
-            "@ondc/org/item_id": "59a05842-2207-4e41-a869-27f934a489a2",
-            "@ondc/org/title_type": "packing",
-            "title": "Packing Charges",
-            "price": {
-              "currency": "INR",
-              "value": "0.0"
-            }
-          },
-          {
-            "@ondc/org/item_id": "59a05842-2207-4e41-a869-27f934a489a2",
-            "@ondc/org/title_type": "delivery",
-            "title": "Delivery Charges",
-            "price": {
-              "currency": "INR",
-              "value": "0.0"
-            }
-          },
           {
             "@ondc/org/item_id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
             "@ondc/org/item_quantity": {
@@ -422,7 +463,7 @@
             }
           },
           {
-            "@ondc/org/item_id": "59a05842-2207-4e41-a869-27f934a489a2",
+            "@ondc/org/item_id": "fc86e6b2-4f77-4f04-a537-810c1ebe8b13",
             "@ondc/org/title_type": "packing",
             "title": "Packing Charges",
             "price": {
@@ -431,7 +472,7 @@
             }
           },
           {
-            "@ondc/org/item_id": "59a05842-2207-4e41-a869-27f934a489a2",
+            "@ondc/org/item_id": "fc86e6b2-4f77-4f04-a537-810c1ebe8b13",
             "@ondc/org/title_type": "delivery",
             "title": "Delivery Charges",
             "price": {
@@ -449,7 +490,79 @@
             }
           },
           {
-            "@ondc/org/item_id": "59a05842-2207-4e41-a869-27f934a489a2",
+            "@ondc/org/item_id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
+            "@ondc/org/item_quantity": {
+              "count": 0
+            },
+            "@ondc/org/title_type": "item",
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "120.0"
+              }
+            },
+            "title": "Cashews",
+            "price": {
+              "currency": "INR",
+              "value": "0.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "fc86e6b2-4f77-4f04-a537-810c1ebe8b13",
+            "@ondc/org/title_type": "packing",
+            "title": "Packing Charges",
+            "price": {
+              "currency": "INR",
+              "value": "0.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "fc86e6b2-4f77-4f04-a537-810c1ebe8b13",
+            "@ondc/org/title_type": "delivery",
+            "title": "Delivery Charges",
+            "price": {
+              "currency": "INR",
+              "value": "0.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+            "@ondc/org/item_quantity": {
+              "count": 0
+            },
+            "@ondc/org/title_type": "item",
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "120.0"
+              }
+            },
+            "title": "Walnuts",
+            "price": {
+              "currency": "INR",
+              "value": "0.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "fc86e6b2-4f77-4f04-a537-810c1ebe8b13",
+            "@ondc/org/title_type": "packing",
+            "title": "Packing Charges",
+            "price": {
+              "currency": "INR",
+              "value": "0.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "fc86e6b2-4f77-4f04-a537-810c1ebe8b13",
+            "@ondc/org/title_type": "delivery",
+            "title": "Delivery Charges",
+            "price": {
+              "currency": "INR",
+              "value": "0.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "fc86e6b2-4f77-4f04-a537-810c1ebe8b13",
             "@ondc/org/title_type": "misc",
             "title": "Convenience Fee",
             "price": {
@@ -464,8 +577,8 @@
         "uri": "https://razorpay.com/",
         "tl_method": "http/get",
         "params": {
-          "transaction_id": "order_PkVPrEniq5bWbv",
-          "amount": "1401.72",
+          "transaction_id": "order_PmsVwseRIRk2FE",
+          "amount": "1364.71",
           "currency": "INR"
         },
         "type": "ON-ORDER",
@@ -496,8 +609,8 @@
           "id": "001"
         }
       },
-      "created_at": "2025-01-17T12:10:37.837Z",
-      "updated_at": "2025-01-17T12:11:20.550Z"
+      "created_at": "2025-01-23T12:04:13.417Z",
+      "updated_at": "2025-01-23T12:05:10.200Z"
     }
   }
 }

--- a/Pirimid/SellerApp/Retail/RET-10/FLOW_4/on_confirm.json
+++ b/Pirimid/SellerApp/Retail/RET-10/FLOW_4/on_confirm.json
@@ -9,13 +9,13 @@
     "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
     "bpp_id": "ondc.pirimidtech.com/v2/seller",
     "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-    "transaction_id": "d02d4bc1-becf-4f37-a3b8-ff14d24144ab",
-    "message_id": "d069b641-459f-44cb-92b3-98fa9f552750",
-    "timestamp": "2025-01-17T12:11:08.422Z"
+    "transaction_id": "9ed41e8f-56cf-437a-ae53-d7d64409ef2e",
+    "message_id": "d4efb134-bd4a-4ee7-b2cc-9a56273abc08",
+    "timestamp": "2025-01-23T12:04:57.317Z"
   },
   "message": {
     "order": {
-      "id": "2025-01-17-558256",
+      "id": "2025-01-23-702967",
       "state": "Created",
       "provider": {
         "id": "e2008459-7e90-493e-b02e-cae52ca53214",
@@ -27,18 +27,25 @@
       },
       "items": [
         {
-          "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
-          "quantity": {
-            "count": 3
-          },
-          "fulfillment_id": "ce0e2d9c-7db0-403e-a30a-3491d390931e"
-        },
-        {
           "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
           "quantity": {
-            "count": 3
+            "count": 2
           },
-          "fulfillment_id": "ce0e2d9c-7db0-403e-a30a-3491d390931e"
+          "fulfillment_id": "0f1fca5b-8a66-41f9-ab45-2afa92dcb5c1"
+        },
+        {
+          "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "0f1fca5b-8a66-41f9-ab45-2afa92dcb5c1"
+        },
+        {
+          "id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "0f1fca5b-8a66-41f9-ab45-2afa92dcb5c1"
         }
       ],
       "billing": {
@@ -54,12 +61,12 @@
         },
         "email": "fhemanshu@gmail.com",
         "phone": "7202959020",
-        "created_at": "2025-01-17T12:10:45.183Z",
-        "updated_at": "2025-01-17T12:10:45.183Z"
+        "created_at": "2025-01-23T12:04:27.137Z",
+        "updated_at": "2025-01-23T12:04:27.137Z"
       },
       "fulfillments": [
         {
-          "id": "ce0e2d9c-7db0-403e-a30a-3491d390931e",
+          "id": "0f1fca5b-8a66-41f9-ab45-2afa92dcb5c1",
           "type": "Delivery",
           "@ondc/org/TAT": "PT99H",
           "@ondc/org/provider_name": "LoadShare",
@@ -80,7 +87,7 @@
                 "locality": "Ashok Vatika",
                 "city": "Ahmedabad",
                 "state": "Gujarat",
-                "area_code": "380058"
+                "area_code": "380054"
               }
             },
             "contact": {
@@ -114,49 +121,13 @@
       "quote": {
         "price": {
           "currency": "INR",
-          "value": "1401.72"
+          "value": "1364.71"
         },
         "breakup": [
           {
-            "@ondc/org/item_id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
-            "@ondc/org/item_quantity": {
-              "count": 3
-            },
-            "@ondc/org/title_type": "item",
-            "item": {
-              "price": {
-                "currency": "INR",
-                "value": "120.0"
-              }
-            },
-            "title": "Cashews",
-            "price": {
-              "currency": "INR",
-              "value": "360.0"
-            }
-          },
-          {
-            "@ondc/org/item_id": "ce0e2d9c-7db0-403e-a30a-3491d390931e",
-            "@ondc/org/title_type": "packing",
-            "title": "Packing Charges",
-            "price": {
-              "currency": "INR",
-              "value": "5.0"
-            }
-          },
-          {
-            "@ondc/org/item_id": "ce0e2d9c-7db0-403e-a30a-3491d390931e",
-            "@ondc/org/title_type": "delivery",
-            "title": "Delivery Charges",
-            "price": {
-              "currency": "INR",
-              "value": "100.0"
-            }
-          },
-          {
             "@ondc/org/item_id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
             "@ondc/org/item_quantity": {
-              "count": 3
+              "count": 2
             },
             "@ondc/org/title_type": "item",
             "item": {
@@ -168,11 +139,11 @@
             "title": "Nutraj-California-Almonds-1Kg",
             "price": {
               "currency": "INR",
-              "value": "660.0"
+              "value": "440.0"
             }
           },
           {
-            "@ondc/org/item_id": "ce0e2d9c-7db0-403e-a30a-3491d390931e",
+            "@ondc/org/item_id": "0f1fca5b-8a66-41f9-ab45-2afa92dcb5c1",
             "@ondc/org/title_type": "packing",
             "title": "Packing Charges",
             "price": {
@@ -181,7 +152,7 @@
             }
           },
           {
-            "@ondc/org/item_id": "ce0e2d9c-7db0-403e-a30a-3491d390931e",
+            "@ondc/org/item_id": "0f1fca5b-8a66-41f9-ab45-2afa92dcb5c1",
             "@ondc/org/title_type": "delivery",
             "title": "Delivery Charges",
             "price": {
@@ -195,16 +166,88 @@
             "title": "Tax",
             "price": {
               "currency": "INR",
-              "value": "122.1"
+              "value": "81.4"
             }
           },
           {
-            "@ondc/org/item_id": "ce0e2d9c-7db0-403e-a30a-3491d390931e",
+            "@ondc/org/item_id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "@ondc/org/title_type": "item",
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "120.0"
+              }
+            },
+            "title": "Cashews",
+            "price": {
+              "currency": "INR",
+              "value": "240.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "0f1fca5b-8a66-41f9-ab45-2afa92dcb5c1",
+            "@ondc/org/title_type": "packing",
+            "title": "Packing Charges",
+            "price": {
+              "currency": "INR",
+              "value": "5.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "0f1fca5b-8a66-41f9-ab45-2afa92dcb5c1",
+            "@ondc/org/title_type": "delivery",
+            "title": "Delivery Charges",
+            "price": {
+              "currency": "INR",
+              "value": "100.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "@ondc/org/title_type": "item",
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "120.0"
+              }
+            },
+            "title": "Walnuts",
+            "price": {
+              "currency": "INR",
+              "value": "240.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "0f1fca5b-8a66-41f9-ab45-2afa92dcb5c1",
+            "@ondc/org/title_type": "packing",
+            "title": "Packing Charges",
+            "price": {
+              "currency": "INR",
+              "value": "5.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "0f1fca5b-8a66-41f9-ab45-2afa92dcb5c1",
+            "@ondc/org/title_type": "delivery",
+            "title": "Delivery Charges",
+            "price": {
+              "currency": "INR",
+              "value": "100.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "0f1fca5b-8a66-41f9-ab45-2afa92dcb5c1",
             "@ondc/org/title_type": "misc",
             "title": "Convenience Fee",
             "price": {
               "currency": "INR",
-              "value": "49.62"
+              "value": "48.31"
             }
           }
         ],
@@ -214,8 +257,8 @@
         "uri": "https://razorpay.com/",
         "tl_method": "http/get",
         "params": {
-          "transaction_id": "order_PkVPrEniq5bWbv",
-          "amount": "1401.72",
+          "transaction_id": "order_PmsVwseRIRk2FE",
+          "amount": "1364.71",
           "currency": "INR"
         },
         "type": "ON-ORDER",
@@ -240,8 +283,8 @@
           }
         ]
       },
-      "created_at": "2025-01-17T12:11:07.597Z",
-      "updated_at": "2025-01-17T12:11:08.422Z",
+      "created_at": "2025-01-23T12:04:56.020Z",
+      "updated_at": "2025-01-23T12:04:57.317Z",
       "tags": [
         {
           "code": "bpp_terms",

--- a/Pirimid/SellerApp/Retail/RET-10/FLOW_4/on_init.json
+++ b/Pirimid/SellerApp/Retail/RET-10/FLOW_4/on_init.json
@@ -9,9 +9,9 @@
     "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
     "bpp_id": "ondc.pirimidtech.com/v2/seller",
     "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-    "transaction_id": "d02d4bc1-becf-4f37-a3b8-ff14d24144ab",
-    "message_id": "299cbae8-b8e5-4f29-aed5-f34887462e64",
-    "timestamp": "2025-01-17T12:10:46.154Z",
+    "transaction_id": "9ed41e8f-56cf-437a-ae53-d7d64409ef2e",
+    "message_id": "997ce9d7-5c7a-413d-9d3b-fb6836e05e0d",
+    "timestamp": "2025-01-23T12:04:28.046Z",
     "ttl": "PT30S"
   },
   "message": {
@@ -26,24 +26,34 @@
       },
       "items": [
         {
-          "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
-          "quantity": {
-            "unitized": {
-              "count": "3"
-            },
-            "count": 3
-          },
-          "fulfillment_id": "ce0e2d9c-7db0-403e-a30a-3491d390931e"
-        },
-        {
           "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
           "quantity": {
             "unitized": {
-              "count": "3"
+              "count": "2"
             },
-            "count": 3
+            "count": 2
           },
-          "fulfillment_id": "ce0e2d9c-7db0-403e-a30a-3491d390931e"
+          "fulfillment_id": "0f1fca5b-8a66-41f9-ab45-2afa92dcb5c1"
+        },
+        {
+          "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
+          "quantity": {
+            "unitized": {
+              "count": "2"
+            },
+            "count": 2
+          },
+          "fulfillment_id": "0f1fca5b-8a66-41f9-ab45-2afa92dcb5c1"
+        },
+        {
+          "id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+          "quantity": {
+            "unitized": {
+              "count": "2"
+            },
+            "count": 2
+          },
+          "fulfillment_id": "0f1fca5b-8a66-41f9-ab45-2afa92dcb5c1"
         }
       ],
       "billing": {
@@ -59,19 +69,13 @@
         },
         "email": "fhemanshu@gmail.com",
         "phone": "7202959020",
-        "created_at": "2025-01-17T12:10:45.183Z",
-        "updated_at": "2025-01-17T12:10:45.183Z"
+        "created_at": "2025-01-23T12:04:27.137Z",
+        "updated_at": "2025-01-23T12:04:27.137Z"
       },
       "fulfillments": [
         {
-          "id": "ce0e2d9c-7db0-403e-a30a-3491d390931e",
+          "id": "0f1fca5b-8a66-41f9-ab45-2afa92dcb5c1",
           "type": "Delivery",
-          "provider_id": "ondc.loadshare.com/ondc/18275",
-          "state": {
-            "descriptor": {
-              "code": "INITIALIZING"
-            }
-          },
           "tracking": false,
           "end": {
             "location": {
@@ -85,9 +89,6 @@
                 "country": "IND",
                 "area_code": "380015"
               }
-            },
-            "time": {
-              "range": {}
             },
             "instructions": {
               "name": "Status for pickup",
@@ -108,49 +109,13 @@
       "quote": {
         "price": {
           "currency": "INR",
-          "value": "1401.72"
+          "value": "1364.71"
         },
         "breakup": [
           {
-            "@ondc/org/item_id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
-            "@ondc/org/item_quantity": {
-              "count": 3
-            },
-            "@ondc/org/title_type": "item",
-            "item": {
-              "price": {
-                "currency": "INR",
-                "value": "120.0"
-              }
-            },
-            "title": "Cashews",
-            "price": {
-              "currency": "INR",
-              "value": "360.0"
-            }
-          },
-          {
-            "@ondc/org/item_id": "ce0e2d9c-7db0-403e-a30a-3491d390931e",
-            "@ondc/org/title_type": "packing",
-            "title": "Packing Charges",
-            "price": {
-              "currency": "INR",
-              "value": "5.0"
-            }
-          },
-          {
-            "@ondc/org/item_id": "ce0e2d9c-7db0-403e-a30a-3491d390931e",
-            "@ondc/org/title_type": "delivery",
-            "title": "Delivery Charges",
-            "price": {
-              "currency": "INR",
-              "value": "100.0"
-            }
-          },
-          {
             "@ondc/org/item_id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
             "@ondc/org/item_quantity": {
-              "count": 3
+              "count": 2
             },
             "@ondc/org/title_type": "item",
             "item": {
@@ -162,11 +127,11 @@
             "title": "Nutraj-California-Almonds-1Kg",
             "price": {
               "currency": "INR",
-              "value": "660.0"
+              "value": "440.0"
             }
           },
           {
-            "@ondc/org/item_id": "ce0e2d9c-7db0-403e-a30a-3491d390931e",
+            "@ondc/org/item_id": "0f1fca5b-8a66-41f9-ab45-2afa92dcb5c1",
             "@ondc/org/title_type": "packing",
             "title": "Packing Charges",
             "price": {
@@ -175,7 +140,7 @@
             }
           },
           {
-            "@ondc/org/item_id": "ce0e2d9c-7db0-403e-a30a-3491d390931e",
+            "@ondc/org/item_id": "0f1fca5b-8a66-41f9-ab45-2afa92dcb5c1",
             "@ondc/org/title_type": "delivery",
             "title": "Delivery Charges",
             "price": {
@@ -189,26 +154,98 @@
             "title": "Tax",
             "price": {
               "currency": "INR",
-              "value": "122.1"
+              "value": "81.4"
             }
           },
           {
-            "@ondc/org/item_id": "ce0e2d9c-7db0-403e-a30a-3491d390931e",
+            "@ondc/org/item_id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "@ondc/org/title_type": "item",
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "120.0"
+              }
+            },
+            "title": "Cashews",
+            "price": {
+              "currency": "INR",
+              "value": "240.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "0f1fca5b-8a66-41f9-ab45-2afa92dcb5c1",
+            "@ondc/org/title_type": "packing",
+            "title": "Packing Charges",
+            "price": {
+              "currency": "INR",
+              "value": "5.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "0f1fca5b-8a66-41f9-ab45-2afa92dcb5c1",
+            "@ondc/org/title_type": "delivery",
+            "title": "Delivery Charges",
+            "price": {
+              "currency": "INR",
+              "value": "100.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "@ondc/org/title_type": "item",
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "120.0"
+              }
+            },
+            "title": "Walnuts",
+            "price": {
+              "currency": "INR",
+              "value": "240.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "0f1fca5b-8a66-41f9-ab45-2afa92dcb5c1",
+            "@ondc/org/title_type": "packing",
+            "title": "Packing Charges",
+            "price": {
+              "currency": "INR",
+              "value": "5.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "0f1fca5b-8a66-41f9-ab45-2afa92dcb5c1",
+            "@ondc/org/title_type": "delivery",
+            "title": "Delivery Charges",
+            "price": {
+              "currency": "INR",
+              "value": "100.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "0f1fca5b-8a66-41f9-ab45-2afa92dcb5c1",
             "@ondc/org/title_type": "misc",
             "title": "Convenience Fee",
             "price": {
               "currency": "INR",
-              "value": "49.62"
+              "value": "48.31"
             }
           }
         ],
         "ttl": "P1D"
       },
       "payment": {
-        "uri": "https://ondc-pirimid-payment.netlify.app/payment/d02d4bc1-becf-4f37-a3b8-ff14d24144ab",
+        "uri": "https://ondc-pirimid-payment.netlify.app/payment/9ed41e8f-56cf-437a-ae53-d7d64409ef2e",
         "type": "ON-ORDER",
         "status": "NOT-PAID",
-        "collected_by": "BPP",
+        "collected_by": "BAP",
         "@ondc/org/buyer_app_finder_fee_type": "percent",
         "@ondc/org/buyer_app_finder_fee_amount": "3.0",
         "@ondc/org/withholding_amount": "0.0",
@@ -228,8 +265,8 @@
           }
         ]
       },
-      "created_at": "2025-01-17T12:10:37.837Z",
-      "updated_at": "2025-01-17T12:10:46.169Z",
+      "created_at": "2025-01-23T12:04:13.417Z",
+      "updated_at": "2025-01-23T12:04:28.071Z",
       "tags": [
         {
           "code": "bpp_terms",

--- a/Pirimid/SellerApp/Retail/RET-10/FLOW_4/on_search_full_catalog_refresh.json
+++ b/Pirimid/SellerApp/Retail/RET-10/FLOW_4/on_search_full_catalog_refresh.json
@@ -9,9 +9,9 @@
     "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
     "bpp_id": "ondc.pirimidtech.com/v2/seller",
     "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-    "transaction_id": "e53a74c5-7ce6-4498-800c-e7d90db0f2fa",
-    "message_id": "45726578-5033-41e0-b35f-2fcbcebe8f82",
-    "timestamp": "2025-01-17T12:00:21.411Z",
+    "transaction_id": "2a274964-3eec-4793-888c-1d30ef845cd1",
+    "message_id": "c5c58f68-8483-4490-b318-a1436c6ee88b",
+    "timestamp": "2025-01-23T12:00:21.519Z",
     "ttl": "PT30S"
   },
   "message": {
@@ -58,70 +58,8 @@
           "@ondc/org/fssai_license_no": "12345678912345",
           "time": {
             "label": "enable",
-            "timestamp": "2025-01-17T12:00:21.411Z"
+            "timestamp": "2025-01-23T12:00:21.519Z"
           },
-          "categories": [
-            {
-              "id": "variant10000",
-              "descriptor": {
-                "name": "Variant for Nutraj-California-Almonds-1Kg"
-              },
-              "tags": [
-                {
-                  "code": "type",
-                  "list": [
-                    {
-                      "code": "type",
-                      "value": "variant_group"
-                    }
-                  ]
-                },
-                {
-                  "code": "attr",
-                  "list": [
-                    {
-                      "code": "name",
-                      "value": "item.quantity.unitized.measure"
-                    },
-                    {
-                      "code": "seq",
-                      "value": "1"
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "id": "variant10001",
-              "descriptor": {
-                "name": "Variant for Cashews"
-              },
-              "tags": [
-                {
-                  "code": "type",
-                  "list": [
-                    {
-                      "code": "type",
-                      "value": "variant_group"
-                    }
-                  ]
-                },
-                {
-                  "code": "attr",
-                  "list": [
-                    {
-                      "code": "name",
-                      "value": "item.quantity.unitized.measure"
-                    },
-                    {
-                      "code": "seq",
-                      "value": "1"
-                    }
-                  ]
-                }
-              ]
-            }
-          ],
           "fulfillments": [
             {
               "id": "1",
@@ -141,11 +79,11 @@
                 "locality": "Ashok Vatika",
                 "city": "Ahmedabad",
                 "state": "Gujarat",
-                "area_code": "380058"
+                "area_code": "380054"
               },
               "time": {
                 "label": "enable",
-                "timestamp": "2024-12-04T13:50:34.608Z",
+                "timestamp": "2025-01-22T07:34:34.534Z",
                 "range": {
                   "start": "0930",
                   "end": "1930"
@@ -162,12 +100,85 @@
           ],
           "items": [
             {
+              "id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+              "descriptor": {
+                "name": "Walnuts",
+                "code": "1:12345678",
+                "symbol": "https://c8.alamy.com/comp/2HCTDG2/modern-design-walnut-leaf-nature-green-logo-design-2HCTDG2.jpg",
+                "short_desc": "WONDERLAND California Whole Walnut Walnuts (Akhrot)  (500 g)",
+                "long_desc": "WONDERLAND California Whole Walnut Walnuts (Akhrot)  (500 g)",
+                "images": [
+                  "https://rukminim2.flixcart.com/image/416/416/xif0q/nut-dry-fruit/h/x/t/500-california-whole-walnut-1-pouch-wonderland-original-imagy632bnvk8fde.jpeg?q=70",
+                  "https://rukminim2.flixcart.com/image/416/416/xif0q/nut-dry-fruit/q/r/t/500-california-whole-walnut-1-pouch-wonderland-original-imagy6326hdk68cd.jpeg?q=70"
+                ]
+              },
+              "price": {
+                "currency": "INR",
+                "value": "120.0",
+                "maximum_value": "200.0"
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "value": "500",
+                    "unit": "gram"
+                  }
+                }
+              },
+              "category_id": "Snacks, Dry Fruits, Nuts",
+              "fulfillment_id": "1",
+              "location_id": "39550822-c3bb-4918-bd25-2d19ef6a9aca",
+              "time": {
+                "label": "enable",
+                "timestamp": "2025-01-23T12:00:21.519Z"
+              },
+              "@ondc/org/returnable": true,
+              "@ondc/org/seller_pickup_return": false,
+              "@ondc/org/return_window": "P7D",
+              "@ondc/org/cancellable": true,
+              "@ondc/org/time_to_ship": "PT3H",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "PirimidFintech,user@gmail.com,7744774477",
+              "@ondc/org/statutory_reqs_prepackaged_food": {
+                "nutritional_info": "nutritional_info",
+                "additives_info": "additives_info",
+                "brand_owner_FSSAI_license_no": "12345678912345",
+                "other_FSSAI_license_no": "12345678912345",
+                "importer_FSSAI_license_no": "12345678912345"
+              },
+              "tags": [
+                {
+                  "code": "origin",
+                  "list": [
+                    {
+                      "code": "Country",
+                      "value": "IND"
+                    }
+                  ]
+                },
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
               "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
-              "parent_item_id": "variant10000",
               "descriptor": {
                 "name": "Nutraj-California-Almonds-1Kg",
                 "code": "1:12345678",
-                "symbol": "symbols.in/symbol.jpg",
+                "symbol": "https://img.freepik.com/premium-vector/almonds-nuts-nature-farm-vintage-logo-icon-symbol-vector-illustration-minimalist-design_889650-491.jpg?semt=ais_hybrid",
                 "short_desc": "Nutraj California Almond kernels 1kg Pouch|Badam Giri|Dry Fruits and Nuts|Grocery",
                 "long_desc": "Nutraj California Almond kernels 1kg Pouch|Badam Giri|Dry Fruits and Nuts|Grocery",
                 "images": [
@@ -198,7 +209,7 @@
               "location_id": "39550822-c3bb-4918-bd25-2d19ef6a9aca",
               "time": {
                 "label": "enable",
-                "timestamp": "2025-01-17T12:00:21.411Z"
+                "timestamp": "2025-01-23T12:00:21.519Z"
               },
               "@ondc/org/returnable": true,
               "@ondc/org/seller_pickup_return": false,
@@ -237,11 +248,10 @@
             },
             {
               "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
-              "parent_item_id": "variant10001",
               "descriptor": {
                 "name": "Cashews",
                 "code": "1:12345678",
-                "symbol": "symbols.in/symbol.jpg",
+                "symbol": "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTVlckKW1pwOvmkj9_s_rPbAvcsr_EdmIStMA&s",
                 "short_desc": "Emart Brand - Vedaka Whole Cashews | 500 Gram | Kaju Nuts Grade W320 | Plant Based Protein | Gluten-Free | Nutty Flavor | Healthy Snack | Rich Delicious Taste",
                 "long_desc": "Emart Brand - Vedaka Whole Cashews | 500 Gram | Kaju Nuts Grade W320 | Plant Based Protein | Gluten-Free | Nutty Flavor | Healthy Snack | Rich Delicious Taste",
                 "images": [
@@ -251,7 +261,7 @@
               "price": {
                 "currency": "INR",
                 "value": "120.0",
-                "maximum_value": "258.0"
+                "maximum_value": "212.0"
               },
               "quantity": {
                 "available": {
@@ -262,8 +272,8 @@
                 },
                 "unitized": {
                   "measure": {
-                    "value": "1",
-                    "unit": "kilogram"
+                    "value": "500",
+                    "unit": "gram"
                   }
                 }
               },
@@ -272,7 +282,7 @@
               "location_id": "39550822-c3bb-4918-bd25-2d19ef6a9aca",
               "time": {
                 "label": "enable",
-                "timestamp": "2025-01-17T12:00:21.411Z"
+                "timestamp": "2025-01-23T12:00:21.519Z"
               },
               "@ondc/org/returnable": true,
               "@ondc/org/seller_pickup_return": false,
@@ -342,36 +352,7 @@
               "list": [
                 {
                   "code": "type",
-                  "value": "Order"
-                },
-                {
-                  "code": "location",
-                  "value": "39550822-c3bb-4918-bd25-2d19ef6a9aca"
-                },
-                {
-                  "code": "day_from",
-                  "value": "1"
-                },
-                {
-                  "code": "day_to",
-                  "value": "7"
-                },
-                {
-                  "code": "time_from",
-                  "value": "0930"
-                },
-                {
-                  "code": "time_to",
-                  "value": "1930"
-                }
-              ]
-            },
-            {
-              "code": "timing",
-              "list": [
-                {
-                  "code": "type",
-                  "value": "Delivery"
+                  "value": "All"
                 },
                 {
                   "code": "location",

--- a/Pirimid/SellerApp/Retail/RET-10/FLOW_4/on_select.json
+++ b/Pirimid/SellerApp/Retail/RET-10/FLOW_4/on_select.json
@@ -9,9 +9,9 @@
     "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
     "bpp_id": "ondc.pirimidtech.com/v2/seller",
     "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-    "transaction_id": "d02d4bc1-becf-4f37-a3b8-ff14d24144ab",
-    "message_id": "37a3a6bd-2c33-4f68-ae84-67f20100fa77",
-    "timestamp": "2025-01-17T12:10:37.825Z"
+    "transaction_id": "9ed41e8f-56cf-437a-ae53-d7d64409ef2e",
+    "message_id": "d49c48c4-7b76-4dd7-a294-98860891daed",
+    "timestamp": "2025-01-23T12:04:13.304Z"
   },
   "message": {
     "order": {
@@ -25,17 +25,21 @@
       },
       "items": [
         {
-          "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
-          "fulfillment_id": "ce0e2d9c-7db0-403e-a30a-3491d390931e"
+          "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
+          "fulfillment_id": "0f1fca5b-8a66-41f9-ab45-2afa92dcb5c1"
         },
         {
-          "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
-          "fulfillment_id": "ce0e2d9c-7db0-403e-a30a-3491d390931e"
+          "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
+          "fulfillment_id": "0f1fca5b-8a66-41f9-ab45-2afa92dcb5c1"
+        },
+        {
+          "id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+          "fulfillment_id": "0f1fca5b-8a66-41f9-ab45-2afa92dcb5c1"
         }
       ],
       "fulfillments": [
         {
-          "id": "ce0e2d9c-7db0-403e-a30a-3491d390931e",
+          "id": "0f1fca5b-8a66-41f9-ab45-2afa92dcb5c1",
           "type": "Delivery",
           "@ondc/org/category": "Standard Delivery",
           "@ondc/org/TAT": "PT99H",
@@ -51,57 +55,13 @@
       "quote": {
         "price": {
           "currency": "INR",
-          "value": "1401.72"
+          "value": "1364.71"
         },
         "breakup": [
           {
-            "@ondc/org/item_id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
-            "@ondc/org/item_quantity": {
-              "count": 3
-            },
-            "@ondc/org/title_type": "item",
-            "item": {
-              "price": {
-                "currency": "INR",
-                "value": "120.0"
-              },
-              "quantity": {
-                "available": {
-                  "count": "99"
-                },
-                "maximum": {
-                  "count": "99"
-                }
-              }
-            },
-            "title": "Cashews",
-            "price": {
-              "currency": "INR",
-              "value": "360.0"
-            }
-          },
-          {
-            "@ondc/org/item_id": "ce0e2d9c-7db0-403e-a30a-3491d390931e",
-            "@ondc/org/title_type": "packing",
-            "title": "Packing Charges",
-            "price": {
-              "currency": "INR",
-              "value": "5.0"
-            }
-          },
-          {
-            "@ondc/org/item_id": "ce0e2d9c-7db0-403e-a30a-3491d390931e",
-            "@ondc/org/title_type": "delivery",
-            "title": "Delivery Charges",
-            "price": {
-              "currency": "INR",
-              "value": "100.0"
-            }
-          },
-          {
             "@ondc/org/item_id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
             "@ondc/org/item_quantity": {
-              "count": 3
+              "count": 2
             },
             "@ondc/org/title_type": "item",
             "item": {
@@ -121,11 +81,11 @@
             "title": "Nutraj-California-Almonds-1Kg",
             "price": {
               "currency": "INR",
-              "value": "660.0"
+              "value": "440.0"
             }
           },
           {
-            "@ondc/org/item_id": "ce0e2d9c-7db0-403e-a30a-3491d390931e",
+            "@ondc/org/item_id": "0f1fca5b-8a66-41f9-ab45-2afa92dcb5c1",
             "@ondc/org/title_type": "packing",
             "title": "Packing Charges",
             "price": {
@@ -134,7 +94,7 @@
             }
           },
           {
-            "@ondc/org/item_id": "ce0e2d9c-7db0-403e-a30a-3491d390931e",
+            "@ondc/org/item_id": "0f1fca5b-8a66-41f9-ab45-2afa92dcb5c1",
             "@ondc/org/title_type": "delivery",
             "title": "Delivery Charges",
             "price": {
@@ -148,16 +108,104 @@
             "title": "Tax",
             "price": {
               "currency": "INR",
-              "value": "122.1"
+              "value": "81.4"
             }
           },
           {
-            "@ondc/org/item_id": "ce0e2d9c-7db0-403e-a30a-3491d390931e",
+            "@ondc/org/item_id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "@ondc/org/title_type": "item",
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "120.0"
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                }
+              }
+            },
+            "title": "Cashews",
+            "price": {
+              "currency": "INR",
+              "value": "240.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "0f1fca5b-8a66-41f9-ab45-2afa92dcb5c1",
+            "@ondc/org/title_type": "packing",
+            "title": "Packing Charges",
+            "price": {
+              "currency": "INR",
+              "value": "5.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "0f1fca5b-8a66-41f9-ab45-2afa92dcb5c1",
+            "@ondc/org/title_type": "delivery",
+            "title": "Delivery Charges",
+            "price": {
+              "currency": "INR",
+              "value": "100.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "@ondc/org/title_type": "item",
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "120.0"
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                }
+              }
+            },
+            "title": "Walnuts",
+            "price": {
+              "currency": "INR",
+              "value": "240.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "0f1fca5b-8a66-41f9-ab45-2afa92dcb5c1",
+            "@ondc/org/title_type": "packing",
+            "title": "Packing Charges",
+            "price": {
+              "currency": "INR",
+              "value": "5.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "0f1fca5b-8a66-41f9-ab45-2afa92dcb5c1",
+            "@ondc/org/title_type": "delivery",
+            "title": "Delivery Charges",
+            "price": {
+              "currency": "INR",
+              "value": "100.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "0f1fca5b-8a66-41f9-ab45-2afa92dcb5c1",
             "@ondc/org/title_type": "misc",
             "title": "Convenience Fee",
             "price": {
               "currency": "INR",
-              "value": "49.62"
+              "value": "48.31"
             }
           }
         ],

--- a/Pirimid/SellerApp/Retail/RET-10/FLOW_4/search_full_catalog_refresh.json
+++ b/Pirimid/SellerApp/Retail/RET-10/FLOW_4/search_full_catalog_refresh.json
@@ -7,9 +7,9 @@
     "core_version": "1.2.0",
     "bap_id": "buyer-app-preprod-v2.ondc.org",
     "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
-    "transaction_id": "e53a74c5-7ce6-4498-800c-e7d90db0f2fa",
-    "message_id": "45726578-5033-41e0-b35f-2fcbcebe8f82",
-    "timestamp": "2025-01-17T12:00:01.818Z",
+    "transaction_id": "2a274964-3eec-4793-888c-1d30ef845cd1",
+    "message_id": "c5c58f68-8483-4490-b318-a1436c6ee88b",
+    "timestamp": "2025-01-23T12:00:01.908Z",
     "ttl": "PT30S"
   },
   "message": {

--- a/Pirimid/SellerApp/Retail/RET-10/FLOW_4/select.json
+++ b/Pirimid/SellerApp/Retail/RET-10/FLOW_4/select.json
@@ -8,9 +8,9 @@
     "bap_id": "buyer-app-preprod-v2.ondc.org",
     "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
     "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-    "transaction_id": "d02d4bc1-becf-4f37-a3b8-ff14d24144ab",
-    "message_id": "37a3a6bd-2c33-4f68-ae84-67f20100fa77",
-    "timestamp": "2025-01-17T12:10:36.382Z",
+    "transaction_id": "9ed41e8f-56cf-437a-ae53-d7d64409ef2e",
+    "message_id": "d49c48c4-7b76-4dd7-a294-98860891daed",
+    "timestamp": "2025-01-23T12:04:10.851Z",
     "bpp_id": "ondc.pirimidtech.com/v2/seller",
     "ttl": "PT30S"
   },
@@ -18,16 +18,23 @@
     "order": {
       "items": [
         {
-          "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
+          "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
           "quantity": {
-            "count": 3
+            "count": 2
           },
           "location_id": "39550822-c3bb-4918-bd25-2d19ef6a9aca"
         },
         {
-          "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
+          "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
           "quantity": {
-            "count": 3
+            "count": 2
+          },
+          "location_id": "39550822-c3bb-4918-bd25-2d19ef6a9aca"
+        },
+        {
+          "id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+          "quantity": {
+            "count": 2
           },
           "location_id": "39550822-c3bb-4918-bd25-2d19ef6a9aca"
         }

--- a/Pirimid/SellerApp/Retail/RET-10/FLOW_5/confirm.json
+++ b/Pirimid/SellerApp/Retail/RET-10/FLOW_5/confirm.json
@@ -8,15 +8,15 @@
     "bap_id": "buyer-app-preprod-v2.ondc.org",
     "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
     "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-    "transaction_id": "042f9d64-5233-43b6-aea9-3563d9fc4bad",
-    "message_id": "92f88395-6016-40ed-8055-20e1da617ac9",
-    "timestamp": "2025-01-18T04:38:51.420Z",
+    "transaction_id": "99d39ee1-5651-4f0a-8f2a-0a0ee8db9c9d",
+    "message_id": "cb404011-4cca-4e7e-9af0-8260d3dd02b4",
+    "timestamp": "2025-01-23T12:23:17.611Z",
     "bpp_id": "ondc.pirimidtech.com/v2/seller",
     "ttl": "PT30S"
   },
   "message": {
     "order": {
-      "id": "2025-01-18-429408",
+      "id": "2025-01-23-459524",
       "state": "Created",
       "billing": {
         "address": {
@@ -31,23 +31,30 @@
         "phone": "7202959020",
         "name": "Hemanshu Faldu",
         "email": "fhemanshu@gmail.com",
-        "created_at": "2025-01-18T04:38:29.524Z",
-        "updated_at": "2025-01-18T04:38:29.524Z"
+        "created_at": "2025-01-23T12:22:56.533Z",
+        "updated_at": "2025-01-23T12:22:56.533Z"
       },
       "items": [
         {
           "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
           "quantity": {
-            "count": 3
+            "count": 2
           },
-          "fulfillment_id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40"
+          "fulfillment_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d"
         },
         {
           "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
           "quantity": {
-            "count": 3
+            "count": 2
           },
-          "fulfillment_id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40"
+          "fulfillment_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d"
+        },
+        {
+          "id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d"
         }
       ],
       "provider": {
@@ -61,7 +68,7 @@
       "fulfillments": [
         {
           "@ondc/org/TAT": "PT99H",
-          "id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40",
+          "id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
           "tracking": false,
           "end": {
             "contact": {
@@ -91,9 +98,9 @@
         "uri": "https://razorpay.com/",
         "tl_method": "http/get",
         "params": {
-          "amount": "1401.72",
+          "amount": "1364.71",
           "currency": "INR",
-          "transaction_id": "order_PkmFEkFcTwn3Jj"
+          "transaction_id": "order_PmspSHrmelUv3U"
         },
         "status": "PAID",
         "type": "ON-ORDER",
@@ -120,13 +127,13 @@
       "quote": {
         "price": {
           "currency": "INR",
-          "value": "1401.72"
+          "value": "1364.71"
         },
         "breakup": [
           {
             "@ondc/org/item_id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
             "@ondc/org/item_quantity": {
-              "count": 3
+              "count": 2
             },
             "@ondc/org/title_type": "item",
             "item": {
@@ -138,11 +145,11 @@
             "title": "Nutraj-California-Almonds-1Kg",
             "price": {
               "currency": "INR",
-              "value": "660.0"
+              "value": "440.0"
             }
           },
           {
-            "@ondc/org/item_id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40",
+            "@ondc/org/item_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
             "@ondc/org/title_type": "packing",
             "title": "Packing Charges",
             "price": {
@@ -151,7 +158,7 @@
             }
           },
           {
-            "@ondc/org/item_id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40",
+            "@ondc/org/item_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
             "@ondc/org/title_type": "delivery",
             "title": "Delivery Charges",
             "price": {
@@ -165,13 +172,13 @@
             "title": "Tax",
             "price": {
               "currency": "INR",
-              "value": "122.1"
+              "value": "81.4"
             }
           },
           {
             "@ondc/org/item_id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
             "@ondc/org/item_quantity": {
-              "count": 3
+              "count": 2
             },
             "@ondc/org/title_type": "item",
             "item": {
@@ -183,11 +190,11 @@
             "title": "Cashews",
             "price": {
               "currency": "INR",
-              "value": "360.0"
+              "value": "240.0"
             }
           },
           {
-            "@ondc/org/item_id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40",
+            "@ondc/org/item_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
             "@ondc/org/title_type": "packing",
             "title": "Packing Charges",
             "price": {
@@ -196,7 +203,7 @@
             }
           },
           {
-            "@ondc/org/item_id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40",
+            "@ondc/org/item_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
             "@ondc/org/title_type": "delivery",
             "title": "Delivery Charges",
             "price": {
@@ -205,12 +212,48 @@
             }
           },
           {
-            "@ondc/org/item_id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40",
+            "@ondc/org/item_id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "@ondc/org/title_type": "item",
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "120.0"
+              }
+            },
+            "title": "Walnuts",
+            "price": {
+              "currency": "INR",
+              "value": "240.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
+            "@ondc/org/title_type": "packing",
+            "title": "Packing Charges",
+            "price": {
+              "currency": "INR",
+              "value": "5.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
+            "@ondc/org/title_type": "delivery",
+            "title": "Delivery Charges",
+            "price": {
+              "currency": "INR",
+              "value": "100.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
             "@ondc/org/title_type": "misc",
             "title": "Convenience Fee",
             "price": {
               "currency": "INR",
-              "value": "49.62"
+              "value": "48.31"
             }
           }
         ],
@@ -240,8 +283,8 @@
           ]
         }
       ],
-      "created_at": "2025-01-18T04:38:51.420Z",
-      "updated_at": "2025-01-18T04:38:51.420Z"
+      "created_at": "2025-01-23T12:23:17.611Z",
+      "updated_at": "2025-01-23T12:23:17.611Z"
     }
   }
 }

--- a/Pirimid/SellerApp/Retail/RET-10/FLOW_5/init.json
+++ b/Pirimid/SellerApp/Retail/RET-10/FLOW_5/init.json
@@ -8,9 +8,9 @@
     "bap_id": "buyer-app-preprod-v2.ondc.org",
     "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
     "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-    "transaction_id": "042f9d64-5233-43b6-aea9-3563d9fc4bad",
-    "message_id": "cc0342a3-c32c-4eb1-a6cf-34881abbd2a0",
-    "timestamp": "2025-01-18T04:38:29.524Z",
+    "transaction_id": "99d39ee1-5651-4f0a-8f2a-0a0ee8db9c9d",
+    "message_id": "4a3994f1-205d-465a-b59d-438edc4188e3",
+    "timestamp": "2025-01-23T12:22:56.533Z",
     "bpp_id": "ondc.pirimidtech.com/v2/seller",
     "ttl": "PT30S"
   },
@@ -28,18 +28,26 @@
         {
           "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
           "quantity": {
-            "count": 3
+            "count": 2
           },
           "location_id": "39550822-c3bb-4918-bd25-2d19ef6a9aca",
-          "fulfillment_id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40"
+          "fulfillment_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d"
         },
         {
           "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
           "quantity": {
-            "count": 3
+            "count": 2
           },
           "location_id": "39550822-c3bb-4918-bd25-2d19ef6a9aca",
-          "fulfillment_id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40"
+          "fulfillment_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d"
+        },
+        {
+          "id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+          "quantity": {
+            "count": 2
+          },
+          "location_id": "39550822-c3bb-4918-bd25-2d19ef6a9aca",
+          "fulfillment_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d"
         }
       ],
       "billing": {
@@ -55,12 +63,12 @@
         "phone": "7202959020",
         "name": "Hemanshu Faldu",
         "email": "fhemanshu@gmail.com",
-        "created_at": "2025-01-18T04:38:29.524Z",
-        "updated_at": "2025-01-18T04:38:29.524Z"
+        "created_at": "2025-01-23T12:22:56.533Z",
+        "updated_at": "2025-01-23T12:22:56.533Z"
       },
       "fulfillments": [
         {
-          "id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40",
+          "id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
           "type": "Delivery",
           "end": {
             "contact": {

--- a/Pirimid/SellerApp/Retail/RET-10/FLOW_5/log_validation_utility_request.json
+++ b/Pirimid/SellerApp/Retail/RET-10/FLOW_5/log_validation_utility_request.json
@@ -13,9 +13,9 @@
                 "core_version": "1.2.0",
                 "bap_id": "buyer-app-preprod-v2.ondc.org",
                 "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
-                "transaction_id": "e53a74c5-7ce6-4498-800c-e7d90db0f2fa",
-                "message_id": "45726578-5033-41e0-b35f-2fcbcebe8f82",
-                "timestamp": "2025-01-17T12:00:01.818Z",
+                "transaction_id": "2a274964-3eec-4793-888c-1d30ef845cd1",
+                "message_id": "c5c58f68-8483-4490-b318-a1436c6ee88b",
+                "timestamp": "2025-01-23T12:00:01.908Z",
                 "ttl": "PT30S"
             },
             "message": {
@@ -41,9 +41,9 @@
                 "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
                 "bpp_id": "ondc.pirimidtech.com/v2/seller",
                 "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-                "transaction_id": "e53a74c5-7ce6-4498-800c-e7d90db0f2fa",
-                "message_id": "45726578-5033-41e0-b35f-2fcbcebe8f82",
-                "timestamp": "2025-01-17T12:00:21.411Z",
+                "transaction_id": "2a274964-3eec-4793-888c-1d30ef845cd1",
+                "message_id": "c5c58f68-8483-4490-b318-a1436c6ee88b",
+                "timestamp": "2025-01-23T12:00:21.519Z",
                 "ttl": "PT30S"
             },
             "message": {
@@ -90,70 +90,8 @@
                             "@ondc/org/fssai_license_no": "12345678912345",
                             "time": {
                                 "label": "enable",
-                                "timestamp": "2025-01-17T12:00:21.411Z"
+                                "timestamp": "2025-01-23T12:00:21.519Z"
                             },
-                            "categories": [
-                                {
-                                    "id": "variant10000",
-                                    "descriptor": {
-                                        "name": "Variant for Nutraj-California-Almonds-1Kg"
-                                    },
-                                    "tags": [
-                                        {
-                                            "code": "type",
-                                            "list": [
-                                                {
-                                                    "code": "type",
-                                                    "value": "variant_group"
-                                                }
-                                            ]
-                                        },
-                                        {
-                                            "code": "attr",
-                                            "list": [
-                                                {
-                                                    "code": "name",
-                                                    "value": "item.quantity.unitized.measure"
-                                                },
-                                                {
-                                                    "code": "seq",
-                                                    "value": "1"
-                                                }
-                                            ]
-                                        }
-                                    ]
-                                },
-                                {
-                                    "id": "variant10001",
-                                    "descriptor": {
-                                        "name": "Variant for Cashews"
-                                    },
-                                    "tags": [
-                                        {
-                                            "code": "type",
-                                            "list": [
-                                                {
-                                                    "code": "type",
-                                                    "value": "variant_group"
-                                                }
-                                            ]
-                                        },
-                                        {
-                                            "code": "attr",
-                                            "list": [
-                                                {
-                                                    "code": "name",
-                                                    "value": "item.quantity.unitized.measure"
-                                                },
-                                                {
-                                                    "code": "seq",
-                                                    "value": "1"
-                                                }
-                                            ]
-                                        }
-                                    ]
-                                }
-                            ],
                             "fulfillments": [
                                 {
                                     "id": "1",
@@ -173,11 +111,11 @@
                                         "locality": "Ashok Vatika",
                                         "city": "Ahmedabad",
                                         "state": "Gujarat",
-                                        "area_code": "380058"
+                                        "area_code": "380054"
                                     },
                                     "time": {
                                         "label": "enable",
-                                        "timestamp": "2024-12-04T13:50:34.608Z",
+                                        "timestamp": "2025-01-22T07:34:34.534Z",
                                         "range": {
                                             "start": "0930",
                                             "end": "1930"
@@ -194,12 +132,85 @@
                             ],
                             "items": [
                                 {
+                                    "id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+                                    "descriptor": {
+                                        "name": "Walnuts",
+                                        "code": "1:12345678",
+                                        "symbol": "https://c8.alamy.com/comp/2HCTDG2/modern-design-walnut-leaf-nature-green-logo-design-2HCTDG2.jpg",
+                                        "short_desc": "WONDERLAND California Whole Walnut Walnuts (Akhrot)  (500 g)",
+                                        "long_desc": "WONDERLAND California Whole Walnut Walnuts (Akhrot)  (500 g)",
+                                        "images": [
+                                            "https://rukminim2.flixcart.com/image/416/416/xif0q/nut-dry-fruit/h/x/t/500-california-whole-walnut-1-pouch-wonderland-original-imagy632bnvk8fde.jpeg?q=70",
+                                            "https://rukminim2.flixcart.com/image/416/416/xif0q/nut-dry-fruit/q/r/t/500-california-whole-walnut-1-pouch-wonderland-original-imagy6326hdk68cd.jpeg?q=70"
+                                        ]
+                                    },
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "120.0",
+                                        "maximum_value": "200.0"
+                                    },
+                                    "quantity": {
+                                        "available": {
+                                            "count": "99"
+                                        },
+                                        "maximum": {
+                                            "count": "99"
+                                        },
+                                        "unitized": {
+                                            "measure": {
+                                                "value": "500",
+                                                "unit": "gram"
+                                            }
+                                        }
+                                    },
+                                    "category_id": "Snacks, Dry Fruits, Nuts",
+                                    "fulfillment_id": "1",
+                                    "location_id": "39550822-c3bb-4918-bd25-2d19ef6a9aca",
+                                    "time": {
+                                        "label": "enable",
+                                        "timestamp": "2025-01-23T12:00:21.519Z"
+                                    },
+                                    "@ondc/org/returnable": true,
+                                    "@ondc/org/seller_pickup_return": false,
+                                    "@ondc/org/return_window": "P7D",
+                                    "@ondc/org/cancellable": true,
+                                    "@ondc/org/time_to_ship": "PT3H",
+                                    "@ondc/org/available_on_cod": false,
+                                    "@ondc/org/contact_details_consumer_care": "PirimidFintech,user@gmail.com,7744774477",
+                                    "@ondc/org/statutory_reqs_prepackaged_food": {
+                                        "nutritional_info": "nutritional_info",
+                                        "additives_info": "additives_info",
+                                        "brand_owner_FSSAI_license_no": "12345678912345",
+                                        "other_FSSAI_license_no": "12345678912345",
+                                        "importer_FSSAI_license_no": "12345678912345"
+                                    },
+                                    "tags": [
+                                        {
+                                            "code": "origin",
+                                            "list": [
+                                                {
+                                                    "code": "Country",
+                                                    "value": "IND"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "veg_nonveg",
+                                            "list": [
+                                                {
+                                                    "code": "veg",
+                                                    "value": "yes"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                {
                                     "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
-                                    "parent_item_id": "variant10000",
                                     "descriptor": {
                                         "name": "Nutraj-California-Almonds-1Kg",
                                         "code": "1:12345678",
-                                        "symbol": "symbols.in/symbol.jpg",
+                                        "symbol": "https://img.freepik.com/premium-vector/almonds-nuts-nature-farm-vintage-logo-icon-symbol-vector-illustration-minimalist-design_889650-491.jpg?semt=ais_hybrid",
                                         "short_desc": "Nutraj California Almond kernels 1kg Pouch|Badam Giri|Dry Fruits and Nuts|Grocery",
                                         "long_desc": "Nutraj California Almond kernels 1kg Pouch|Badam Giri|Dry Fruits and Nuts|Grocery",
                                         "images": [
@@ -230,7 +241,7 @@
                                     "location_id": "39550822-c3bb-4918-bd25-2d19ef6a9aca",
                                     "time": {
                                         "label": "enable",
-                                        "timestamp": "2025-01-17T12:00:21.411Z"
+                                        "timestamp": "2025-01-23T12:00:21.519Z"
                                     },
                                     "@ondc/org/returnable": true,
                                     "@ondc/org/seller_pickup_return": false,
@@ -269,11 +280,10 @@
                                 },
                                 {
                                     "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
-                                    "parent_item_id": "variant10001",
                                     "descriptor": {
                                         "name": "Cashews",
                                         "code": "1:12345678",
-                                        "symbol": "symbols.in/symbol.jpg",
+                                        "symbol": "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTVlckKW1pwOvmkj9_s_rPbAvcsr_EdmIStMA&s",
                                         "short_desc": "Emart Brand - Vedaka Whole Cashews | 500 Gram | Kaju Nuts Grade W320 | Plant Based Protein | Gluten-Free | Nutty Flavor | Healthy Snack | Rich Delicious Taste",
                                         "long_desc": "Emart Brand - Vedaka Whole Cashews | 500 Gram | Kaju Nuts Grade W320 | Plant Based Protein | Gluten-Free | Nutty Flavor | Healthy Snack | Rich Delicious Taste",
                                         "images": [
@@ -283,7 +293,7 @@
                                     "price": {
                                         "currency": "INR",
                                         "value": "120.0",
-                                        "maximum_value": "258.0"
+                                        "maximum_value": "212.0"
                                     },
                                     "quantity": {
                                         "available": {
@@ -294,8 +304,8 @@
                                         },
                                         "unitized": {
                                             "measure": {
-                                                "value": "1",
-                                                "unit": "kilogram"
+                                                "value": "500",
+                                                "unit": "gram"
                                             }
                                         }
                                     },
@@ -304,7 +314,7 @@
                                     "location_id": "39550822-c3bb-4918-bd25-2d19ef6a9aca",
                                     "time": {
                                         "label": "enable",
-                                        "timestamp": "2025-01-17T12:00:21.411Z"
+                                        "timestamp": "2025-01-23T12:00:21.519Z"
                                     },
                                     "@ondc/org/returnable": true,
                                     "@ondc/org/seller_pickup_return": false,
@@ -374,36 +384,7 @@
                                     "list": [
                                         {
                                             "code": "type",
-                                            "value": "Order"
-                                        },
-                                        {
-                                            "code": "location",
-                                            "value": "39550822-c3bb-4918-bd25-2d19ef6a9aca"
-                                        },
-                                        {
-                                            "code": "day_from",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "day_to",
-                                            "value": "7"
-                                        },
-                                        {
-                                            "code": "time_from",
-                                            "value": "0930"
-                                        },
-                                        {
-                                            "code": "time_to",
-                                            "value": "1930"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "timing",
-                                    "list": [
-                                        {
-                                            "code": "type",
-                                            "value": "Delivery"
+                                            "value": "All"
                                         },
                                         {
                                             "code": "location",
@@ -443,9 +424,9 @@
                 "bap_id": "buyer-app-preprod-v2.ondc.org",
                 "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
                 "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-                "transaction_id": "042f9d64-5233-43b6-aea9-3563d9fc4bad",
-                "message_id": "dd6f2a5d-b066-40a6-a08e-aef7c48027d3",
-                "timestamp": "2025-01-18T04:38:20.411Z",
+                "transaction_id": "99d39ee1-5651-4f0a-8f2a-0a0ee8db9c9d",
+                "message_id": "0e061ee7-0302-436a-88e6-e1437235f613",
+                "timestamp": "2025-01-23T12:22:37.665Z",
                 "bpp_id": "ondc.pirimidtech.com/v2/seller",
                 "ttl": "PT30S"
             },
@@ -455,14 +436,21 @@
                         {
                             "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
                             "quantity": {
-                                "count": 3
+                                "count": 2
                             },
                             "location_id": "39550822-c3bb-4918-bd25-2d19ef6a9aca"
                         },
                         {
                             "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
                             "quantity": {
-                                "count": 3
+                                "count": 2
+                            },
+                            "location_id": "39550822-c3bb-4918-bd25-2d19ef6a9aca"
+                        },
+                        {
+                            "id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+                            "quantity": {
+                                "count": 2
                             },
                             "location_id": "39550822-c3bb-4918-bd25-2d19ef6a9aca"
                         }
@@ -501,9 +489,9 @@
                 "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
                 "bpp_id": "ondc.pirimidtech.com/v2/seller",
                 "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-                "transaction_id": "042f9d64-5233-43b6-aea9-3563d9fc4bad",
-                "message_id": "dd6f2a5d-b066-40a6-a08e-aef7c48027d3",
-                "timestamp": "2025-01-18T04:38:21.860Z"
+                "transaction_id": "99d39ee1-5651-4f0a-8f2a-0a0ee8db9c9d",
+                "message_id": "0e061ee7-0302-436a-88e6-e1437235f613",
+                "timestamp": "2025-01-23T12:22:38.493Z"
             },
             "message": {
                 "order": {
@@ -517,17 +505,21 @@
                     },
                     "items": [
                         {
-                            "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
-                            "fulfillment_id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40"
+                            "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
+                            "fulfillment_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d"
                         },
                         {
-                            "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
-                            "fulfillment_id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40"
+                            "id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+                            "fulfillment_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d"
+                        },
+                        {
+                            "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
+                            "fulfillment_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d"
                         }
                     ],
                     "fulfillments": [
                         {
-                            "id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40",
+                            "id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
                             "type": "Delivery",
                             "@ondc/org/category": "Standard Delivery",
                             "@ondc/org/TAT": "PT99H",
@@ -543,13 +535,13 @@
                     "quote": {
                         "price": {
                             "currency": "INR",
-                            "value": "1401.72"
+                            "value": "1364.71"
                         },
                         "breakup": [
                             {
                                 "@ondc/org/item_id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
                                 "@ondc/org/item_quantity": {
-                                    "count": 3
+                                    "count": 2
                                 },
                                 "@ondc/org/title_type": "item",
                                 "item": {
@@ -569,11 +561,11 @@
                                 "title": "Nutraj-California-Almonds-1Kg",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "660.0"
+                                    "value": "440.0"
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40",
+                                "@ondc/org/item_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
                                 "@ondc/org/title_type": "packing",
                                 "title": "Packing Charges",
                                 "price": {
@@ -582,7 +574,7 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40",
+                                "@ondc/org/item_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
                                 "@ondc/org/title_type": "delivery",
                                 "title": "Delivery Charges",
                                 "price": {
@@ -596,13 +588,13 @@
                                 "title": "Tax",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "122.1"
+                                    "value": "81.4"
                                 }
                             },
                             {
                                 "@ondc/org/item_id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
                                 "@ondc/org/item_quantity": {
-                                    "count": 3
+                                    "count": 2
                                 },
                                 "@ondc/org/title_type": "item",
                                 "item": {
@@ -622,11 +614,11 @@
                                 "title": "Cashews",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "360.0"
+                                    "value": "240.0"
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40",
+                                "@ondc/org/item_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
                                 "@ondc/org/title_type": "packing",
                                 "title": "Packing Charges",
                                 "price": {
@@ -635,7 +627,7 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40",
+                                "@ondc/org/item_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
                                 "@ondc/org/title_type": "delivery",
                                 "title": "Delivery Charges",
                                 "price": {
@@ -644,12 +636,56 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40",
+                                "@ondc/org/item_id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+                                "@ondc/org/item_quantity": {
+                                    "count": 2
+                                },
+                                "@ondc/org/title_type": "item",
+                                "item": {
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "120.0"
+                                    },
+                                    "quantity": {
+                                        "available": {
+                                            "count": "99"
+                                        },
+                                        "maximum": {
+                                            "count": "99"
+                                        }
+                                    }
+                                },
+                                "title": "Walnuts",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "240.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
+                                "@ondc/org/title_type": "packing",
+                                "title": "Packing Charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "5.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
+                                "@ondc/org/title_type": "delivery",
+                                "title": "Delivery Charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "100.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
                                 "@ondc/org/title_type": "misc",
                                 "title": "Convenience Fee",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "49.62"
+                                    "value": "48.31"
                                 }
                             }
                         ],
@@ -668,9 +704,9 @@
                 "bap_id": "buyer-app-preprod-v2.ondc.org",
                 "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
                 "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-                "transaction_id": "042f9d64-5233-43b6-aea9-3563d9fc4bad",
-                "message_id": "cc0342a3-c32c-4eb1-a6cf-34881abbd2a0",
-                "timestamp": "2025-01-18T04:38:29.524Z",
+                "transaction_id": "99d39ee1-5651-4f0a-8f2a-0a0ee8db9c9d",
+                "message_id": "4a3994f1-205d-465a-b59d-438edc4188e3",
+                "timestamp": "2025-01-23T12:22:56.533Z",
                 "bpp_id": "ondc.pirimidtech.com/v2/seller",
                 "ttl": "PT30S"
             },
@@ -688,18 +724,26 @@
                         {
                             "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
                             "quantity": {
-                                "count": 3
+                                "count": 2
                             },
                             "location_id": "39550822-c3bb-4918-bd25-2d19ef6a9aca",
-                            "fulfillment_id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40"
+                            "fulfillment_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d"
                         },
                         {
                             "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
                             "quantity": {
-                                "count": 3
+                                "count": 2
                             },
                             "location_id": "39550822-c3bb-4918-bd25-2d19ef6a9aca",
-                            "fulfillment_id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40"
+                            "fulfillment_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d"
+                        },
+                        {
+                            "id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+                            "quantity": {
+                                "count": 2
+                            },
+                            "location_id": "39550822-c3bb-4918-bd25-2d19ef6a9aca",
+                            "fulfillment_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d"
                         }
                     ],
                     "billing": {
@@ -715,12 +759,12 @@
                         "phone": "7202959020",
                         "name": "Hemanshu Faldu",
                         "email": "fhemanshu@gmail.com",
-                        "created_at": "2025-01-18T04:38:29.524Z",
-                        "updated_at": "2025-01-18T04:38:29.524Z"
+                        "created_at": "2025-01-23T12:22:56.533Z",
+                        "updated_at": "2025-01-23T12:22:56.533Z"
                     },
                     "fulfillments": [
                         {
-                            "id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40",
+                            "id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
                             "type": "Delivery",
                             "end": {
                                 "contact": {
@@ -756,9 +800,9 @@
                 "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
                 "bpp_id": "ondc.pirimidtech.com/v2/seller",
                 "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-                "transaction_id": "042f9d64-5233-43b6-aea9-3563d9fc4bad",
-                "message_id": "cc0342a3-c32c-4eb1-a6cf-34881abbd2a0",
-                "timestamp": "2025-01-18T04:38:30.286Z",
+                "transaction_id": "99d39ee1-5651-4f0a-8f2a-0a0ee8db9c9d",
+                "message_id": "4a3994f1-205d-465a-b59d-438edc4188e3",
+                "timestamp": "2025-01-23T12:22:57.280Z",
                 "ttl": "PT30S"
             },
             "message": {
@@ -776,21 +820,31 @@
                             "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
                             "quantity": {
                                 "unitized": {
-                                    "count": "3"
+                                    "count": "2"
                                 },
-                                "count": 3
+                                "count": 2
                             },
-                            "fulfillment_id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40"
+                            "fulfillment_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d"
                         },
                         {
                             "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
                             "quantity": {
                                 "unitized": {
-                                    "count": "3"
+                                    "count": "2"
                                 },
-                                "count": 3
+                                "count": 2
                             },
-                            "fulfillment_id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40"
+                            "fulfillment_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d"
+                        },
+                        {
+                            "id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+                            "quantity": {
+                                "unitized": {
+                                    "count": "2"
+                                },
+                                "count": 2
+                            },
+                            "fulfillment_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d"
                         }
                     ],
                     "billing": {
@@ -806,19 +860,13 @@
                         },
                         "email": "fhemanshu@gmail.com",
                         "phone": "7202959020",
-                        "created_at": "2025-01-18T04:38:29.524Z",
-                        "updated_at": "2025-01-18T04:38:29.524Z"
+                        "created_at": "2025-01-23T12:22:56.533Z",
+                        "updated_at": "2025-01-23T12:22:56.533Z"
                     },
                     "fulfillments": [
                         {
-                            "id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40",
+                            "id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
                             "type": "Delivery",
-                            "provider_id": "ondc.loadshare.com/ondc/18275",
-                            "state": {
-                                "descriptor": {
-                                    "code": "INITIALIZING"
-                                }
-                            },
                             "tracking": false,
                             "end": {
                                 "location": {
@@ -832,9 +880,6 @@
                                         "country": "IND",
                                         "area_code": "380015"
                                     }
-                                },
-                                "time": {
-                                    "range": {}
                                 },
                                 "instructions": {
                                     "name": "Status for pickup",
@@ -855,13 +900,13 @@
                     "quote": {
                         "price": {
                             "currency": "INR",
-                            "value": "1401.72"
+                            "value": "1364.71"
                         },
                         "breakup": [
                             {
                                 "@ondc/org/item_id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
                                 "@ondc/org/item_quantity": {
-                                    "count": 3
+                                    "count": 2
                                 },
                                 "@ondc/org/title_type": "item",
                                 "item": {
@@ -873,11 +918,11 @@
                                 "title": "Nutraj-California-Almonds-1Kg",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "660.0"
+                                    "value": "440.0"
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40",
+                                "@ondc/org/item_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
                                 "@ondc/org/title_type": "packing",
                                 "title": "Packing Charges",
                                 "price": {
@@ -886,7 +931,7 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40",
+                                "@ondc/org/item_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
                                 "@ondc/org/title_type": "delivery",
                                 "title": "Delivery Charges",
                                 "price": {
@@ -900,13 +945,13 @@
                                 "title": "Tax",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "122.1"
+                                    "value": "81.4"
                                 }
                             },
                             {
                                 "@ondc/org/item_id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
                                 "@ondc/org/item_quantity": {
-                                    "count": 3
+                                    "count": 2
                                 },
                                 "@ondc/org/title_type": "item",
                                 "item": {
@@ -918,11 +963,11 @@
                                 "title": "Cashews",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "360.0"
+                                    "value": "240.0"
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40",
+                                "@ondc/org/item_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
                                 "@ondc/org/title_type": "packing",
                                 "title": "Packing Charges",
                                 "price": {
@@ -931,7 +976,7 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40",
+                                "@ondc/org/item_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
                                 "@ondc/org/title_type": "delivery",
                                 "title": "Delivery Charges",
                                 "price": {
@@ -940,22 +985,58 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40",
+                                "@ondc/org/item_id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+                                "@ondc/org/item_quantity": {
+                                    "count": 2
+                                },
+                                "@ondc/org/title_type": "item",
+                                "item": {
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "120.0"
+                                    }
+                                },
+                                "title": "Walnuts",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "240.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
+                                "@ondc/org/title_type": "packing",
+                                "title": "Packing Charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "5.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
+                                "@ondc/org/title_type": "delivery",
+                                "title": "Delivery Charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "100.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
                                 "@ondc/org/title_type": "misc",
                                 "title": "Convenience Fee",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "49.62"
+                                    "value": "48.31"
                                 }
                             }
                         ],
                         "ttl": "P1D"
                     },
                     "payment": {
-                        "uri": "https://ondc-pirimid-payment.netlify.app/payment/042f9d64-5233-43b6-aea9-3563d9fc4bad",
+                        "uri": "https://ondc-pirimid-payment.netlify.app/payment/99d39ee1-5651-4f0a-8f2a-0a0ee8db9c9d",
                         "type": "ON-ORDER",
                         "status": "NOT-PAID",
-                        "collected_by": "BPP",
+                        "collected_by": "BAP",
                         "@ondc/org/buyer_app_finder_fee_type": "percent",
                         "@ondc/org/buyer_app_finder_fee_amount": "3.0",
                         "@ondc/org/withholding_amount": "0.0",
@@ -975,8 +1056,8 @@
                             }
                         ]
                     },
-                    "created_at": "2025-01-18T04:38:21.871Z",
-                    "updated_at": "2025-01-18T04:38:30.291Z",
+                    "created_at": "2025-01-23T12:22:15.585Z",
+                    "updated_at": "2025-01-23T12:22:57.291Z",
                     "tags": [
                         {
                             "code": "bpp_terms",
@@ -1005,15 +1086,15 @@
                 "bap_id": "buyer-app-preprod-v2.ondc.org",
                 "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
                 "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-                "transaction_id": "042f9d64-5233-43b6-aea9-3563d9fc4bad",
-                "message_id": "92f88395-6016-40ed-8055-20e1da617ac9",
-                "timestamp": "2025-01-18T04:38:51.420Z",
+                "transaction_id": "99d39ee1-5651-4f0a-8f2a-0a0ee8db9c9d",
+                "message_id": "cb404011-4cca-4e7e-9af0-8260d3dd02b4",
+                "timestamp": "2025-01-23T12:23:17.611Z",
                 "bpp_id": "ondc.pirimidtech.com/v2/seller",
                 "ttl": "PT30S"
             },
             "message": {
                 "order": {
-                    "id": "2025-01-18-429408",
+                    "id": "2025-01-23-459524",
                     "state": "Created",
                     "billing": {
                         "address": {
@@ -1028,23 +1109,30 @@
                         "phone": "7202959020",
                         "name": "Hemanshu Faldu",
                         "email": "fhemanshu@gmail.com",
-                        "created_at": "2025-01-18T04:38:29.524Z",
-                        "updated_at": "2025-01-18T04:38:29.524Z"
+                        "created_at": "2025-01-23T12:22:56.533Z",
+                        "updated_at": "2025-01-23T12:22:56.533Z"
                     },
                     "items": [
                         {
                             "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
                             "quantity": {
-                                "count": 3
+                                "count": 2
                             },
-                            "fulfillment_id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40"
+                            "fulfillment_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d"
                         },
                         {
                             "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
                             "quantity": {
-                                "count": 3
+                                "count": 2
                             },
-                            "fulfillment_id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40"
+                            "fulfillment_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d"
+                        },
+                        {
+                            "id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+                            "quantity": {
+                                "count": 2
+                            },
+                            "fulfillment_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d"
                         }
                     ],
                     "provider": {
@@ -1058,7 +1146,7 @@
                     "fulfillments": [
                         {
                             "@ondc/org/TAT": "PT99H",
-                            "id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40",
+                            "id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
                             "tracking": false,
                             "end": {
                                 "contact": {
@@ -1088,9 +1176,9 @@
                         "uri": "https://razorpay.com/",
                         "tl_method": "http/get",
                         "params": {
-                            "amount": "1401.72",
+                            "amount": "1364.71",
                             "currency": "INR",
-                            "transaction_id": "order_PkmFEkFcTwn3Jj"
+                            "transaction_id": "order_PmspSHrmelUv3U"
                         },
                         "status": "PAID",
                         "type": "ON-ORDER",
@@ -1117,13 +1205,13 @@
                     "quote": {
                         "price": {
                             "currency": "INR",
-                            "value": "1401.72"
+                            "value": "1364.71"
                         },
                         "breakup": [
                             {
                                 "@ondc/org/item_id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
                                 "@ondc/org/item_quantity": {
-                                    "count": 3
+                                    "count": 2
                                 },
                                 "@ondc/org/title_type": "item",
                                 "item": {
@@ -1135,11 +1223,11 @@
                                 "title": "Nutraj-California-Almonds-1Kg",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "660.0"
+                                    "value": "440.0"
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40",
+                                "@ondc/org/item_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
                                 "@ondc/org/title_type": "packing",
                                 "title": "Packing Charges",
                                 "price": {
@@ -1148,7 +1236,7 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40",
+                                "@ondc/org/item_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
                                 "@ondc/org/title_type": "delivery",
                                 "title": "Delivery Charges",
                                 "price": {
@@ -1162,13 +1250,13 @@
                                 "title": "Tax",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "122.1"
+                                    "value": "81.4"
                                 }
                             },
                             {
                                 "@ondc/org/item_id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
                                 "@ondc/org/item_quantity": {
-                                    "count": 3
+                                    "count": 2
                                 },
                                 "@ondc/org/title_type": "item",
                                 "item": {
@@ -1180,11 +1268,11 @@
                                 "title": "Cashews",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "360.0"
+                                    "value": "240.0"
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40",
+                                "@ondc/org/item_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
                                 "@ondc/org/title_type": "packing",
                                 "title": "Packing Charges",
                                 "price": {
@@ -1193,7 +1281,7 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40",
+                                "@ondc/org/item_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
                                 "@ondc/org/title_type": "delivery",
                                 "title": "Delivery Charges",
                                 "price": {
@@ -1202,12 +1290,48 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40",
+                                "@ondc/org/item_id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+                                "@ondc/org/item_quantity": {
+                                    "count": 2
+                                },
+                                "@ondc/org/title_type": "item",
+                                "item": {
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "120.0"
+                                    }
+                                },
+                                "title": "Walnuts",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "240.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
+                                "@ondc/org/title_type": "packing",
+                                "title": "Packing Charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "5.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
+                                "@ondc/org/title_type": "delivery",
+                                "title": "Delivery Charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "100.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
                                 "@ondc/org/title_type": "misc",
                                 "title": "Convenience Fee",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "49.62"
+                                    "value": "48.31"
                                 }
                             }
                         ],
@@ -1237,8 +1361,8 @@
                             ]
                         }
                     ],
-                    "created_at": "2025-01-18T04:38:51.420Z",
-                    "updated_at": "2025-01-18T04:38:51.420Z"
+                    "created_at": "2025-01-23T12:23:17.611Z",
+                    "updated_at": "2025-01-23T12:23:17.611Z"
                 }
             }
         },
@@ -1253,13 +1377,13 @@
                 "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
                 "bpp_id": "ondc.pirimidtech.com/v2/seller",
                 "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-                "transaction_id": "042f9d64-5233-43b6-aea9-3563d9fc4bad",
-                "message_id": "92f88395-6016-40ed-8055-20e1da617ac9",
-                "timestamp": "2025-01-18T04:38:52.266Z"
+                "transaction_id": "99d39ee1-5651-4f0a-8f2a-0a0ee8db9c9d",
+                "message_id": "cb404011-4cca-4e7e-9af0-8260d3dd02b4",
+                "timestamp": "2025-01-23T12:23:18.562Z"
             },
             "message": {
                 "order": {
-                    "id": "2025-01-18-429408",
+                    "id": "2025-01-23-459524",
                     "state": "Created",
                     "provider": {
                         "id": "e2008459-7e90-493e-b02e-cae52ca53214",
@@ -1273,16 +1397,23 @@
                         {
                             "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
                             "quantity": {
-                                "count": 3
+                                "count": 2
                             },
-                            "fulfillment_id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40"
+                            "fulfillment_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d"
                         },
                         {
                             "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
                             "quantity": {
-                                "count": 3
+                                "count": 2
                             },
-                            "fulfillment_id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40"
+                            "fulfillment_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d"
+                        },
+                        {
+                            "id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+                            "quantity": {
+                                "count": 2
+                            },
+                            "fulfillment_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d"
                         }
                     ],
                     "billing": {
@@ -1298,12 +1429,12 @@
                         },
                         "email": "fhemanshu@gmail.com",
                         "phone": "7202959020",
-                        "created_at": "2025-01-18T04:38:29.524Z",
-                        "updated_at": "2025-01-18T04:38:29.524Z"
+                        "created_at": "2025-01-23T12:22:56.533Z",
+                        "updated_at": "2025-01-23T12:22:56.533Z"
                     },
                     "fulfillments": [
                         {
-                            "id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40",
+                            "id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
                             "type": "Delivery",
                             "@ondc/org/TAT": "PT99H",
                             "@ondc/org/provider_name": "LoadShare",
@@ -1324,7 +1455,7 @@
                                         "locality": "Ashok Vatika",
                                         "city": "Ahmedabad",
                                         "state": "Gujarat",
-                                        "area_code": "380058"
+                                        "area_code": "380054"
                                     }
                                 },
                                 "contact": {
@@ -1358,13 +1489,13 @@
                     "quote": {
                         "price": {
                             "currency": "INR",
-                            "value": "1401.72"
+                            "value": "1364.71"
                         },
                         "breakup": [
                             {
                                 "@ondc/org/item_id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
                                 "@ondc/org/item_quantity": {
-                                    "count": 3
+                                    "count": 2
                                 },
                                 "@ondc/org/title_type": "item",
                                 "item": {
@@ -1376,11 +1507,11 @@
                                 "title": "Nutraj-California-Almonds-1Kg",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "660.0"
+                                    "value": "440.0"
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40",
+                                "@ondc/org/item_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
                                 "@ondc/org/title_type": "packing",
                                 "title": "Packing Charges",
                                 "price": {
@@ -1389,7 +1520,7 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40",
+                                "@ondc/org/item_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
                                 "@ondc/org/title_type": "delivery",
                                 "title": "Delivery Charges",
                                 "price": {
@@ -1403,13 +1534,13 @@
                                 "title": "Tax",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "122.1"
+                                    "value": "81.4"
                                 }
                             },
                             {
                                 "@ondc/org/item_id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
                                 "@ondc/org/item_quantity": {
-                                    "count": 3
+                                    "count": 2
                                 },
                                 "@ondc/org/title_type": "item",
                                 "item": {
@@ -1421,11 +1552,11 @@
                                 "title": "Cashews",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "360.0"
+                                    "value": "240.0"
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40",
+                                "@ondc/org/item_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
                                 "@ondc/org/title_type": "packing",
                                 "title": "Packing Charges",
                                 "price": {
@@ -1434,7 +1565,7 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40",
+                                "@ondc/org/item_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
                                 "@ondc/org/title_type": "delivery",
                                 "title": "Delivery Charges",
                                 "price": {
@@ -1443,12 +1574,48 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40",
+                                "@ondc/org/item_id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+                                "@ondc/org/item_quantity": {
+                                    "count": 2
+                                },
+                                "@ondc/org/title_type": "item",
+                                "item": {
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "120.0"
+                                    }
+                                },
+                                "title": "Walnuts",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "240.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
+                                "@ondc/org/title_type": "packing",
+                                "title": "Packing Charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "5.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
+                                "@ondc/org/title_type": "delivery",
+                                "title": "Delivery Charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "100.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
                                 "@ondc/org/title_type": "misc",
                                 "title": "Convenience Fee",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "49.62"
+                                    "value": "48.31"
                                 }
                             }
                         ],
@@ -1458,8 +1625,8 @@
                         "uri": "https://razorpay.com/",
                         "tl_method": "http/get",
                         "params": {
-                            "transaction_id": "order_PkmFEkFcTwn3Jj",
-                            "amount": "1401.72",
+                            "transaction_id": "order_PmspSHrmelUv3U",
+                            "amount": "1364.71",
                             "currency": "INR"
                         },
                         "type": "ON-ORDER",
@@ -1484,8 +1651,8 @@
                             }
                         ]
                     },
-                    "created_at": "2025-01-18T04:38:51.420Z",
-                    "updated_at": "2025-01-18T04:38:52.266Z",
+                    "created_at": "2025-01-23T12:23:17.611Z",
+                    "updated_at": "2025-01-23T12:23:18.562Z",
                     "tags": [
                         {
                             "code": "bpp_terms",
@@ -1528,14 +1695,14 @@
                 "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
                 "bpp_id": "ondc.pirimidtech.com/v2/seller",
                 "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-                "transaction_id": "042f9d64-5233-43b6-aea9-3563d9fc4bad",
-                "message_id": "86c63de0-570f-46a2-bb57-dcb0ee384273",
-                "timestamp": "2025-01-18T04:39:27.600Z",
+                "transaction_id": "99d39ee1-5651-4f0a-8f2a-0a0ee8db9c9d",
+                "message_id": "f41223b7-a008-4ee9-af4c-53dbd6d971c1",
+                "timestamp": "2025-01-23T12:23:43.030Z",
                 "ttl": "PT30S"
             },
             "message": {
                 "order": {
-                    "id": "2025-01-18-429408",
+                    "id": "2025-01-23-459524",
                     "state": "Accepted",
                     "provider": {
                         "id": "e2008459-7e90-493e-b02e-cae52ca53214",
@@ -1549,16 +1716,23 @@
                         {
                             "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
                             "quantity": {
-                                "count": 3
+                                "count": 2
                             },
-                            "fulfillment_id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40"
+                            "fulfillment_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d"
                         },
                         {
                             "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
                             "quantity": {
-                                "count": 3
+                                "count": 2
                             },
-                            "fulfillment_id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40"
+                            "fulfillment_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d"
+                        },
+                        {
+                            "id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+                            "quantity": {
+                                "count": 2
+                            },
+                            "fulfillment_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d"
                         }
                     ],
                     "billing": {
@@ -1574,12 +1748,12 @@
                         },
                         "email": "fhemanshu@gmail.com",
                         "phone": "7202959020",
-                        "created_at": "2025-01-18T04:38:29.524Z",
-                        "updated_at": "2025-01-18T04:38:29.524Z"
+                        "created_at": "2025-01-23T12:22:56.533Z",
+                        "updated_at": "2025-01-23T12:22:56.533Z"
                     },
                     "fulfillments": [
                         {
-                            "id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40",
+                            "id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
                             "type": "Delivery",
                             "@ondc/org/TAT": "PT99H",
                             "provider_id": "ondc.loadshare.com/ondc/18275",
@@ -1601,13 +1775,13 @@
                                         "locality": "Ashok Vatika",
                                         "city": "Ahmedabad",
                                         "state": "Gujarat",
-                                        "area_code": "380058"
+                                        "area_code": "380054"
                                     }
                                 },
                                 "time": {
                                     "range": {
-                                        "start": "2025-01-18T04:39:27.598Z",
-                                        "end": "2025-01-18T07:39:27.598Z"
+                                        "start": "2025-01-23T12:23:43.027Z",
+                                        "end": "2025-01-23T15:23:43.027Z"
                                     }
                                 },
                                 "instructions": {
@@ -1636,8 +1810,8 @@
                                 },
                                 "time": {
                                     "range": {
-                                        "start": "2025-01-18T07:39:27.598Z",
-                                        "end": "2025-01-22T07:39:27.598Z"
+                                        "start": "2025-01-23T15:23:43.027Z",
+                                        "end": "2025-01-27T15:23:43.027Z"
                                     }
                                 },
                                 "contact": {
@@ -1653,13 +1827,13 @@
                     "quote": {
                         "price": {
                             "currency": "INR",
-                            "value": "1401.72"
+                            "value": "1364.71"
                         },
                         "breakup": [
                             {
                                 "@ondc/org/item_id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
                                 "@ondc/org/item_quantity": {
-                                    "count": 3
+                                    "count": 2
                                 },
                                 "@ondc/org/title_type": "item",
                                 "item": {
@@ -1671,11 +1845,11 @@
                                 "title": "Nutraj-California-Almonds-1Kg",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "660.0"
+                                    "value": "440.0"
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40",
+                                "@ondc/org/item_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
                                 "@ondc/org/title_type": "packing",
                                 "title": "Packing Charges",
                                 "price": {
@@ -1684,7 +1858,7 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40",
+                                "@ondc/org/item_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
                                 "@ondc/org/title_type": "delivery",
                                 "title": "Delivery Charges",
                                 "price": {
@@ -1698,13 +1872,13 @@
                                 "title": "Tax",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "122.1"
+                                    "value": "81.4"
                                 }
                             },
                             {
                                 "@ondc/org/item_id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
                                 "@ondc/org/item_quantity": {
-                                    "count": 3
+                                    "count": 2
                                 },
                                 "@ondc/org/title_type": "item",
                                 "item": {
@@ -1716,11 +1890,11 @@
                                 "title": "Cashews",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "360.0"
+                                    "value": "240.0"
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40",
+                                "@ondc/org/item_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
                                 "@ondc/org/title_type": "packing",
                                 "title": "Packing Charges",
                                 "price": {
@@ -1729,7 +1903,7 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40",
+                                "@ondc/org/item_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
                                 "@ondc/org/title_type": "delivery",
                                 "title": "Delivery Charges",
                                 "price": {
@@ -1738,12 +1912,48 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40",
+                                "@ondc/org/item_id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+                                "@ondc/org/item_quantity": {
+                                    "count": 2
+                                },
+                                "@ondc/org/title_type": "item",
+                                "item": {
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "120.0"
+                                    }
+                                },
+                                "title": "Walnuts",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "240.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
+                                "@ondc/org/title_type": "packing",
+                                "title": "Packing Charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "5.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
+                                "@ondc/org/title_type": "delivery",
+                                "title": "Delivery Charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "100.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
                                 "@ondc/org/title_type": "misc",
                                 "title": "Convenience Fee",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "49.62"
+                                    "value": "48.31"
                                 }
                             }
                         ],
@@ -1753,8 +1963,8 @@
                         "uri": "https://razorpay.com/",
                         "tl_method": "http/get",
                         "params": {
-                            "transaction_id": "order_PkmFEkFcTwn3Jj",
-                            "amount": "1401.72",
+                            "transaction_id": "order_PmspSHrmelUv3U",
+                            "amount": "1364.71",
                             "currency": "INR"
                         },
                         "type": "ON-ORDER",
@@ -1779,8 +1989,8 @@
                             }
                         ]
                     },
-                    "created_at": "2025-01-18T04:38:51.420Z",
-                    "updated_at": "2025-01-18T04:39:27.600Z"
+                    "created_at": "2025-01-23T12:23:17.611Z",
+                    "updated_at": "2025-01-23T12:23:43.030Z"
                 }
             }
         },
@@ -1795,14 +2005,14 @@
                 "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
                 "bpp_id": "ondc.pirimidtech.com/v2/seller",
                 "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-                "transaction_id": "042f9d64-5233-43b6-aea9-3563d9fc4bad",
-                "message_id": "6faa83b9-109b-43e3-b465-c1ba72a393fb",
-                "timestamp": "2025-01-18T04:39:31.486Z",
+                "transaction_id": "99d39ee1-5651-4f0a-8f2a-0a0ee8db9c9d",
+                "message_id": "cc905d0b-8183-4aaa-b2c0-72a037ef0047",
+                "timestamp": "2025-01-23T12:23:48.608Z",
                 "ttl": "PT30S"
             },
             "message": {
                 "order": {
-                    "id": "2025-01-18-429408",
+                    "id": "2025-01-23-459524",
                     "state": "In-progress",
                     "provider": {
                         "id": "e2008459-7e90-493e-b02e-cae52ca53214",
@@ -1816,16 +2026,23 @@
                         {
                             "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
                             "quantity": {
-                                "count": 3
+                                "count": 2
                             },
-                            "fulfillment_id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40"
+                            "fulfillment_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d"
                         },
                         {
                             "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
                             "quantity": {
-                                "count": 3
+                                "count": 2
                             },
-                            "fulfillment_id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40"
+                            "fulfillment_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d"
+                        },
+                        {
+                            "id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+                            "quantity": {
+                                "count": 2
+                            },
+                            "fulfillment_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d"
                         }
                     ],
                     "billing": {
@@ -1841,12 +2058,12 @@
                         },
                         "email": "fhemanshu@gmail.com",
                         "phone": "7202959020",
-                        "created_at": "2025-01-18T04:38:29.524Z",
-                        "updated_at": "2025-01-18T04:38:29.524Z"
+                        "created_at": "2025-01-23T12:22:56.533Z",
+                        "updated_at": "2025-01-23T12:22:56.533Z"
                     },
                     "fulfillments": [
                         {
-                            "id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40",
+                            "id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
                             "type": "Delivery",
                             "@ondc/org/TAT": "PT99H",
                             "provider_id": "ondc.loadshare.com/ondc/18275",
@@ -1877,13 +2094,13 @@
                                         "locality": "Ashok Vatika",
                                         "city": "Ahmedabad",
                                         "state": "Gujarat",
-                                        "area_code": "380058"
+                                        "area_code": "380054"
                                     }
                                 },
                                 "time": {
                                     "range": {
-                                        "start": "2025-01-18T04:39:27.598Z",
-                                        "end": "2025-01-18T07:39:27.598Z"
+                                        "start": "2025-01-23T12:23:43.027Z",
+                                        "end": "2025-01-23T15:23:43.027Z"
                                     }
                                 },
                                 "instructions": {
@@ -1912,8 +2129,8 @@
                                 },
                                 "time": {
                                     "range": {
-                                        "start": "2025-01-18T07:39:27.598Z",
-                                        "end": "2025-01-22T07:39:27.598Z"
+                                        "start": "2025-01-23T15:23:43.027Z",
+                                        "end": "2025-01-27T15:23:43.027Z"
                                     }
                                 },
                                 "contact": {
@@ -1923,19 +2140,30 @@
                                 "person": {
                                     "name": "Hemanshu Faldu"
                                 }
-                            }
+                            },
+                            "tags": [
+                                {
+                                    "code": "routing",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "P2P"
+                                        }
+                                    ]
+                                }
+                            ]
                         }
                     ],
                     "quote": {
                         "price": {
                             "currency": "INR",
-                            "value": "1401.72"
+                            "value": "1364.71"
                         },
                         "breakup": [
                             {
                                 "@ondc/org/item_id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
                                 "@ondc/org/item_quantity": {
-                                    "count": 3
+                                    "count": 2
                                 },
                                 "@ondc/org/title_type": "item",
                                 "item": {
@@ -1947,11 +2175,11 @@
                                 "title": "Nutraj-California-Almonds-1Kg",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "660.0"
+                                    "value": "440.0"
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40",
+                                "@ondc/org/item_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
                                 "@ondc/org/title_type": "packing",
                                 "title": "Packing Charges",
                                 "price": {
@@ -1960,7 +2188,7 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40",
+                                "@ondc/org/item_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
                                 "@ondc/org/title_type": "delivery",
                                 "title": "Delivery Charges",
                                 "price": {
@@ -1974,13 +2202,13 @@
                                 "title": "Tax",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "122.1"
+                                    "value": "81.4"
                                 }
                             },
                             {
                                 "@ondc/org/item_id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
                                 "@ondc/org/item_quantity": {
-                                    "count": 3
+                                    "count": 2
                                 },
                                 "@ondc/org/title_type": "item",
                                 "item": {
@@ -1992,11 +2220,11 @@
                                 "title": "Cashews",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "360.0"
+                                    "value": "240.0"
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40",
+                                "@ondc/org/item_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
                                 "@ondc/org/title_type": "packing",
                                 "title": "Packing Charges",
                                 "price": {
@@ -2005,7 +2233,7 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40",
+                                "@ondc/org/item_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
                                 "@ondc/org/title_type": "delivery",
                                 "title": "Delivery Charges",
                                 "price": {
@@ -2014,12 +2242,48 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40",
+                                "@ondc/org/item_id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+                                "@ondc/org/item_quantity": {
+                                    "count": 2
+                                },
+                                "@ondc/org/title_type": "item",
+                                "item": {
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "120.0"
+                                    }
+                                },
+                                "title": "Walnuts",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "240.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
+                                "@ondc/org/title_type": "packing",
+                                "title": "Packing Charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "5.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
+                                "@ondc/org/title_type": "delivery",
+                                "title": "Delivery Charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "100.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
                                 "@ondc/org/title_type": "misc",
                                 "title": "Convenience Fee",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "49.62"
+                                    "value": "48.31"
                                 }
                             }
                         ],
@@ -2029,8 +2293,8 @@
                         "uri": "https://razorpay.com/",
                         "tl_method": "http/get",
                         "params": {
-                            "transaction_id": "order_PkmFEkFcTwn3Jj",
-                            "amount": "1401.72",
+                            "transaction_id": "order_PmspSHrmelUv3U",
+                            "amount": "1364.71",
                             "currency": "INR"
                         },
                         "type": "ON-ORDER",
@@ -2055,8 +2319,8 @@
                             }
                         ]
                     },
-                    "created_at": "2025-01-18T04:38:51.420Z",
-                    "updated_at": "2025-01-18T04:39:31.486Z"
+                    "created_at": "2025-01-23T12:23:17.611Z",
+                    "updated_at": "2025-01-23T12:23:48.608Z"
                 }
             }
         },
@@ -2071,14 +2335,14 @@
                 "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
                 "bpp_id": "ondc.pirimidtech.com/v2/seller",
                 "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-                "transaction_id": "042f9d64-5233-43b6-aea9-3563d9fc4bad",
-                "message_id": "f86ce25c-612d-487f-9b6e-1ce7ef3b83db",
-                "timestamp": "2025-01-18T04:39:36.777Z",
+                "transaction_id": "99d39ee1-5651-4f0a-8f2a-0a0ee8db9c9d",
+                "message_id": "189c386a-492b-463d-9f23-0d983664cb08",
+                "timestamp": "2025-01-23T12:23:56.301Z",
                 "ttl": "PT30S"
             },
             "message": {
                 "order": {
-                    "id": "2025-01-18-429408",
+                    "id": "2025-01-23-459524",
                     "state": "In-progress",
                     "provider": {
                         "id": "e2008459-7e90-493e-b02e-cae52ca53214",
@@ -2092,21 +2356,28 @@
                         {
                             "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
                             "quantity": {
-                                "count": 3
+                                "count": 2
                             },
-                            "fulfillment_id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40"
+                            "fulfillment_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d"
                         },
                         {
                             "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
                             "quantity": {
-                                "count": 3
+                                "count": 2
                             },
-                            "fulfillment_id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40"
+                            "fulfillment_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d"
+                        },
+                        {
+                            "id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+                            "quantity": {
+                                "count": 2
+                            },
+                            "fulfillment_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d"
                         }
                     ],
                     "documents": [
                         {
-                            "url": "https://ondc.pirimidtech.com/v2/seller/api/order/invoice/502a64aa-3c44-4bc7-ab44-af9d9b077fc2",
+                            "url": "https://ondc.pirimidtech.com/v2/seller/api/order/invoice/ef59d53e-1d0e-41d3-b382-0ceef31ae3e5",
                             "label": "Invoice"
                         }
                     ],
@@ -2123,12 +2394,12 @@
                         },
                         "email": "fhemanshu@gmail.com",
                         "phone": "7202959020",
-                        "created_at": "2025-01-18T04:38:29.524Z",
-                        "updated_at": "2025-01-18T04:38:29.524Z"
+                        "created_at": "2025-01-23T12:22:56.533Z",
+                        "updated_at": "2025-01-23T12:22:56.533Z"
                     },
                     "fulfillments": [
                         {
-                            "id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40",
+                            "id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
                             "type": "Delivery",
                             "@ondc/org/TAT": "PT99H",
                             "provider_id": "ondc.loadshare.com/ondc/18275",
@@ -2159,14 +2430,14 @@
                                         "locality": "Ashok Vatika",
                                         "city": "Ahmedabad",
                                         "state": "Gujarat",
-                                        "area_code": "380058"
+                                        "area_code": "380054"
                                     }
                                 },
                                 "time": {
-                                    "timestamp": "2025-01-18T04:39:36.775Z",
+                                    "timestamp": "2025-01-23T12:23:56.299Z",
                                     "range": {
-                                        "start": "2025-01-18T04:39:27.598Z",
-                                        "end": "2025-01-18T07:39:27.598Z"
+                                        "start": "2025-01-23T12:23:43.027Z",
+                                        "end": "2025-01-23T15:23:43.027Z"
                                     }
                                 },
                                 "instructions": {
@@ -2195,8 +2466,8 @@
                                 },
                                 "time": {
                                     "range": {
-                                        "start": "2025-01-18T07:39:27.598Z",
-                                        "end": "2025-01-22T07:39:27.598Z"
+                                        "start": "2025-01-23T15:23:43.027Z",
+                                        "end": "2025-01-27T15:23:43.027Z"
                                     }
                                 },
                                 "contact": {
@@ -2223,13 +2494,13 @@
                     "quote": {
                         "price": {
                             "currency": "INR",
-                            "value": "1401.72"
+                            "value": "1364.71"
                         },
                         "breakup": [
                             {
                                 "@ondc/org/item_id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
                                 "@ondc/org/item_quantity": {
-                                    "count": 3
+                                    "count": 2
                                 },
                                 "@ondc/org/title_type": "item",
                                 "item": {
@@ -2241,11 +2512,11 @@
                                 "title": "Nutraj-California-Almonds-1Kg",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "660.0"
+                                    "value": "440.0"
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40",
+                                "@ondc/org/item_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
                                 "@ondc/org/title_type": "packing",
                                 "title": "Packing Charges",
                                 "price": {
@@ -2254,7 +2525,7 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40",
+                                "@ondc/org/item_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
                                 "@ondc/org/title_type": "delivery",
                                 "title": "Delivery Charges",
                                 "price": {
@@ -2268,13 +2539,13 @@
                                 "title": "Tax",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "122.1"
+                                    "value": "81.4"
                                 }
                             },
                             {
                                 "@ondc/org/item_id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
                                 "@ondc/org/item_quantity": {
-                                    "count": 3
+                                    "count": 2
                                 },
                                 "@ondc/org/title_type": "item",
                                 "item": {
@@ -2286,11 +2557,11 @@
                                 "title": "Cashews",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "360.0"
+                                    "value": "240.0"
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40",
+                                "@ondc/org/item_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
                                 "@ondc/org/title_type": "packing",
                                 "title": "Packing Charges",
                                 "price": {
@@ -2299,7 +2570,7 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40",
+                                "@ondc/org/item_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
                                 "@ondc/org/title_type": "delivery",
                                 "title": "Delivery Charges",
                                 "price": {
@@ -2308,12 +2579,48 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40",
+                                "@ondc/org/item_id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+                                "@ondc/org/item_quantity": {
+                                    "count": 2
+                                },
+                                "@ondc/org/title_type": "item",
+                                "item": {
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "120.0"
+                                    }
+                                },
+                                "title": "Walnuts",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "240.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
+                                "@ondc/org/title_type": "packing",
+                                "title": "Packing Charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "5.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
+                                "@ondc/org/title_type": "delivery",
+                                "title": "Delivery Charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "100.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
                                 "@ondc/org/title_type": "misc",
                                 "title": "Convenience Fee",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "49.62"
+                                    "value": "48.31"
                                 }
                             }
                         ],
@@ -2323,8 +2630,8 @@
                         "uri": "https://razorpay.com/",
                         "tl_method": "http/get",
                         "params": {
-                            "transaction_id": "order_PkmFEkFcTwn3Jj",
-                            "amount": "1401.72",
+                            "transaction_id": "order_PmspSHrmelUv3U",
+                            "amount": "1364.71",
                             "currency": "INR"
                         },
                         "type": "ON-ORDER",
@@ -2349,8 +2656,8 @@
                             }
                         ]
                     },
-                    "created_at": "2025-01-18T04:38:51.420Z",
-                    "updated_at": "2025-01-18T04:39:36.777Z"
+                    "created_at": "2025-01-23T12:23:17.611Z",
+                    "updated_at": "2025-01-23T12:23:56.301Z"
                 }
             }
         },
@@ -2365,14 +2672,14 @@
                 "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
                 "bpp_id": "ondc.pirimidtech.com/v2/seller",
                 "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-                "transaction_id": "042f9d64-5233-43b6-aea9-3563d9fc4bad",
-                "message_id": "d3c520d5-6a38-41d1-8c9d-68ad5f3e0e57",
-                "timestamp": "2025-01-18T15:49:15.589Z",
+                "transaction_id": "99d39ee1-5651-4f0a-8f2a-0a0ee8db9c9d",
+                "message_id": "dd9fce37-c85d-4ecc-8356-092351ad7935",
+                "timestamp": "2025-01-24T05:27:44.552Z",
                 "ttl": "PT30S"
             },
             "message": {
                 "order": {
-                    "id": "2025-01-18-429408",
+                    "id": "2025-01-23-459524",
                     "state": "In-progress",
                     "provider": {
                         "id": "e2008459-7e90-493e-b02e-cae52ca53214",
@@ -2386,21 +2693,28 @@
                         {
                             "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
                             "quantity": {
-                                "count": 3
+                                "count": 2
                             },
-                            "fulfillment_id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40"
+                            "fulfillment_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d"
                         },
                         {
                             "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
                             "quantity": {
-                                "count": 3
+                                "count": 2
                             },
-                            "fulfillment_id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40"
+                            "fulfillment_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d"
+                        },
+                        {
+                            "id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+                            "quantity": {
+                                "count": 2
+                            },
+                            "fulfillment_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d"
                         }
                     ],
                     "documents": [
                         {
-                            "url": "https://ondc.pirimidtech.com/v2/seller/api/order/invoice/502a64aa-3c44-4bc7-ab44-af9d9b077fc2",
+                            "url": "https://ondc.pirimidtech.com/v2/seller/api/order/invoice/ef59d53e-1d0e-41d3-b382-0ceef31ae3e5",
                             "label": "Invoice"
                         }
                     ],
@@ -2417,12 +2731,12 @@
                         },
                         "email": "fhemanshu@gmail.com",
                         "phone": "7202959020",
-                        "created_at": "2025-01-18T04:38:29.524Z",
-                        "updated_at": "2025-01-18T04:38:29.524Z"
+                        "created_at": "2025-01-23T12:22:56.533Z",
+                        "updated_at": "2025-01-23T12:22:56.533Z"
                     },
                     "fulfillments": [
                         {
-                            "id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40",
+                            "id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
                             "type": "Delivery",
                             "@ondc/org/TAT": "PT99H",
                             "provider_id": "ondc.loadshare.com/ondc/18275",
@@ -2453,14 +2767,14 @@
                                         "locality": "Ashok Vatika",
                                         "city": "Ahmedabad",
                                         "state": "Gujarat",
-                                        "area_code": "380058"
+                                        "area_code": "380054"
                                     }
                                 },
                                 "time": {
-                                    "timestamp": "2025-01-18T04:39:36.775Z",
+                                    "timestamp": "2025-01-23T12:23:56.299Z",
                                     "range": {
-                                        "start": "2025-01-18T04:39:27.598Z",
-                                        "end": "2025-01-18T07:39:27.598Z"
+                                        "start": "2025-01-23T12:23:43.027Z",
+                                        "end": "2025-01-23T15:23:43.027Z"
                                     }
                                 },
                                 "instructions": {
@@ -2489,8 +2803,8 @@
                                 },
                                 "time": {
                                     "range": {
-                                        "start": "2025-01-18T07:39:27.598Z",
-                                        "end": "2025-01-22T07:39:27.598Z"
+                                        "start": "2025-01-23T15:23:43.027Z",
+                                        "end": "2025-01-27T15:23:43.027Z"
                                     }
                                 },
                                 "contact": {
@@ -2517,13 +2831,13 @@
                     "quote": {
                         "price": {
                             "currency": "INR",
-                            "value": "1401.72"
+                            "value": "1364.71"
                         },
                         "breakup": [
                             {
                                 "@ondc/org/item_id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
                                 "@ondc/org/item_quantity": {
-                                    "count": 3
+                                    "count": 2
                                 },
                                 "@ondc/org/title_type": "item",
                                 "item": {
@@ -2535,11 +2849,11 @@
                                 "title": "Nutraj-California-Almonds-1Kg",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "660.0"
+                                    "value": "440.0"
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40",
+                                "@ondc/org/item_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
                                 "@ondc/org/title_type": "packing",
                                 "title": "Packing Charges",
                                 "price": {
@@ -2548,7 +2862,7 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40",
+                                "@ondc/org/item_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
                                 "@ondc/org/title_type": "delivery",
                                 "title": "Delivery Charges",
                                 "price": {
@@ -2562,13 +2876,13 @@
                                 "title": "Tax",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "122.1"
+                                    "value": "81.4"
                                 }
                             },
                             {
                                 "@ondc/org/item_id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
                                 "@ondc/org/item_quantity": {
-                                    "count": 3
+                                    "count": 2
                                 },
                                 "@ondc/org/title_type": "item",
                                 "item": {
@@ -2580,11 +2894,11 @@
                                 "title": "Cashews",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "360.0"
+                                    "value": "240.0"
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40",
+                                "@ondc/org/item_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
                                 "@ondc/org/title_type": "packing",
                                 "title": "Packing Charges",
                                 "price": {
@@ -2593,7 +2907,7 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40",
+                                "@ondc/org/item_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
                                 "@ondc/org/title_type": "delivery",
                                 "title": "Delivery Charges",
                                 "price": {
@@ -2602,12 +2916,48 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40",
+                                "@ondc/org/item_id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+                                "@ondc/org/item_quantity": {
+                                    "count": 2
+                                },
+                                "@ondc/org/title_type": "item",
+                                "item": {
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "120.0"
+                                    }
+                                },
+                                "title": "Walnuts",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "240.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
+                                "@ondc/org/title_type": "packing",
+                                "title": "Packing Charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "5.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
+                                "@ondc/org/title_type": "delivery",
+                                "title": "Delivery Charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "100.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
                                 "@ondc/org/title_type": "misc",
                                 "title": "Convenience Fee",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "49.62"
+                                    "value": "48.31"
                                 }
                             }
                         ],
@@ -2617,8 +2967,8 @@
                         "uri": "https://razorpay.com/",
                         "tl_method": "http/get",
                         "params": {
-                            "transaction_id": "order_PkmFEkFcTwn3Jj",
-                            "amount": "1401.72",
+                            "transaction_id": "order_PmspSHrmelUv3U",
+                            "amount": "1364.71",
                             "currency": "INR"
                         },
                         "type": "ON-ORDER",
@@ -2643,8 +2993,8 @@
                             }
                         ]
                     },
-                    "created_at": "2025-01-18T04:38:51.420Z",
-                    "updated_at": "2025-01-18T15:49:15.589Z"
+                    "created_at": "2025-01-23T12:23:17.611Z",
+                    "updated_at": "2025-01-24T05:27:44.552Z"
                 }
             }
         },
@@ -2659,14 +3009,14 @@
                 "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
                 "bpp_id": "ondc.pirimidtech.com/v2/seller",
                 "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-                "transaction_id": "042f9d64-5233-43b6-aea9-3563d9fc4bad",
-                "message_id": "7717a170-f238-4e98-b5dd-d96658beea8b",
-                "timestamp": "2025-01-18T15:51:33.142Z",
+                "transaction_id": "99d39ee1-5651-4f0a-8f2a-0a0ee8db9c9d",
+                "message_id": "dc812e87-1de4-4215-8584-bf52923f5676",
+                "timestamp": "2025-01-24T05:28:52.474Z",
                 "ttl": "PT30S"
             },
             "message": {
                 "order": {
-                    "id": "2025-01-18-429408",
+                    "id": "2025-01-23-459524",
                     "state": "Cancelled",
                     "provider": {
                         "id": "e2008459-7e90-493e-b02e-cae52ca53214",
@@ -2680,30 +3030,44 @@
                         {
                             "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
                             "quantity": {
-                                "count": 3
+                                "count": 0
                             },
-                            "fulfillment_id": "1a40ac02-0724-4aaa-99de-945e81e592d9"
+                            "fulfillment_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d"
                         },
                         {
                             "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
                             "quantity": {
-                                "count": 3
+                                "count": 0
                             },
-                            "fulfillment_id": "1a40ac02-0724-4aaa-99de-945e81e592d9"
+                            "fulfillment_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d"
+                        },
+                        {
+                            "id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+                            "quantity": {
+                                "count": 0
+                            },
+                            "fulfillment_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d"
                         },
                         {
                             "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
                             "quantity": {
-                                "count": 0
+                                "count": 2
                             },
-                            "fulfillment_id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40"
+                            "fulfillment_id": "7b293f91-e8a9-4333-89bc-ef5f7efa5ce6"
                         },
                         {
                             "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
                             "quantity": {
-                                "count": 0
+                                "count": 2
                             },
-                            "fulfillment_id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40"
+                            "fulfillment_id": "7b293f91-e8a9-4333-89bc-ef5f7efa5ce6"
+                        },
+                        {
+                            "id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+                            "quantity": {
+                                "count": 2
+                            },
+                            "fulfillment_id": "7b293f91-e8a9-4333-89bc-ef5f7efa5ce6"
                         }
                     ],
                     "billing": {
@@ -2719,12 +3083,12 @@
                         },
                         "email": "fhemanshu@gmail.com",
                         "phone": "7202959020",
-                        "created_at": "2025-01-18T04:38:29.524Z",
-                        "updated_at": "2025-01-18T04:38:29.524Z"
+                        "created_at": "2025-01-23T12:22:56.533Z",
+                        "updated_at": "2025-01-23T12:22:56.533Z"
                     },
                     "fulfillments": [
                         {
-                            "id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40",
+                            "id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
                             "type": "Delivery",
                             "@ondc/org/TAT": "PT99H",
                             "provider_id": "ondc.loadshare.com/ondc/18275",
@@ -2755,14 +3119,14 @@
                                         "locality": "Ashok Vatika",
                                         "city": "Ahmedabad",
                                         "state": "Gujarat",
-                                        "area_code": "380058"
+                                        "area_code": "380054"
                                     }
                                 },
                                 "time": {
-                                    "timestamp": "2025-01-18T04:39:36.775Z",
+                                    "timestamp": "2025-01-23T12:23:56.299Z",
                                     "range": {
-                                        "start": "2025-01-18T04:39:27.598Z",
-                                        "end": "2025-01-18T07:39:27.598Z"
+                                        "start": "2025-01-23T12:23:43.027Z",
+                                        "end": "2025-01-23T15:23:43.027Z"
                                     }
                                 },
                                 "instructions": {
@@ -2791,8 +3155,8 @@
                                 },
                                 "time": {
                                     "range": {
-                                        "start": "2025-01-18T07:39:27.598Z",
-                                        "end": "2025-01-22T07:39:27.598Z"
+                                        "start": "2025-01-23T15:23:43.027Z",
+                                        "end": "2025-01-27T15:23:43.027Z"
                                     }
                                 },
                                 "contact": {
@@ -2809,7 +3173,7 @@
                                     "list": [
                                         {
                                             "code": "reason_id",
-                                            "value": "012"
+                                            "value": "014"
                                         },
                                         {
                                             "code": "initiated_by",
@@ -2817,7 +3181,7 @@
                                         },
                                         {
                                             "code": "rto_id",
-                                            "value": "1a40ac02-0724-4aaa-99de-945e81e592d9"
+                                            "value": "7b293f91-e8a9-4333-89bc-ef5f7efa5ce6"
                                         }
                                     ]
                                 },
@@ -2830,14 +3194,14 @@
                                         },
                                         {
                                             "code": "updated_at",
-                                            "value": "2025-01-18T15:49:15.589Z"
+                                            "value": "2025-01-24T05:27:44.552Z"
                                         }
                                     ]
                                 }
                             ]
                         },
                         {
-                            "id": "1a40ac02-0724-4aaa-99de-945e81e592d9",
+                            "id": "7b293f91-e8a9-4333-89bc-ef5f7efa5ce6",
                             "type": "RTO",
                             "@ondc/org/TAT": "PT2H",
                             "@ondc/org/provider_name": "LoadShare",
@@ -2861,7 +3225,7 @@
                                     }
                                 },
                                 "time": {
-                                    "timestamp": "2025-01-18T15:51:33.091Z"
+                                    "timestamp": "2025-01-24T05:28:52.332Z"
                                 },
                                 "instructions": {
                                     "name": "Status for pickup",
@@ -2891,7 +3255,7 @@
                                         "locality": "Ashok Vatika",
                                         "city": "Ahmedabad",
                                         "state": "Gujarat",
-                                        "area_code": "380058"
+                                        "area_code": "380054"
                                     }
                                 },
                                 "instructions": {
@@ -2915,7 +3279,7 @@
                                         },
                                         {
                                             "code": "id",
-                                            "value": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40"
+                                            "value": "4dab34c2-b680-4a0e-bc90-68a77d412e3d"
                                         },
                                         {
                                             "code": "currency",
@@ -2923,7 +3287,7 @@
                                         },
                                         {
                                             "code": "value",
-                                            "value": "-49.62"
+                                            "value": "-48.31"
                                         }
                                     ]
                                 },
@@ -2944,7 +3308,7 @@
                                         },
                                         {
                                             "code": "value",
-                                            "value": "-660.0"
+                                            "value": "-440.0"
                                         }
                                     ]
                                 },
@@ -2957,7 +3321,7 @@
                                         },
                                         {
                                             "code": "id",
-                                            "value": "1a40ac02-0724-4aaa-99de-945e81e592d9"
+                                            "value": "7b293f91-e8a9-4333-89bc-ef5f7efa5ce6"
                                         },
                                         {
                                             "code": "currency",
@@ -2978,7 +3342,7 @@
                                         },
                                         {
                                             "code": "id",
-                                            "value": "1a40ac02-0724-4aaa-99de-945e81e592d9"
+                                            "value": "7b293f91-e8a9-4333-89bc-ef5f7efa5ce6"
                                         },
                                         {
                                             "code": "currency",
@@ -2999,7 +3363,7 @@
                                         },
                                         {
                                             "code": "id",
-                                            "value": "1a40ac02-0724-4aaa-99de-945e81e592d9"
+                                            "value": "7b293f91-e8a9-4333-89bc-ef5f7efa5ce6"
                                         },
                                         {
                                             "code": "currency",
@@ -3007,7 +3371,7 @@
                                         },
                                         {
                                             "code": "value",
-                                            "value": "-122.1"
+                                            "value": "-81.4"
                                         }
                                     ]
                                 },
@@ -3028,7 +3392,7 @@
                                         },
                                         {
                                             "code": "value",
-                                            "value": "-360.0"
+                                            "value": "-240.0"
                                         }
                                     ]
                                 },
@@ -3041,7 +3405,7 @@
                                         },
                                         {
                                             "code": "id",
-                                            "value": "1a40ac02-0724-4aaa-99de-945e81e592d9"
+                                            "value": "7b293f91-e8a9-4333-89bc-ef5f7efa5ce6"
                                         },
                                         {
                                             "code": "currency",
@@ -3062,7 +3426,70 @@
                                         },
                                         {
                                             "code": "id",
-                                            "value": "1a40ac02-0724-4aaa-99de-945e81e592d9"
+                                            "value": "7b293f91-e8a9-4333-89bc-ef5f7efa5ce6"
+                                        },
+                                        {
+                                            "code": "currency",
+                                            "value": "INR"
+                                        },
+                                        {
+                                            "code": "value",
+                                            "value": "-100.0"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "quote_trail",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "item"
+                                        },
+                                        {
+                                            "code": "id",
+                                            "value": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7"
+                                        },
+                                        {
+                                            "code": "currency",
+                                            "value": "INR"
+                                        },
+                                        {
+                                            "code": "value",
+                                            "value": "-240.0"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "quote_trail",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "packing"
+                                        },
+                                        {
+                                            "code": "id",
+                                            "value": "7b293f91-e8a9-4333-89bc-ef5f7efa5ce6"
+                                        },
+                                        {
+                                            "code": "currency",
+                                            "value": "INR"
+                                        },
+                                        {
+                                            "code": "value",
+                                            "value": "-5.0"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "quote_trail",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "delivery"
+                                        },
+                                        {
+                                            "code": "id",
+                                            "value": "7b293f91-e8a9-4333-89bc-ef5f7efa5ce6"
                                         },
                                         {
                                             "code": "currency",
@@ -3102,7 +3529,7 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "1a40ac02-0724-4aaa-99de-945e81e592d9",
+                                "@ondc/org/item_id": "7b293f91-e8a9-4333-89bc-ef5f7efa5ce6",
                                 "@ondc/org/title_type": "packing",
                                 "title": "Packing Charges",
                                 "price": {
@@ -3111,7 +3538,7 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "1a40ac02-0724-4aaa-99de-945e81e592d9",
+                                "@ondc/org/item_id": "7b293f91-e8a9-4333-89bc-ef5f7efa5ce6",
                                 "@ondc/org/title_type": "delivery",
                                 "title": "Delivery Charges",
                                 "price": {
@@ -3147,7 +3574,7 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "1a40ac02-0724-4aaa-99de-945e81e592d9",
+                                "@ondc/org/item_id": "7b293f91-e8a9-4333-89bc-ef5f7efa5ce6",
                                 "@ondc/org/title_type": "packing",
                                 "title": "Packing Charges",
                                 "price": {
@@ -3156,7 +3583,7 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "1a40ac02-0724-4aaa-99de-945e81e592d9",
+                                "@ondc/org/item_id": "7b293f91-e8a9-4333-89bc-ef5f7efa5ce6",
                                 "@ondc/org/title_type": "delivery",
                                 "title": "Delivery Charges",
                                 "price": {
@@ -3165,7 +3592,43 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "1a40ac02-0724-4aaa-99de-945e81e592d9",
+                                "@ondc/org/item_id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+                                "@ondc/org/item_quantity": {
+                                    "count": 0
+                                },
+                                "@ondc/org/title_type": "item",
+                                "item": {
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "120.0"
+                                    }
+                                },
+                                "title": "Walnuts",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "0.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "7b293f91-e8a9-4333-89bc-ef5f7efa5ce6",
+                                "@ondc/org/title_type": "packing",
+                                "title": "Packing Charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "0.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "7b293f91-e8a9-4333-89bc-ef5f7efa5ce6",
+                                "@ondc/org/title_type": "delivery",
+                                "title": "Delivery Charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "0.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "7b293f91-e8a9-4333-89bc-ef5f7efa5ce6",
                                 "@ondc/org/title_type": "misc",
                                 "title": "Convenience Fee",
                                 "price": {
@@ -3180,8 +3643,8 @@
                         "uri": "https://razorpay.com/",
                         "tl_method": "http/get",
                         "params": {
-                            "transaction_id": "order_PkmFEkFcTwn3Jj",
-                            "amount": "1401.72",
+                            "transaction_id": "order_PmspSHrmelUv3U",
+                            "amount": "1364.71",
                             "currency": "INR"
                         },
                         "type": "ON-ORDER",
@@ -3209,11 +3672,11 @@
                     "cancellation": {
                         "cancelled_by": "ondc.pirimidtech.com/v2/seller",
                         "reason": {
-                            "id": "012"
+                            "id": "014"
                         }
                     },
-                    "created_at": "2025-01-18T04:38:21.871Z",
-                    "updated_at": "2025-01-18T15:51:33.125Z"
+                    "created_at": "2025-01-23T12:22:15.585Z",
+                    "updated_at": "2025-01-24T05:28:52.437Z"
                 }
             }
         },
@@ -3228,14 +3691,14 @@
                 "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
                 "bpp_id": "ondc.pirimidtech.com/v2/seller",
                 "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-                "transaction_id": "042f9d64-5233-43b6-aea9-3563d9fc4bad",
-                "message_id": "e71a4eee-2004-4a18-8238-48ef7a6b531d",
-                "timestamp": "2025-01-18T15:52:03.594Z",
+                "transaction_id": "99d39ee1-5651-4f0a-8f2a-0a0ee8db9c9d",
+                "message_id": "d9aa29c4-e07d-4abb-b46a-c43276d9b519",
+                "timestamp": "2025-01-24T05:29:40.398Z",
                 "ttl": "PT30S"
             },
             "message": {
                 "order": {
-                    "id": "2025-01-18-429408",
+                    "id": "2025-01-23-459524",
                     "state": "Cancelled",
                     "provider": {
                         "id": "e2008459-7e90-493e-b02e-cae52ca53214",
@@ -3249,30 +3712,44 @@
                         {
                             "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
                             "quantity": {
-                                "count": 3
+                                "count": 0
                             },
-                            "fulfillment_id": "1a40ac02-0724-4aaa-99de-945e81e592d9"
+                            "fulfillment_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d"
                         },
                         {
                             "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
                             "quantity": {
-                                "count": 3
+                                "count": 0
                             },
-                            "fulfillment_id": "1a40ac02-0724-4aaa-99de-945e81e592d9"
+                            "fulfillment_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d"
+                        },
+                        {
+                            "id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+                            "quantity": {
+                                "count": 0
+                            },
+                            "fulfillment_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d"
                         },
                         {
                             "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
                             "quantity": {
-                                "count": 0
+                                "count": 2
                             },
-                            "fulfillment_id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40"
+                            "fulfillment_id": "7b293f91-e8a9-4333-89bc-ef5f7efa5ce6"
                         },
                         {
                             "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
                             "quantity": {
-                                "count": 0
+                                "count": 2
                             },
-                            "fulfillment_id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40"
+                            "fulfillment_id": "7b293f91-e8a9-4333-89bc-ef5f7efa5ce6"
+                        },
+                        {
+                            "id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+                            "quantity": {
+                                "count": 2
+                            },
+                            "fulfillment_id": "7b293f91-e8a9-4333-89bc-ef5f7efa5ce6"
                         }
                     ],
                     "billing": {
@@ -3288,12 +3765,12 @@
                         },
                         "email": "fhemanshu@gmail.com",
                         "phone": "7202959020",
-                        "created_at": "2025-01-18T04:38:29.524Z",
-                        "updated_at": "2025-01-18T04:38:29.524Z"
+                        "created_at": "2025-01-23T12:22:56.533Z",
+                        "updated_at": "2025-01-23T12:22:56.533Z"
                     },
                     "fulfillments": [
                         {
-                            "id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40",
+                            "id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
                             "type": "Delivery",
                             "@ondc/org/TAT": "PT99H",
                             "provider_id": "ondc.loadshare.com/ondc/18275",
@@ -3324,14 +3801,14 @@
                                         "locality": "Ashok Vatika",
                                         "city": "Ahmedabad",
                                         "state": "Gujarat",
-                                        "area_code": "380058"
+                                        "area_code": "380054"
                                     }
                                 },
                                 "time": {
-                                    "timestamp": "2025-01-18T04:39:36.775Z",
+                                    "timestamp": "2025-01-23T12:23:56.299Z",
                                     "range": {
-                                        "start": "2025-01-18T04:39:27.598Z",
-                                        "end": "2025-01-18T07:39:27.598Z"
+                                        "start": "2025-01-23T12:23:43.027Z",
+                                        "end": "2025-01-23T15:23:43.027Z"
                                     }
                                 },
                                 "instructions": {
@@ -3360,8 +3837,8 @@
                                 },
                                 "time": {
                                     "range": {
-                                        "start": "2025-01-18T07:39:27.598Z",
-                                        "end": "2025-01-22T07:39:27.598Z"
+                                        "start": "2025-01-23T15:23:43.027Z",
+                                        "end": "2025-01-27T15:23:43.027Z"
                                     }
                                 },
                                 "contact": {
@@ -3378,7 +3855,7 @@
                                     "list": [
                                         {
                                             "code": "reason_id",
-                                            "value": "012"
+                                            "value": "014"
                                         },
                                         {
                                             "code": "initiated_by",
@@ -3386,7 +3863,7 @@
                                         },
                                         {
                                             "code": "rto_id",
-                                            "value": "1a40ac02-0724-4aaa-99de-945e81e592d9"
+                                            "value": "7b293f91-e8a9-4333-89bc-ef5f7efa5ce6"
                                         }
                                     ]
                                 },
@@ -3399,14 +3876,14 @@
                                         },
                                         {
                                             "code": "updated_at",
-                                            "value": "2025-01-18T15:49:15.589Z"
+                                            "value": "2025-01-24T05:27:44.552Z"
                                         }
                                     ]
                                 }
                             ]
                         },
                         {
-                            "id": "1a40ac02-0724-4aaa-99de-945e81e592d9",
+                            "id": "7b293f91-e8a9-4333-89bc-ef5f7efa5ce6",
                             "type": "RTO",
                             "@ondc/org/TAT": "PT2H",
                             "@ondc/org/provider_name": "LoadShare",
@@ -3430,7 +3907,7 @@
                                     }
                                 },
                                 "time": {
-                                    "timestamp": "2025-01-18T15:51:33.091Z"
+                                    "timestamp": "2025-01-24T05:28:52.332Z"
                                 },
                                 "instructions": {
                                     "name": "Status for pickup",
@@ -3460,11 +3937,11 @@
                                         "locality": "Ashok Vatika",
                                         "city": "Ahmedabad",
                                         "state": "Gujarat",
-                                        "area_code": "380058"
+                                        "area_code": "380054"
                                     }
                                 },
                                 "time": {
-                                    "timestamp": "2025-01-18T15:52:03.593Z"
+                                    "timestamp": "2025-01-24T05:29:40.396Z"
                                 },
                                 "instructions": {
                                     "name": "Status for pickup",
@@ -3487,7 +3964,7 @@
                                         },
                                         {
                                             "code": "id",
-                                            "value": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40"
+                                            "value": "4dab34c2-b680-4a0e-bc90-68a77d412e3d"
                                         },
                                         {
                                             "code": "currency",
@@ -3495,7 +3972,7 @@
                                         },
                                         {
                                             "code": "value",
-                                            "value": "-49.62"
+                                            "value": "-48.31"
                                         }
                                     ]
                                 },
@@ -3516,7 +3993,7 @@
                                         },
                                         {
                                             "code": "value",
-                                            "value": "-660.0"
+                                            "value": "-440.0"
                                         }
                                     ]
                                 },
@@ -3529,7 +4006,7 @@
                                         },
                                         {
                                             "code": "id",
-                                            "value": "1a40ac02-0724-4aaa-99de-945e81e592d9"
+                                            "value": "7b293f91-e8a9-4333-89bc-ef5f7efa5ce6"
                                         },
                                         {
                                             "code": "currency",
@@ -3550,7 +4027,7 @@
                                         },
                                         {
                                             "code": "id",
-                                            "value": "1a40ac02-0724-4aaa-99de-945e81e592d9"
+                                            "value": "7b293f91-e8a9-4333-89bc-ef5f7efa5ce6"
                                         },
                                         {
                                             "code": "currency",
@@ -3571,7 +4048,7 @@
                                         },
                                         {
                                             "code": "id",
-                                            "value": "1a40ac02-0724-4aaa-99de-945e81e592d9"
+                                            "value": "7b293f91-e8a9-4333-89bc-ef5f7efa5ce6"
                                         },
                                         {
                                             "code": "currency",
@@ -3579,7 +4056,7 @@
                                         },
                                         {
                                             "code": "value",
-                                            "value": "-122.1"
+                                            "value": "-81.4"
                                         }
                                     ]
                                 },
@@ -3600,7 +4077,7 @@
                                         },
                                         {
                                             "code": "value",
-                                            "value": "-360.0"
+                                            "value": "-240.0"
                                         }
                                     ]
                                 },
@@ -3613,7 +4090,7 @@
                                         },
                                         {
                                             "code": "id",
-                                            "value": "1a40ac02-0724-4aaa-99de-945e81e592d9"
+                                            "value": "7b293f91-e8a9-4333-89bc-ef5f7efa5ce6"
                                         },
                                         {
                                             "code": "currency",
@@ -3634,7 +4111,70 @@
                                         },
                                         {
                                             "code": "id",
-                                            "value": "1a40ac02-0724-4aaa-99de-945e81e592d9"
+                                            "value": "7b293f91-e8a9-4333-89bc-ef5f7efa5ce6"
+                                        },
+                                        {
+                                            "code": "currency",
+                                            "value": "INR"
+                                        },
+                                        {
+                                            "code": "value",
+                                            "value": "-100.0"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "quote_trail",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "item"
+                                        },
+                                        {
+                                            "code": "id",
+                                            "value": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7"
+                                        },
+                                        {
+                                            "code": "currency",
+                                            "value": "INR"
+                                        },
+                                        {
+                                            "code": "value",
+                                            "value": "-240.0"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "quote_trail",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "packing"
+                                        },
+                                        {
+                                            "code": "id",
+                                            "value": "7b293f91-e8a9-4333-89bc-ef5f7efa5ce6"
+                                        },
+                                        {
+                                            "code": "currency",
+                                            "value": "INR"
+                                        },
+                                        {
+                                            "code": "value",
+                                            "value": "-5.0"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "quote_trail",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "delivery"
+                                        },
+                                        {
+                                            "code": "id",
+                                            "value": "7b293f91-e8a9-4333-89bc-ef5f7efa5ce6"
                                         },
                                         {
                                             "code": "currency",
@@ -3674,7 +4214,7 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "1a40ac02-0724-4aaa-99de-945e81e592d9",
+                                "@ondc/org/item_id": "7b293f91-e8a9-4333-89bc-ef5f7efa5ce6",
                                 "@ondc/org/title_type": "packing",
                                 "title": "Packing Charges",
                                 "price": {
@@ -3683,7 +4223,7 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "1a40ac02-0724-4aaa-99de-945e81e592d9",
+                                "@ondc/org/item_id": "7b293f91-e8a9-4333-89bc-ef5f7efa5ce6",
                                 "@ondc/org/title_type": "delivery",
                                 "title": "Delivery Charges",
                                 "price": {
@@ -3719,7 +4259,7 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "1a40ac02-0724-4aaa-99de-945e81e592d9",
+                                "@ondc/org/item_id": "7b293f91-e8a9-4333-89bc-ef5f7efa5ce6",
                                 "@ondc/org/title_type": "packing",
                                 "title": "Packing Charges",
                                 "price": {
@@ -3728,7 +4268,7 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "1a40ac02-0724-4aaa-99de-945e81e592d9",
+                                "@ondc/org/item_id": "7b293f91-e8a9-4333-89bc-ef5f7efa5ce6",
                                 "@ondc/org/title_type": "delivery",
                                 "title": "Delivery Charges",
                                 "price": {
@@ -3737,7 +4277,43 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "1a40ac02-0724-4aaa-99de-945e81e592d9",
+                                "@ondc/org/item_id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+                                "@ondc/org/item_quantity": {
+                                    "count": 0
+                                },
+                                "@ondc/org/title_type": "item",
+                                "item": {
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "120.0"
+                                    }
+                                },
+                                "title": "Walnuts",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "0.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "7b293f91-e8a9-4333-89bc-ef5f7efa5ce6",
+                                "@ondc/org/title_type": "packing",
+                                "title": "Packing Charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "0.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "7b293f91-e8a9-4333-89bc-ef5f7efa5ce6",
+                                "@ondc/org/title_type": "delivery",
+                                "title": "Delivery Charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "0.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "7b293f91-e8a9-4333-89bc-ef5f7efa5ce6",
                                 "@ondc/org/title_type": "misc",
                                 "title": "Convenience Fee",
                                 "price": {
@@ -3752,8 +4328,8 @@
                         "uri": "https://razorpay.com/",
                         "tl_method": "http/get",
                         "params": {
-                            "transaction_id": "order_PkmFEkFcTwn3Jj",
-                            "amount": "1401.72",
+                            "transaction_id": "order_PmspSHrmelUv3U",
+                            "amount": "1364.71",
                             "currency": "INR"
                         },
                         "type": "ON-ORDER",
@@ -3781,11 +4357,11 @@
                     "cancellation": {
                         "cancelled_by": "ondc.pirimidtech.com/v2/seller",
                         "reason": {
-                            "id": "012"
+                            "id": "014"
                         }
                     },
-                    "created_at": "2025-01-18T04:38:51.420Z",
-                    "updated_at": "2025-01-18T15:52:03.594Z"
+                    "created_at": "2025-01-23T12:23:17.611Z",
+                    "updated_at": "2025-01-24T05:29:40.398Z"
                 }
             }
         }

--- a/Pirimid/SellerApp/Retail/RET-10/FLOW_5/log_validation_utitlity_response.json
+++ b/Pirimid/SellerApp/Retail/RET-10/FLOW_5/log_validation_utitlity_response.json
@@ -1,13 +1,17 @@
 {
-    "success": true,
+    "success": false,
     "response": {
-        "message": "Logs were verified successfully",
-        "report": {},
+        "message": "Logs were not verified successfully",
+        "report": {
+            "on_search_full_catalog_refresh": {
+                "prvdr0categories": "Support for variants is mandatory, categories must be present in bpp/providers[0]"
+            }
+        },
         "bpp_id": "ondc.pirimidtech.com/v2/seller",
         "bap_id": "buyer-app-preprod-v2.ondc.org",
         "domain": "ONDC:RET10",
-        "reportTimestamp": "2025-01-19T04:34:02.257Z"
+        "reportTimestamp": "2025-01-24T05:55:37.496Z"
     },
-    "signature": "RjDgJ5P0o6d/bz14GEjyh84WDh11D6ODAiGAvuzTeUAGmQ43k4VwAl5vNrH1Hyjy7K0WNJV9afnpWBtpd3ikCA==",
-    "signTimestamp": "2025-01-19T04:34:02.257Z"
+    "signature": "zwRrx29xUnhl8tgAUdDXU4hxJNIAhj7YLBAbVGqrVmZDsur6kWg3m8vPTm668Kr8dOit0gmg2TxxI/BpTErSCg==",
+    "signTimestamp": "2025-01-24T05:55:37.496Z"
 }

--- a/Pirimid/SellerApp/Retail/RET-10/FLOW_5/on_cancel.json
+++ b/Pirimid/SellerApp/Retail/RET-10/FLOW_5/on_cancel.json
@@ -9,14 +9,14 @@
     "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
     "bpp_id": "ondc.pirimidtech.com/v2/seller",
     "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-    "transaction_id": "042f9d64-5233-43b6-aea9-3563d9fc4bad",
-    "message_id": "7717a170-f238-4e98-b5dd-d96658beea8b",
-    "timestamp": "2025-01-18T15:51:33.142Z",
+    "transaction_id": "99d39ee1-5651-4f0a-8f2a-0a0ee8db9c9d",
+    "message_id": "dc812e87-1de4-4215-8584-bf52923f5676",
+    "timestamp": "2025-01-24T05:28:52.474Z",
     "ttl": "PT30S"
   },
   "message": {
     "order": {
-      "id": "2025-01-18-429408",
+      "id": "2025-01-23-459524",
       "state": "Cancelled",
       "provider": {
         "id": "e2008459-7e90-493e-b02e-cae52ca53214",
@@ -30,30 +30,44 @@
         {
           "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
           "quantity": {
-            "count": 3
+            "count": 0
           },
-          "fulfillment_id": "1a40ac02-0724-4aaa-99de-945e81e592d9"
+          "fulfillment_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d"
         },
         {
           "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
           "quantity": {
-            "count": 3
+            "count": 0
           },
-          "fulfillment_id": "1a40ac02-0724-4aaa-99de-945e81e592d9"
+          "fulfillment_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d"
+        },
+        {
+          "id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+          "quantity": {
+            "count": 0
+          },
+          "fulfillment_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d"
         },
         {
           "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
           "quantity": {
-            "count": 0
+            "count": 2
           },
-          "fulfillment_id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40"
+          "fulfillment_id": "7b293f91-e8a9-4333-89bc-ef5f7efa5ce6"
         },
         {
           "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
           "quantity": {
-            "count": 0
+            "count": 2
           },
-          "fulfillment_id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40"
+          "fulfillment_id": "7b293f91-e8a9-4333-89bc-ef5f7efa5ce6"
+        },
+        {
+          "id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "7b293f91-e8a9-4333-89bc-ef5f7efa5ce6"
         }
       ],
       "billing": {
@@ -69,12 +83,12 @@
         },
         "email": "fhemanshu@gmail.com",
         "phone": "7202959020",
-        "created_at": "2025-01-18T04:38:29.524Z",
-        "updated_at": "2025-01-18T04:38:29.524Z"
+        "created_at": "2025-01-23T12:22:56.533Z",
+        "updated_at": "2025-01-23T12:22:56.533Z"
       },
       "fulfillments": [
         {
-          "id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40",
+          "id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
           "type": "Delivery",
           "@ondc/org/TAT": "PT99H",
           "provider_id": "ondc.loadshare.com/ondc/18275",
@@ -105,14 +119,14 @@
                 "locality": "Ashok Vatika",
                 "city": "Ahmedabad",
                 "state": "Gujarat",
-                "area_code": "380058"
+                "area_code": "380054"
               }
             },
             "time": {
-              "timestamp": "2025-01-18T04:39:36.775Z",
+              "timestamp": "2025-01-23T12:23:56.299Z",
               "range": {
-                "start": "2025-01-18T04:39:27.598Z",
-                "end": "2025-01-18T07:39:27.598Z"
+                "start": "2025-01-23T12:23:43.027Z",
+                "end": "2025-01-23T15:23:43.027Z"
               }
             },
             "instructions": {
@@ -141,8 +155,8 @@
             },
             "time": {
               "range": {
-                "start": "2025-01-18T07:39:27.598Z",
-                "end": "2025-01-22T07:39:27.598Z"
+                "start": "2025-01-23T15:23:43.027Z",
+                "end": "2025-01-27T15:23:43.027Z"
               }
             },
             "contact": {
@@ -159,7 +173,7 @@
               "list": [
                 {
                   "code": "reason_id",
-                  "value": "012"
+                  "value": "014"
                 },
                 {
                   "code": "initiated_by",
@@ -167,7 +181,7 @@
                 },
                 {
                   "code": "rto_id",
-                  "value": "1a40ac02-0724-4aaa-99de-945e81e592d9"
+                  "value": "7b293f91-e8a9-4333-89bc-ef5f7efa5ce6"
                 }
               ]
             },
@@ -180,14 +194,14 @@
                 },
                 {
                   "code": "updated_at",
-                  "value": "2025-01-18T15:49:15.589Z"
+                  "value": "2025-01-24T05:27:44.552Z"
                 }
               ]
             }
           ]
         },
         {
-          "id": "1a40ac02-0724-4aaa-99de-945e81e592d9",
+          "id": "7b293f91-e8a9-4333-89bc-ef5f7efa5ce6",
           "type": "RTO",
           "@ondc/org/TAT": "PT2H",
           "@ondc/org/provider_name": "LoadShare",
@@ -211,7 +225,7 @@
               }
             },
             "time": {
-              "timestamp": "2025-01-18T15:51:33.091Z"
+              "timestamp": "2025-01-24T05:28:52.332Z"
             },
             "instructions": {
               "name": "Status for pickup",
@@ -241,7 +255,7 @@
                 "locality": "Ashok Vatika",
                 "city": "Ahmedabad",
                 "state": "Gujarat",
-                "area_code": "380058"
+                "area_code": "380054"
               }
             },
             "instructions": {
@@ -265,7 +279,7 @@
                 },
                 {
                   "code": "id",
-                  "value": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40"
+                  "value": "4dab34c2-b680-4a0e-bc90-68a77d412e3d"
                 },
                 {
                   "code": "currency",
@@ -273,7 +287,7 @@
                 },
                 {
                   "code": "value",
-                  "value": "-49.62"
+                  "value": "-48.31"
                 }
               ]
             },
@@ -294,7 +308,7 @@
                 },
                 {
                   "code": "value",
-                  "value": "-660.0"
+                  "value": "-440.0"
                 }
               ]
             },
@@ -307,7 +321,7 @@
                 },
                 {
                   "code": "id",
-                  "value": "1a40ac02-0724-4aaa-99de-945e81e592d9"
+                  "value": "7b293f91-e8a9-4333-89bc-ef5f7efa5ce6"
                 },
                 {
                   "code": "currency",
@@ -328,7 +342,7 @@
                 },
                 {
                   "code": "id",
-                  "value": "1a40ac02-0724-4aaa-99de-945e81e592d9"
+                  "value": "7b293f91-e8a9-4333-89bc-ef5f7efa5ce6"
                 },
                 {
                   "code": "currency",
@@ -349,7 +363,7 @@
                 },
                 {
                   "code": "id",
-                  "value": "1a40ac02-0724-4aaa-99de-945e81e592d9"
+                  "value": "7b293f91-e8a9-4333-89bc-ef5f7efa5ce6"
                 },
                 {
                   "code": "currency",
@@ -357,7 +371,7 @@
                 },
                 {
                   "code": "value",
-                  "value": "-122.1"
+                  "value": "-81.4"
                 }
               ]
             },
@@ -378,7 +392,7 @@
                 },
                 {
                   "code": "value",
-                  "value": "-360.0"
+                  "value": "-240.0"
                 }
               ]
             },
@@ -391,7 +405,7 @@
                 },
                 {
                   "code": "id",
-                  "value": "1a40ac02-0724-4aaa-99de-945e81e592d9"
+                  "value": "7b293f91-e8a9-4333-89bc-ef5f7efa5ce6"
                 },
                 {
                   "code": "currency",
@@ -412,7 +426,70 @@
                 },
                 {
                   "code": "id",
-                  "value": "1a40ac02-0724-4aaa-99de-945e81e592d9"
+                  "value": "7b293f91-e8a9-4333-89bc-ef5f7efa5ce6"
+                },
+                {
+                  "code": "currency",
+                  "value": "INR"
+                },
+                {
+                  "code": "value",
+                  "value": "-100.0"
+                }
+              ]
+            },
+            {
+              "code": "quote_trail",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "item"
+                },
+                {
+                  "code": "id",
+                  "value": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7"
+                },
+                {
+                  "code": "currency",
+                  "value": "INR"
+                },
+                {
+                  "code": "value",
+                  "value": "-240.0"
+                }
+              ]
+            },
+            {
+              "code": "quote_trail",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "packing"
+                },
+                {
+                  "code": "id",
+                  "value": "7b293f91-e8a9-4333-89bc-ef5f7efa5ce6"
+                },
+                {
+                  "code": "currency",
+                  "value": "INR"
+                },
+                {
+                  "code": "value",
+                  "value": "-5.0"
+                }
+              ]
+            },
+            {
+              "code": "quote_trail",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "delivery"
+                },
+                {
+                  "code": "id",
+                  "value": "7b293f91-e8a9-4333-89bc-ef5f7efa5ce6"
                 },
                 {
                   "code": "currency",
@@ -452,7 +529,7 @@
             }
           },
           {
-            "@ondc/org/item_id": "1a40ac02-0724-4aaa-99de-945e81e592d9",
+            "@ondc/org/item_id": "7b293f91-e8a9-4333-89bc-ef5f7efa5ce6",
             "@ondc/org/title_type": "packing",
             "title": "Packing Charges",
             "price": {
@@ -461,7 +538,7 @@
             }
           },
           {
-            "@ondc/org/item_id": "1a40ac02-0724-4aaa-99de-945e81e592d9",
+            "@ondc/org/item_id": "7b293f91-e8a9-4333-89bc-ef5f7efa5ce6",
             "@ondc/org/title_type": "delivery",
             "title": "Delivery Charges",
             "price": {
@@ -497,7 +574,7 @@
             }
           },
           {
-            "@ondc/org/item_id": "1a40ac02-0724-4aaa-99de-945e81e592d9",
+            "@ondc/org/item_id": "7b293f91-e8a9-4333-89bc-ef5f7efa5ce6",
             "@ondc/org/title_type": "packing",
             "title": "Packing Charges",
             "price": {
@@ -506,7 +583,7 @@
             }
           },
           {
-            "@ondc/org/item_id": "1a40ac02-0724-4aaa-99de-945e81e592d9",
+            "@ondc/org/item_id": "7b293f91-e8a9-4333-89bc-ef5f7efa5ce6",
             "@ondc/org/title_type": "delivery",
             "title": "Delivery Charges",
             "price": {
@@ -515,7 +592,43 @@
             }
           },
           {
-            "@ondc/org/item_id": "1a40ac02-0724-4aaa-99de-945e81e592d9",
+            "@ondc/org/item_id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+            "@ondc/org/item_quantity": {
+              "count": 0
+            },
+            "@ondc/org/title_type": "item",
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "120.0"
+              }
+            },
+            "title": "Walnuts",
+            "price": {
+              "currency": "INR",
+              "value": "0.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "7b293f91-e8a9-4333-89bc-ef5f7efa5ce6",
+            "@ondc/org/title_type": "packing",
+            "title": "Packing Charges",
+            "price": {
+              "currency": "INR",
+              "value": "0.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "7b293f91-e8a9-4333-89bc-ef5f7efa5ce6",
+            "@ondc/org/title_type": "delivery",
+            "title": "Delivery Charges",
+            "price": {
+              "currency": "INR",
+              "value": "0.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "7b293f91-e8a9-4333-89bc-ef5f7efa5ce6",
             "@ondc/org/title_type": "misc",
             "title": "Convenience Fee",
             "price": {
@@ -530,8 +643,8 @@
         "uri": "https://razorpay.com/",
         "tl_method": "http/get",
         "params": {
-          "transaction_id": "order_PkmFEkFcTwn3Jj",
-          "amount": "1401.72",
+          "transaction_id": "order_PmspSHrmelUv3U",
+          "amount": "1364.71",
           "currency": "INR"
         },
         "type": "ON-ORDER",
@@ -559,11 +672,11 @@
       "cancellation": {
         "cancelled_by": "ondc.pirimidtech.com/v2/seller",
         "reason": {
-          "id": "012"
+          "id": "014"
         }
       },
-      "created_at": "2025-01-18T04:38:21.871Z",
-      "updated_at": "2025-01-18T15:51:33.125Z"
+      "created_at": "2025-01-23T12:22:15.585Z",
+      "updated_at": "2025-01-24T05:28:52.437Z"
     }
   }
 }

--- a/Pirimid/SellerApp/Retail/RET-10/FLOW_5/on_confirm.json
+++ b/Pirimid/SellerApp/Retail/RET-10/FLOW_5/on_confirm.json
@@ -9,13 +9,13 @@
     "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
     "bpp_id": "ondc.pirimidtech.com/v2/seller",
     "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-    "transaction_id": "042f9d64-5233-43b6-aea9-3563d9fc4bad",
-    "message_id": "92f88395-6016-40ed-8055-20e1da617ac9",
-    "timestamp": "2025-01-18T04:38:52.266Z"
+    "transaction_id": "99d39ee1-5651-4f0a-8f2a-0a0ee8db9c9d",
+    "message_id": "cb404011-4cca-4e7e-9af0-8260d3dd02b4",
+    "timestamp": "2025-01-23T12:23:18.562Z"
   },
   "message": {
     "order": {
-      "id": "2025-01-18-429408",
+      "id": "2025-01-23-459524",
       "state": "Created",
       "provider": {
         "id": "e2008459-7e90-493e-b02e-cae52ca53214",
@@ -29,16 +29,23 @@
         {
           "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
           "quantity": {
-            "count": 3
+            "count": 2
           },
-          "fulfillment_id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40"
+          "fulfillment_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d"
         },
         {
           "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
           "quantity": {
-            "count": 3
+            "count": 2
           },
-          "fulfillment_id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40"
+          "fulfillment_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d"
+        },
+        {
+          "id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d"
         }
       ],
       "billing": {
@@ -54,12 +61,12 @@
         },
         "email": "fhemanshu@gmail.com",
         "phone": "7202959020",
-        "created_at": "2025-01-18T04:38:29.524Z",
-        "updated_at": "2025-01-18T04:38:29.524Z"
+        "created_at": "2025-01-23T12:22:56.533Z",
+        "updated_at": "2025-01-23T12:22:56.533Z"
       },
       "fulfillments": [
         {
-          "id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40",
+          "id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
           "type": "Delivery",
           "@ondc/org/TAT": "PT99H",
           "@ondc/org/provider_name": "LoadShare",
@@ -80,7 +87,7 @@
                 "locality": "Ashok Vatika",
                 "city": "Ahmedabad",
                 "state": "Gujarat",
-                "area_code": "380058"
+                "area_code": "380054"
               }
             },
             "contact": {
@@ -114,13 +121,13 @@
       "quote": {
         "price": {
           "currency": "INR",
-          "value": "1401.72"
+          "value": "1364.71"
         },
         "breakup": [
           {
             "@ondc/org/item_id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
             "@ondc/org/item_quantity": {
-              "count": 3
+              "count": 2
             },
             "@ondc/org/title_type": "item",
             "item": {
@@ -132,11 +139,11 @@
             "title": "Nutraj-California-Almonds-1Kg",
             "price": {
               "currency": "INR",
-              "value": "660.0"
+              "value": "440.0"
             }
           },
           {
-            "@ondc/org/item_id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40",
+            "@ondc/org/item_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
             "@ondc/org/title_type": "packing",
             "title": "Packing Charges",
             "price": {
@@ -145,7 +152,7 @@
             }
           },
           {
-            "@ondc/org/item_id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40",
+            "@ondc/org/item_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
             "@ondc/org/title_type": "delivery",
             "title": "Delivery Charges",
             "price": {
@@ -159,13 +166,13 @@
             "title": "Tax",
             "price": {
               "currency": "INR",
-              "value": "122.1"
+              "value": "81.4"
             }
           },
           {
             "@ondc/org/item_id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
             "@ondc/org/item_quantity": {
-              "count": 3
+              "count": 2
             },
             "@ondc/org/title_type": "item",
             "item": {
@@ -177,11 +184,11 @@
             "title": "Cashews",
             "price": {
               "currency": "INR",
-              "value": "360.0"
+              "value": "240.0"
             }
           },
           {
-            "@ondc/org/item_id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40",
+            "@ondc/org/item_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
             "@ondc/org/title_type": "packing",
             "title": "Packing Charges",
             "price": {
@@ -190,7 +197,7 @@
             }
           },
           {
-            "@ondc/org/item_id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40",
+            "@ondc/org/item_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
             "@ondc/org/title_type": "delivery",
             "title": "Delivery Charges",
             "price": {
@@ -199,12 +206,48 @@
             }
           },
           {
-            "@ondc/org/item_id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40",
+            "@ondc/org/item_id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "@ondc/org/title_type": "item",
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "120.0"
+              }
+            },
+            "title": "Walnuts",
+            "price": {
+              "currency": "INR",
+              "value": "240.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
+            "@ondc/org/title_type": "packing",
+            "title": "Packing Charges",
+            "price": {
+              "currency": "INR",
+              "value": "5.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
+            "@ondc/org/title_type": "delivery",
+            "title": "Delivery Charges",
+            "price": {
+              "currency": "INR",
+              "value": "100.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
             "@ondc/org/title_type": "misc",
             "title": "Convenience Fee",
             "price": {
               "currency": "INR",
-              "value": "49.62"
+              "value": "48.31"
             }
           }
         ],
@@ -214,8 +257,8 @@
         "uri": "https://razorpay.com/",
         "tl_method": "http/get",
         "params": {
-          "transaction_id": "order_PkmFEkFcTwn3Jj",
-          "amount": "1401.72",
+          "transaction_id": "order_PmspSHrmelUv3U",
+          "amount": "1364.71",
           "currency": "INR"
         },
         "type": "ON-ORDER",
@@ -240,8 +283,8 @@
           }
         ]
       },
-      "created_at": "2025-01-18T04:38:51.420Z",
-      "updated_at": "2025-01-18T04:38:52.266Z",
+      "created_at": "2025-01-23T12:23:17.611Z",
+      "updated_at": "2025-01-23T12:23:18.562Z",
       "tags": [
         {
           "code": "bpp_terms",

--- a/Pirimid/SellerApp/Retail/RET-10/FLOW_5/on_init.json
+++ b/Pirimid/SellerApp/Retail/RET-10/FLOW_5/on_init.json
@@ -9,9 +9,9 @@
     "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
     "bpp_id": "ondc.pirimidtech.com/v2/seller",
     "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-    "transaction_id": "042f9d64-5233-43b6-aea9-3563d9fc4bad",
-    "message_id": "cc0342a3-c32c-4eb1-a6cf-34881abbd2a0",
-    "timestamp": "2025-01-18T04:38:30.286Z",
+    "transaction_id": "99d39ee1-5651-4f0a-8f2a-0a0ee8db9c9d",
+    "message_id": "4a3994f1-205d-465a-b59d-438edc4188e3",
+    "timestamp": "2025-01-23T12:22:57.280Z",
     "ttl": "PT30S"
   },
   "message": {
@@ -29,21 +29,31 @@
           "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
           "quantity": {
             "unitized": {
-              "count": "3"
+              "count": "2"
             },
-            "count": 3
+            "count": 2
           },
-          "fulfillment_id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40"
+          "fulfillment_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d"
         },
         {
           "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
           "quantity": {
             "unitized": {
-              "count": "3"
+              "count": "2"
             },
-            "count": 3
+            "count": 2
           },
-          "fulfillment_id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40"
+          "fulfillment_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d"
+        },
+        {
+          "id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+          "quantity": {
+            "unitized": {
+              "count": "2"
+            },
+            "count": 2
+          },
+          "fulfillment_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d"
         }
       ],
       "billing": {
@@ -59,19 +69,13 @@
         },
         "email": "fhemanshu@gmail.com",
         "phone": "7202959020",
-        "created_at": "2025-01-18T04:38:29.524Z",
-        "updated_at": "2025-01-18T04:38:29.524Z"
+        "created_at": "2025-01-23T12:22:56.533Z",
+        "updated_at": "2025-01-23T12:22:56.533Z"
       },
       "fulfillments": [
         {
-          "id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40",
+          "id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
           "type": "Delivery",
-          "provider_id": "ondc.loadshare.com/ondc/18275",
-          "state": {
-            "descriptor": {
-              "code": "INITIALIZING"
-            }
-          },
           "tracking": false,
           "end": {
             "location": {
@@ -85,9 +89,6 @@
                 "country": "IND",
                 "area_code": "380015"
               }
-            },
-            "time": {
-              "range": {}
             },
             "instructions": {
               "name": "Status for pickup",
@@ -108,13 +109,13 @@
       "quote": {
         "price": {
           "currency": "INR",
-          "value": "1401.72"
+          "value": "1364.71"
         },
         "breakup": [
           {
             "@ondc/org/item_id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
             "@ondc/org/item_quantity": {
-              "count": 3
+              "count": 2
             },
             "@ondc/org/title_type": "item",
             "item": {
@@ -126,11 +127,11 @@
             "title": "Nutraj-California-Almonds-1Kg",
             "price": {
               "currency": "INR",
-              "value": "660.0"
+              "value": "440.0"
             }
           },
           {
-            "@ondc/org/item_id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40",
+            "@ondc/org/item_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
             "@ondc/org/title_type": "packing",
             "title": "Packing Charges",
             "price": {
@@ -139,7 +140,7 @@
             }
           },
           {
-            "@ondc/org/item_id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40",
+            "@ondc/org/item_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
             "@ondc/org/title_type": "delivery",
             "title": "Delivery Charges",
             "price": {
@@ -153,13 +154,13 @@
             "title": "Tax",
             "price": {
               "currency": "INR",
-              "value": "122.1"
+              "value": "81.4"
             }
           },
           {
             "@ondc/org/item_id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
             "@ondc/org/item_quantity": {
-              "count": 3
+              "count": 2
             },
             "@ondc/org/title_type": "item",
             "item": {
@@ -171,11 +172,11 @@
             "title": "Cashews",
             "price": {
               "currency": "INR",
-              "value": "360.0"
+              "value": "240.0"
             }
           },
           {
-            "@ondc/org/item_id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40",
+            "@ondc/org/item_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
             "@ondc/org/title_type": "packing",
             "title": "Packing Charges",
             "price": {
@@ -184,7 +185,7 @@
             }
           },
           {
-            "@ondc/org/item_id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40",
+            "@ondc/org/item_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
             "@ondc/org/title_type": "delivery",
             "title": "Delivery Charges",
             "price": {
@@ -193,22 +194,58 @@
             }
           },
           {
-            "@ondc/org/item_id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40",
+            "@ondc/org/item_id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "@ondc/org/title_type": "item",
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "120.0"
+              }
+            },
+            "title": "Walnuts",
+            "price": {
+              "currency": "INR",
+              "value": "240.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
+            "@ondc/org/title_type": "packing",
+            "title": "Packing Charges",
+            "price": {
+              "currency": "INR",
+              "value": "5.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
+            "@ondc/org/title_type": "delivery",
+            "title": "Delivery Charges",
+            "price": {
+              "currency": "INR",
+              "value": "100.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
             "@ondc/org/title_type": "misc",
             "title": "Convenience Fee",
             "price": {
               "currency": "INR",
-              "value": "49.62"
+              "value": "48.31"
             }
           }
         ],
         "ttl": "P1D"
       },
       "payment": {
-        "uri": "https://ondc-pirimid-payment.netlify.app/payment/042f9d64-5233-43b6-aea9-3563d9fc4bad",
+        "uri": "https://ondc-pirimid-payment.netlify.app/payment/99d39ee1-5651-4f0a-8f2a-0a0ee8db9c9d",
         "type": "ON-ORDER",
         "status": "NOT-PAID",
-        "collected_by": "BPP",
+        "collected_by": "BAP",
         "@ondc/org/buyer_app_finder_fee_type": "percent",
         "@ondc/org/buyer_app_finder_fee_amount": "3.0",
         "@ondc/org/withholding_amount": "0.0",
@@ -228,8 +265,8 @@
           }
         ]
       },
-      "created_at": "2025-01-18T04:38:21.871Z",
-      "updated_at": "2025-01-18T04:38:30.291Z",
+      "created_at": "2025-01-23T12:22:15.585Z",
+      "updated_at": "2025-01-23T12:22:57.291Z",
       "tags": [
         {
           "code": "bpp_terms",

--- a/Pirimid/SellerApp/Retail/RET-10/FLOW_5/on_search_full_catalog_refresh.json
+++ b/Pirimid/SellerApp/Retail/RET-10/FLOW_5/on_search_full_catalog_refresh.json
@@ -9,9 +9,9 @@
     "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
     "bpp_id": "ondc.pirimidtech.com/v2/seller",
     "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-    "transaction_id": "e53a74c5-7ce6-4498-800c-e7d90db0f2fa",
-    "message_id": "45726578-5033-41e0-b35f-2fcbcebe8f82",
-    "timestamp": "2025-01-17T12:00:21.411Z",
+    "transaction_id": "2a274964-3eec-4793-888c-1d30ef845cd1",
+    "message_id": "c5c58f68-8483-4490-b318-a1436c6ee88b",
+    "timestamp": "2025-01-23T12:00:21.519Z",
     "ttl": "PT30S"
   },
   "message": {
@@ -58,70 +58,8 @@
           "@ondc/org/fssai_license_no": "12345678912345",
           "time": {
             "label": "enable",
-            "timestamp": "2025-01-17T12:00:21.411Z"
+            "timestamp": "2025-01-23T12:00:21.519Z"
           },
-          "categories": [
-            {
-              "id": "variant10000",
-              "descriptor": {
-                "name": "Variant for Nutraj-California-Almonds-1Kg"
-              },
-              "tags": [
-                {
-                  "code": "type",
-                  "list": [
-                    {
-                      "code": "type",
-                      "value": "variant_group"
-                    }
-                  ]
-                },
-                {
-                  "code": "attr",
-                  "list": [
-                    {
-                      "code": "name",
-                      "value": "item.quantity.unitized.measure"
-                    },
-                    {
-                      "code": "seq",
-                      "value": "1"
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "id": "variant10001",
-              "descriptor": {
-                "name": "Variant for Cashews"
-              },
-              "tags": [
-                {
-                  "code": "type",
-                  "list": [
-                    {
-                      "code": "type",
-                      "value": "variant_group"
-                    }
-                  ]
-                },
-                {
-                  "code": "attr",
-                  "list": [
-                    {
-                      "code": "name",
-                      "value": "item.quantity.unitized.measure"
-                    },
-                    {
-                      "code": "seq",
-                      "value": "1"
-                    }
-                  ]
-                }
-              ]
-            }
-          ],
           "fulfillments": [
             {
               "id": "1",
@@ -141,11 +79,11 @@
                 "locality": "Ashok Vatika",
                 "city": "Ahmedabad",
                 "state": "Gujarat",
-                "area_code": "380058"
+                "area_code": "380054"
               },
               "time": {
                 "label": "enable",
-                "timestamp": "2024-12-04T13:50:34.608Z",
+                "timestamp": "2025-01-22T07:34:34.534Z",
                 "range": {
                   "start": "0930",
                   "end": "1930"
@@ -162,12 +100,85 @@
           ],
           "items": [
             {
+              "id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+              "descriptor": {
+                "name": "Walnuts",
+                "code": "1:12345678",
+                "symbol": "https://c8.alamy.com/comp/2HCTDG2/modern-design-walnut-leaf-nature-green-logo-design-2HCTDG2.jpg",
+                "short_desc": "WONDERLAND California Whole Walnut Walnuts (Akhrot)  (500 g)",
+                "long_desc": "WONDERLAND California Whole Walnut Walnuts (Akhrot)  (500 g)",
+                "images": [
+                  "https://rukminim2.flixcart.com/image/416/416/xif0q/nut-dry-fruit/h/x/t/500-california-whole-walnut-1-pouch-wonderland-original-imagy632bnvk8fde.jpeg?q=70",
+                  "https://rukminim2.flixcart.com/image/416/416/xif0q/nut-dry-fruit/q/r/t/500-california-whole-walnut-1-pouch-wonderland-original-imagy6326hdk68cd.jpeg?q=70"
+                ]
+              },
+              "price": {
+                "currency": "INR",
+                "value": "120.0",
+                "maximum_value": "200.0"
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "value": "500",
+                    "unit": "gram"
+                  }
+                }
+              },
+              "category_id": "Snacks, Dry Fruits, Nuts",
+              "fulfillment_id": "1",
+              "location_id": "39550822-c3bb-4918-bd25-2d19ef6a9aca",
+              "time": {
+                "label": "enable",
+                "timestamp": "2025-01-23T12:00:21.519Z"
+              },
+              "@ondc/org/returnable": true,
+              "@ondc/org/seller_pickup_return": false,
+              "@ondc/org/return_window": "P7D",
+              "@ondc/org/cancellable": true,
+              "@ondc/org/time_to_ship": "PT3H",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "PirimidFintech,user@gmail.com,7744774477",
+              "@ondc/org/statutory_reqs_prepackaged_food": {
+                "nutritional_info": "nutritional_info",
+                "additives_info": "additives_info",
+                "brand_owner_FSSAI_license_no": "12345678912345",
+                "other_FSSAI_license_no": "12345678912345",
+                "importer_FSSAI_license_no": "12345678912345"
+              },
+              "tags": [
+                {
+                  "code": "origin",
+                  "list": [
+                    {
+                      "code": "Country",
+                      "value": "IND"
+                    }
+                  ]
+                },
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
               "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
-              "parent_item_id": "variant10000",
               "descriptor": {
                 "name": "Nutraj-California-Almonds-1Kg",
                 "code": "1:12345678",
-                "symbol": "symbols.in/symbol.jpg",
+                "symbol": "https://img.freepik.com/premium-vector/almonds-nuts-nature-farm-vintage-logo-icon-symbol-vector-illustration-minimalist-design_889650-491.jpg?semt=ais_hybrid",
                 "short_desc": "Nutraj California Almond kernels 1kg Pouch|Badam Giri|Dry Fruits and Nuts|Grocery",
                 "long_desc": "Nutraj California Almond kernels 1kg Pouch|Badam Giri|Dry Fruits and Nuts|Grocery",
                 "images": [
@@ -198,7 +209,7 @@
               "location_id": "39550822-c3bb-4918-bd25-2d19ef6a9aca",
               "time": {
                 "label": "enable",
-                "timestamp": "2025-01-17T12:00:21.411Z"
+                "timestamp": "2025-01-23T12:00:21.519Z"
               },
               "@ondc/org/returnable": true,
               "@ondc/org/seller_pickup_return": false,
@@ -237,11 +248,10 @@
             },
             {
               "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
-              "parent_item_id": "variant10001",
               "descriptor": {
                 "name": "Cashews",
                 "code": "1:12345678",
-                "symbol": "symbols.in/symbol.jpg",
+                "symbol": "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTVlckKW1pwOvmkj9_s_rPbAvcsr_EdmIStMA&s",
                 "short_desc": "Emart Brand - Vedaka Whole Cashews | 500 Gram | Kaju Nuts Grade W320 | Plant Based Protein | Gluten-Free | Nutty Flavor | Healthy Snack | Rich Delicious Taste",
                 "long_desc": "Emart Brand - Vedaka Whole Cashews | 500 Gram | Kaju Nuts Grade W320 | Plant Based Protein | Gluten-Free | Nutty Flavor | Healthy Snack | Rich Delicious Taste",
                 "images": [
@@ -251,7 +261,7 @@
               "price": {
                 "currency": "INR",
                 "value": "120.0",
-                "maximum_value": "258.0"
+                "maximum_value": "212.0"
               },
               "quantity": {
                 "available": {
@@ -262,8 +272,8 @@
                 },
                 "unitized": {
                   "measure": {
-                    "value": "1",
-                    "unit": "kilogram"
+                    "value": "500",
+                    "unit": "gram"
                   }
                 }
               },
@@ -272,7 +282,7 @@
               "location_id": "39550822-c3bb-4918-bd25-2d19ef6a9aca",
               "time": {
                 "label": "enable",
-                "timestamp": "2025-01-17T12:00:21.411Z"
+                "timestamp": "2025-01-23T12:00:21.519Z"
               },
               "@ondc/org/returnable": true,
               "@ondc/org/seller_pickup_return": false,
@@ -342,36 +352,7 @@
               "list": [
                 {
                   "code": "type",
-                  "value": "Order"
-                },
-                {
-                  "code": "location",
-                  "value": "39550822-c3bb-4918-bd25-2d19ef6a9aca"
-                },
-                {
-                  "code": "day_from",
-                  "value": "1"
-                },
-                {
-                  "code": "day_to",
-                  "value": "7"
-                },
-                {
-                  "code": "time_from",
-                  "value": "0930"
-                },
-                {
-                  "code": "time_to",
-                  "value": "1930"
-                }
-              ]
-            },
-            {
-              "code": "timing",
-              "list": [
-                {
-                  "code": "type",
-                  "value": "Delivery"
+                  "value": "All"
                 },
                 {
                   "code": "location",

--- a/Pirimid/SellerApp/Retail/RET-10/FLOW_5/on_select.json
+++ b/Pirimid/SellerApp/Retail/RET-10/FLOW_5/on_select.json
@@ -9,9 +9,9 @@
     "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
     "bpp_id": "ondc.pirimidtech.com/v2/seller",
     "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-    "transaction_id": "042f9d64-5233-43b6-aea9-3563d9fc4bad",
-    "message_id": "dd6f2a5d-b066-40a6-a08e-aef7c48027d3",
-    "timestamp": "2025-01-18T04:38:21.860Z"
+    "transaction_id": "99d39ee1-5651-4f0a-8f2a-0a0ee8db9c9d",
+    "message_id": "0e061ee7-0302-436a-88e6-e1437235f613",
+    "timestamp": "2025-01-23T12:22:38.493Z"
   },
   "message": {
     "order": {
@@ -25,17 +25,21 @@
       },
       "items": [
         {
-          "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
-          "fulfillment_id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40"
+          "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
+          "fulfillment_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d"
         },
         {
-          "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
-          "fulfillment_id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40"
+          "id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+          "fulfillment_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d"
+        },
+        {
+          "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
+          "fulfillment_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d"
         }
       ],
       "fulfillments": [
         {
-          "id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40",
+          "id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
           "type": "Delivery",
           "@ondc/org/category": "Standard Delivery",
           "@ondc/org/TAT": "PT99H",
@@ -51,13 +55,13 @@
       "quote": {
         "price": {
           "currency": "INR",
-          "value": "1401.72"
+          "value": "1364.71"
         },
         "breakup": [
           {
             "@ondc/org/item_id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
             "@ondc/org/item_quantity": {
-              "count": 3
+              "count": 2
             },
             "@ondc/org/title_type": "item",
             "item": {
@@ -77,11 +81,11 @@
             "title": "Nutraj-California-Almonds-1Kg",
             "price": {
               "currency": "INR",
-              "value": "660.0"
+              "value": "440.0"
             }
           },
           {
-            "@ondc/org/item_id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40",
+            "@ondc/org/item_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
             "@ondc/org/title_type": "packing",
             "title": "Packing Charges",
             "price": {
@@ -90,7 +94,7 @@
             }
           },
           {
-            "@ondc/org/item_id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40",
+            "@ondc/org/item_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
             "@ondc/org/title_type": "delivery",
             "title": "Delivery Charges",
             "price": {
@@ -104,13 +108,13 @@
             "title": "Tax",
             "price": {
               "currency": "INR",
-              "value": "122.1"
+              "value": "81.4"
             }
           },
           {
             "@ondc/org/item_id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
             "@ondc/org/item_quantity": {
-              "count": 3
+              "count": 2
             },
             "@ondc/org/title_type": "item",
             "item": {
@@ -130,11 +134,11 @@
             "title": "Cashews",
             "price": {
               "currency": "INR",
-              "value": "360.0"
+              "value": "240.0"
             }
           },
           {
-            "@ondc/org/item_id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40",
+            "@ondc/org/item_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
             "@ondc/org/title_type": "packing",
             "title": "Packing Charges",
             "price": {
@@ -143,7 +147,7 @@
             }
           },
           {
-            "@ondc/org/item_id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40",
+            "@ondc/org/item_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
             "@ondc/org/title_type": "delivery",
             "title": "Delivery Charges",
             "price": {
@@ -152,12 +156,56 @@
             }
           },
           {
-            "@ondc/org/item_id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40",
+            "@ondc/org/item_id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "@ondc/org/title_type": "item",
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "120.0"
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                }
+              }
+            },
+            "title": "Walnuts",
+            "price": {
+              "currency": "INR",
+              "value": "240.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
+            "@ondc/org/title_type": "packing",
+            "title": "Packing Charges",
+            "price": {
+              "currency": "INR",
+              "value": "5.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
+            "@ondc/org/title_type": "delivery",
+            "title": "Delivery Charges",
+            "price": {
+              "currency": "INR",
+              "value": "100.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
             "@ondc/org/title_type": "misc",
             "title": "Convenience Fee",
             "price": {
               "currency": "INR",
-              "value": "49.62"
+              "value": "48.31"
             }
           }
         ],

--- a/Pirimid/SellerApp/Retail/RET-10/FLOW_5/on_status_out_for_delivery.json
+++ b/Pirimid/SellerApp/Retail/RET-10/FLOW_5/on_status_out_for_delivery.json
@@ -9,14 +9,14 @@
     "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
     "bpp_id": "ondc.pirimidtech.com/v2/seller",
     "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-    "transaction_id": "042f9d64-5233-43b6-aea9-3563d9fc4bad",
-    "message_id": "d3c520d5-6a38-41d1-8c9d-68ad5f3e0e57",
-    "timestamp": "2025-01-18T15:49:15.589Z",
+    "transaction_id": "99d39ee1-5651-4f0a-8f2a-0a0ee8db9c9d",
+    "message_id": "dd9fce37-c85d-4ecc-8356-092351ad7935",
+    "timestamp": "2025-01-24T05:27:44.552Z",
     "ttl": "PT30S"
   },
   "message": {
     "order": {
-      "id": "2025-01-18-429408",
+      "id": "2025-01-23-459524",
       "state": "In-progress",
       "provider": {
         "id": "e2008459-7e90-493e-b02e-cae52ca53214",
@@ -30,21 +30,28 @@
         {
           "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
           "quantity": {
-            "count": 3
+            "count": 2
           },
-          "fulfillment_id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40"
+          "fulfillment_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d"
         },
         {
           "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
           "quantity": {
-            "count": 3
+            "count": 2
           },
-          "fulfillment_id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40"
+          "fulfillment_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d"
+        },
+        {
+          "id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d"
         }
       ],
       "documents": [
         {
-          "url": "https://ondc.pirimidtech.com/v2/seller/api/order/invoice/502a64aa-3c44-4bc7-ab44-af9d9b077fc2",
+          "url": "https://ondc.pirimidtech.com/v2/seller/api/order/invoice/ef59d53e-1d0e-41d3-b382-0ceef31ae3e5",
           "label": "Invoice"
         }
       ],
@@ -61,12 +68,12 @@
         },
         "email": "fhemanshu@gmail.com",
         "phone": "7202959020",
-        "created_at": "2025-01-18T04:38:29.524Z",
-        "updated_at": "2025-01-18T04:38:29.524Z"
+        "created_at": "2025-01-23T12:22:56.533Z",
+        "updated_at": "2025-01-23T12:22:56.533Z"
       },
       "fulfillments": [
         {
-          "id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40",
+          "id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
           "type": "Delivery",
           "@ondc/org/TAT": "PT99H",
           "provider_id": "ondc.loadshare.com/ondc/18275",
@@ -97,14 +104,14 @@
                 "locality": "Ashok Vatika",
                 "city": "Ahmedabad",
                 "state": "Gujarat",
-                "area_code": "380058"
+                "area_code": "380054"
               }
             },
             "time": {
-              "timestamp": "2025-01-18T04:39:36.775Z",
+              "timestamp": "2025-01-23T12:23:56.299Z",
               "range": {
-                "start": "2025-01-18T04:39:27.598Z",
-                "end": "2025-01-18T07:39:27.598Z"
+                "start": "2025-01-23T12:23:43.027Z",
+                "end": "2025-01-23T15:23:43.027Z"
               }
             },
             "instructions": {
@@ -133,8 +140,8 @@
             },
             "time": {
               "range": {
-                "start": "2025-01-18T07:39:27.598Z",
-                "end": "2025-01-22T07:39:27.598Z"
+                "start": "2025-01-23T15:23:43.027Z",
+                "end": "2025-01-27T15:23:43.027Z"
               }
             },
             "contact": {
@@ -161,13 +168,13 @@
       "quote": {
         "price": {
           "currency": "INR",
-          "value": "1401.72"
+          "value": "1364.71"
         },
         "breakup": [
           {
             "@ondc/org/item_id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
             "@ondc/org/item_quantity": {
-              "count": 3
+              "count": 2
             },
             "@ondc/org/title_type": "item",
             "item": {
@@ -179,11 +186,11 @@
             "title": "Nutraj-California-Almonds-1Kg",
             "price": {
               "currency": "INR",
-              "value": "660.0"
+              "value": "440.0"
             }
           },
           {
-            "@ondc/org/item_id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40",
+            "@ondc/org/item_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
             "@ondc/org/title_type": "packing",
             "title": "Packing Charges",
             "price": {
@@ -192,7 +199,7 @@
             }
           },
           {
-            "@ondc/org/item_id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40",
+            "@ondc/org/item_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
             "@ondc/org/title_type": "delivery",
             "title": "Delivery Charges",
             "price": {
@@ -206,13 +213,13 @@
             "title": "Tax",
             "price": {
               "currency": "INR",
-              "value": "122.1"
+              "value": "81.4"
             }
           },
           {
             "@ondc/org/item_id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
             "@ondc/org/item_quantity": {
-              "count": 3
+              "count": 2
             },
             "@ondc/org/title_type": "item",
             "item": {
@@ -224,11 +231,11 @@
             "title": "Cashews",
             "price": {
               "currency": "INR",
-              "value": "360.0"
+              "value": "240.0"
             }
           },
           {
-            "@ondc/org/item_id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40",
+            "@ondc/org/item_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
             "@ondc/org/title_type": "packing",
             "title": "Packing Charges",
             "price": {
@@ -237,7 +244,7 @@
             }
           },
           {
-            "@ondc/org/item_id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40",
+            "@ondc/org/item_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
             "@ondc/org/title_type": "delivery",
             "title": "Delivery Charges",
             "price": {
@@ -246,12 +253,48 @@
             }
           },
           {
-            "@ondc/org/item_id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40",
+            "@ondc/org/item_id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "@ondc/org/title_type": "item",
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "120.0"
+              }
+            },
+            "title": "Walnuts",
+            "price": {
+              "currency": "INR",
+              "value": "240.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
+            "@ondc/org/title_type": "packing",
+            "title": "Packing Charges",
+            "price": {
+              "currency": "INR",
+              "value": "5.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
+            "@ondc/org/title_type": "delivery",
+            "title": "Delivery Charges",
+            "price": {
+              "currency": "INR",
+              "value": "100.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
             "@ondc/org/title_type": "misc",
             "title": "Convenience Fee",
             "price": {
               "currency": "INR",
-              "value": "49.62"
+              "value": "48.31"
             }
           }
         ],
@@ -261,8 +304,8 @@
         "uri": "https://razorpay.com/",
         "tl_method": "http/get",
         "params": {
-          "transaction_id": "order_PkmFEkFcTwn3Jj",
-          "amount": "1401.72",
+          "transaction_id": "order_PmspSHrmelUv3U",
+          "amount": "1364.71",
           "currency": "INR"
         },
         "type": "ON-ORDER",
@@ -287,8 +330,8 @@
           }
         ]
       },
-      "created_at": "2025-01-18T04:38:51.420Z",
-      "updated_at": "2025-01-18T15:49:15.589Z"
+      "created_at": "2025-01-23T12:23:17.611Z",
+      "updated_at": "2025-01-24T05:27:44.552Z"
     }
   }
 }

--- a/Pirimid/SellerApp/Retail/RET-10/FLOW_5/on_status_packed.json
+++ b/Pirimid/SellerApp/Retail/RET-10/FLOW_5/on_status_packed.json
@@ -9,14 +9,14 @@
     "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
     "bpp_id": "ondc.pirimidtech.com/v2/seller",
     "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-    "transaction_id": "042f9d64-5233-43b6-aea9-3563d9fc4bad",
-    "message_id": "6faa83b9-109b-43e3-b465-c1ba72a393fb",
-    "timestamp": "2025-01-18T04:39:31.486Z",
+    "transaction_id": "99d39ee1-5651-4f0a-8f2a-0a0ee8db9c9d",
+    "message_id": "cc905d0b-8183-4aaa-b2c0-72a037ef0047",
+    "timestamp": "2025-01-23T12:23:48.608Z",
     "ttl": "PT30S"
   },
   "message": {
     "order": {
-      "id": "2025-01-18-429408",
+      "id": "2025-01-23-459524",
       "state": "In-progress",
       "provider": {
         "id": "e2008459-7e90-493e-b02e-cae52ca53214",
@@ -30,16 +30,23 @@
         {
           "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
           "quantity": {
-            "count": 3
+            "count": 2
           },
-          "fulfillment_id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40"
+          "fulfillment_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d"
         },
         {
           "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
           "quantity": {
-            "count": 3
+            "count": 2
           },
-          "fulfillment_id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40"
+          "fulfillment_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d"
+        },
+        {
+          "id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d"
         }
       ],
       "billing": {
@@ -55,12 +62,12 @@
         },
         "email": "fhemanshu@gmail.com",
         "phone": "7202959020",
-        "created_at": "2025-01-18T04:38:29.524Z",
-        "updated_at": "2025-01-18T04:38:29.524Z"
+        "created_at": "2025-01-23T12:22:56.533Z",
+        "updated_at": "2025-01-23T12:22:56.533Z"
       },
       "fulfillments": [
         {
-          "id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40",
+          "id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
           "type": "Delivery",
           "@ondc/org/TAT": "PT99H",
           "provider_id": "ondc.loadshare.com/ondc/18275",
@@ -91,13 +98,13 @@
                 "locality": "Ashok Vatika",
                 "city": "Ahmedabad",
                 "state": "Gujarat",
-                "area_code": "380058"
+                "area_code": "380054"
               }
             },
             "time": {
               "range": {
-                "start": "2025-01-18T04:39:27.598Z",
-                "end": "2025-01-18T07:39:27.598Z"
+                "start": "2025-01-23T12:23:43.027Z",
+                "end": "2025-01-23T15:23:43.027Z"
               }
             },
             "instructions": {
@@ -126,8 +133,8 @@
             },
             "time": {
               "range": {
-                "start": "2025-01-18T07:39:27.598Z",
-                "end": "2025-01-22T07:39:27.598Z"
+                "start": "2025-01-23T15:23:43.027Z",
+                "end": "2025-01-27T15:23:43.027Z"
               }
             },
             "contact": {
@@ -137,19 +144,30 @@
             "person": {
               "name": "Hemanshu Faldu"
             }
-          }
+          },
+          "tags": [
+            {
+              "code": "routing",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "P2P"
+                }
+              ]
+            }
+          ]
         }
       ],
       "quote": {
         "price": {
           "currency": "INR",
-          "value": "1401.72"
+          "value": "1364.71"
         },
         "breakup": [
           {
             "@ondc/org/item_id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
             "@ondc/org/item_quantity": {
-              "count": 3
+              "count": 2
             },
             "@ondc/org/title_type": "item",
             "item": {
@@ -161,11 +179,11 @@
             "title": "Nutraj-California-Almonds-1Kg",
             "price": {
               "currency": "INR",
-              "value": "660.0"
+              "value": "440.0"
             }
           },
           {
-            "@ondc/org/item_id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40",
+            "@ondc/org/item_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
             "@ondc/org/title_type": "packing",
             "title": "Packing Charges",
             "price": {
@@ -174,7 +192,7 @@
             }
           },
           {
-            "@ondc/org/item_id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40",
+            "@ondc/org/item_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
             "@ondc/org/title_type": "delivery",
             "title": "Delivery Charges",
             "price": {
@@ -188,13 +206,13 @@
             "title": "Tax",
             "price": {
               "currency": "INR",
-              "value": "122.1"
+              "value": "81.4"
             }
           },
           {
             "@ondc/org/item_id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
             "@ondc/org/item_quantity": {
-              "count": 3
+              "count": 2
             },
             "@ondc/org/title_type": "item",
             "item": {
@@ -206,11 +224,11 @@
             "title": "Cashews",
             "price": {
               "currency": "INR",
-              "value": "360.0"
+              "value": "240.0"
             }
           },
           {
-            "@ondc/org/item_id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40",
+            "@ondc/org/item_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
             "@ondc/org/title_type": "packing",
             "title": "Packing Charges",
             "price": {
@@ -219,7 +237,7 @@
             }
           },
           {
-            "@ondc/org/item_id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40",
+            "@ondc/org/item_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
             "@ondc/org/title_type": "delivery",
             "title": "Delivery Charges",
             "price": {
@@ -228,12 +246,48 @@
             }
           },
           {
-            "@ondc/org/item_id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40",
+            "@ondc/org/item_id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "@ondc/org/title_type": "item",
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "120.0"
+              }
+            },
+            "title": "Walnuts",
+            "price": {
+              "currency": "INR",
+              "value": "240.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
+            "@ondc/org/title_type": "packing",
+            "title": "Packing Charges",
+            "price": {
+              "currency": "INR",
+              "value": "5.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
+            "@ondc/org/title_type": "delivery",
+            "title": "Delivery Charges",
+            "price": {
+              "currency": "INR",
+              "value": "100.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
             "@ondc/org/title_type": "misc",
             "title": "Convenience Fee",
             "price": {
               "currency": "INR",
-              "value": "49.62"
+              "value": "48.31"
             }
           }
         ],
@@ -243,8 +297,8 @@
         "uri": "https://razorpay.com/",
         "tl_method": "http/get",
         "params": {
-          "transaction_id": "order_PkmFEkFcTwn3Jj",
-          "amount": "1401.72",
+          "transaction_id": "order_PmspSHrmelUv3U",
+          "amount": "1364.71",
           "currency": "INR"
         },
         "type": "ON-ORDER",
@@ -269,8 +323,8 @@
           }
         ]
       },
-      "created_at": "2025-01-18T04:38:51.420Z",
-      "updated_at": "2025-01-18T04:39:31.486Z"
+      "created_at": "2025-01-23T12:23:17.611Z",
+      "updated_at": "2025-01-23T12:23:48.608Z"
     }
   }
 }

--- a/Pirimid/SellerApp/Retail/RET-10/FLOW_5/on_status_pending.json
+++ b/Pirimid/SellerApp/Retail/RET-10/FLOW_5/on_status_pending.json
@@ -9,14 +9,14 @@
     "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
     "bpp_id": "ondc.pirimidtech.com/v2/seller",
     "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-    "transaction_id": "042f9d64-5233-43b6-aea9-3563d9fc4bad",
-    "message_id": "86c63de0-570f-46a2-bb57-dcb0ee384273",
-    "timestamp": "2025-01-18T04:39:27.600Z",
+    "transaction_id": "99d39ee1-5651-4f0a-8f2a-0a0ee8db9c9d",
+    "message_id": "f41223b7-a008-4ee9-af4c-53dbd6d971c1",
+    "timestamp": "2025-01-23T12:23:43.030Z",
     "ttl": "PT30S"
   },
   "message": {
     "order": {
-      "id": "2025-01-18-429408",
+      "id": "2025-01-23-459524",
       "state": "Accepted",
       "provider": {
         "id": "e2008459-7e90-493e-b02e-cae52ca53214",
@@ -30,16 +30,23 @@
         {
           "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
           "quantity": {
-            "count": 3
+            "count": 2
           },
-          "fulfillment_id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40"
+          "fulfillment_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d"
         },
         {
           "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
           "quantity": {
-            "count": 3
+            "count": 2
           },
-          "fulfillment_id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40"
+          "fulfillment_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d"
+        },
+        {
+          "id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d"
         }
       ],
       "billing": {
@@ -55,12 +62,12 @@
         },
         "email": "fhemanshu@gmail.com",
         "phone": "7202959020",
-        "created_at": "2025-01-18T04:38:29.524Z",
-        "updated_at": "2025-01-18T04:38:29.524Z"
+        "created_at": "2025-01-23T12:22:56.533Z",
+        "updated_at": "2025-01-23T12:22:56.533Z"
       },
       "fulfillments": [
         {
-          "id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40",
+          "id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
           "type": "Delivery",
           "@ondc/org/TAT": "PT99H",
           "provider_id": "ondc.loadshare.com/ondc/18275",
@@ -82,13 +89,13 @@
                 "locality": "Ashok Vatika",
                 "city": "Ahmedabad",
                 "state": "Gujarat",
-                "area_code": "380058"
+                "area_code": "380054"
               }
             },
             "time": {
               "range": {
-                "start": "2025-01-18T04:39:27.598Z",
-                "end": "2025-01-18T07:39:27.598Z"
+                "start": "2025-01-23T12:23:43.027Z",
+                "end": "2025-01-23T15:23:43.027Z"
               }
             },
             "instructions": {
@@ -117,8 +124,8 @@
             },
             "time": {
               "range": {
-                "start": "2025-01-18T07:39:27.598Z",
-                "end": "2025-01-22T07:39:27.598Z"
+                "start": "2025-01-23T15:23:43.027Z",
+                "end": "2025-01-27T15:23:43.027Z"
               }
             },
             "contact": {
@@ -134,13 +141,13 @@
       "quote": {
         "price": {
           "currency": "INR",
-          "value": "1401.72"
+          "value": "1364.71"
         },
         "breakup": [
           {
             "@ondc/org/item_id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
             "@ondc/org/item_quantity": {
-              "count": 3
+              "count": 2
             },
             "@ondc/org/title_type": "item",
             "item": {
@@ -152,11 +159,11 @@
             "title": "Nutraj-California-Almonds-1Kg",
             "price": {
               "currency": "INR",
-              "value": "660.0"
+              "value": "440.0"
             }
           },
           {
-            "@ondc/org/item_id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40",
+            "@ondc/org/item_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
             "@ondc/org/title_type": "packing",
             "title": "Packing Charges",
             "price": {
@@ -165,7 +172,7 @@
             }
           },
           {
-            "@ondc/org/item_id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40",
+            "@ondc/org/item_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
             "@ondc/org/title_type": "delivery",
             "title": "Delivery Charges",
             "price": {
@@ -179,13 +186,13 @@
             "title": "Tax",
             "price": {
               "currency": "INR",
-              "value": "122.1"
+              "value": "81.4"
             }
           },
           {
             "@ondc/org/item_id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
             "@ondc/org/item_quantity": {
-              "count": 3
+              "count": 2
             },
             "@ondc/org/title_type": "item",
             "item": {
@@ -197,11 +204,11 @@
             "title": "Cashews",
             "price": {
               "currency": "INR",
-              "value": "360.0"
+              "value": "240.0"
             }
           },
           {
-            "@ondc/org/item_id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40",
+            "@ondc/org/item_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
             "@ondc/org/title_type": "packing",
             "title": "Packing Charges",
             "price": {
@@ -210,7 +217,7 @@
             }
           },
           {
-            "@ondc/org/item_id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40",
+            "@ondc/org/item_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
             "@ondc/org/title_type": "delivery",
             "title": "Delivery Charges",
             "price": {
@@ -219,12 +226,48 @@
             }
           },
           {
-            "@ondc/org/item_id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40",
+            "@ondc/org/item_id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "@ondc/org/title_type": "item",
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "120.0"
+              }
+            },
+            "title": "Walnuts",
+            "price": {
+              "currency": "INR",
+              "value": "240.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
+            "@ondc/org/title_type": "packing",
+            "title": "Packing Charges",
+            "price": {
+              "currency": "INR",
+              "value": "5.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
+            "@ondc/org/title_type": "delivery",
+            "title": "Delivery Charges",
+            "price": {
+              "currency": "INR",
+              "value": "100.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
             "@ondc/org/title_type": "misc",
             "title": "Convenience Fee",
             "price": {
               "currency": "INR",
-              "value": "49.62"
+              "value": "48.31"
             }
           }
         ],
@@ -234,8 +277,8 @@
         "uri": "https://razorpay.com/",
         "tl_method": "http/get",
         "params": {
-          "transaction_id": "order_PkmFEkFcTwn3Jj",
-          "amount": "1401.72",
+          "transaction_id": "order_PmspSHrmelUv3U",
+          "amount": "1364.71",
           "currency": "INR"
         },
         "type": "ON-ORDER",
@@ -260,8 +303,8 @@
           }
         ]
       },
-      "created_at": "2025-01-18T04:38:51.420Z",
-      "updated_at": "2025-01-18T04:39:27.600Z"
+      "created_at": "2025-01-23T12:23:17.611Z",
+      "updated_at": "2025-01-23T12:23:43.030Z"
     }
   }
 }

--- a/Pirimid/SellerApp/Retail/RET-10/FLOW_5/on_status_picked.json
+++ b/Pirimid/SellerApp/Retail/RET-10/FLOW_5/on_status_picked.json
@@ -9,14 +9,14 @@
     "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
     "bpp_id": "ondc.pirimidtech.com/v2/seller",
     "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-    "transaction_id": "042f9d64-5233-43b6-aea9-3563d9fc4bad",
-    "message_id": "f86ce25c-612d-487f-9b6e-1ce7ef3b83db",
-    "timestamp": "2025-01-18T04:39:36.777Z",
+    "transaction_id": "99d39ee1-5651-4f0a-8f2a-0a0ee8db9c9d",
+    "message_id": "189c386a-492b-463d-9f23-0d983664cb08",
+    "timestamp": "2025-01-23T12:23:56.301Z",
     "ttl": "PT30S"
   },
   "message": {
     "order": {
-      "id": "2025-01-18-429408",
+      "id": "2025-01-23-459524",
       "state": "In-progress",
       "provider": {
         "id": "e2008459-7e90-493e-b02e-cae52ca53214",
@@ -30,21 +30,28 @@
         {
           "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
           "quantity": {
-            "count": 3
+            "count": 2
           },
-          "fulfillment_id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40"
+          "fulfillment_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d"
         },
         {
           "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
           "quantity": {
-            "count": 3
+            "count": 2
           },
-          "fulfillment_id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40"
+          "fulfillment_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d"
+        },
+        {
+          "id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+          "quantity": {
+            "count": 2
+          },
+          "fulfillment_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d"
         }
       ],
       "documents": [
         {
-          "url": "https://ondc.pirimidtech.com/v2/seller/api/order/invoice/502a64aa-3c44-4bc7-ab44-af9d9b077fc2",
+          "url": "https://ondc.pirimidtech.com/v2/seller/api/order/invoice/ef59d53e-1d0e-41d3-b382-0ceef31ae3e5",
           "label": "Invoice"
         }
       ],
@@ -61,12 +68,12 @@
         },
         "email": "fhemanshu@gmail.com",
         "phone": "7202959020",
-        "created_at": "2025-01-18T04:38:29.524Z",
-        "updated_at": "2025-01-18T04:38:29.524Z"
+        "created_at": "2025-01-23T12:22:56.533Z",
+        "updated_at": "2025-01-23T12:22:56.533Z"
       },
       "fulfillments": [
         {
-          "id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40",
+          "id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
           "type": "Delivery",
           "@ondc/org/TAT": "PT99H",
           "provider_id": "ondc.loadshare.com/ondc/18275",
@@ -97,14 +104,14 @@
                 "locality": "Ashok Vatika",
                 "city": "Ahmedabad",
                 "state": "Gujarat",
-                "area_code": "380058"
+                "area_code": "380054"
               }
             },
             "time": {
-              "timestamp": "2025-01-18T04:39:36.775Z",
+              "timestamp": "2025-01-23T12:23:56.299Z",
               "range": {
-                "start": "2025-01-18T04:39:27.598Z",
-                "end": "2025-01-18T07:39:27.598Z"
+                "start": "2025-01-23T12:23:43.027Z",
+                "end": "2025-01-23T15:23:43.027Z"
               }
             },
             "instructions": {
@@ -133,8 +140,8 @@
             },
             "time": {
               "range": {
-                "start": "2025-01-18T07:39:27.598Z",
-                "end": "2025-01-22T07:39:27.598Z"
+                "start": "2025-01-23T15:23:43.027Z",
+                "end": "2025-01-27T15:23:43.027Z"
               }
             },
             "contact": {
@@ -161,13 +168,13 @@
       "quote": {
         "price": {
           "currency": "INR",
-          "value": "1401.72"
+          "value": "1364.71"
         },
         "breakup": [
           {
             "@ondc/org/item_id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
             "@ondc/org/item_quantity": {
-              "count": 3
+              "count": 2
             },
             "@ondc/org/title_type": "item",
             "item": {
@@ -179,11 +186,11 @@
             "title": "Nutraj-California-Almonds-1Kg",
             "price": {
               "currency": "INR",
-              "value": "660.0"
+              "value": "440.0"
             }
           },
           {
-            "@ondc/org/item_id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40",
+            "@ondc/org/item_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
             "@ondc/org/title_type": "packing",
             "title": "Packing Charges",
             "price": {
@@ -192,7 +199,7 @@
             }
           },
           {
-            "@ondc/org/item_id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40",
+            "@ondc/org/item_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
             "@ondc/org/title_type": "delivery",
             "title": "Delivery Charges",
             "price": {
@@ -206,13 +213,13 @@
             "title": "Tax",
             "price": {
               "currency": "INR",
-              "value": "122.1"
+              "value": "81.4"
             }
           },
           {
             "@ondc/org/item_id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
             "@ondc/org/item_quantity": {
-              "count": 3
+              "count": 2
             },
             "@ondc/org/title_type": "item",
             "item": {
@@ -224,11 +231,11 @@
             "title": "Cashews",
             "price": {
               "currency": "INR",
-              "value": "360.0"
+              "value": "240.0"
             }
           },
           {
-            "@ondc/org/item_id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40",
+            "@ondc/org/item_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
             "@ondc/org/title_type": "packing",
             "title": "Packing Charges",
             "price": {
@@ -237,7 +244,7 @@
             }
           },
           {
-            "@ondc/org/item_id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40",
+            "@ondc/org/item_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
             "@ondc/org/title_type": "delivery",
             "title": "Delivery Charges",
             "price": {
@@ -246,12 +253,48 @@
             }
           },
           {
-            "@ondc/org/item_id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40",
+            "@ondc/org/item_id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+            "@ondc/org/item_quantity": {
+              "count": 2
+            },
+            "@ondc/org/title_type": "item",
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "120.0"
+              }
+            },
+            "title": "Walnuts",
+            "price": {
+              "currency": "INR",
+              "value": "240.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
+            "@ondc/org/title_type": "packing",
+            "title": "Packing Charges",
+            "price": {
+              "currency": "INR",
+              "value": "5.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
+            "@ondc/org/title_type": "delivery",
+            "title": "Delivery Charges",
+            "price": {
+              "currency": "INR",
+              "value": "100.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
             "@ondc/org/title_type": "misc",
             "title": "Convenience Fee",
             "price": {
               "currency": "INR",
-              "value": "49.62"
+              "value": "48.31"
             }
           }
         ],
@@ -261,8 +304,8 @@
         "uri": "https://razorpay.com/",
         "tl_method": "http/get",
         "params": {
-          "transaction_id": "order_PkmFEkFcTwn3Jj",
-          "amount": "1401.72",
+          "transaction_id": "order_PmspSHrmelUv3U",
+          "amount": "1364.71",
           "currency": "INR"
         },
         "type": "ON-ORDER",
@@ -287,8 +330,8 @@
           }
         ]
       },
-      "created_at": "2025-01-18T04:38:51.420Z",
-      "updated_at": "2025-01-18T04:39:36.777Z"
+      "created_at": "2025-01-23T12:23:17.611Z",
+      "updated_at": "2025-01-23T12:23:56.301Z"
     }
   }
 }

--- a/Pirimid/SellerApp/Retail/RET-10/FLOW_5/on_status_rto_delivered_disposed.json
+++ b/Pirimid/SellerApp/Retail/RET-10/FLOW_5/on_status_rto_delivered_disposed.json
@@ -9,14 +9,14 @@
         "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
         "bpp_id": "ondc.pirimidtech.com/v2/seller",
         "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-        "transaction_id": "042f9d64-5233-43b6-aea9-3563d9fc4bad",
-        "message_id": "e71a4eee-2004-4a18-8238-48ef7a6b531d",
-        "timestamp": "2025-01-18T15:52:03.594Z",
+        "transaction_id": "99d39ee1-5651-4f0a-8f2a-0a0ee8db9c9d",
+        "message_id": "d9aa29c4-e07d-4abb-b46a-c43276d9b519",
+        "timestamp": "2025-01-24T05:29:40.398Z",
         "ttl": "PT30S"
     },
     "message": {
         "order": {
-            "id": "2025-01-18-429408",
+            "id": "2025-01-23-459524",
             "state": "Cancelled",
             "provider": {
                 "id": "e2008459-7e90-493e-b02e-cae52ca53214",
@@ -30,30 +30,44 @@
                 {
                     "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
                     "quantity": {
-                        "count": 3
+                        "count": 0
                     },
-                    "fulfillment_id": "1a40ac02-0724-4aaa-99de-945e81e592d9"
+                    "fulfillment_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d"
                 },
                 {
                     "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
                     "quantity": {
-                        "count": 3
+                        "count": 0
                     },
-                    "fulfillment_id": "1a40ac02-0724-4aaa-99de-945e81e592d9"
+                    "fulfillment_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d"
+                },
+                {
+                    "id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+                    "quantity": {
+                        "count": 0
+                    },
+                    "fulfillment_id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d"
                 },
                 {
                     "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
                     "quantity": {
-                        "count": 0
+                        "count": 2
                     },
-                    "fulfillment_id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40"
+                    "fulfillment_id": "7b293f91-e8a9-4333-89bc-ef5f7efa5ce6"
                 },
                 {
                     "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
                     "quantity": {
-                        "count": 0
+                        "count": 2
                     },
-                    "fulfillment_id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40"
+                    "fulfillment_id": "7b293f91-e8a9-4333-89bc-ef5f7efa5ce6"
+                },
+                {
+                    "id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+                    "quantity": {
+                        "count": 2
+                    },
+                    "fulfillment_id": "7b293f91-e8a9-4333-89bc-ef5f7efa5ce6"
                 }
             ],
             "billing": {
@@ -69,12 +83,12 @@
                 },
                 "email": "fhemanshu@gmail.com",
                 "phone": "7202959020",
-                "created_at": "2025-01-18T04:38:29.524Z",
-                "updated_at": "2025-01-18T04:38:29.524Z"
+                "created_at": "2025-01-23T12:22:56.533Z",
+                "updated_at": "2025-01-23T12:22:56.533Z"
             },
             "fulfillments": [
                 {
-                    "id": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40",
+                    "id": "4dab34c2-b680-4a0e-bc90-68a77d412e3d",
                     "type": "Delivery",
                     "@ondc/org/TAT": "PT99H",
                     "provider_id": "ondc.loadshare.com/ondc/18275",
@@ -105,14 +119,14 @@
                                 "locality": "Ashok Vatika",
                                 "city": "Ahmedabad",
                                 "state": "Gujarat",
-                                "area_code": "380058"
+                                "area_code": "380054"
                             }
                         },
                         "time": {
-                            "timestamp": "2025-01-18T04:39:36.775Z",
+                            "timestamp": "2025-01-23T12:23:56.299Z",
                             "range": {
-                                "start": "2025-01-18T04:39:27.598Z",
-                                "end": "2025-01-18T07:39:27.598Z"
+                                "start": "2025-01-23T12:23:43.027Z",
+                                "end": "2025-01-23T15:23:43.027Z"
                             }
                         },
                         "instructions": {
@@ -141,8 +155,8 @@
                         },
                         "time": {
                             "range": {
-                                "start": "2025-01-18T07:39:27.598Z",
-                                "end": "2025-01-22T07:39:27.598Z"
+                                "start": "2025-01-23T15:23:43.027Z",
+                                "end": "2025-01-27T15:23:43.027Z"
                             }
                         },
                         "contact": {
@@ -159,7 +173,7 @@
                             "list": [
                                 {
                                     "code": "reason_id",
-                                    "value": "012"
+                                    "value": "014"
                                 },
                                 {
                                     "code": "initiated_by",
@@ -167,7 +181,7 @@
                                 },
                                 {
                                     "code": "rto_id",
-                                    "value": "1a40ac02-0724-4aaa-99de-945e81e592d9"
+                                    "value": "7b293f91-e8a9-4333-89bc-ef5f7efa5ce6"
                                 }
                             ]
                         },
@@ -180,14 +194,14 @@
                                 },
                                 {
                                     "code": "updated_at",
-                                    "value": "2025-01-18T15:49:15.589Z"
+                                    "value": "2025-01-24T05:27:44.552Z"
                                 }
                             ]
                         }
                     ]
                 },
                 {
-                    "id": "1a40ac02-0724-4aaa-99de-945e81e592d9",
+                    "id": "7b293f91-e8a9-4333-89bc-ef5f7efa5ce6",
                     "type": "RTO",
                     "@ondc/org/TAT": "PT2H",
                     "@ondc/org/provider_name": "LoadShare",
@@ -211,7 +225,7 @@
                             }
                         },
                         "time": {
-                            "timestamp": "2025-01-18T15:51:33.091Z"
+                            "timestamp": "2025-01-24T05:28:52.332Z"
                         },
                         "instructions": {
                             "name": "Status for pickup",
@@ -241,11 +255,11 @@
                                 "locality": "Ashok Vatika",
                                 "city": "Ahmedabad",
                                 "state": "Gujarat",
-                                "area_code": "380058"
+                                "area_code": "380054"
                             }
                         },
                         "time": {
-                            "timestamp": "2025-01-18T15:52:03.593Z"
+                            "timestamp": "2025-01-24T05:29:40.396Z"
                         },
                         "instructions": {
                             "name": "Status for pickup",
@@ -268,7 +282,7 @@
                                 },
                                 {
                                     "code": "id",
-                                    "value": "dbfc2804-bfa6-4dc9-9035-ea6c53edef40"
+                                    "value": "4dab34c2-b680-4a0e-bc90-68a77d412e3d"
                                 },
                                 {
                                     "code": "currency",
@@ -276,7 +290,7 @@
                                 },
                                 {
                                     "code": "value",
-                                    "value": "-49.62"
+                                    "value": "-48.31"
                                 }
                             ]
                         },
@@ -297,7 +311,7 @@
                                 },
                                 {
                                     "code": "value",
-                                    "value": "-660.0"
+                                    "value": "-440.0"
                                 }
                             ]
                         },
@@ -310,7 +324,7 @@
                                 },
                                 {
                                     "code": "id",
-                                    "value": "1a40ac02-0724-4aaa-99de-945e81e592d9"
+                                    "value": "7b293f91-e8a9-4333-89bc-ef5f7efa5ce6"
                                 },
                                 {
                                     "code": "currency",
@@ -331,7 +345,7 @@
                                 },
                                 {
                                     "code": "id",
-                                    "value": "1a40ac02-0724-4aaa-99de-945e81e592d9"
+                                    "value": "7b293f91-e8a9-4333-89bc-ef5f7efa5ce6"
                                 },
                                 {
                                     "code": "currency",
@@ -352,7 +366,7 @@
                                 },
                                 {
                                     "code": "id",
-                                    "value": "1a40ac02-0724-4aaa-99de-945e81e592d9"
+                                    "value": "7b293f91-e8a9-4333-89bc-ef5f7efa5ce6"
                                 },
                                 {
                                     "code": "currency",
@@ -360,7 +374,7 @@
                                 },
                                 {
                                     "code": "value",
-                                    "value": "-122.1"
+                                    "value": "-81.4"
                                 }
                             ]
                         },
@@ -381,7 +395,7 @@
                                 },
                                 {
                                     "code": "value",
-                                    "value": "-360.0"
+                                    "value": "-240.0"
                                 }
                             ]
                         },
@@ -394,7 +408,7 @@
                                 },
                                 {
                                     "code": "id",
-                                    "value": "1a40ac02-0724-4aaa-99de-945e81e592d9"
+                                    "value": "7b293f91-e8a9-4333-89bc-ef5f7efa5ce6"
                                 },
                                 {
                                     "code": "currency",
@@ -415,7 +429,70 @@
                                 },
                                 {
                                     "code": "id",
-                                    "value": "1a40ac02-0724-4aaa-99de-945e81e592d9"
+                                    "value": "7b293f91-e8a9-4333-89bc-ef5f7efa5ce6"
+                                },
+                                {
+                                    "code": "currency",
+                                    "value": "INR"
+                                },
+                                {
+                                    "code": "value",
+                                    "value": "-100.0"
+                                }
+                            ]
+                        },
+                        {
+                            "code": "quote_trail",
+                            "list": [
+                                {
+                                    "code": "type",
+                                    "value": "item"
+                                },
+                                {
+                                    "code": "id",
+                                    "value": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7"
+                                },
+                                {
+                                    "code": "currency",
+                                    "value": "INR"
+                                },
+                                {
+                                    "code": "value",
+                                    "value": "-240.0"
+                                }
+                            ]
+                        },
+                        {
+                            "code": "quote_trail",
+                            "list": [
+                                {
+                                    "code": "type",
+                                    "value": "packing"
+                                },
+                                {
+                                    "code": "id",
+                                    "value": "7b293f91-e8a9-4333-89bc-ef5f7efa5ce6"
+                                },
+                                {
+                                    "code": "currency",
+                                    "value": "INR"
+                                },
+                                {
+                                    "code": "value",
+                                    "value": "-5.0"
+                                }
+                            ]
+                        },
+                        {
+                            "code": "quote_trail",
+                            "list": [
+                                {
+                                    "code": "type",
+                                    "value": "delivery"
+                                },
+                                {
+                                    "code": "id",
+                                    "value": "7b293f91-e8a9-4333-89bc-ef5f7efa5ce6"
                                 },
                                 {
                                     "code": "currency",
@@ -455,7 +532,7 @@
                         }
                     },
                     {
-                        "@ondc/org/item_id": "1a40ac02-0724-4aaa-99de-945e81e592d9",
+                        "@ondc/org/item_id": "7b293f91-e8a9-4333-89bc-ef5f7efa5ce6",
                         "@ondc/org/title_type": "packing",
                         "title": "Packing Charges",
                         "price": {
@@ -464,7 +541,7 @@
                         }
                     },
                     {
-                        "@ondc/org/item_id": "1a40ac02-0724-4aaa-99de-945e81e592d9",
+                        "@ondc/org/item_id": "7b293f91-e8a9-4333-89bc-ef5f7efa5ce6",
                         "@ondc/org/title_type": "delivery",
                         "title": "Delivery Charges",
                         "price": {
@@ -500,7 +577,7 @@
                         }
                     },
                     {
-                        "@ondc/org/item_id": "1a40ac02-0724-4aaa-99de-945e81e592d9",
+                        "@ondc/org/item_id": "7b293f91-e8a9-4333-89bc-ef5f7efa5ce6",
                         "@ondc/org/title_type": "packing",
                         "title": "Packing Charges",
                         "price": {
@@ -509,7 +586,7 @@
                         }
                     },
                     {
-                        "@ondc/org/item_id": "1a40ac02-0724-4aaa-99de-945e81e592d9",
+                        "@ondc/org/item_id": "7b293f91-e8a9-4333-89bc-ef5f7efa5ce6",
                         "@ondc/org/title_type": "delivery",
                         "title": "Delivery Charges",
                         "price": {
@@ -518,7 +595,43 @@
                         }
                     },
                     {
-                        "@ondc/org/item_id": "1a40ac02-0724-4aaa-99de-945e81e592d9",
+                        "@ondc/org/item_id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+                        "@ondc/org/item_quantity": {
+                            "count": 0
+                        },
+                        "@ondc/org/title_type": "item",
+                        "item": {
+                            "price": {
+                                "currency": "INR",
+                                "value": "120.0"
+                            }
+                        },
+                        "title": "Walnuts",
+                        "price": {
+                            "currency": "INR",
+                            "value": "0.0"
+                        }
+                    },
+                    {
+                        "@ondc/org/item_id": "7b293f91-e8a9-4333-89bc-ef5f7efa5ce6",
+                        "@ondc/org/title_type": "packing",
+                        "title": "Packing Charges",
+                        "price": {
+                            "currency": "INR",
+                            "value": "0.0"
+                        }
+                    },
+                    {
+                        "@ondc/org/item_id": "7b293f91-e8a9-4333-89bc-ef5f7efa5ce6",
+                        "@ondc/org/title_type": "delivery",
+                        "title": "Delivery Charges",
+                        "price": {
+                            "currency": "INR",
+                            "value": "0.0"
+                        }
+                    },
+                    {
+                        "@ondc/org/item_id": "7b293f91-e8a9-4333-89bc-ef5f7efa5ce6",
                         "@ondc/org/title_type": "misc",
                         "title": "Convenience Fee",
                         "price": {
@@ -533,8 +646,8 @@
                 "uri": "https://razorpay.com/",
                 "tl_method": "http/get",
                 "params": {
-                    "transaction_id": "order_PkmFEkFcTwn3Jj",
-                    "amount": "1401.72",
+                    "transaction_id": "order_PmspSHrmelUv3U",
+                    "amount": "1364.71",
                     "currency": "INR"
                 },
                 "type": "ON-ORDER",
@@ -562,11 +675,11 @@
             "cancellation": {
                 "cancelled_by": "ondc.pirimidtech.com/v2/seller",
                 "reason": {
-                    "id": "012"
+                    "id": "014"
                 }
             },
-            "created_at": "2025-01-18T04:38:51.420Z",
-            "updated_at": "2025-01-18T15:52:03.594Z"
+            "created_at": "2025-01-23T12:23:17.611Z",
+            "updated_at": "2025-01-24T05:29:40.398Z"
         }
     }
 }

--- a/Pirimid/SellerApp/Retail/RET-10/FLOW_5/search_full_catalog_refresh.json
+++ b/Pirimid/SellerApp/Retail/RET-10/FLOW_5/search_full_catalog_refresh.json
@@ -7,9 +7,9 @@
     "core_version": "1.2.0",
     "bap_id": "buyer-app-preprod-v2.ondc.org",
     "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
-    "transaction_id": "e53a74c5-7ce6-4498-800c-e7d90db0f2fa",
-    "message_id": "45726578-5033-41e0-b35f-2fcbcebe8f82",
-    "timestamp": "2025-01-17T12:00:01.818Z",
+    "transaction_id": "2a274964-3eec-4793-888c-1d30ef845cd1",
+    "message_id": "c5c58f68-8483-4490-b318-a1436c6ee88b",
+    "timestamp": "2025-01-23T12:00:01.908Z",
     "ttl": "PT30S"
   },
   "message": {

--- a/Pirimid/SellerApp/Retail/RET-10/FLOW_5/select.json
+++ b/Pirimid/SellerApp/Retail/RET-10/FLOW_5/select.json
@@ -8,9 +8,9 @@
     "bap_id": "buyer-app-preprod-v2.ondc.org",
     "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
     "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-    "transaction_id": "042f9d64-5233-43b6-aea9-3563d9fc4bad",
-    "message_id": "dd6f2a5d-b066-40a6-a08e-aef7c48027d3",
-    "timestamp": "2025-01-18T04:38:20.411Z",
+    "transaction_id": "99d39ee1-5651-4f0a-8f2a-0a0ee8db9c9d",
+    "message_id": "0e061ee7-0302-436a-88e6-e1437235f613",
+    "timestamp": "2025-01-23T12:22:37.665Z",
     "bpp_id": "ondc.pirimidtech.com/v2/seller",
     "ttl": "PT30S"
   },
@@ -20,14 +20,21 @@
         {
           "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
           "quantity": {
-            "count": 3
+            "count": 2
           },
           "location_id": "39550822-c3bb-4918-bd25-2d19ef6a9aca"
         },
         {
           "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
           "quantity": {
-            "count": 3
+            "count": 2
+          },
+          "location_id": "39550822-c3bb-4918-bd25-2d19ef6a9aca"
+        },
+        {
+          "id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+          "quantity": {
+            "count": 2
           },
           "location_id": "39550822-c3bb-4918-bd25-2d19ef6a9aca"
         }

--- a/Pirimid/SellerApp/Retail/RET-10/FLOW_6/confirm.json
+++ b/Pirimid/SellerApp/Retail/RET-10/FLOW_6/confirm.json
@@ -8,15 +8,15 @@
     "bap_id": "buyer-app-preprod-v2.ondc.org",
     "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
     "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-    "transaction_id": "82b9cba3-1fb4-4b53-825e-904368636e74",
-    "message_id": "f84c010d-615c-446d-8b6e-e66f58470b78",
-    "timestamp": "2025-01-18T04:40:23.079Z",
+    "transaction_id": "e35a5fd4-3758-429e-84d0-4d831a501733",
+    "message_id": "910f4f8b-dd2f-4ab6-b202-1a154f31873c",
+    "timestamp": "2025-01-23T12:25:10.086Z",
     "bpp_id": "ondc.pirimidtech.com/v2/seller",
     "ttl": "PT30S"
   },
   "message": {
     "order": {
-      "id": "2025-01-18-743091",
+      "id": "2025-01-23-103725",
       "state": "Created",
       "billing": {
         "address": {
@@ -31,8 +31,8 @@
         "phone": "7202959020",
         "name": "Hemanshu Faldu",
         "email": "fhemanshu@gmail.com",
-        "created_at": "2025-01-18T04:39:55.715Z",
-        "updated_at": "2025-01-18T04:39:55.715Z"
+        "created_at": "2025-01-23T12:24:49.484Z",
+        "updated_at": "2025-01-23T12:24:49.484Z"
       },
       "items": [
         {
@@ -40,14 +40,21 @@
           "quantity": {
             "count": 3
           },
-          "fulfillment_id": "59021f2c-bed5-4797-82e1-b06febf27eda"
+          "fulfillment_id": "6dc21188-26a8-456c-9d28-1561bd0779c9"
         },
         {
           "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
           "quantity": {
             "count": 3
           },
-          "fulfillment_id": "59021f2c-bed5-4797-82e1-b06febf27eda"
+          "fulfillment_id": "6dc21188-26a8-456c-9d28-1561bd0779c9"
+        },
+        {
+          "id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+          "quantity": {
+            "count": 3
+          },
+          "fulfillment_id": "6dc21188-26a8-456c-9d28-1561bd0779c9"
         }
       ],
       "provider": {
@@ -61,7 +68,7 @@
       "fulfillments": [
         {
           "@ondc/org/TAT": "PT99H",
-          "id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+          "id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
           "tracking": false,
           "end": {
             "contact": {
@@ -91,9 +98,9 @@
         "uri": "https://razorpay.com/",
         "tl_method": "http/get",
         "params": {
-          "amount": "1401.72",
+          "amount": "1883.79",
           "currency": "INR",
-          "transaction_id": "order_PkmGkn5hmLCG83"
+          "transaction_id": "order_PmsrRxRfEkwUOs"
         },
         "status": "PAID",
         "type": "ON-ORDER",
@@ -120,7 +127,7 @@
       "quote": {
         "price": {
           "currency": "INR",
-          "value": "1401.72"
+          "value": "1883.79"
         },
         "breakup": [
           {
@@ -142,7 +149,7 @@
             }
           },
           {
-            "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+            "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
             "@ondc/org/title_type": "packing",
             "title": "Packing Charges",
             "price": {
@@ -151,7 +158,7 @@
             }
           },
           {
-            "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+            "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
             "@ondc/org/title_type": "delivery",
             "title": "Delivery Charges",
             "price": {
@@ -187,7 +194,7 @@
             }
           },
           {
-            "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+            "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
             "@ondc/org/title_type": "packing",
             "title": "Packing Charges",
             "price": {
@@ -196,7 +203,7 @@
             }
           },
           {
-            "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+            "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
             "@ondc/org/title_type": "delivery",
             "title": "Delivery Charges",
             "price": {
@@ -205,12 +212,48 @@
             }
           },
           {
-            "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+            "@ondc/org/item_id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+            "@ondc/org/item_quantity": {
+              "count": 3
+            },
+            "@ondc/org/title_type": "item",
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "120.0"
+              }
+            },
+            "title": "Walnuts",
+            "price": {
+              "currency": "INR",
+              "value": "360.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
+            "@ondc/org/title_type": "packing",
+            "title": "Packing Charges",
+            "price": {
+              "currency": "INR",
+              "value": "5.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
+            "@ondc/org/title_type": "delivery",
+            "title": "Delivery Charges",
+            "price": {
+              "currency": "INR",
+              "value": "100.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
             "@ondc/org/title_type": "misc",
             "title": "Convenience Fee",
             "price": {
               "currency": "INR",
-              "value": "49.62"
+              "value": "66.69"
             }
           }
         ],
@@ -240,8 +283,8 @@
           ]
         }
       ],
-      "created_at": "2025-01-18T04:40:23.079Z",
-      "updated_at": "2025-01-18T04:40:23.079Z"
+      "created_at": "2025-01-23T12:25:10.086Z",
+      "updated_at": "2025-01-23T12:25:10.086Z"
     }
   }
 }

--- a/Pirimid/SellerApp/Retail/RET-10/FLOW_6/init.json
+++ b/Pirimid/SellerApp/Retail/RET-10/FLOW_6/init.json
@@ -8,9 +8,9 @@
     "bap_id": "buyer-app-preprod-v2.ondc.org",
     "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
     "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-    "transaction_id": "82b9cba3-1fb4-4b53-825e-904368636e74",
-    "message_id": "e5ebd64d-5a78-444f-a7db-d74cb2eebcef",
-    "timestamp": "2025-01-18T04:39:55.715Z",
+    "transaction_id": "e35a5fd4-3758-429e-84d0-4d831a501733",
+    "message_id": "f687722c-a82c-4f49-adbd-6ec190026c2e",
+    "timestamp": "2025-01-23T12:24:49.484Z",
     "bpp_id": "ondc.pirimidtech.com/v2/seller",
     "ttl": "PT30S"
   },
@@ -31,7 +31,7 @@
             "count": 3
           },
           "location_id": "39550822-c3bb-4918-bd25-2d19ef6a9aca",
-          "fulfillment_id": "59021f2c-bed5-4797-82e1-b06febf27eda"
+          "fulfillment_id": "6dc21188-26a8-456c-9d28-1561bd0779c9"
         },
         {
           "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
@@ -39,7 +39,15 @@
             "count": 3
           },
           "location_id": "39550822-c3bb-4918-bd25-2d19ef6a9aca",
-          "fulfillment_id": "59021f2c-bed5-4797-82e1-b06febf27eda"
+          "fulfillment_id": "6dc21188-26a8-456c-9d28-1561bd0779c9"
+        },
+        {
+          "id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+          "quantity": {
+            "count": 3
+          },
+          "location_id": "39550822-c3bb-4918-bd25-2d19ef6a9aca",
+          "fulfillment_id": "6dc21188-26a8-456c-9d28-1561bd0779c9"
         }
       ],
       "billing": {
@@ -55,12 +63,12 @@
         "phone": "7202959020",
         "name": "Hemanshu Faldu",
         "email": "fhemanshu@gmail.com",
-        "created_at": "2025-01-18T04:39:55.715Z",
-        "updated_at": "2025-01-18T04:39:55.715Z"
+        "created_at": "2025-01-23T12:24:49.484Z",
+        "updated_at": "2025-01-23T12:24:49.484Z"
       },
       "fulfillments": [
         {
-          "id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+          "id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
           "type": "Delivery",
           "end": {
             "contact": {

--- a/Pirimid/SellerApp/Retail/RET-10/FLOW_6/log_validation_utility_request.json
+++ b/Pirimid/SellerApp/Retail/RET-10/FLOW_6/log_validation_utility_request.json
@@ -4,7 +4,7 @@
     "bap_id": "buyer-app-preprod-v2.ondc.org",
     "bpp_id": "ondc.pirimidtech.com/v2/seller",
     "payload": {
-        "search_full_catalog_refresh": {
+          "search_full_catalog_refresh": {
             "context": {
                 "domain": "ONDC:RET10",
                 "action": "search",
@@ -13,9 +13,9 @@
                 "core_version": "1.2.0",
                 "bap_id": "buyer-app-preprod-v2.ondc.org",
                 "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
-                "transaction_id": "e53a74c5-7ce6-4498-800c-e7d90db0f2fa",
-                "message_id": "45726578-5033-41e0-b35f-2fcbcebe8f82",
-                "timestamp": "2025-01-17T12:00:01.818Z",
+                "transaction_id": "2a274964-3eec-4793-888c-1d30ef845cd1",
+                "message_id": "c5c58f68-8483-4490-b318-a1436c6ee88b",
+                "timestamp": "2025-01-23T12:00:01.908Z",
                 "ttl": "PT30S"
             },
             "message": {
@@ -41,9 +41,9 @@
                 "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
                 "bpp_id": "ondc.pirimidtech.com/v2/seller",
                 "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-                "transaction_id": "e53a74c5-7ce6-4498-800c-e7d90db0f2fa",
-                "message_id": "45726578-5033-41e0-b35f-2fcbcebe8f82",
-                "timestamp": "2025-01-17T12:00:21.411Z",
+                "transaction_id": "2a274964-3eec-4793-888c-1d30ef845cd1",
+                "message_id": "c5c58f68-8483-4490-b318-a1436c6ee88b",
+                "timestamp": "2025-01-23T12:00:21.519Z",
                 "ttl": "PT30S"
             },
             "message": {
@@ -90,70 +90,8 @@
                             "@ondc/org/fssai_license_no": "12345678912345",
                             "time": {
                                 "label": "enable",
-                                "timestamp": "2025-01-17T12:00:21.411Z"
+                                "timestamp": "2025-01-23T12:00:21.519Z"
                             },
-                            "categories": [
-                                {
-                                    "id": "variant10000",
-                                    "descriptor": {
-                                        "name": "Variant for Nutraj-California-Almonds-1Kg"
-                                    },
-                                    "tags": [
-                                        {
-                                            "code": "type",
-                                            "list": [
-                                                {
-                                                    "code": "type",
-                                                    "value": "variant_group"
-                                                }
-                                            ]
-                                        },
-                                        {
-                                            "code": "attr",
-                                            "list": [
-                                                {
-                                                    "code": "name",
-                                                    "value": "item.quantity.unitized.measure"
-                                                },
-                                                {
-                                                    "code": "seq",
-                                                    "value": "1"
-                                                }
-                                            ]
-                                        }
-                                    ]
-                                },
-                                {
-                                    "id": "variant10001",
-                                    "descriptor": {
-                                        "name": "Variant for Cashews"
-                                    },
-                                    "tags": [
-                                        {
-                                            "code": "type",
-                                            "list": [
-                                                {
-                                                    "code": "type",
-                                                    "value": "variant_group"
-                                                }
-                                            ]
-                                        },
-                                        {
-                                            "code": "attr",
-                                            "list": [
-                                                {
-                                                    "code": "name",
-                                                    "value": "item.quantity.unitized.measure"
-                                                },
-                                                {
-                                                    "code": "seq",
-                                                    "value": "1"
-                                                }
-                                            ]
-                                        }
-                                    ]
-                                }
-                            ],
                             "fulfillments": [
                                 {
                                     "id": "1",
@@ -173,11 +111,11 @@
                                         "locality": "Ashok Vatika",
                                         "city": "Ahmedabad",
                                         "state": "Gujarat",
-                                        "area_code": "380058"
+                                        "area_code": "380054"
                                     },
                                     "time": {
                                         "label": "enable",
-                                        "timestamp": "2024-12-04T13:50:34.608Z",
+                                        "timestamp": "2025-01-22T07:34:34.534Z",
                                         "range": {
                                             "start": "0930",
                                             "end": "1930"
@@ -194,12 +132,85 @@
                             ],
                             "items": [
                                 {
+                                    "id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+                                    "descriptor": {
+                                        "name": "Walnuts",
+                                        "code": "1:12345678",
+                                        "symbol": "https://c8.alamy.com/comp/2HCTDG2/modern-design-walnut-leaf-nature-green-logo-design-2HCTDG2.jpg",
+                                        "short_desc": "WONDERLAND California Whole Walnut Walnuts (Akhrot)  (500 g)",
+                                        "long_desc": "WONDERLAND California Whole Walnut Walnuts (Akhrot)  (500 g)",
+                                        "images": [
+                                            "https://rukminim2.flixcart.com/image/416/416/xif0q/nut-dry-fruit/h/x/t/500-california-whole-walnut-1-pouch-wonderland-original-imagy632bnvk8fde.jpeg?q=70",
+                                            "https://rukminim2.flixcart.com/image/416/416/xif0q/nut-dry-fruit/q/r/t/500-california-whole-walnut-1-pouch-wonderland-original-imagy6326hdk68cd.jpeg?q=70"
+                                        ]
+                                    },
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "120.0",
+                                        "maximum_value": "200.0"
+                                    },
+                                    "quantity": {
+                                        "available": {
+                                            "count": "99"
+                                        },
+                                        "maximum": {
+                                            "count": "99"
+                                        },
+                                        "unitized": {
+                                            "measure": {
+                                                "value": "500",
+                                                "unit": "gram"
+                                            }
+                                        }
+                                    },
+                                    "category_id": "Snacks, Dry Fruits, Nuts",
+                                    "fulfillment_id": "1",
+                                    "location_id": "39550822-c3bb-4918-bd25-2d19ef6a9aca",
+                                    "time": {
+                                        "label": "enable",
+                                        "timestamp": "2025-01-23T12:00:21.519Z"
+                                    },
+                                    "@ondc/org/returnable": true,
+                                    "@ondc/org/seller_pickup_return": false,
+                                    "@ondc/org/return_window": "P7D",
+                                    "@ondc/org/cancellable": true,
+                                    "@ondc/org/time_to_ship": "PT3H",
+                                    "@ondc/org/available_on_cod": false,
+                                    "@ondc/org/contact_details_consumer_care": "PirimidFintech,user@gmail.com,7744774477",
+                                    "@ondc/org/statutory_reqs_prepackaged_food": {
+                                        "nutritional_info": "nutritional_info",
+                                        "additives_info": "additives_info",
+                                        "brand_owner_FSSAI_license_no": "12345678912345",
+                                        "other_FSSAI_license_no": "12345678912345",
+                                        "importer_FSSAI_license_no": "12345678912345"
+                                    },
+                                    "tags": [
+                                        {
+                                            "code": "origin",
+                                            "list": [
+                                                {
+                                                    "code": "Country",
+                                                    "value": "IND"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "code": "veg_nonveg",
+                                            "list": [
+                                                {
+                                                    "code": "veg",
+                                                    "value": "yes"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                {
                                     "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
-                                    "parent_item_id": "variant10000",
                                     "descriptor": {
                                         "name": "Nutraj-California-Almonds-1Kg",
                                         "code": "1:12345678",
-                                        "symbol": "symbols.in/symbol.jpg",
+                                        "symbol": "https://img.freepik.com/premium-vector/almonds-nuts-nature-farm-vintage-logo-icon-symbol-vector-illustration-minimalist-design_889650-491.jpg?semt=ais_hybrid",
                                         "short_desc": "Nutraj California Almond kernels 1kg Pouch|Badam Giri|Dry Fruits and Nuts|Grocery",
                                         "long_desc": "Nutraj California Almond kernels 1kg Pouch|Badam Giri|Dry Fruits and Nuts|Grocery",
                                         "images": [
@@ -230,7 +241,7 @@
                                     "location_id": "39550822-c3bb-4918-bd25-2d19ef6a9aca",
                                     "time": {
                                         "label": "enable",
-                                        "timestamp": "2025-01-17T12:00:21.411Z"
+                                        "timestamp": "2025-01-23T12:00:21.519Z"
                                     },
                                     "@ondc/org/returnable": true,
                                     "@ondc/org/seller_pickup_return": false,
@@ -269,11 +280,10 @@
                                 },
                                 {
                                     "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
-                                    "parent_item_id": "variant10001",
                                     "descriptor": {
                                         "name": "Cashews",
                                         "code": "1:12345678",
-                                        "symbol": "symbols.in/symbol.jpg",
+                                        "symbol": "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTVlckKW1pwOvmkj9_s_rPbAvcsr_EdmIStMA&s",
                                         "short_desc": "Emart Brand - Vedaka Whole Cashews | 500 Gram | Kaju Nuts Grade W320 | Plant Based Protein | Gluten-Free | Nutty Flavor | Healthy Snack | Rich Delicious Taste",
                                         "long_desc": "Emart Brand - Vedaka Whole Cashews | 500 Gram | Kaju Nuts Grade W320 | Plant Based Protein | Gluten-Free | Nutty Flavor | Healthy Snack | Rich Delicious Taste",
                                         "images": [
@@ -283,7 +293,7 @@
                                     "price": {
                                         "currency": "INR",
                                         "value": "120.0",
-                                        "maximum_value": "258.0"
+                                        "maximum_value": "212.0"
                                     },
                                     "quantity": {
                                         "available": {
@@ -294,8 +304,8 @@
                                         },
                                         "unitized": {
                                             "measure": {
-                                                "value": "1",
-                                                "unit": "kilogram"
+                                                "value": "500",
+                                                "unit": "gram"
                                             }
                                         }
                                     },
@@ -304,7 +314,7 @@
                                     "location_id": "39550822-c3bb-4918-bd25-2d19ef6a9aca",
                                     "time": {
                                         "label": "enable",
-                                        "timestamp": "2025-01-17T12:00:21.411Z"
+                                        "timestamp": "2025-01-23T12:00:21.519Z"
                                     },
                                     "@ondc/org/returnable": true,
                                     "@ondc/org/seller_pickup_return": false,
@@ -374,36 +384,7 @@
                                     "list": [
                                         {
                                             "code": "type",
-                                            "value": "Order"
-                                        },
-                                        {
-                                            "code": "location",
-                                            "value": "39550822-c3bb-4918-bd25-2d19ef6a9aca"
-                                        },
-                                        {
-                                            "code": "day_from",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "day_to",
-                                            "value": "7"
-                                        },
-                                        {
-                                            "code": "time_from",
-                                            "value": "0930"
-                                        },
-                                        {
-                                            "code": "time_to",
-                                            "value": "1930"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "timing",
-                                    "list": [
-                                        {
-                                            "code": "type",
-                                            "value": "Delivery"
+                                            "value": "All"
                                         },
                                         {
                                             "code": "location",
@@ -443,9 +424,9 @@
                 "bap_id": "buyer-app-preprod-v2.ondc.org",
                 "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
                 "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-                "transaction_id": "82b9cba3-1fb4-4b53-825e-904368636e74",
-                "message_id": "3b8fc2b8-8b27-49d2-9952-dc997bd8f282",
-                "timestamp": "2025-01-18T04:39:46.507Z",
+                "transaction_id": "e35a5fd4-3758-429e-84d0-4d831a501733",
+                "message_id": "424472ba-775e-447f-8961-eaaa3327e8c9",
+                "timestamp": "2025-01-23T12:24:37.225Z",
                 "bpp_id": "ondc.pirimidtech.com/v2/seller",
                 "ttl": "PT30S"
             },
@@ -461,6 +442,13 @@
                         },
                         {
                             "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
+                            "quantity": {
+                                "count": 3
+                            },
+                            "location_id": "39550822-c3bb-4918-bd25-2d19ef6a9aca"
+                        },
+                        {
+                            "id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
                             "quantity": {
                                 "count": 3
                             },
@@ -501,9 +489,9 @@
                 "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
                 "bpp_id": "ondc.pirimidtech.com/v2/seller",
                 "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-                "transaction_id": "82b9cba3-1fb4-4b53-825e-904368636e74",
-                "message_id": "3b8fc2b8-8b27-49d2-9952-dc997bd8f282",
-                "timestamp": "2025-01-18T04:39:47.958Z"
+                "transaction_id": "e35a5fd4-3758-429e-84d0-4d831a501733",
+                "message_id": "424472ba-775e-447f-8961-eaaa3327e8c9",
+                "timestamp": "2025-01-23T12:24:39.043Z"
             },
             "message": {
                 "order": {
@@ -518,16 +506,20 @@
                     "items": [
                         {
                             "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
-                            "fulfillment_id": "59021f2c-bed5-4797-82e1-b06febf27eda"
+                            "fulfillment_id": "6dc21188-26a8-456c-9d28-1561bd0779c9"
                         },
                         {
                             "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
-                            "fulfillment_id": "59021f2c-bed5-4797-82e1-b06febf27eda"
+                            "fulfillment_id": "6dc21188-26a8-456c-9d28-1561bd0779c9"
+                        },
+                        {
+                            "id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+                            "fulfillment_id": "6dc21188-26a8-456c-9d28-1561bd0779c9"
                         }
                     ],
                     "fulfillments": [
                         {
-                            "id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+                            "id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
                             "type": "Delivery",
                             "@ondc/org/category": "Standard Delivery",
                             "@ondc/org/TAT": "PT99H",
@@ -543,7 +535,7 @@
                     "quote": {
                         "price": {
                             "currency": "INR",
-                            "value": "1401.72"
+                            "value": "1883.79"
                         },
                         "breakup": [
                             {
@@ -573,7 +565,7 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+                                "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
                                 "@ondc/org/title_type": "packing",
                                 "title": "Packing Charges",
                                 "price": {
@@ -582,7 +574,7 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+                                "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
                                 "@ondc/org/title_type": "delivery",
                                 "title": "Delivery Charges",
                                 "price": {
@@ -626,7 +618,7 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+                                "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
                                 "@ondc/org/title_type": "packing",
                                 "title": "Packing Charges",
                                 "price": {
@@ -635,7 +627,7 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+                                "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
                                 "@ondc/org/title_type": "delivery",
                                 "title": "Delivery Charges",
                                 "price": {
@@ -644,12 +636,56 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+                                "@ondc/org/item_id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+                                "@ondc/org/item_quantity": {
+                                    "count": 3
+                                },
+                                "@ondc/org/title_type": "item",
+                                "item": {
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "120.0"
+                                    },
+                                    "quantity": {
+                                        "available": {
+                                            "count": "99"
+                                        },
+                                        "maximum": {
+                                            "count": "99"
+                                        }
+                                    }
+                                },
+                                "title": "Walnuts",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "360.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
+                                "@ondc/org/title_type": "packing",
+                                "title": "Packing Charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "5.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
+                                "@ondc/org/title_type": "delivery",
+                                "title": "Delivery Charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "100.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
                                 "@ondc/org/title_type": "misc",
                                 "title": "Convenience Fee",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "49.62"
+                                    "value": "66.69"
                                 }
                             }
                         ],
@@ -668,9 +704,9 @@
                 "bap_id": "buyer-app-preprod-v2.ondc.org",
                 "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
                 "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-                "transaction_id": "82b9cba3-1fb4-4b53-825e-904368636e74",
-                "message_id": "e5ebd64d-5a78-444f-a7db-d74cb2eebcef",
-                "timestamp": "2025-01-18T04:39:55.715Z",
+                "transaction_id": "e35a5fd4-3758-429e-84d0-4d831a501733",
+                "message_id": "f687722c-a82c-4f49-adbd-6ec190026c2e",
+                "timestamp": "2025-01-23T12:24:49.484Z",
                 "bpp_id": "ondc.pirimidtech.com/v2/seller",
                 "ttl": "PT30S"
             },
@@ -691,7 +727,7 @@
                                 "count": 3
                             },
                             "location_id": "39550822-c3bb-4918-bd25-2d19ef6a9aca",
-                            "fulfillment_id": "59021f2c-bed5-4797-82e1-b06febf27eda"
+                            "fulfillment_id": "6dc21188-26a8-456c-9d28-1561bd0779c9"
                         },
                         {
                             "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
@@ -699,7 +735,15 @@
                                 "count": 3
                             },
                             "location_id": "39550822-c3bb-4918-bd25-2d19ef6a9aca",
-                            "fulfillment_id": "59021f2c-bed5-4797-82e1-b06febf27eda"
+                            "fulfillment_id": "6dc21188-26a8-456c-9d28-1561bd0779c9"
+                        },
+                        {
+                            "id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+                            "quantity": {
+                                "count": 3
+                            },
+                            "location_id": "39550822-c3bb-4918-bd25-2d19ef6a9aca",
+                            "fulfillment_id": "6dc21188-26a8-456c-9d28-1561bd0779c9"
                         }
                     ],
                     "billing": {
@@ -715,12 +759,12 @@
                         "phone": "7202959020",
                         "name": "Hemanshu Faldu",
                         "email": "fhemanshu@gmail.com",
-                        "created_at": "2025-01-18T04:39:55.715Z",
-                        "updated_at": "2025-01-18T04:39:55.715Z"
+                        "created_at": "2025-01-23T12:24:49.484Z",
+                        "updated_at": "2025-01-23T12:24:49.484Z"
                     },
                     "fulfillments": [
                         {
-                            "id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+                            "id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
                             "type": "Delivery",
                             "end": {
                                 "contact": {
@@ -756,9 +800,9 @@
                 "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
                 "bpp_id": "ondc.pirimidtech.com/v2/seller",
                 "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-                "transaction_id": "82b9cba3-1fb4-4b53-825e-904368636e74",
-                "message_id": "e5ebd64d-5a78-444f-a7db-d74cb2eebcef",
-                "timestamp": "2025-01-18T04:39:56.488Z",
+                "transaction_id": "e35a5fd4-3758-429e-84d0-4d831a501733",
+                "message_id": "f687722c-a82c-4f49-adbd-6ec190026c2e",
+                "timestamp": "2025-01-23T12:24:50.309Z",
                 "ttl": "PT30S"
             },
             "message": {
@@ -780,7 +824,7 @@
                                 },
                                 "count": 3
                             },
-                            "fulfillment_id": "59021f2c-bed5-4797-82e1-b06febf27eda"
+                            "fulfillment_id": "6dc21188-26a8-456c-9d28-1561bd0779c9"
                         },
                         {
                             "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
@@ -790,7 +834,17 @@
                                 },
                                 "count": 3
                             },
-                            "fulfillment_id": "59021f2c-bed5-4797-82e1-b06febf27eda"
+                            "fulfillment_id": "6dc21188-26a8-456c-9d28-1561bd0779c9"
+                        },
+                        {
+                            "id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+                            "quantity": {
+                                "unitized": {
+                                    "count": "3"
+                                },
+                                "count": 3
+                            },
+                            "fulfillment_id": "6dc21188-26a8-456c-9d28-1561bd0779c9"
                         }
                     ],
                     "billing": {
@@ -806,19 +860,13 @@
                         },
                         "email": "fhemanshu@gmail.com",
                         "phone": "7202959020",
-                        "created_at": "2025-01-18T04:39:55.715Z",
-                        "updated_at": "2025-01-18T04:39:55.715Z"
+                        "created_at": "2025-01-23T12:24:49.484Z",
+                        "updated_at": "2025-01-23T12:24:49.484Z"
                     },
                     "fulfillments": [
                         {
-                            "id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+                            "id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
                             "type": "Delivery",
-                            "provider_id": "ondc.loadshare.com/ondc/18275",
-                            "state": {
-                                "descriptor": {
-                                    "code": "INITIALIZING"
-                                }
-                            },
                             "tracking": false,
                             "end": {
                                 "location": {
@@ -832,9 +880,6 @@
                                         "country": "IND",
                                         "area_code": "380015"
                                     }
-                                },
-                                "time": {
-                                    "range": {}
                                 },
                                 "instructions": {
                                     "name": "Status for pickup",
@@ -855,7 +900,7 @@
                     "quote": {
                         "price": {
                             "currency": "INR",
-                            "value": "1401.72"
+                            "value": "1883.79"
                         },
                         "breakup": [
                             {
@@ -877,7 +922,7 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+                                "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
                                 "@ondc/org/title_type": "packing",
                                 "title": "Packing Charges",
                                 "price": {
@@ -886,7 +931,7 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+                                "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
                                 "@ondc/org/title_type": "delivery",
                                 "title": "Delivery Charges",
                                 "price": {
@@ -922,7 +967,7 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+                                "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
                                 "@ondc/org/title_type": "packing",
                                 "title": "Packing Charges",
                                 "price": {
@@ -931,7 +976,7 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+                                "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
                                 "@ondc/org/title_type": "delivery",
                                 "title": "Delivery Charges",
                                 "price": {
@@ -940,22 +985,58 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+                                "@ondc/org/item_id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+                                "@ondc/org/item_quantity": {
+                                    "count": 3
+                                },
+                                "@ondc/org/title_type": "item",
+                                "item": {
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "120.0"
+                                    }
+                                },
+                                "title": "Walnuts",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "360.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
+                                "@ondc/org/title_type": "packing",
+                                "title": "Packing Charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "5.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
+                                "@ondc/org/title_type": "delivery",
+                                "title": "Delivery Charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "100.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
                                 "@ondc/org/title_type": "misc",
                                 "title": "Convenience Fee",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "49.62"
+                                    "value": "66.69"
                                 }
                             }
                         ],
                         "ttl": "P1D"
                     },
                     "payment": {
-                        "uri": "https://ondc-pirimid-payment.netlify.app/payment/82b9cba3-1fb4-4b53-825e-904368636e74",
+                        "uri": "https://ondc-pirimid-payment.netlify.app/payment/e35a5fd4-3758-429e-84d0-4d831a501733",
                         "type": "ON-ORDER",
                         "status": "NOT-PAID",
-                        "collected_by": "BPP",
+                        "collected_by": "BAP",
                         "@ondc/org/buyer_app_finder_fee_type": "percent",
                         "@ondc/org/buyer_app_finder_fee_amount": "3.0",
                         "@ondc/org/withholding_amount": "0.0",
@@ -975,8 +1056,8 @@
                             }
                         ]
                     },
-                    "created_at": "2025-01-18T04:39:47.970Z",
-                    "updated_at": "2025-01-18T04:39:56.492Z",
+                    "created_at": "2025-01-23T12:24:39.050Z",
+                    "updated_at": "2025-01-23T12:24:50.315Z",
                     "tags": [
                         {
                             "code": "bpp_terms",
@@ -1005,15 +1086,15 @@
                 "bap_id": "buyer-app-preprod-v2.ondc.org",
                 "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
                 "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-                "transaction_id": "82b9cba3-1fb4-4b53-825e-904368636e74",
-                "message_id": "f84c010d-615c-446d-8b6e-e66f58470b78",
-                "timestamp": "2025-01-18T04:40:23.079Z",
+                "transaction_id": "e35a5fd4-3758-429e-84d0-4d831a501733",
+                "message_id": "910f4f8b-dd2f-4ab6-b202-1a154f31873c",
+                "timestamp": "2025-01-23T12:25:10.086Z",
                 "bpp_id": "ondc.pirimidtech.com/v2/seller",
                 "ttl": "PT30S"
             },
             "message": {
                 "order": {
-                    "id": "2025-01-18-743091",
+                    "id": "2025-01-23-103725",
                     "state": "Created",
                     "billing": {
                         "address": {
@@ -1028,8 +1109,8 @@
                         "phone": "7202959020",
                         "name": "Hemanshu Faldu",
                         "email": "fhemanshu@gmail.com",
-                        "created_at": "2025-01-18T04:39:55.715Z",
-                        "updated_at": "2025-01-18T04:39:55.715Z"
+                        "created_at": "2025-01-23T12:24:49.484Z",
+                        "updated_at": "2025-01-23T12:24:49.484Z"
                     },
                     "items": [
                         {
@@ -1037,14 +1118,21 @@
                             "quantity": {
                                 "count": 3
                             },
-                            "fulfillment_id": "59021f2c-bed5-4797-82e1-b06febf27eda"
+                            "fulfillment_id": "6dc21188-26a8-456c-9d28-1561bd0779c9"
                         },
                         {
                             "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
                             "quantity": {
                                 "count": 3
                             },
-                            "fulfillment_id": "59021f2c-bed5-4797-82e1-b06febf27eda"
+                            "fulfillment_id": "6dc21188-26a8-456c-9d28-1561bd0779c9"
+                        },
+                        {
+                            "id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+                            "quantity": {
+                                "count": 3
+                            },
+                            "fulfillment_id": "6dc21188-26a8-456c-9d28-1561bd0779c9"
                         }
                     ],
                     "provider": {
@@ -1058,7 +1146,7 @@
                     "fulfillments": [
                         {
                             "@ondc/org/TAT": "PT99H",
-                            "id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+                            "id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
                             "tracking": false,
                             "end": {
                                 "contact": {
@@ -1088,9 +1176,9 @@
                         "uri": "https://razorpay.com/",
                         "tl_method": "http/get",
                         "params": {
-                            "amount": "1401.72",
+                            "amount": "1883.79",
                             "currency": "INR",
-                            "transaction_id": "order_PkmGkn5hmLCG83"
+                            "transaction_id": "order_PmsrRxRfEkwUOs"
                         },
                         "status": "PAID",
                         "type": "ON-ORDER",
@@ -1117,7 +1205,7 @@
                     "quote": {
                         "price": {
                             "currency": "INR",
-                            "value": "1401.72"
+                            "value": "1883.79"
                         },
                         "breakup": [
                             {
@@ -1139,7 +1227,7 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+                                "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
                                 "@ondc/org/title_type": "packing",
                                 "title": "Packing Charges",
                                 "price": {
@@ -1148,7 +1236,7 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+                                "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
                                 "@ondc/org/title_type": "delivery",
                                 "title": "Delivery Charges",
                                 "price": {
@@ -1184,7 +1272,7 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+                                "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
                                 "@ondc/org/title_type": "packing",
                                 "title": "Packing Charges",
                                 "price": {
@@ -1193,7 +1281,7 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+                                "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
                                 "@ondc/org/title_type": "delivery",
                                 "title": "Delivery Charges",
                                 "price": {
@@ -1202,12 +1290,48 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+                                "@ondc/org/item_id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+                                "@ondc/org/item_quantity": {
+                                    "count": 3
+                                },
+                                "@ondc/org/title_type": "item",
+                                "item": {
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "120.0"
+                                    }
+                                },
+                                "title": "Walnuts",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "360.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
+                                "@ondc/org/title_type": "packing",
+                                "title": "Packing Charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "5.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
+                                "@ondc/org/title_type": "delivery",
+                                "title": "Delivery Charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "100.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
                                 "@ondc/org/title_type": "misc",
                                 "title": "Convenience Fee",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "49.62"
+                                    "value": "66.69"
                                 }
                             }
                         ],
@@ -1237,8 +1361,8 @@
                             ]
                         }
                     ],
-                    "created_at": "2025-01-18T04:40:23.079Z",
-                    "updated_at": "2025-01-18T04:40:23.079Z"
+                    "created_at": "2025-01-23T12:25:10.086Z",
+                    "updated_at": "2025-01-23T12:25:10.086Z"
                 }
             }
         },
@@ -1253,13 +1377,13 @@
                 "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
                 "bpp_id": "ondc.pirimidtech.com/v2/seller",
                 "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-                "transaction_id": "82b9cba3-1fb4-4b53-825e-904368636e74",
-                "message_id": "f84c010d-615c-446d-8b6e-e66f58470b78",
-                "timestamp": "2025-01-18T04:40:23.892Z"
+                "transaction_id": "e35a5fd4-3758-429e-84d0-4d831a501733",
+                "message_id": "910f4f8b-dd2f-4ab6-b202-1a154f31873c",
+                "timestamp": "2025-01-23T12:25:11.058Z"
             },
             "message": {
                 "order": {
-                    "id": "2025-01-18-743091",
+                    "id": "2025-01-23-103725",
                     "state": "Created",
                     "provider": {
                         "id": "e2008459-7e90-493e-b02e-cae52ca53214",
@@ -1275,14 +1399,21 @@
                             "quantity": {
                                 "count": 3
                             },
-                            "fulfillment_id": "59021f2c-bed5-4797-82e1-b06febf27eda"
+                            "fulfillment_id": "6dc21188-26a8-456c-9d28-1561bd0779c9"
                         },
                         {
                             "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
                             "quantity": {
                                 "count": 3
                             },
-                            "fulfillment_id": "59021f2c-bed5-4797-82e1-b06febf27eda"
+                            "fulfillment_id": "6dc21188-26a8-456c-9d28-1561bd0779c9"
+                        },
+                        {
+                            "id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+                            "quantity": {
+                                "count": 3
+                            },
+                            "fulfillment_id": "6dc21188-26a8-456c-9d28-1561bd0779c9"
                         }
                     ],
                     "billing": {
@@ -1298,12 +1429,12 @@
                         },
                         "email": "fhemanshu@gmail.com",
                         "phone": "7202959020",
-                        "created_at": "2025-01-18T04:39:55.715Z",
-                        "updated_at": "2025-01-18T04:39:55.715Z"
+                        "created_at": "2025-01-23T12:24:49.484Z",
+                        "updated_at": "2025-01-23T12:24:49.484Z"
                     },
                     "fulfillments": [
                         {
-                            "id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+                            "id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
                             "type": "Delivery",
                             "@ondc/org/TAT": "PT99H",
                             "@ondc/org/provider_name": "LoadShare",
@@ -1324,7 +1455,7 @@
                                         "locality": "Ashok Vatika",
                                         "city": "Ahmedabad",
                                         "state": "Gujarat",
-                                        "area_code": "380058"
+                                        "area_code": "380054"
                                     }
                                 },
                                 "contact": {
@@ -1358,7 +1489,7 @@
                     "quote": {
                         "price": {
                             "currency": "INR",
-                            "value": "1401.72"
+                            "value": "1883.79"
                         },
                         "breakup": [
                             {
@@ -1380,7 +1511,7 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+                                "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
                                 "@ondc/org/title_type": "packing",
                                 "title": "Packing Charges",
                                 "price": {
@@ -1389,7 +1520,7 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+                                "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
                                 "@ondc/org/title_type": "delivery",
                                 "title": "Delivery Charges",
                                 "price": {
@@ -1425,7 +1556,7 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+                                "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
                                 "@ondc/org/title_type": "packing",
                                 "title": "Packing Charges",
                                 "price": {
@@ -1434,7 +1565,7 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+                                "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
                                 "@ondc/org/title_type": "delivery",
                                 "title": "Delivery Charges",
                                 "price": {
@@ -1443,12 +1574,48 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+                                "@ondc/org/item_id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+                                "@ondc/org/item_quantity": {
+                                    "count": 3
+                                },
+                                "@ondc/org/title_type": "item",
+                                "item": {
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "120.0"
+                                    }
+                                },
+                                "title": "Walnuts",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "360.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
+                                "@ondc/org/title_type": "packing",
+                                "title": "Packing Charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "5.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
+                                "@ondc/org/title_type": "delivery",
+                                "title": "Delivery Charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "100.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
                                 "@ondc/org/title_type": "misc",
                                 "title": "Convenience Fee",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "49.62"
+                                    "value": "66.69"
                                 }
                             }
                         ],
@@ -1458,8 +1625,8 @@
                         "uri": "https://razorpay.com/",
                         "tl_method": "http/get",
                         "params": {
-                            "transaction_id": "order_PkmGkn5hmLCG83",
-                            "amount": "1401.72",
+                            "transaction_id": "order_PmsrRxRfEkwUOs",
+                            "amount": "1883.79",
                             "currency": "INR"
                         },
                         "type": "ON-ORDER",
@@ -1484,8 +1651,8 @@
                             }
                         ]
                     },
-                    "created_at": "2025-01-18T04:40:23.079Z",
-                    "updated_at": "2025-01-18T04:40:23.892Z",
+                    "created_at": "2025-01-23T12:25:10.086Z",
+                    "updated_at": "2025-01-23T12:25:11.058Z",
                     "tags": [
                         {
                             "code": "bpp_terms",
@@ -1528,14 +1695,14 @@
                 "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
                 "bpp_id": "ondc.pirimidtech.com/v2/seller",
                 "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-                "transaction_id": "82b9cba3-1fb4-4b53-825e-904368636e74",
-                "message_id": "cb273720-15b8-47d1-8781-a2d842ea26f5",
-                "timestamp": "2025-01-18T04:40:57.704Z",
+                "transaction_id": "e35a5fd4-3758-429e-84d0-4d831a501733",
+                "message_id": "6513d9e8-e1fc-4dbf-8e10-dbb4796dbbc8",
+                "timestamp": "2025-01-23T12:25:37.698Z",
                 "ttl": "PT30S"
             },
             "message": {
                 "order": {
-                    "id": "2025-01-18-743091",
+                    "id": "2025-01-23-103725",
                     "state": "Created",
                     "provider": {
                         "id": "e2008459-7e90-493e-b02e-cae52ca53214",
@@ -1551,26 +1718,33 @@
                             "quantity": {
                                 "count": 3
                             },
-                            "fulfillment_id": "59021f2c-bed5-4797-82e1-b06febf27eda"
+                            "fulfillment_id": "6dc21188-26a8-456c-9d28-1561bd0779c9"
+                        },
+                        {
+                            "id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+                            "quantity": {
+                                "count": 3
+                            },
+                            "fulfillment_id": "6dc21188-26a8-456c-9d28-1561bd0779c9"
                         },
                         {
                             "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
                             "quantity": {
                                 "count": 2
                             },
-                            "fulfillment_id": "59021f2c-bed5-4797-82e1-b06febf27eda"
+                            "fulfillment_id": "6dc21188-26a8-456c-9d28-1561bd0779c9"
                         },
                         {
                             "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
                             "quantity": {
                                 "count": 1
                             },
-                            "fulfillment_id": "d856122c-15d5-4211-8484-4a8cb4541948"
+                            "fulfillment_id": "ec3a2ef5-9f47-4934-b4d5-a8d4dca6f9c8"
                         }
                     ],
                     "documents": [
                         {
-                            "url": "https://ondc.pirimidtech.com/v2/seller/api/order/invoice/d16658c3-f55b-4ffb-8d07-b43b16ac2ef0",
+                            "url": "https://ondc.pirimidtech.com/v2/seller/api/order/invoice/a840e0cc-8f95-4439-958f-bf5e6c2d271c",
                             "label": "Invoice"
                         }
                     ],
@@ -1587,12 +1761,12 @@
                         },
                         "email": "fhemanshu@gmail.com",
                         "phone": "7202959020",
-                        "created_at": "2025-01-18T04:39:55.715Z",
-                        "updated_at": "2025-01-18T04:39:55.715Z"
+                        "created_at": "2025-01-23T12:24:49.484Z",
+                        "updated_at": "2025-01-23T12:24:49.484Z"
                     },
                     "fulfillments": [
                         {
-                            "id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+                            "id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
                             "type": "Delivery",
                             "@ondc/org/TAT": "PT99H",
                             "@ondc/org/provider_name": "LoadShare",
@@ -1613,7 +1787,7 @@
                                         "locality": "Ashok Vatika",
                                         "city": "Ahmedabad",
                                         "state": "Gujarat",
-                                        "area_code": "380058"
+                                        "area_code": "380054"
                                     }
                                 },
                                 "contact": {
@@ -1644,7 +1818,7 @@
                             }
                         },
                         {
-                            "id": "d856122c-15d5-4211-8484-4a8cb4541948",
+                            "id": "ec3a2ef5-9f47-4934-b4d5-a8d4dca6f9c8",
                             "type": "Cancel",
                             "state": {
                                 "descriptor": {
@@ -1730,7 +1904,7 @@
                     "quote": {
                         "price": {
                             "currency": "INR",
-                            "value": "1131.45"
+                            "value": "1613.52"
                         },
                         "breakup": [
                             {
@@ -1752,7 +1926,7 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+                                "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
                                 "@ondc/org/title_type": "packing",
                                 "title": "Packing Charges",
                                 "price": {
@@ -1761,7 +1935,43 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+                                "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
+                                "@ondc/org/title_type": "delivery",
+                                "title": "Delivery Charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "100.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+                                "@ondc/org/item_quantity": {
+                                    "count": 3
+                                },
+                                "@ondc/org/title_type": "item",
+                                "item": {
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "120.0"
+                                    }
+                                },
+                                "title": "Walnuts",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "360.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
+                                "@ondc/org/title_type": "packing",
+                                "title": "Packing Charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "5.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
                                 "@ondc/org/title_type": "delivery",
                                 "title": "Delivery Charges",
                                 "price": {
@@ -1788,7 +1998,7 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+                                "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
                                 "@ondc/org/title_type": "packing",
                                 "title": "Packing Charges",
                                 "price": {
@@ -1797,7 +2007,7 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+                                "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
                                 "@ondc/org/title_type": "delivery",
                                 "title": "Delivery Charges",
                                 "price": {
@@ -1815,12 +2025,12 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "d856122c-15d5-4211-8484-4a8cb4541948",
+                                "@ondc/org/item_id": "ec3a2ef5-9f47-4934-b4d5-a8d4dca6f9c8",
                                 "@ondc/org/title_type": "misc",
                                 "title": "Convenience Fee",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "40.05"
+                                    "value": "57.12"
                                 }
                             }
                         ],
@@ -1830,8 +2040,8 @@
                         "uri": "https://razorpay.com/",
                         "tl_method": "http/get",
                         "params": {
-                            "transaction_id": "order_PkmGkn5hmLCG83",
-                            "amount": "1401.72",
+                            "transaction_id": "order_PmsrRxRfEkwUOs",
+                            "amount": "1883.79",
                             "currency": "INR"
                         },
                         "type": "ON-ORDER",
@@ -1856,8 +2066,8 @@
                             }
                         ]
                     },
-                    "created_at": "2025-01-18T04:39:47.970Z",
-                    "updated_at": "2025-01-18T04:40:57.704Z"
+                    "created_at": "2025-01-23T12:24:39.050Z",
+                    "updated_at": "2025-01-23T12:25:37.698Z"
                 }
             }
         },
@@ -1870,19 +2080,19 @@
                 "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
                 "bpp_id": "ondc.pirimidtech.com/v2/seller",
                 "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-                "transaction_id": "82b9cba3-1fb4-4b53-825e-904368636e74",
-                "message_id": "36dc0f08-e65a-47df-808f-4ef9edf01e9d",
+                "transaction_id": "e35a5fd4-3758-429e-84d0-4d831a501733",
+                "message_id": "a845e674-dd44-4eeb-b5a7-c28e64969fed",
                 "city": "std:079",
                 "country": "IND",
-                "timestamp": "2025-01-18T04:40:58.885Z"
+                "timestamp": "2025-01-23T12:25:39.036Z"
             },
             "message": {
                 "update_target": "payment",
                 "order": {
-                    "id": "2025-01-18-743091",
+                    "id": "2025-01-23-103725",
                     "fulfillments": [
                         {
-                            "id": "d856122c-15d5-4211-8484-4a8cb4541948",
+                            "id": "ec3a2ef5-9f47-4934-b4d5-a8d4dca6f9c8",
                             "type": "Cancel"
                         }
                     ],
@@ -1893,7 +2103,7 @@
                                 "settlement_phase": "refund",
                                 "settlement_type": "wallet",
                                 "settlement_amount": "270.27",
-                                "settlement_timestamp": "2025-01-18T04:40:58.885Z"
+                                "settlement_timestamp": "2025-01-23T12:25:39.036Z"
                             }
                         ]
                     }
@@ -1911,14 +2121,14 @@
                 "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
                 "bpp_id": "ondc.pirimidtech.com/v2/seller",
                 "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-                "transaction_id": "82b9cba3-1fb4-4b53-825e-904368636e74",
-                "message_id": "49e9dc17-cbee-4c26-9584-c1032eef9f28",
-                "timestamp": "2025-01-18T04:41:21.410Z",
+                "transaction_id": "e35a5fd4-3758-429e-84d0-4d831a501733",
+                "message_id": "8deb6341-9101-4288-bc86-5aba18284a32",
+                "timestamp": "2025-01-23T12:26:33.440Z",
                 "ttl": "PT30S"
             },
             "message": {
                 "order": {
-                    "id": "2025-01-18-743091",
+                    "id": "2025-01-23-103725",
                     "state": "Accepted",
                     "provider": {
                         "id": "e2008459-7e90-493e-b02e-cae52ca53214",
@@ -1934,21 +2144,28 @@
                             "quantity": {
                                 "count": 3
                             },
-                            "fulfillment_id": "59021f2c-bed5-4797-82e1-b06febf27eda"
+                            "fulfillment_id": "6dc21188-26a8-456c-9d28-1561bd0779c9"
+                        },
+                        {
+                            "id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+                            "quantity": {
+                                "count": 3
+                            },
+                            "fulfillment_id": "6dc21188-26a8-456c-9d28-1561bd0779c9"
                         },
                         {
                             "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
                             "quantity": {
                                 "count": 2
                             },
-                            "fulfillment_id": "59021f2c-bed5-4797-82e1-b06febf27eda"
+                            "fulfillment_id": "6dc21188-26a8-456c-9d28-1561bd0779c9"
                         },
                         {
                             "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
                             "quantity": {
                                 "count": 1
                             },
-                            "fulfillment_id": "d856122c-15d5-4211-8484-4a8cb4541948"
+                            "fulfillment_id": "ec3a2ef5-9f47-4934-b4d5-a8d4dca6f9c8"
                         }
                     ],
                     "billing": {
@@ -1964,12 +2181,12 @@
                         },
                         "email": "fhemanshu@gmail.com",
                         "phone": "7202959020",
-                        "created_at": "2025-01-18T04:39:55.715Z",
-                        "updated_at": "2025-01-18T04:39:55.715Z"
+                        "created_at": "2025-01-23T12:24:49.484Z",
+                        "updated_at": "2025-01-23T12:24:49.484Z"
                     },
                     "fulfillments": [
                         {
-                            "id": "d856122c-15d5-4211-8484-4a8cb4541948",
+                            "id": "ec3a2ef5-9f47-4934-b4d5-a8d4dca6f9c8",
                             "type": "Cancel",
                             "state": {
                                 "descriptor": {
@@ -2052,7 +2269,7 @@
                             ]
                         },
                         {
-                            "id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+                            "id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
                             "type": "Delivery",
                             "@ondc/org/TAT": "PT99H",
                             "provider_id": "ondc.loadshare.com/ondc/18275",
@@ -2074,13 +2291,13 @@
                                         "locality": "Ashok Vatika",
                                         "city": "Ahmedabad",
                                         "state": "Gujarat",
-                                        "area_code": "380058"
+                                        "area_code": "380054"
                                     }
                                 },
                                 "time": {
                                     "range": {
-                                        "start": "2025-01-18T04:41:21.404Z",
-                                        "end": "2025-01-18T07:41:21.404Z"
+                                        "start": "2025-01-23T12:26:33.368Z",
+                                        "end": "2025-01-23T15:26:33.368Z"
                                     }
                                 },
                                 "instructions": {
@@ -2109,8 +2326,8 @@
                                 },
                                 "time": {
                                     "range": {
-                                        "start": "2025-01-18T07:41:21.404Z",
-                                        "end": "2025-01-22T07:41:21.404Z"
+                                        "start": "2025-01-23T15:26:33.368Z",
+                                        "end": "2025-01-27T15:26:33.368Z"
                                     }
                                 },
                                 "contact": {
@@ -2126,7 +2343,7 @@
                     "quote": {
                         "price": {
                             "currency": "INR",
-                            "value": "1131.45"
+                            "value": "1613.52"
                         },
                         "breakup": [
                             {
@@ -2148,7 +2365,7 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+                                "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
                                 "@ondc/org/title_type": "packing",
                                 "title": "Packing Charges",
                                 "price": {
@@ -2157,7 +2374,43 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+                                "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
+                                "@ondc/org/title_type": "delivery",
+                                "title": "Delivery Charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "100.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+                                "@ondc/org/item_quantity": {
+                                    "count": 3
+                                },
+                                "@ondc/org/title_type": "item",
+                                "item": {
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "120.0"
+                                    }
+                                },
+                                "title": "Walnuts",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "360.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
+                                "@ondc/org/title_type": "packing",
+                                "title": "Packing Charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "5.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
                                 "@ondc/org/title_type": "delivery",
                                 "title": "Delivery Charges",
                                 "price": {
@@ -2184,7 +2437,7 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+                                "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
                                 "@ondc/org/title_type": "packing",
                                 "title": "Packing Charges",
                                 "price": {
@@ -2193,7 +2446,7 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+                                "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
                                 "@ondc/org/title_type": "delivery",
                                 "title": "Delivery Charges",
                                 "price": {
@@ -2211,12 +2464,12 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "d856122c-15d5-4211-8484-4a8cb4541948",
+                                "@ondc/org/item_id": "ec3a2ef5-9f47-4934-b4d5-a8d4dca6f9c8",
                                 "@ondc/org/title_type": "misc",
                                 "title": "Convenience Fee",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "40.05"
+                                    "value": "57.12"
                                 }
                             }
                         ],
@@ -2226,8 +2479,8 @@
                         "uri": "https://razorpay.com/",
                         "tl_method": "http/get",
                         "params": {
-                            "transaction_id": "order_PkmGkn5hmLCG83",
-                            "amount": "1401.72",
+                            "transaction_id": "order_PmsrRxRfEkwUOs",
+                            "amount": "1883.79",
                             "currency": "INR"
                         },
                         "type": "ON-ORDER",
@@ -2244,7 +2497,7 @@
                                 "settlement_phase": "refund",
                                 "settlement_amount": "270.27",
                                 "settlement_type": "wallet",
-                                "settlement_timestamp": "2025-01-18T04:40:58.885Z"
+                                "settlement_timestamp": "2025-01-23T12:25:39.036Z"
                             },
                             {
                                 "settlement_counterparty": "seller-app",
@@ -2259,8 +2512,8 @@
                             }
                         ]
                     },
-                    "created_at": "2025-01-18T04:40:23.079Z",
-                    "updated_at": "2025-01-18T04:41:21.410Z"
+                    "created_at": "2025-01-23T12:25:10.086Z",
+                    "updated_at": "2025-01-23T12:26:33.440Z"
                 }
             }
         },
@@ -2275,14 +2528,14 @@
                 "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
                 "bpp_id": "ondc.pirimidtech.com/v2/seller",
                 "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-                "transaction_id": "82b9cba3-1fb4-4b53-825e-904368636e74",
-                "message_id": "fd501eee-532b-49a9-a7dd-4fdf9c993dc0",
-                "timestamp": "2025-01-18T04:41:27.341Z",
+                "transaction_id": "e35a5fd4-3758-429e-84d0-4d831a501733",
+                "message_id": "72de7b9b-9eb6-4cc1-adfd-cf211237547e",
+                "timestamp": "2025-01-23T12:26:38.545Z",
                 "ttl": "PT30S"
             },
             "message": {
                 "order": {
-                    "id": "2025-01-18-743091",
+                    "id": "2025-01-23-103725",
                     "state": "In-progress",
                     "provider": {
                         "id": "e2008459-7e90-493e-b02e-cae52ca53214",
@@ -2298,21 +2551,28 @@
                             "quantity": {
                                 "count": 3
                             },
-                            "fulfillment_id": "59021f2c-bed5-4797-82e1-b06febf27eda"
+                            "fulfillment_id": "6dc21188-26a8-456c-9d28-1561bd0779c9"
+                        },
+                        {
+                            "id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+                            "quantity": {
+                                "count": 3
+                            },
+                            "fulfillment_id": "6dc21188-26a8-456c-9d28-1561bd0779c9"
                         },
                         {
                             "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
                             "quantity": {
                                 "count": 2
                             },
-                            "fulfillment_id": "59021f2c-bed5-4797-82e1-b06febf27eda"
+                            "fulfillment_id": "6dc21188-26a8-456c-9d28-1561bd0779c9"
                         },
                         {
                             "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
                             "quantity": {
                                 "count": 1
                             },
-                            "fulfillment_id": "d856122c-15d5-4211-8484-4a8cb4541948"
+                            "fulfillment_id": "ec3a2ef5-9f47-4934-b4d5-a8d4dca6f9c8"
                         }
                     ],
                     "billing": {
@@ -2328,12 +2588,12 @@
                         },
                         "email": "fhemanshu@gmail.com",
                         "phone": "7202959020",
-                        "created_at": "2025-01-18T04:39:55.715Z",
-                        "updated_at": "2025-01-18T04:39:55.715Z"
+                        "created_at": "2025-01-23T12:24:49.484Z",
+                        "updated_at": "2025-01-23T12:24:49.484Z"
                     },
                     "fulfillments": [
                         {
-                            "id": "d856122c-15d5-4211-8484-4a8cb4541948",
+                            "id": "ec3a2ef5-9f47-4934-b4d5-a8d4dca6f9c8",
                             "type": "Cancel",
                             "state": {
                                 "descriptor": {
@@ -2416,7 +2676,7 @@
                             ]
                         },
                         {
-                            "id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+                            "id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
                             "type": "Delivery",
                             "@ondc/org/TAT": "PT99H",
                             "provider_id": "ondc.loadshare.com/ondc/18275",
@@ -2447,13 +2707,13 @@
                                         "locality": "Ashok Vatika",
                                         "city": "Ahmedabad",
                                         "state": "Gujarat",
-                                        "area_code": "380058"
+                                        "area_code": "380054"
                                     }
                                 },
                                 "time": {
                                     "range": {
-                                        "start": "2025-01-18T04:41:21.404Z",
-                                        "end": "2025-01-18T07:41:21.404Z"
+                                        "start": "2025-01-23T12:26:33.368Z",
+                                        "end": "2025-01-23T15:26:33.368Z"
                                     }
                                 },
                                 "instructions": {
@@ -2482,8 +2742,8 @@
                                 },
                                 "time": {
                                     "range": {
-                                        "start": "2025-01-18T07:41:21.404Z",
-                                        "end": "2025-01-22T07:41:21.404Z"
+                                        "start": "2025-01-23T15:26:33.368Z",
+                                        "end": "2025-01-27T15:26:33.368Z"
                                     }
                                 },
                                 "contact": {
@@ -2493,13 +2753,24 @@
                                 "person": {
                                     "name": "Hemanshu Faldu"
                                 }
-                            }
+                            },
+                            "tags": [
+                                {
+                                    "code": "routing",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "P2P"
+                                        }
+                                    ]
+                                }
+                            ]
                         }
                     ],
                     "quote": {
                         "price": {
                             "currency": "INR",
-                            "value": "1131.45"
+                            "value": "1613.52"
                         },
                         "breakup": [
                             {
@@ -2521,7 +2792,7 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+                                "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
                                 "@ondc/org/title_type": "packing",
                                 "title": "Packing Charges",
                                 "price": {
@@ -2530,7 +2801,43 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+                                "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
+                                "@ondc/org/title_type": "delivery",
+                                "title": "Delivery Charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "100.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+                                "@ondc/org/item_quantity": {
+                                    "count": 3
+                                },
+                                "@ondc/org/title_type": "item",
+                                "item": {
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "120.0"
+                                    }
+                                },
+                                "title": "Walnuts",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "360.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
+                                "@ondc/org/title_type": "packing",
+                                "title": "Packing Charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "5.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
                                 "@ondc/org/title_type": "delivery",
                                 "title": "Delivery Charges",
                                 "price": {
@@ -2557,7 +2864,7 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+                                "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
                                 "@ondc/org/title_type": "packing",
                                 "title": "Packing Charges",
                                 "price": {
@@ -2566,7 +2873,7 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+                                "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
                                 "@ondc/org/title_type": "delivery",
                                 "title": "Delivery Charges",
                                 "price": {
@@ -2584,12 +2891,12 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "d856122c-15d5-4211-8484-4a8cb4541948",
+                                "@ondc/org/item_id": "ec3a2ef5-9f47-4934-b4d5-a8d4dca6f9c8",
                                 "@ondc/org/title_type": "misc",
                                 "title": "Convenience Fee",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "40.05"
+                                    "value": "57.12"
                                 }
                             }
                         ],
@@ -2599,8 +2906,8 @@
                         "uri": "https://razorpay.com/",
                         "tl_method": "http/get",
                         "params": {
-                            "transaction_id": "order_PkmGkn5hmLCG83",
-                            "amount": "1401.72",
+                            "transaction_id": "order_PmsrRxRfEkwUOs",
+                            "amount": "1883.79",
                             "currency": "INR"
                         },
                         "type": "ON-ORDER",
@@ -2617,7 +2924,7 @@
                                 "settlement_phase": "refund",
                                 "settlement_amount": "270.27",
                                 "settlement_type": "wallet",
-                                "settlement_timestamp": "2025-01-18T04:40:58.885Z"
+                                "settlement_timestamp": "2025-01-23T12:25:39.036Z"
                             },
                             {
                                 "settlement_counterparty": "seller-app",
@@ -2632,8 +2939,8 @@
                             }
                         ]
                     },
-                    "created_at": "2025-01-18T04:40:23.079Z",
-                    "updated_at": "2025-01-18T04:41:27.341Z"
+                    "created_at": "2025-01-23T12:25:10.086Z",
+                    "updated_at": "2025-01-23T12:26:38.545Z"
                 }
             }
         },
@@ -2648,14 +2955,14 @@
                 "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
                 "bpp_id": "ondc.pirimidtech.com/v2/seller",
                 "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-                "transaction_id": "82b9cba3-1fb4-4b53-825e-904368636e74",
-                "message_id": "b48a746b-f206-4de1-bcf5-b95f73cb8107",
-                "timestamp": "2025-01-18T04:41:32.497Z",
+                "transaction_id": "e35a5fd4-3758-429e-84d0-4d831a501733",
+                "message_id": "3e272b41-2e21-4be8-9069-094852c8208e",
+                "timestamp": "2025-01-23T12:26:52.548Z",
                 "ttl": "PT30S"
             },
             "message": {
                 "order": {
-                    "id": "2025-01-18-743091",
+                    "id": "2025-01-23-103725",
                     "state": "In-progress",
                     "provider": {
                         "id": "e2008459-7e90-493e-b02e-cae52ca53214",
@@ -2671,26 +2978,33 @@
                             "quantity": {
                                 "count": 3
                             },
-                            "fulfillment_id": "59021f2c-bed5-4797-82e1-b06febf27eda"
+                            "fulfillment_id": "6dc21188-26a8-456c-9d28-1561bd0779c9"
+                        },
+                        {
+                            "id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+                            "quantity": {
+                                "count": 3
+                            },
+                            "fulfillment_id": "6dc21188-26a8-456c-9d28-1561bd0779c9"
                         },
                         {
                             "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
                             "quantity": {
                                 "count": 2
                             },
-                            "fulfillment_id": "59021f2c-bed5-4797-82e1-b06febf27eda"
+                            "fulfillment_id": "6dc21188-26a8-456c-9d28-1561bd0779c9"
                         },
                         {
                             "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
                             "quantity": {
                                 "count": 1
                             },
-                            "fulfillment_id": "d856122c-15d5-4211-8484-4a8cb4541948"
+                            "fulfillment_id": "ec3a2ef5-9f47-4934-b4d5-a8d4dca6f9c8"
                         }
                     ],
                     "documents": [
                         {
-                            "url": "https://ondc.pirimidtech.com/v2/seller/api/order/invoice/d16658c3-f55b-4ffb-8d07-b43b16ac2ef0",
+                            "url": "https://ondc.pirimidtech.com/v2/seller/api/order/invoice/a840e0cc-8f95-4439-958f-bf5e6c2d271c",
                             "label": "Invoice"
                         }
                     ],
@@ -2707,12 +3021,12 @@
                         },
                         "email": "fhemanshu@gmail.com",
                         "phone": "7202959020",
-                        "created_at": "2025-01-18T04:39:55.715Z",
-                        "updated_at": "2025-01-18T04:39:55.715Z"
+                        "created_at": "2025-01-23T12:24:49.484Z",
+                        "updated_at": "2025-01-23T12:24:49.484Z"
                     },
                     "fulfillments": [
                         {
-                            "id": "d856122c-15d5-4211-8484-4a8cb4541948",
+                            "id": "ec3a2ef5-9f47-4934-b4d5-a8d4dca6f9c8",
                             "type": "Cancel",
                             "state": {
                                 "descriptor": {
@@ -2795,7 +3109,7 @@
                             ]
                         },
                         {
-                            "id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+                            "id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
                             "type": "Delivery",
                             "@ondc/org/TAT": "PT99H",
                             "provider_id": "ondc.loadshare.com/ondc/18275",
@@ -2826,14 +3140,14 @@
                                         "locality": "Ashok Vatika",
                                         "city": "Ahmedabad",
                                         "state": "Gujarat",
-                                        "area_code": "380058"
+                                        "area_code": "380054"
                                     }
                                 },
                                 "time": {
-                                    "timestamp": "2025-01-18T04:41:32.495Z",
+                                    "timestamp": "2025-01-23T12:26:52.535Z",
                                     "range": {
-                                        "start": "2025-01-18T04:41:21.404Z",
-                                        "end": "2025-01-18T07:41:21.404Z"
+                                        "start": "2025-01-23T12:26:33.368Z",
+                                        "end": "2025-01-23T15:26:33.368Z"
                                     }
                                 },
                                 "instructions": {
@@ -2862,8 +3176,8 @@
                                 },
                                 "time": {
                                     "range": {
-                                        "start": "2025-01-18T07:41:21.404Z",
-                                        "end": "2025-01-22T07:41:21.404Z"
+                                        "start": "2025-01-23T15:26:33.368Z",
+                                        "end": "2025-01-27T15:26:33.368Z"
                                     }
                                 },
                                 "contact": {
@@ -2890,7 +3204,7 @@
                     "quote": {
                         "price": {
                             "currency": "INR",
-                            "value": "1131.45"
+                            "value": "1613.52"
                         },
                         "breakup": [
                             {
@@ -2912,7 +3226,7 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+                                "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
                                 "@ondc/org/title_type": "packing",
                                 "title": "Packing Charges",
                                 "price": {
@@ -2921,7 +3235,43 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+                                "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
+                                "@ondc/org/title_type": "delivery",
+                                "title": "Delivery Charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "100.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+                                "@ondc/org/item_quantity": {
+                                    "count": 3
+                                },
+                                "@ondc/org/title_type": "item",
+                                "item": {
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "120.0"
+                                    }
+                                },
+                                "title": "Walnuts",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "360.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
+                                "@ondc/org/title_type": "packing",
+                                "title": "Packing Charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "5.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
                                 "@ondc/org/title_type": "delivery",
                                 "title": "Delivery Charges",
                                 "price": {
@@ -2948,7 +3298,7 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+                                "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
                                 "@ondc/org/title_type": "packing",
                                 "title": "Packing Charges",
                                 "price": {
@@ -2957,7 +3307,7 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+                                "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
                                 "@ondc/org/title_type": "delivery",
                                 "title": "Delivery Charges",
                                 "price": {
@@ -2975,12 +3325,12 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "d856122c-15d5-4211-8484-4a8cb4541948",
+                                "@ondc/org/item_id": "ec3a2ef5-9f47-4934-b4d5-a8d4dca6f9c8",
                                 "@ondc/org/title_type": "misc",
                                 "title": "Convenience Fee",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "40.05"
+                                    "value": "57.12"
                                 }
                             }
                         ],
@@ -2990,8 +3340,8 @@
                         "uri": "https://razorpay.com/",
                         "tl_method": "http/get",
                         "params": {
-                            "transaction_id": "order_PkmGkn5hmLCG83",
-                            "amount": "1401.72",
+                            "transaction_id": "order_PmsrRxRfEkwUOs",
+                            "amount": "1883.79",
                             "currency": "INR"
                         },
                         "type": "ON-ORDER",
@@ -3008,7 +3358,7 @@
                                 "settlement_phase": "refund",
                                 "settlement_amount": "270.27",
                                 "settlement_type": "wallet",
-                                "settlement_timestamp": "2025-01-18T04:40:58.885Z"
+                                "settlement_timestamp": "2025-01-23T12:25:39.036Z"
                             },
                             {
                                 "settlement_counterparty": "seller-app",
@@ -3023,8 +3373,8 @@
                             }
                         ]
                     },
-                    "created_at": "2025-01-18T04:40:23.079Z",
-                    "updated_at": "2025-01-18T04:41:32.497Z"
+                    "created_at": "2025-01-23T12:25:10.086Z",
+                    "updated_at": "2025-01-23T12:26:52.548Z"
                 }
             }
         },
@@ -3039,14 +3389,14 @@
                 "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
                 "bpp_id": "ondc.pirimidtech.com/v2/seller",
                 "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-                "transaction_id": "82b9cba3-1fb4-4b53-825e-904368636e74",
-                "message_id": "a259083e-7ae3-4f0e-9442-3a8d545b0045",
-                "timestamp": "2025-01-18T16:03:18.947Z",
+                "transaction_id": "e35a5fd4-3758-429e-84d0-4d831a501733",
+                "message_id": "5e0aa811-5a04-4faa-8ae0-5a7a9fa1515a",
+                "timestamp": "2025-01-24T05:34:12.554Z",
                 "ttl": "PT30S"
             },
             "message": {
                 "order": {
-                    "id": "2025-01-18-743091",
+                    "id": "2025-01-23-103725",
                     "state": "In-progress",
                     "provider": {
                         "id": "e2008459-7e90-493e-b02e-cae52ca53214",
@@ -3062,26 +3412,33 @@
                             "quantity": {
                                 "count": 3
                             },
-                            "fulfillment_id": "59021f2c-bed5-4797-82e1-b06febf27eda"
+                            "fulfillment_id": "6dc21188-26a8-456c-9d28-1561bd0779c9"
+                        },
+                        {
+                            "id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+                            "quantity": {
+                                "count": 3
+                            },
+                            "fulfillment_id": "6dc21188-26a8-456c-9d28-1561bd0779c9"
                         },
                         {
                             "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
                             "quantity": {
                                 "count": 2
                             },
-                            "fulfillment_id": "59021f2c-bed5-4797-82e1-b06febf27eda"
+                            "fulfillment_id": "6dc21188-26a8-456c-9d28-1561bd0779c9"
                         },
                         {
                             "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
                             "quantity": {
                                 "count": 1
                             },
-                            "fulfillment_id": "d856122c-15d5-4211-8484-4a8cb4541948"
+                            "fulfillment_id": "ec3a2ef5-9f47-4934-b4d5-a8d4dca6f9c8"
                         }
                     ],
                     "documents": [
                         {
-                            "url": "https://ondc.pirimidtech.com/v2/seller/api/order/invoice/d16658c3-f55b-4ffb-8d07-b43b16ac2ef0",
+                            "url": "https://ondc.pirimidtech.com/v2/seller/api/order/invoice/a840e0cc-8f95-4439-958f-bf5e6c2d271c",
                             "label": "Invoice"
                         }
                     ],
@@ -3098,12 +3455,12 @@
                         },
                         "email": "fhemanshu@gmail.com",
                         "phone": "7202959020",
-                        "created_at": "2025-01-18T04:39:55.715Z",
-                        "updated_at": "2025-01-18T04:39:55.715Z"
+                        "created_at": "2025-01-23T12:24:49.484Z",
+                        "updated_at": "2025-01-23T12:24:49.484Z"
                     },
                     "fulfillments": [
                         {
-                            "id": "d856122c-15d5-4211-8484-4a8cb4541948",
+                            "id": "ec3a2ef5-9f47-4934-b4d5-a8d4dca6f9c8",
                             "type": "Cancel",
                             "state": {
                                 "descriptor": {
@@ -3186,7 +3543,7 @@
                             ]
                         },
                         {
-                            "id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+                            "id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
                             "type": "Delivery",
                             "@ondc/org/TAT": "PT99H",
                             "provider_id": "ondc.loadshare.com/ondc/18275",
@@ -3217,14 +3574,14 @@
                                         "locality": "Ashok Vatika",
                                         "city": "Ahmedabad",
                                         "state": "Gujarat",
-                                        "area_code": "380058"
+                                        "area_code": "380054"
                                     }
                                 },
                                 "time": {
-                                    "timestamp": "2025-01-18T04:41:32.495Z",
+                                    "timestamp": "2025-01-23T12:26:52.535Z",
                                     "range": {
-                                        "start": "2025-01-18T04:41:21.404Z",
-                                        "end": "2025-01-18T07:41:21.404Z"
+                                        "start": "2025-01-23T12:26:33.368Z",
+                                        "end": "2025-01-23T15:26:33.368Z"
                                     }
                                 },
                                 "instructions": {
@@ -3253,8 +3610,8 @@
                                 },
                                 "time": {
                                     "range": {
-                                        "start": "2025-01-18T07:41:21.404Z",
-                                        "end": "2025-01-22T07:41:21.404Z"
+                                        "start": "2025-01-23T15:26:33.368Z",
+                                        "end": "2025-01-27T15:26:33.368Z"
                                     }
                                 },
                                 "contact": {
@@ -3281,7 +3638,7 @@
                     "quote": {
                         "price": {
                             "currency": "INR",
-                            "value": "1131.45"
+                            "value": "1613.52"
                         },
                         "breakup": [
                             {
@@ -3303,7 +3660,7 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+                                "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
                                 "@ondc/org/title_type": "packing",
                                 "title": "Packing Charges",
                                 "price": {
@@ -3312,7 +3669,43 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+                                "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
+                                "@ondc/org/title_type": "delivery",
+                                "title": "Delivery Charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "100.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+                                "@ondc/org/item_quantity": {
+                                    "count": 3
+                                },
+                                "@ondc/org/title_type": "item",
+                                "item": {
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "120.0"
+                                    }
+                                },
+                                "title": "Walnuts",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "360.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
+                                "@ondc/org/title_type": "packing",
+                                "title": "Packing Charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "5.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
                                 "@ondc/org/title_type": "delivery",
                                 "title": "Delivery Charges",
                                 "price": {
@@ -3339,7 +3732,7 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+                                "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
                                 "@ondc/org/title_type": "packing",
                                 "title": "Packing Charges",
                                 "price": {
@@ -3348,7 +3741,7 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+                                "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
                                 "@ondc/org/title_type": "delivery",
                                 "title": "Delivery Charges",
                                 "price": {
@@ -3366,12 +3759,12 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "d856122c-15d5-4211-8484-4a8cb4541948",
+                                "@ondc/org/item_id": "ec3a2ef5-9f47-4934-b4d5-a8d4dca6f9c8",
                                 "@ondc/org/title_type": "misc",
                                 "title": "Convenience Fee",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "40.05"
+                                    "value": "57.12"
                                 }
                             }
                         ],
@@ -3381,8 +3774,8 @@
                         "uri": "https://razorpay.com/",
                         "tl_method": "http/get",
                         "params": {
-                            "transaction_id": "order_PkmGkn5hmLCG83",
-                            "amount": "1401.72",
+                            "transaction_id": "order_PmsrRxRfEkwUOs",
+                            "amount": "1883.79",
                             "currency": "INR"
                         },
                         "type": "ON-ORDER",
@@ -3399,7 +3792,7 @@
                                 "settlement_phase": "refund",
                                 "settlement_amount": "270.27",
                                 "settlement_type": "wallet",
-                                "settlement_timestamp": "2025-01-18T04:40:58.885Z"
+                                "settlement_timestamp": "2025-01-23T12:25:39.036Z"
                             },
                             {
                                 "settlement_counterparty": "seller-app",
@@ -3414,8 +3807,8 @@
                             }
                         ]
                     },
-                    "created_at": "2025-01-18T04:40:23.079Z",
-                    "updated_at": "2025-01-18T16:03:18.947Z"
+                    "created_at": "2025-01-23T12:25:10.086Z",
+                    "updated_at": "2025-01-24T05:34:12.554Z"
                 }
             }
         },
@@ -3430,14 +3823,14 @@
                 "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
                 "bpp_id": "ondc.pirimidtech.com/v2/seller",
                 "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-                "transaction_id": "82b9cba3-1fb4-4b53-825e-904368636e74",
-                "message_id": "f7ace1d7-c971-4251-ba41-d042cb644fe6",
-                "timestamp": "2025-01-18T16:03:23.653Z",
+                "transaction_id": "e35a5fd4-3758-429e-84d0-4d831a501733",
+                "message_id": "ecbc30d5-4c3f-4dd7-a8b5-f46266545ddc",
+                "timestamp": "2025-01-24T05:34:21.328Z",
                 "ttl": "PT30S"
             },
             "message": {
                 "order": {
-                    "id": "2025-01-18-743091",
+                    "id": "2025-01-23-103725",
                     "state": "Completed",
                     "provider": {
                         "id": "e2008459-7e90-493e-b02e-cae52ca53214",
@@ -3453,26 +3846,33 @@
                             "quantity": {
                                 "count": 3
                             },
-                            "fulfillment_id": "59021f2c-bed5-4797-82e1-b06febf27eda"
+                            "fulfillment_id": "6dc21188-26a8-456c-9d28-1561bd0779c9"
+                        },
+                        {
+                            "id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+                            "quantity": {
+                                "count": 3
+                            },
+                            "fulfillment_id": "6dc21188-26a8-456c-9d28-1561bd0779c9"
                         },
                         {
                             "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
                             "quantity": {
                                 "count": 2
                             },
-                            "fulfillment_id": "59021f2c-bed5-4797-82e1-b06febf27eda"
+                            "fulfillment_id": "6dc21188-26a8-456c-9d28-1561bd0779c9"
                         },
                         {
                             "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
                             "quantity": {
                                 "count": 1
                             },
-                            "fulfillment_id": "d856122c-15d5-4211-8484-4a8cb4541948"
+                            "fulfillment_id": "ec3a2ef5-9f47-4934-b4d5-a8d4dca6f9c8"
                         }
                     ],
                     "documents": [
                         {
-                            "url": "https://ondc.pirimidtech.com/v2/seller/api/order/invoice/d16658c3-f55b-4ffb-8d07-b43b16ac2ef0",
+                            "url": "https://ondc.pirimidtech.com/v2/seller/api/order/invoice/a840e0cc-8f95-4439-958f-bf5e6c2d271c",
                             "label": "Invoice"
                         }
                     ],
@@ -3489,12 +3889,12 @@
                         },
                         "email": "fhemanshu@gmail.com",
                         "phone": "7202959020",
-                        "created_at": "2025-01-18T04:39:55.715Z",
-                        "updated_at": "2025-01-18T04:39:55.715Z"
+                        "created_at": "2025-01-23T12:24:49.484Z",
+                        "updated_at": "2025-01-23T12:24:49.484Z"
                     },
                     "fulfillments": [
                         {
-                            "id": "d856122c-15d5-4211-8484-4a8cb4541948",
+                            "id": "ec3a2ef5-9f47-4934-b4d5-a8d4dca6f9c8",
                             "type": "Cancel",
                             "state": {
                                 "descriptor": {
@@ -3577,7 +3977,7 @@
                             ]
                         },
                         {
-                            "id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+                            "id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
                             "type": "Delivery",
                             "@ondc/org/TAT": "PT99H",
                             "provider_id": "ondc.loadshare.com/ondc/18275",
@@ -3608,14 +4008,14 @@
                                         "locality": "Ashok Vatika",
                                         "city": "Ahmedabad",
                                         "state": "Gujarat",
-                                        "area_code": "380058"
+                                        "area_code": "380054"
                                     }
                                 },
                                 "time": {
-                                    "timestamp": "2025-01-18T04:41:32.495Z",
+                                    "timestamp": "2025-01-23T12:26:52.535Z",
                                     "range": {
-                                        "start": "2025-01-18T04:41:21.404Z",
-                                        "end": "2025-01-18T07:41:21.404Z"
+                                        "start": "2025-01-23T12:26:33.368Z",
+                                        "end": "2025-01-23T15:26:33.368Z"
                                     }
                                 },
                                 "instructions": {
@@ -3643,10 +4043,10 @@
                                     }
                                 },
                                 "time": {
-                                    "timestamp": "2025-01-18T16:03:23.651Z",
+                                    "timestamp": "2025-01-24T05:34:21.324Z",
                                     "range": {
-                                        "start": "2025-01-18T07:41:21.404Z",
-                                        "end": "2025-01-22T07:41:21.404Z"
+                                        "start": "2025-01-23T15:26:33.368Z",
+                                        "end": "2025-01-27T15:26:33.368Z"
                                     }
                                 },
                                 "contact": {
@@ -3673,7 +4073,7 @@
                     "quote": {
                         "price": {
                             "currency": "INR",
-                            "value": "1131.45"
+                            "value": "1613.52"
                         },
                         "breakup": [
                             {
@@ -3695,7 +4095,7 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+                                "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
                                 "@ondc/org/title_type": "packing",
                                 "title": "Packing Charges",
                                 "price": {
@@ -3704,7 +4104,43 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+                                "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
+                                "@ondc/org/title_type": "delivery",
+                                "title": "Delivery Charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "100.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+                                "@ondc/org/item_quantity": {
+                                    "count": 3
+                                },
+                                "@ondc/org/title_type": "item",
+                                "item": {
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "120.0"
+                                    }
+                                },
+                                "title": "Walnuts",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "360.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
+                                "@ondc/org/title_type": "packing",
+                                "title": "Packing Charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "5.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
                                 "@ondc/org/title_type": "delivery",
                                 "title": "Delivery Charges",
                                 "price": {
@@ -3731,7 +4167,7 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+                                "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
                                 "@ondc/org/title_type": "packing",
                                 "title": "Packing Charges",
                                 "price": {
@@ -3740,7 +4176,7 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+                                "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
                                 "@ondc/org/title_type": "delivery",
                                 "title": "Delivery Charges",
                                 "price": {
@@ -3758,12 +4194,12 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "d856122c-15d5-4211-8484-4a8cb4541948",
+                                "@ondc/org/item_id": "ec3a2ef5-9f47-4934-b4d5-a8d4dca6f9c8",
                                 "@ondc/org/title_type": "misc",
                                 "title": "Convenience Fee",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "40.05"
+                                    "value": "57.12"
                                 }
                             }
                         ],
@@ -3773,8 +4209,8 @@
                         "uri": "https://razorpay.com/",
                         "tl_method": "http/get",
                         "params": {
-                            "transaction_id": "order_PkmGkn5hmLCG83",
-                            "amount": "1401.72",
+                            "transaction_id": "order_PmsrRxRfEkwUOs",
+                            "amount": "1883.79",
                             "currency": "INR"
                         },
                         "type": "ON-ORDER",
@@ -3791,7 +4227,7 @@
                                 "settlement_phase": "refund",
                                 "settlement_amount": "270.27",
                                 "settlement_type": "wallet",
-                                "settlement_timestamp": "2025-01-18T04:40:58.885Z"
+                                "settlement_timestamp": "2025-01-23T12:25:39.036Z"
                             },
                             {
                                 "settlement_counterparty": "seller-app",
@@ -3806,8 +4242,8 @@
                             }
                         ]
                     },
-                    "created_at": "2025-01-18T04:40:23.079Z",
-                    "updated_at": "2025-01-18T16:03:23.653Z"
+                    "created_at": "2025-01-23T12:25:10.086Z",
+                    "updated_at": "2025-01-24T05:34:21.328Z"
                 }
             }
         },
@@ -3821,16 +4257,16 @@
                 "bap_id": "buyer-app-preprod-v2.ondc.org",
                 "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
                 "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-                "transaction_id": "82b9cba3-1fb4-4b53-825e-904368636e74",
-                "message_id": "514316be-4639-430e-ba43-548d34c28aa0",
-                "timestamp": "2025-01-18T16:04:26.188Z",
+                "transaction_id": "e35a5fd4-3758-429e-84d0-4d831a501733",
+                "message_id": "9f397d17-2e0e-494a-aa8d-449c447b0d8d",
+                "timestamp": "2025-01-24T05:35:09.213Z",
                 "bpp_id": "ondc.pirimidtech.com/v2/seller",
                 "ttl": "PT30S"
             },
             "message": {
                 "update_target": "item",
                 "order": {
-                    "id": "2025-01-18-743091",
+                    "id": "2025-01-23-103725",
                     "fulfillments": [
                         {
                             "type": "Return",
@@ -3840,7 +4276,7 @@
                                     "list": [
                                         {
                                             "code": "id",
-                                            "value": "678bd10a8455f06951c9542a"
+                                            "value": "6793268da3b38b99e1ec64d6"
                                         },
                                         {
                                             "code": "item_id",
@@ -3852,11 +4288,11 @@
                                         },
                                         {
                                             "code": "item_quantity",
-                                            "value": "1"
+                                            "value": "2"
                                         },
                                         {
                                             "code": "reason_id",
-                                            "value": "001"
+                                            "value": "002"
                                         },
                                         {
                                             "code": "reason_desc",
@@ -3864,7 +4300,7 @@
                                         },
                                         {
                                             "code": "images",
-                                            "value": "https://reference-buyer-app-assets.s3-ap-south-1.amazonaws.com/public-assets/2025-01-18-743091/c8f3fe60-e84a-4d49-ae61-ecbc2232da26.png"
+                                            "value": "https://reference-buyer-app-assets.s3-ap-south-1.amazonaws.com/public-assets/2025-01-23-103725/7d383819-6630-4428-b4d8-b7aae2065ff1.png"
                                         },
                                         {
                                             "code": "ttl_approval",
@@ -3893,14 +4329,14 @@
                 "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
                 "bpp_id": "ondc.pirimidtech.com/v2/seller",
                 "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-                "transaction_id": "82b9cba3-1fb4-4b53-825e-904368636e74",
-                "message_id": "514316be-4639-430e-ba43-548d34c28aa0",
-                "timestamp": "2025-01-18T16:04:27.304Z",
+                "transaction_id": "e35a5fd4-3758-429e-84d0-4d831a501733",
+                "message_id": "9f397d17-2e0e-494a-aa8d-449c447b0d8d",
+                "timestamp": "2025-01-24T05:35:10.361Z",
                 "ttl": "PT30S"
             },
             "message": {
                 "order": {
-                    "id": "2025-01-18-743091",
+                    "id": "2025-01-23-103725",
                     "state": "Completed",
                     "provider": {
                         "id": "e2008459-7e90-493e-b02e-cae52ca53214",
@@ -3916,26 +4352,33 @@
                             "quantity": {
                                 "count": 3
                             },
-                            "fulfillment_id": "59021f2c-bed5-4797-82e1-b06febf27eda"
+                            "fulfillment_id": "6dc21188-26a8-456c-9d28-1561bd0779c9"
+                        },
+                        {
+                            "id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+                            "quantity": {
+                                "count": 3
+                            },
+                            "fulfillment_id": "6dc21188-26a8-456c-9d28-1561bd0779c9"
                         },
                         {
                             "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
                             "quantity": {
                                 "count": 2
                             },
-                            "fulfillment_id": "59021f2c-bed5-4797-82e1-b06febf27eda"
+                            "fulfillment_id": "6dc21188-26a8-456c-9d28-1561bd0779c9"
                         },
                         {
                             "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
                             "quantity": {
                                 "count": 1
                             },
-                            "fulfillment_id": "d856122c-15d5-4211-8484-4a8cb4541948"
+                            "fulfillment_id": "ec3a2ef5-9f47-4934-b4d5-a8d4dca6f9c8"
                         }
                     ],
                     "documents": [
                         {
-                            "url": "https://ondc.pirimidtech.com/v2/seller/api/order/invoice/d16658c3-f55b-4ffb-8d07-b43b16ac2ef0",
+                            "url": "https://ondc.pirimidtech.com/v2/seller/api/order/invoice/a840e0cc-8f95-4439-958f-bf5e6c2d271c",
                             "label": "Invoice"
                         }
                     ],
@@ -3952,12 +4395,12 @@
                         },
                         "email": "fhemanshu@gmail.com",
                         "phone": "7202959020",
-                        "created_at": "2025-01-18T04:39:55.715Z",
-                        "updated_at": "2025-01-18T04:39:55.715Z"
+                        "created_at": "2025-01-23T12:24:49.484Z",
+                        "updated_at": "2025-01-23T12:24:49.484Z"
                     },
                     "fulfillments": [
                         {
-                            "id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+                            "id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
                             "type": "Delivery",
                             "@ondc/org/TAT": "PT99H",
                             "provider_id": "ondc.loadshare.com/ondc/18275",
@@ -3988,14 +4431,14 @@
                                         "locality": "Ashok Vatika",
                                         "city": "Ahmedabad",
                                         "state": "Gujarat",
-                                        "area_code": "380058"
+                                        "area_code": "380054"
                                     }
                                 },
                                 "time": {
-                                    "timestamp": "2025-01-18T04:41:32.495Z",
+                                    "timestamp": "2025-01-23T12:26:52.535Z",
                                     "range": {
-                                        "start": "2025-01-18T04:41:21.404Z",
-                                        "end": "2025-01-18T07:41:21.404Z"
+                                        "start": "2025-01-23T12:26:33.368Z",
+                                        "end": "2025-01-23T15:26:33.368Z"
                                     }
                                 },
                                 "instructions": {
@@ -4023,10 +4466,10 @@
                                     }
                                 },
                                 "time": {
-                                    "timestamp": "2025-01-18T16:03:23.651Z",
+                                    "timestamp": "2025-01-24T05:34:21.324Z",
                                     "range": {
-                                        "start": "2025-01-18T07:41:21.404Z",
-                                        "end": "2025-01-22T07:41:21.404Z"
+                                        "start": "2025-01-23T15:26:33.368Z",
+                                        "end": "2025-01-27T15:26:33.368Z"
                                     }
                                 },
                                 "contact": {
@@ -4050,7 +4493,7 @@
                             ]
                         },
                         {
-                            "id": "d856122c-15d5-4211-8484-4a8cb4541948",
+                            "id": "ec3a2ef5-9f47-4934-b4d5-a8d4dca6f9c8",
                             "type": "Cancel",
                             "state": {
                                 "descriptor": {
@@ -4133,7 +4576,7 @@
                             ]
                         },
                         {
-                            "id": "678bd10a8455f06951c9542a",
+                            "id": "6793268da3b38b99e1ec64d6",
                             "type": "Return",
                             "state": {
                                 "descriptor": {
@@ -4146,7 +4589,7 @@
                                     "list": [
                                         {
                                             "code": "id",
-                                            "value": "678bd10a8455f06951c9542a"
+                                            "value": "6793268da3b38b99e1ec64d6"
                                         },
                                         {
                                             "code": "item_id",
@@ -4158,11 +4601,11 @@
                                         },
                                         {
                                             "code": "item_quantity",
-                                            "value": "1"
+                                            "value": "2"
                                         },
                                         {
                                             "code": "reason_id",
-                                            "value": "001"
+                                            "value": "002"
                                         },
                                         {
                                             "code": "reason_desc",
@@ -4170,7 +4613,7 @@
                                         },
                                         {
                                             "code": "images",
-                                            "value": "https://reference-buyer-app-assets.s3-ap-south-1.amazonaws.com/public-assets/2025-01-18-743091/c8f3fe60-e84a-4d49-ae61-ecbc2232da26.png"
+                                            "value": "https://reference-buyer-app-assets.s3-ap-south-1.amazonaws.com/public-assets/2025-01-23-103725/7d383819-6630-4428-b4d8-b7aae2065ff1.png"
                                         },
                                         {
                                             "code": "ttl_approval",
@@ -4192,7 +4635,7 @@
                     "quote": {
                         "price": {
                             "currency": "INR",
-                            "value": "1131.45"
+                            "value": "1613.52"
                         },
                         "breakup": [
                             {
@@ -4214,7 +4657,7 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+                                "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
                                 "@ondc/org/title_type": "packing",
                                 "title": "Packing Charges",
                                 "price": {
@@ -4223,7 +4666,43 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+                                "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
+                                "@ondc/org/title_type": "delivery",
+                                "title": "Delivery Charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "100.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+                                "@ondc/org/item_quantity": {
+                                    "count": 3
+                                },
+                                "@ondc/org/title_type": "item",
+                                "item": {
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "120.0"
+                                    }
+                                },
+                                "title": "Walnuts",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "360.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
+                                "@ondc/org/title_type": "packing",
+                                "title": "Packing Charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "5.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
                                 "@ondc/org/title_type": "delivery",
                                 "title": "Delivery Charges",
                                 "price": {
@@ -4250,7 +4729,7 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+                                "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
                                 "@ondc/org/title_type": "packing",
                                 "title": "Packing Charges",
                                 "price": {
@@ -4259,7 +4738,7 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+                                "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
                                 "@ondc/org/title_type": "delivery",
                                 "title": "Delivery Charges",
                                 "price": {
@@ -4277,12 +4756,12 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "d856122c-15d5-4211-8484-4a8cb4541948",
+                                "@ondc/org/item_id": "ec3a2ef5-9f47-4934-b4d5-a8d4dca6f9c8",
                                 "@ondc/org/title_type": "misc",
                                 "title": "Convenience Fee",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "40.05"
+                                    "value": "57.12"
                                 }
                             }
                         ],
@@ -4292,8 +4771,8 @@
                         "uri": "https://razorpay.com/",
                         "tl_method": "http/get",
                         "params": {
-                            "transaction_id": "order_PkmGkn5hmLCG83",
-                            "amount": "1401.72",
+                            "transaction_id": "order_PmsrRxRfEkwUOs",
+                            "amount": "1883.79",
                             "currency": "INR"
                         },
                         "type": "ON-ORDER",
@@ -4310,7 +4789,7 @@
                                 "settlement_phase": "refund",
                                 "settlement_amount": "270.27",
                                 "settlement_type": "wallet",
-                                "settlement_timestamp": "2025-01-18T04:40:58.885Z"
+                                "settlement_timestamp": "2025-01-23T12:25:39.036Z"
                             },
                             {
                                 "settlement_counterparty": "seller-app",
@@ -4325,8 +4804,8 @@
                             }
                         ]
                     },
-                    "created_at": "2025-01-18T04:39:47.970Z",
-                    "updated_at": "2025-01-18T16:04:27.304Z"
+                    "created_at": "2025-01-23T12:24:39.050Z",
+                    "updated_at": "2025-01-24T05:35:10.361Z"
                 }
             }
         },
@@ -4341,14 +4820,14 @@
                 "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
                 "bpp_id": "ondc.pirimidtech.com/v2/seller",
                 "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-                "transaction_id": "82b9cba3-1fb4-4b53-825e-904368636e74",
-                "message_id": "f19e6e02-bbce-4e76-abbb-cda88385b5ae",
-                "timestamp": "2025-01-18T16:07:05.975Z",
+                "transaction_id": "e35a5fd4-3758-429e-84d0-4d831a501733",
+                "message_id": "5c2ad3ed-847e-4460-9f01-f1d66eafecb0",
+                "timestamp": "2025-01-24T05:35:48.847Z",
                 "ttl": "PT30S"
             },
             "message": {
                 "order": {
-                    "id": "2025-01-18-743091",
+                    "id": "2025-01-23-103725",
                     "state": "Completed",
                     "provider": {
                         "id": "e2008459-7e90-493e-b02e-cae52ca53214",
@@ -4364,26 +4843,33 @@
                             "quantity": {
                                 "count": 3
                             },
-                            "fulfillment_id": "59021f2c-bed5-4797-82e1-b06febf27eda"
+                            "fulfillment_id": "6dc21188-26a8-456c-9d28-1561bd0779c9"
+                        },
+                        {
+                            "id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+                            "quantity": {
+                                "count": 3
+                            },
+                            "fulfillment_id": "6dc21188-26a8-456c-9d28-1561bd0779c9"
                         },
                         {
                             "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
                             "quantity": {
                                 "count": 2
                             },
-                            "fulfillment_id": "59021f2c-bed5-4797-82e1-b06febf27eda"
+                            "fulfillment_id": "6dc21188-26a8-456c-9d28-1561bd0779c9"
                         },
                         {
                             "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
                             "quantity": {
                                 "count": 1
                             },
-                            "fulfillment_id": "d856122c-15d5-4211-8484-4a8cb4541948"
+                            "fulfillment_id": "ec3a2ef5-9f47-4934-b4d5-a8d4dca6f9c8"
                         }
                     ],
                     "documents": [
                         {
-                            "url": "https://ondc.pirimidtech.com/v2/seller/api/order/invoice/d16658c3-f55b-4ffb-8d07-b43b16ac2ef0",
+                            "url": "https://ondc.pirimidtech.com/v2/seller/api/order/invoice/a840e0cc-8f95-4439-958f-bf5e6c2d271c",
                             "label": "Invoice"
                         }
                     ],
@@ -4400,12 +4886,12 @@
                         },
                         "email": "fhemanshu@gmail.com",
                         "phone": "7202959020",
-                        "created_at": "2025-01-18T04:39:55.715Z",
-                        "updated_at": "2025-01-18T04:39:55.715Z"
+                        "created_at": "2025-01-23T12:24:49.484Z",
+                        "updated_at": "2025-01-23T12:24:49.484Z"
                     },
                     "fulfillments": [
                         {
-                            "id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+                            "id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
                             "type": "Delivery",
                             "@ondc/org/TAT": "PT99H",
                             "provider_id": "ondc.loadshare.com/ondc/18275",
@@ -4436,14 +4922,14 @@
                                         "locality": "Ashok Vatika",
                                         "city": "Ahmedabad",
                                         "state": "Gujarat",
-                                        "area_code": "380058"
+                                        "area_code": "380054"
                                     }
                                 },
                                 "time": {
-                                    "timestamp": "2025-01-18T04:41:32.495Z",
+                                    "timestamp": "2025-01-23T12:26:52.535Z",
                                     "range": {
-                                        "start": "2025-01-18T04:41:21.404Z",
-                                        "end": "2025-01-18T07:41:21.404Z"
+                                        "start": "2025-01-23T12:26:33.368Z",
+                                        "end": "2025-01-23T15:26:33.368Z"
                                     }
                                 },
                                 "instructions": {
@@ -4471,10 +4957,10 @@
                                     }
                                 },
                                 "time": {
-                                    "timestamp": "2025-01-18T16:03:23.651Z",
+                                    "timestamp": "2025-01-24T05:34:21.324Z",
                                     "range": {
-                                        "start": "2025-01-18T07:41:21.404Z",
-                                        "end": "2025-01-22T07:41:21.404Z"
+                                        "start": "2025-01-23T15:26:33.368Z",
+                                        "end": "2025-01-27T15:26:33.368Z"
                                     }
                                 },
                                 "contact": {
@@ -4498,7 +4984,7 @@
                             ]
                         },
                         {
-                            "id": "d856122c-15d5-4211-8484-4a8cb4541948",
+                            "id": "ec3a2ef5-9f47-4934-b4d5-a8d4dca6f9c8",
                             "type": "Cancel",
                             "state": {
                                 "descriptor": {
@@ -4581,7 +5067,7 @@
                             ]
                         },
                         {
-                            "id": "678bd10a8455f06951c9542a",
+                            "id": "6793268da3b38b99e1ec64d6",
                             "type": "Return",
                             "@ondc/org/provider_name": "LoadShare",
                             "state": {
@@ -4604,8 +5090,8 @@
                                 },
                                 "time": {
                                     "range": {
-                                        "start": "2025-01-18T16:08:05.878Z",
-                                        "end": "2025-01-25T16:03:23.651Z"
+                                        "start": "2025-01-24T05:35:50.825Z",
+                                        "end": "2025-01-31T05:34:21.324Z"
                                     }
                                 }
                             },
@@ -4616,7 +5102,7 @@
                                         "locality": "Ashok Vatika",
                                         "city": "Ahmedabad",
                                         "state": "Gujarat",
-                                        "area_code": "380058"
+                                        "area_code": "380054"
                                     }
                                 }
                             },
@@ -4626,7 +5112,7 @@
                                     "list": [
                                         {
                                             "code": "id",
-                                            "value": "678bd10a8455f06951c9542a"
+                                            "value": "6793268da3b38b99e1ec64d6"
                                         },
                                         {
                                             "code": "item_id",
@@ -4638,11 +5124,11 @@
                                         },
                                         {
                                             "code": "item_quantity",
-                                            "value": "1"
+                                            "value": "2"
                                         },
                                         {
                                             "code": "reason_id",
-                                            "value": "001"
+                                            "value": "002"
                                         },
                                         {
                                             "code": "reason_desc",
@@ -4650,7 +5136,7 @@
                                         },
                                         {
                                             "code": "images",
-                                            "value": "https://reference-buyer-app-assets.s3-ap-south-1.amazonaws.com/public-assets/2025-01-18-743091/c8f3fe60-e84a-4d49-ae61-ecbc2232da26.png"
+                                            "value": "https://reference-buyer-app-assets.s3-ap-south-1.amazonaws.com/public-assets/2025-01-23-103725/7d383819-6630-4428-b4d8-b7aae2065ff1.png"
                                         },
                                         {
                                             "code": "ttl_approval",
@@ -4672,7 +5158,7 @@
                     "quote": {
                         "price": {
                             "currency": "INR",
-                            "value": "1131.45"
+                            "value": "1613.52"
                         },
                         "breakup": [
                             {
@@ -4694,7 +5180,7 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+                                "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
                                 "@ondc/org/title_type": "packing",
                                 "title": "Packing Charges",
                                 "price": {
@@ -4703,7 +5189,43 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+                                "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
+                                "@ondc/org/title_type": "delivery",
+                                "title": "Delivery Charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "100.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+                                "@ondc/org/item_quantity": {
+                                    "count": 3
+                                },
+                                "@ondc/org/title_type": "item",
+                                "item": {
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "120.0"
+                                    }
+                                },
+                                "title": "Walnuts",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "360.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
+                                "@ondc/org/title_type": "packing",
+                                "title": "Packing Charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "5.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
                                 "@ondc/org/title_type": "delivery",
                                 "title": "Delivery Charges",
                                 "price": {
@@ -4730,7 +5252,7 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+                                "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
                                 "@ondc/org/title_type": "packing",
                                 "title": "Packing Charges",
                                 "price": {
@@ -4739,7 +5261,7 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+                                "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
                                 "@ondc/org/title_type": "delivery",
                                 "title": "Delivery Charges",
                                 "price": {
@@ -4757,12 +5279,12 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "d856122c-15d5-4211-8484-4a8cb4541948",
+                                "@ondc/org/item_id": "ec3a2ef5-9f47-4934-b4d5-a8d4dca6f9c8",
                                 "@ondc/org/title_type": "misc",
                                 "title": "Convenience Fee",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "40.05"
+                                    "value": "57.12"
                                 }
                             }
                         ],
@@ -4772,8 +5294,8 @@
                         "uri": "https://razorpay.com/",
                         "tl_method": "http/get",
                         "params": {
-                            "transaction_id": "order_PkmGkn5hmLCG83",
-                            "amount": "1401.72",
+                            "transaction_id": "order_PmsrRxRfEkwUOs",
+                            "amount": "1883.79",
                             "currency": "INR"
                         },
                         "type": "ON-ORDER",
@@ -4790,7 +5312,7 @@
                                 "settlement_phase": "refund",
                                 "settlement_amount": "270.27",
                                 "settlement_type": "wallet",
-                                "settlement_timestamp": "2025-01-18T04:40:58.885Z"
+                                "settlement_timestamp": "2025-01-23T12:25:39.036Z"
                             },
                             {
                                 "settlement_counterparty": "seller-app",
@@ -4805,8 +5327,8 @@
                             }
                         ]
                     },
-                    "created_at": "2025-01-18T04:39:47.970Z",
-                    "updated_at": "2025-01-18T16:07:05.975Z"
+                    "created_at": "2025-01-23T12:24:39.050Z",
+                    "updated_at": "2025-01-24T05:35:48.847Z"
                 }
             }
         },
@@ -4821,14 +5343,14 @@
                 "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
                 "bpp_id": "ondc.pirimidtech.com/v2/seller",
                 "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-                "transaction_id": "82b9cba3-1fb4-4b53-825e-904368636e74",
-                "message_id": "e4b561cb-f8b6-44cc-bf27-4f5f514964ab",
-                "timestamp": "2025-01-18T16:09:21.698Z",
+                "transaction_id": "e35a5fd4-3758-429e-84d0-4d831a501733",
+                "message_id": "edc0667a-d6e9-4860-ba89-c5faaec08570",
+                "timestamp": "2025-01-24T05:35:55.439Z",
                 "ttl": "PT30S"
             },
             "message": {
                 "order": {
-                    "id": "2025-01-18-743091",
+                    "id": "2025-01-23-103725",
                     "state": "Completed",
                     "provider": {
                         "id": "e2008459-7e90-493e-b02e-cae52ca53214",
@@ -4840,30 +5362,37 @@
                     },
                     "items": [
                         {
+                            "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
+                            "quantity": {
+                                "count": 1
+                            },
+                            "fulfillment_id": "6dc21188-26a8-456c-9d28-1561bd0779c9"
+                        },
+                        {
+                            "id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+                            "quantity": {
+                                "count": 3
+                            },
+                            "fulfillment_id": "6dc21188-26a8-456c-9d28-1561bd0779c9"
+                        },
+                        {
                             "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
                             "quantity": {
                                 "count": 2
                             },
-                            "fulfillment_id": "59021f2c-bed5-4797-82e1-b06febf27eda"
+                            "fulfillment_id": "6dc21188-26a8-456c-9d28-1561bd0779c9"
                         },
                         {
                             "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
                             "quantity": {
                                 "count": 1
                             },
-                            "fulfillment_id": "d856122c-15d5-4211-8484-4a8cb4541948"
-                        },
-                        {
-                            "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
-                            "quantity": {
-                                "count": 2
-                            },
-                            "fulfillment_id": "59021f2c-bed5-4797-82e1-b06febf27eda"
+                            "fulfillment_id": "ec3a2ef5-9f47-4934-b4d5-a8d4dca6f9c8"
                         }
                     ],
                     "documents": [
                         {
-                            "url": "https://ondc.pirimidtech.com/v2/seller/api/order/invoice/d16658c3-f55b-4ffb-8d07-b43b16ac2ef0",
+                            "url": "https://ondc.pirimidtech.com/v2/seller/api/order/invoice/a840e0cc-8f95-4439-958f-bf5e6c2d271c",
                             "label": "Invoice"
                         }
                     ],
@@ -4880,12 +5409,12 @@
                         },
                         "email": "fhemanshu@gmail.com",
                         "phone": "7202959020",
-                        "created_at": "2025-01-18T04:39:55.715Z",
-                        "updated_at": "2025-01-18T04:39:55.715Z"
+                        "created_at": "2025-01-23T12:24:49.484Z",
+                        "updated_at": "2025-01-23T12:24:49.484Z"
                     },
                     "fulfillments": [
                         {
-                            "id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+                            "id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
                             "type": "Delivery",
                             "@ondc/org/TAT": "PT99H",
                             "provider_id": "ondc.loadshare.com/ondc/18275",
@@ -4916,14 +5445,14 @@
                                         "locality": "Ashok Vatika",
                                         "city": "Ahmedabad",
                                         "state": "Gujarat",
-                                        "area_code": "380058"
+                                        "area_code": "380054"
                                     }
                                 },
                                 "time": {
-                                    "timestamp": "2025-01-18T04:41:32.495Z",
+                                    "timestamp": "2025-01-23T12:26:52.535Z",
                                     "range": {
-                                        "start": "2025-01-18T04:41:21.404Z",
-                                        "end": "2025-01-18T07:41:21.404Z"
+                                        "start": "2025-01-23T12:26:33.368Z",
+                                        "end": "2025-01-23T15:26:33.368Z"
                                     }
                                 },
                                 "instructions": {
@@ -4951,10 +5480,10 @@
                                     }
                                 },
                                 "time": {
-                                    "timestamp": "2025-01-18T16:03:23.651Z",
+                                    "timestamp": "2025-01-24T05:34:21.324Z",
                                     "range": {
-                                        "start": "2025-01-18T07:41:21.404Z",
-                                        "end": "2025-01-22T07:41:21.404Z"
+                                        "start": "2025-01-23T15:26:33.368Z",
+                                        "end": "2025-01-27T15:26:33.368Z"
                                     }
                                 },
                                 "contact": {
@@ -4978,7 +5507,7 @@
                             ]
                         },
                         {
-                            "id": "d856122c-15d5-4211-8484-4a8cb4541948",
+                            "id": "ec3a2ef5-9f47-4934-b4d5-a8d4dca6f9c8",
                             "type": "Cancel",
                             "state": {
                                 "descriptor": {
@@ -5061,7 +5590,7 @@
                             ]
                         },
                         {
-                            "id": "678bd10a8455f06951c9542a",
+                            "id": "6793268da3b38b99e1ec64d6",
                             "type": "Return",
                             "@ondc/org/provider_name": "LoadShare",
                             "state": {
@@ -5083,7 +5612,7 @@
                                     }
                                 },
                                 "time": {
-                                    "timestamp": "2025-01-18T16:09:21.621Z"
+                                    "timestamp": "2025-01-24T05:35:55.380Z"
                                 }
                             },
                             "end": {
@@ -5093,7 +5622,7 @@
                                         "locality": "Ashok Vatika",
                                         "city": "Ahmedabad",
                                         "state": "Gujarat",
-                                        "area_code": "380058"
+                                        "area_code": "380054"
                                     }
                                 }
                             },
@@ -5103,7 +5632,7 @@
                                     "list": [
                                         {
                                             "code": "id",
-                                            "value": "678bd10a8455f06951c9542a"
+                                            "value": "6793268da3b38b99e1ec64d6"
                                         },
                                         {
                                             "code": "item_id",
@@ -5115,11 +5644,11 @@
                                         },
                                         {
                                             "code": "item_quantity",
-                                            "value": "1"
+                                            "value": "2"
                                         },
                                         {
                                             "code": "reason_id",
-                                            "value": "001"
+                                            "value": "002"
                                         },
                                         {
                                             "code": "reason_desc",
@@ -5127,7 +5656,7 @@
                                         },
                                         {
                                             "code": "images",
-                                            "value": "https://reference-buyer-app-assets.s3-ap-south-1.amazonaws.com/public-assets/2025-01-18-743091/c8f3fe60-e84a-4d49-ae61-ecbc2232da26.png"
+                                            "value": "https://reference-buyer-app-assets.s3-ap-south-1.amazonaws.com/public-assets/2025-01-23-103725/7d383819-6630-4428-b4d8-b7aae2065ff1.png"
                                         },
                                         {
                                             "code": "ttl_approval",
@@ -5160,7 +5689,7 @@
                                         },
                                         {
                                             "code": "value",
-                                            "value": "-120"
+                                            "value": "-240"
                                         }
                                     ]
                                 },
@@ -5173,7 +5702,7 @@
                                         },
                                         {
                                             "code": "id",
-                                            "value": "70dd195d-c7ff-46ac-ba42-53ade2f77aef"
+                                            "value": "9333ed9f-c3e6-4e5b-a863-9ccfff56e1a7"
                                         },
                                         {
                                             "code": "currency",
@@ -5181,7 +5710,7 @@
                                         },
                                         {
                                             "code": "value",
-                                            "value": "-4.4"
+                                            "value": "-8.81"
                                         }
                                     ]
                                 }
@@ -5191,9 +5720,81 @@
                     "quote": {
                         "price": {
                             "currency": "INR",
-                            "value": "1007.05"
+                            "value": "1364.71"
                         },
                         "breakup": [
+                            {
+                                "@ondc/org/item_id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
+                                "@ondc/org/item_quantity": {
+                                    "count": 1
+                                },
+                                "@ondc/org/title_type": "item",
+                                "item": {
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "120.0"
+                                    }
+                                },
+                                "title": "Cashews",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "120.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
+                                "@ondc/org/title_type": "packing",
+                                "title": "Packing Charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "5.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
+                                "@ondc/org/title_type": "delivery",
+                                "title": "Delivery Charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "100.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+                                "@ondc/org/item_quantity": {
+                                    "count": 3
+                                },
+                                "@ondc/org/title_type": "item",
+                                "item": {
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "120.0"
+                                    }
+                                },
+                                "title": "Walnuts",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "360.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
+                                "@ondc/org/title_type": "packing",
+                                "title": "Packing Charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "5.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
+                                "@ondc/org/title_type": "delivery",
+                                "title": "Delivery Charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "100.0"
+                                }
+                            },
                             {
                                 "@ondc/org/item_id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
                                 "@ondc/org/item_quantity": {
@@ -5213,7 +5814,7 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+                                "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
                                 "@ondc/org/title_type": "packing",
                                 "title": "Packing Charges",
                                 "price": {
@@ -5222,7 +5823,7 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+                                "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
                                 "@ondc/org/title_type": "delivery",
                                 "title": "Delivery Charges",
                                 "price": {
@@ -5240,48 +5841,12 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
-                                "@ondc/org/item_quantity": {
-                                    "count": 2
-                                },
-                                "@ondc/org/title_type": "item",
-                                "item": {
-                                    "price": {
-                                        "currency": "INR",
-                                        "value": "120.0"
-                                    }
-                                },
-                                "title": "Cashews",
-                                "price": {
-                                    "currency": "INR",
-                                    "value": "240.0"
-                                }
-                            },
-                            {
-                                "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
-                                "@ondc/org/title_type": "packing",
-                                "title": "Packing Charges",
-                                "price": {
-                                    "currency": "INR",
-                                    "value": "5.0"
-                                }
-                            },
-                            {
-                                "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
-                                "@ondc/org/title_type": "delivery",
-                                "title": "Delivery Charges",
-                                "price": {
-                                    "currency": "INR",
-                                    "value": "100.0"
-                                }
-                            },
-                            {
-                                "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+                                "@ondc/org/item_id": "ec3a2ef5-9f47-4934-b4d5-a8d4dca6f9c8",
                                 "@ondc/org/title_type": "misc",
                                 "title": "Convenience Fee",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "35.65"
+                                    "value": "48.31"
                                 }
                             }
                         ],
@@ -5291,8 +5856,8 @@
                         "uri": "https://razorpay.com/",
                         "tl_method": "http/get",
                         "params": {
-                            "transaction_id": "order_PkmGkn5hmLCG83",
-                            "amount": "1401.72",
+                            "transaction_id": "order_PmsrRxRfEkwUOs",
+                            "amount": "1883.79",
                             "currency": "INR"
                         },
                         "type": "ON-ORDER",
@@ -5309,7 +5874,7 @@
                                 "settlement_phase": "refund",
                                 "settlement_amount": "270.27",
                                 "settlement_type": "wallet",
-                                "settlement_timestamp": "2025-01-18T04:40:58.885Z"
+                                "settlement_timestamp": "2025-01-23T12:25:39.036Z"
                             },
                             {
                                 "settlement_counterparty": "seller-app",
@@ -5324,8 +5889,8 @@
                             }
                         ]
                     },
-                    "created_at": "2025-01-18T04:39:47.970Z",
-                    "updated_at": "2025-01-18T16:09:21.698Z"
+                    "created_at": "2025-01-23T12:24:39.050Z",
+                    "updated_at": "2025-01-24T05:35:55.439Z"
                 }
             }
         },
@@ -5338,19 +5903,19 @@
                 "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
                 "bpp_id": "ondc.pirimidtech.com/v2/seller",
                 "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-                "transaction_id": "82b9cba3-1fb4-4b53-825e-904368636e74",
-                "message_id": "2812d8a3-0a2a-4bff-96f7-14b800e0cb6f",
+                "transaction_id": "e35a5fd4-3758-429e-84d0-4d831a501733",
+                "message_id": "135d8307-00c1-4470-a701-79832c4c26d0",
                 "city": "std:079",
                 "country": "IND",
-                "timestamp": "2025-01-18T16:09:23.017Z"
+                "timestamp": "2025-01-24T05:35:56.402Z"
             },
             "message": {
                 "update_target": "payment",
                 "order": {
-                    "id": "2025-01-18-743091",
+                    "id": "2025-01-23-103725",
                     "fulfillments": [
                         {
-                            "id": "678bd10a8455f06951c9542a",
+                            "id": "6793268da3b38b99e1ec64d6",
                             "type": "Return"
                         }
                     ],
@@ -5360,8 +5925,8 @@
                                 "settlement_counterparty": "buyer",
                                 "settlement_phase": "refund",
                                 "settlement_type": "wallet",
-                                "settlement_amount": "124.4",
-                                "settlement_timestamp": "2025-01-18T16:09:23.017Z"
+                                "settlement_amount": "248.81",
+                                "settlement_timestamp": "2025-01-24T05:35:56.402Z"
                             }
                         ]
                     }
@@ -5379,14 +5944,14 @@
                 "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
                 "bpp_id": "ondc.pirimidtech.com/v2/seller",
                 "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-                "transaction_id": "82b9cba3-1fb4-4b53-825e-904368636e74",
-                "message_id": "b0492fd9-f3c8-4db5-a014-26ff03008880",
-                "timestamp": "2025-01-18T16:09:40.790Z",
+                "transaction_id": "e35a5fd4-3758-429e-84d0-4d831a501733",
+                "message_id": "046acb19-a18e-4adb-afc5-97f8e113b0ac",
+                "timestamp": "2025-01-24T05:36:50.031Z",
                 "ttl": "PT30S"
             },
             "message": {
                 "order": {
-                    "id": "2025-01-18-743091",
+                    "id": "2025-01-23-103725",
                     "state": "Completed",
                     "provider": {
                         "id": "e2008459-7e90-493e-b02e-cae52ca53214",
@@ -5398,30 +5963,37 @@
                     },
                     "items": [
                         {
+                            "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
+                            "quantity": {
+                                "count": 1
+                            },
+                            "fulfillment_id": "6dc21188-26a8-456c-9d28-1561bd0779c9"
+                        },
+                        {
+                            "id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+                            "quantity": {
+                                "count": 3
+                            },
+                            "fulfillment_id": "6dc21188-26a8-456c-9d28-1561bd0779c9"
+                        },
+                        {
                             "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
                             "quantity": {
                                 "count": 2
                             },
-                            "fulfillment_id": "59021f2c-bed5-4797-82e1-b06febf27eda"
+                            "fulfillment_id": "6dc21188-26a8-456c-9d28-1561bd0779c9"
                         },
                         {
                             "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
                             "quantity": {
                                 "count": 1
                             },
-                            "fulfillment_id": "d856122c-15d5-4211-8484-4a8cb4541948"
-                        },
-                        {
-                            "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
-                            "quantity": {
-                                "count": 2
-                            },
-                            "fulfillment_id": "59021f2c-bed5-4797-82e1-b06febf27eda"
+                            "fulfillment_id": "ec3a2ef5-9f47-4934-b4d5-a8d4dca6f9c8"
                         }
                     ],
                     "documents": [
                         {
-                            "url": "https://ondc.pirimidtech.com/v2/seller/api/order/invoice/d16658c3-f55b-4ffb-8d07-b43b16ac2ef0",
+                            "url": "https://ondc.pirimidtech.com/v2/seller/api/order/invoice/a840e0cc-8f95-4439-958f-bf5e6c2d271c",
                             "label": "Invoice"
                         }
                     ],
@@ -5438,12 +6010,12 @@
                         },
                         "email": "fhemanshu@gmail.com",
                         "phone": "7202959020",
-                        "created_at": "2025-01-18T04:39:55.715Z",
-                        "updated_at": "2025-01-18T04:39:55.715Z"
+                        "created_at": "2025-01-23T12:24:49.484Z",
+                        "updated_at": "2025-01-23T12:24:49.484Z"
                     },
                     "fulfillments": [
                         {
-                            "id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+                            "id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
                             "type": "Delivery",
                             "@ondc/org/TAT": "PT99H",
                             "provider_id": "ondc.loadshare.com/ondc/18275",
@@ -5474,14 +6046,14 @@
                                         "locality": "Ashok Vatika",
                                         "city": "Ahmedabad",
                                         "state": "Gujarat",
-                                        "area_code": "380058"
+                                        "area_code": "380054"
                                     }
                                 },
                                 "time": {
-                                    "timestamp": "2025-01-18T04:41:32.495Z",
+                                    "timestamp": "2025-01-23T12:26:52.535Z",
                                     "range": {
-                                        "start": "2025-01-18T04:41:21.404Z",
-                                        "end": "2025-01-18T07:41:21.404Z"
+                                        "start": "2025-01-23T12:26:33.368Z",
+                                        "end": "2025-01-23T15:26:33.368Z"
                                     }
                                 },
                                 "instructions": {
@@ -5509,10 +6081,10 @@
                                     }
                                 },
                                 "time": {
-                                    "timestamp": "2025-01-18T16:03:23.651Z",
+                                    "timestamp": "2025-01-24T05:34:21.324Z",
                                     "range": {
-                                        "start": "2025-01-18T07:41:21.404Z",
-                                        "end": "2025-01-22T07:41:21.404Z"
+                                        "start": "2025-01-23T15:26:33.368Z",
+                                        "end": "2025-01-27T15:26:33.368Z"
                                     }
                                 },
                                 "contact": {
@@ -5536,7 +6108,7 @@
                             ]
                         },
                         {
-                            "id": "d856122c-15d5-4211-8484-4a8cb4541948",
+                            "id": "ec3a2ef5-9f47-4934-b4d5-a8d4dca6f9c8",
                             "type": "Cancel",
                             "state": {
                                 "descriptor": {
@@ -5619,7 +6191,7 @@
                             ]
                         },
                         {
-                            "id": "678bd10a8455f06951c9542a",
+                            "id": "6793268da3b38b99e1ec64d6",
                             "type": "Return",
                             "@ondc/org/provider_name": "LoadShare",
                             "state": {
@@ -5641,7 +6213,7 @@
                                     }
                                 },
                                 "time": {
-                                    "timestamp": "2025-01-18T16:09:21.621Z"
+                                    "timestamp": "2025-01-24T05:35:55.380Z"
                                 }
                             },
                             "end": {
@@ -5651,11 +6223,11 @@
                                         "locality": "Ashok Vatika",
                                         "city": "Ahmedabad",
                                         "state": "Gujarat",
-                                        "area_code": "380058"
+                                        "area_code": "380054"
                                     }
                                 },
                                 "time": {
-                                    "timestamp": "2025-01-18T16:09:40.749Z"
+                                    "timestamp": "2025-01-24T05:36:49.982Z"
                                 }
                             },
                             "tags": [
@@ -5664,7 +6236,7 @@
                                     "list": [
                                         {
                                             "code": "id",
-                                            "value": "678bd10a8455f06951c9542a"
+                                            "value": "6793268da3b38b99e1ec64d6"
                                         },
                                         {
                                             "code": "item_id",
@@ -5676,11 +6248,11 @@
                                         },
                                         {
                                             "code": "item_quantity",
-                                            "value": "1"
+                                            "value": "2"
                                         },
                                         {
                                             "code": "reason_id",
-                                            "value": "001"
+                                            "value": "002"
                                         },
                                         {
                                             "code": "reason_desc",
@@ -5688,7 +6260,7 @@
                                         },
                                         {
                                             "code": "images",
-                                            "value": "https://reference-buyer-app-assets.s3-ap-south-1.amazonaws.com/public-assets/2025-01-18-743091/c8f3fe60-e84a-4d49-ae61-ecbc2232da26.png"
+                                            "value": "https://reference-buyer-app-assets.s3-ap-south-1.amazonaws.com/public-assets/2025-01-23-103725/7d383819-6630-4428-b4d8-b7aae2065ff1.png"
                                         },
                                         {
                                             "code": "ttl_approval",
@@ -5721,7 +6293,7 @@
                                         },
                                         {
                                             "code": "value",
-                                            "value": "-120"
+                                            "value": "-240"
                                         }
                                     ]
                                 },
@@ -5734,7 +6306,7 @@
                                         },
                                         {
                                             "code": "id",
-                                            "value": "70dd195d-c7ff-46ac-ba42-53ade2f77aef"
+                                            "value": "9333ed9f-c3e6-4e5b-a863-9ccfff56e1a7"
                                         },
                                         {
                                             "code": "currency",
@@ -5742,7 +6314,7 @@
                                         },
                                         {
                                             "code": "value",
-                                            "value": "-4.4"
+                                            "value": "-8.81"
                                         }
                                     ]
                                 }
@@ -5752,9 +6324,81 @@
                     "quote": {
                         "price": {
                             "currency": "INR",
-                            "value": "1007.05"
+                            "value": "1364.71"
                         },
                         "breakup": [
+                            {
+                                "@ondc/org/item_id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
+                                "@ondc/org/item_quantity": {
+                                    "count": 1
+                                },
+                                "@ondc/org/title_type": "item",
+                                "item": {
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "120.0"
+                                    }
+                                },
+                                "title": "Cashews",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "120.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
+                                "@ondc/org/title_type": "packing",
+                                "title": "Packing Charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "5.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
+                                "@ondc/org/title_type": "delivery",
+                                "title": "Delivery Charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "100.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+                                "@ondc/org/item_quantity": {
+                                    "count": 3
+                                },
+                                "@ondc/org/title_type": "item",
+                                "item": {
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "120.0"
+                                    }
+                                },
+                                "title": "Walnuts",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "360.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
+                                "@ondc/org/title_type": "packing",
+                                "title": "Packing Charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "5.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
+                                "@ondc/org/title_type": "delivery",
+                                "title": "Delivery Charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "100.0"
+                                }
+                            },
                             {
                                 "@ondc/org/item_id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
                                 "@ondc/org/item_quantity": {
@@ -5774,7 +6418,7 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+                                "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
                                 "@ondc/org/title_type": "packing",
                                 "title": "Packing Charges",
                                 "price": {
@@ -5783,7 +6427,7 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+                                "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
                                 "@ondc/org/title_type": "delivery",
                                 "title": "Delivery Charges",
                                 "price": {
@@ -5801,48 +6445,12 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
-                                "@ondc/org/item_quantity": {
-                                    "count": 2
-                                },
-                                "@ondc/org/title_type": "item",
-                                "item": {
-                                    "price": {
-                                        "currency": "INR",
-                                        "value": "120.0"
-                                    }
-                                },
-                                "title": "Cashews",
-                                "price": {
-                                    "currency": "INR",
-                                    "value": "240.0"
-                                }
-                            },
-                            {
-                                "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
-                                "@ondc/org/title_type": "packing",
-                                "title": "Packing Charges",
-                                "price": {
-                                    "currency": "INR",
-                                    "value": "5.0"
-                                }
-                            },
-                            {
-                                "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
-                                "@ondc/org/title_type": "delivery",
-                                "title": "Delivery Charges",
-                                "price": {
-                                    "currency": "INR",
-                                    "value": "100.0"
-                                }
-                            },
-                            {
-                                "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+                                "@ondc/org/item_id": "ec3a2ef5-9f47-4934-b4d5-a8d4dca6f9c8",
                                 "@ondc/org/title_type": "misc",
                                 "title": "Convenience Fee",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "35.65"
+                                    "value": "48.31"
                                 }
                             }
                         ],
@@ -5852,8 +6460,8 @@
                         "uri": "https://razorpay.com/",
                         "tl_method": "http/get",
                         "params": {
-                            "transaction_id": "order_PkmGkn5hmLCG83",
-                            "amount": "1401.72",
+                            "transaction_id": "order_PmsrRxRfEkwUOs",
+                            "amount": "1883.79",
                             "currency": "INR"
                         },
                         "type": "ON-ORDER",
@@ -5868,16 +6476,16 @@
                             {
                                 "settlement_counterparty": "buyer",
                                 "settlement_phase": "refund",
-                                "settlement_amount": "124.4",
+                                "settlement_amount": "248.81",
                                 "settlement_type": "wallet",
-                                "settlement_timestamp": "2025-01-18T16:09:23.017Z"
+                                "settlement_timestamp": "2025-01-24T05:35:56.402Z"
                             },
                             {
                                 "settlement_counterparty": "buyer",
                                 "settlement_phase": "refund",
                                 "settlement_amount": "270.27",
                                 "settlement_type": "wallet",
-                                "settlement_timestamp": "2025-01-18T04:40:58.885Z"
+                                "settlement_timestamp": "2025-01-23T12:25:39.036Z"
                             },
                             {
                                 "settlement_counterparty": "seller-app",
@@ -5892,8 +6500,8 @@
                             }
                         ]
                     },
-                    "created_at": "2025-01-18T04:39:47.970Z",
-                    "updated_at": "2025-01-18T16:09:40.790Z"
+                    "created_at": "2025-01-23T12:24:39.050Z",
+                    "updated_at": "2025-01-24T05:36:50.031Z"
                 }
             }
         },
@@ -5907,16 +6515,16 @@
                 "bap_id": "buyer-app-preprod-v2.ondc.org",
                 "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
                 "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-                "transaction_id": "82b9cba3-1fb4-4b53-825e-904368636e74",
-                "message_id": "945a1b17-6d01-4eed-89e7-6209d3c48fa6",
-                "timestamp": "2025-01-18T16:10:04.344Z",
+                "transaction_id": "e35a5fd4-3758-429e-84d0-4d831a501733",
+                "message_id": "104d0ea4-ba58-4984-b9b4-371fd6a95aed",
+                "timestamp": "2025-01-24T05:37:10.285Z",
                 "bpp_id": "ondc.pirimidtech.com/v2/seller",
                 "ttl": "PT30S"
             },
             "message": {
                 "update_target": "item",
                 "order": {
-                    "id": "2025-01-18-743091",
+                    "id": "2025-01-23-103725",
                     "fulfillments": [
                         {
                             "type": "Return",
@@ -5926,11 +6534,11 @@
                                     "list": [
                                         {
                                             "code": "id",
-                                            "value": "678bd25c8455f06951c954a8"
+                                            "value": "67932706a3b38b99e1ec6555"
                                         },
                                         {
                                             "code": "item_id",
-                                            "value": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9"
+                                            "value": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7"
                                         },
                                         {
                                             "code": "parent_item_id",
@@ -5938,7 +6546,7 @@
                                         },
                                         {
                                             "code": "item_quantity",
-                                            "value": "1"
+                                            "value": "2"
                                         },
                                         {
                                             "code": "reason_id",
@@ -5950,7 +6558,7 @@
                                         },
                                         {
                                             "code": "images",
-                                            "value": "https://reference-buyer-app-assets.s3-ap-south-1.amazonaws.com/public-assets/2025-01-18-743091/824c6fb6-842f-477b-9a79-6ebaa14519ad.png"
+                                            "value": "https://reference-buyer-app-assets.s3-ap-south-1.amazonaws.com/public-assets/2025-01-23-103725/0ddb2db8-2cca-4e38-8040-c5a06d98fdd5.png"
                                         },
                                         {
                                             "code": "ttl_approval",
@@ -5979,14 +6587,14 @@
                 "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
                 "bpp_id": "ondc.pirimidtech.com/v2/seller",
                 "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-                "transaction_id": "82b9cba3-1fb4-4b53-825e-904368636e74",
-                "message_id": "945a1b17-6d01-4eed-89e7-6209d3c48fa6",
-                "timestamp": "2025-01-18T16:10:05.171Z",
+                "transaction_id": "e35a5fd4-3758-429e-84d0-4d831a501733",
+                "message_id": "104d0ea4-ba58-4984-b9b4-371fd6a95aed",
+                "timestamp": "2025-01-24T05:37:11.189Z",
                 "ttl": "PT30S"
             },
             "message": {
                 "order": {
-                    "id": "2025-01-18-743091",
+                    "id": "2025-01-23-103725",
                     "state": "Completed",
                     "provider": {
                         "id": "e2008459-7e90-493e-b02e-cae52ca53214",
@@ -5998,30 +6606,37 @@
                     },
                     "items": [
                         {
+                            "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
+                            "quantity": {
+                                "count": 1
+                            },
+                            "fulfillment_id": "6dc21188-26a8-456c-9d28-1561bd0779c9"
+                        },
+                        {
+                            "id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+                            "quantity": {
+                                "count": 3
+                            },
+                            "fulfillment_id": "6dc21188-26a8-456c-9d28-1561bd0779c9"
+                        },
+                        {
                             "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
                             "quantity": {
                                 "count": 2
                             },
-                            "fulfillment_id": "59021f2c-bed5-4797-82e1-b06febf27eda"
+                            "fulfillment_id": "6dc21188-26a8-456c-9d28-1561bd0779c9"
                         },
                         {
                             "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
                             "quantity": {
                                 "count": 1
                             },
-                            "fulfillment_id": "d856122c-15d5-4211-8484-4a8cb4541948"
-                        },
-                        {
-                            "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
-                            "quantity": {
-                                "count": 2
-                            },
-                            "fulfillment_id": "59021f2c-bed5-4797-82e1-b06febf27eda"
+                            "fulfillment_id": "ec3a2ef5-9f47-4934-b4d5-a8d4dca6f9c8"
                         }
                     ],
                     "documents": [
                         {
-                            "url": "https://ondc.pirimidtech.com/v2/seller/api/order/invoice/d16658c3-f55b-4ffb-8d07-b43b16ac2ef0",
+                            "url": "https://ondc.pirimidtech.com/v2/seller/api/order/invoice/a840e0cc-8f95-4439-958f-bf5e6c2d271c",
                             "label": "Invoice"
                         }
                     ],
@@ -6038,12 +6653,12 @@
                         },
                         "email": "fhemanshu@gmail.com",
                         "phone": "7202959020",
-                        "created_at": "2025-01-18T04:39:55.715Z",
-                        "updated_at": "2025-01-18T04:39:55.715Z"
+                        "created_at": "2025-01-23T12:24:49.484Z",
+                        "updated_at": "2025-01-23T12:24:49.484Z"
                     },
                     "fulfillments": [
                         {
-                            "id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+                            "id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
                             "type": "Delivery",
                             "@ondc/org/TAT": "PT99H",
                             "provider_id": "ondc.loadshare.com/ondc/18275",
@@ -6074,14 +6689,14 @@
                                         "locality": "Ashok Vatika",
                                         "city": "Ahmedabad",
                                         "state": "Gujarat",
-                                        "area_code": "380058"
+                                        "area_code": "380054"
                                     }
                                 },
                                 "time": {
-                                    "timestamp": "2025-01-18T04:41:32.495Z",
+                                    "timestamp": "2025-01-23T12:26:52.535Z",
                                     "range": {
-                                        "start": "2025-01-18T04:41:21.404Z",
-                                        "end": "2025-01-18T07:41:21.404Z"
+                                        "start": "2025-01-23T12:26:33.368Z",
+                                        "end": "2025-01-23T15:26:33.368Z"
                                     }
                                 },
                                 "instructions": {
@@ -6109,10 +6724,10 @@
                                     }
                                 },
                                 "time": {
-                                    "timestamp": "2025-01-18T16:03:23.651Z",
+                                    "timestamp": "2025-01-24T05:34:21.324Z",
                                     "range": {
-                                        "start": "2025-01-18T07:41:21.404Z",
-                                        "end": "2025-01-22T07:41:21.404Z"
+                                        "start": "2025-01-23T15:26:33.368Z",
+                                        "end": "2025-01-27T15:26:33.368Z"
                                     }
                                 },
                                 "contact": {
@@ -6136,7 +6751,7 @@
                             ]
                         },
                         {
-                            "id": "d856122c-15d5-4211-8484-4a8cb4541948",
+                            "id": "ec3a2ef5-9f47-4934-b4d5-a8d4dca6f9c8",
                             "type": "Cancel",
                             "state": {
                                 "descriptor": {
@@ -6219,7 +6834,63 @@
                             ]
                         },
                         {
-                            "id": "678bd10a8455f06951c9542a",
+                            "id": "67932706a3b38b99e1ec6555",
+                            "type": "Return",
+                            "state": {
+                                "descriptor": {
+                                    "code": "Return_Initiated"
+                                }
+                            },
+                            "tags": [
+                                {
+                                    "code": "return_request",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "67932706a3b38b99e1ec6555"
+                                        },
+                                        {
+                                            "code": "item_id",
+                                            "value": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7"
+                                        },
+                                        {
+                                            "code": "parent_item_id",
+                                            "value": ""
+                                        },
+                                        {
+                                            "code": "item_quantity",
+                                            "value": "2"
+                                        },
+                                        {
+                                            "code": "reason_id",
+                                            "value": "001"
+                                        },
+                                        {
+                                            "code": "reason_desc",
+                                            "value": "detailed description for return"
+                                        },
+                                        {
+                                            "code": "images",
+                                            "value": "https://reference-buyer-app-assets.s3-ap-south-1.amazonaws.com/public-assets/2025-01-23-103725/0ddb2db8-2cca-4e38-8040-c5a06d98fdd5.png"
+                                        },
+                                        {
+                                            "code": "ttl_approval",
+                                            "value": "PT24H"
+                                        },
+                                        {
+                                            "code": "ttl_reverseqc",
+                                            "value": "P3D"
+                                        },
+                                        {
+                                            "code": "initiated_by",
+                                            "value": "buyer-app-preprod-v2.ondc.org"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "6793268da3b38b99e1ec64d6",
                             "type": "Return",
                             "@ondc/org/provider_name": "LoadShare",
                             "state": {
@@ -6241,7 +6912,7 @@
                                     }
                                 },
                                 "time": {
-                                    "timestamp": "2025-01-18T16:09:21.621Z"
+                                    "timestamp": "2025-01-24T05:35:55.380Z"
                                 }
                             },
                             "end": {
@@ -6251,11 +6922,11 @@
                                         "locality": "Ashok Vatika",
                                         "city": "Ahmedabad",
                                         "state": "Gujarat",
-                                        "area_code": "380058"
+                                        "area_code": "380054"
                                     }
                                 },
                                 "time": {
-                                    "timestamp": "2025-01-18T16:09:40.749Z"
+                                    "timestamp": "2025-01-24T05:36:49.982Z"
                                 }
                             },
                             "tags": [
@@ -6264,7 +6935,7 @@
                                     "list": [
                                         {
                                             "code": "id",
-                                            "value": "678bd10a8455f06951c9542a"
+                                            "value": "6793268da3b38b99e1ec64d6"
                                         },
                                         {
                                             "code": "item_id",
@@ -6276,11 +6947,11 @@
                                         },
                                         {
                                             "code": "item_quantity",
-                                            "value": "1"
+                                            "value": "2"
                                         },
                                         {
                                             "code": "reason_id",
-                                            "value": "001"
+                                            "value": "002"
                                         },
                                         {
                                             "code": "reason_desc",
@@ -6288,7 +6959,7 @@
                                         },
                                         {
                                             "code": "images",
-                                            "value": "https://reference-buyer-app-assets.s3-ap-south-1.amazonaws.com/public-assets/2025-01-18-743091/c8f3fe60-e84a-4d49-ae61-ecbc2232da26.png"
+                                            "value": "https://reference-buyer-app-assets.s3-ap-south-1.amazonaws.com/public-assets/2025-01-23-103725/7d383819-6630-4428-b4d8-b7aae2065ff1.png"
                                         },
                                         {
                                             "code": "ttl_approval",
@@ -6321,7 +6992,7 @@
                                         },
                                         {
                                             "code": "value",
-                                            "value": "-120"
+                                            "value": "-240"
                                         }
                                     ]
                                 },
@@ -6334,7 +7005,7 @@
                                         },
                                         {
                                             "code": "id",
-                                            "value": "70dd195d-c7ff-46ac-ba42-53ade2f77aef"
+                                            "value": "9333ed9f-c3e6-4e5b-a863-9ccfff56e1a7"
                                         },
                                         {
                                             "code": "currency",
@@ -6342,63 +7013,7 @@
                                         },
                                         {
                                             "code": "value",
-                                            "value": "-4.4"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "678bd25c8455f06951c954a8",
-                            "type": "Return",
-                            "state": {
-                                "descriptor": {
-                                    "code": "Return_Initiated"
-                                }
-                            },
-                            "tags": [
-                                {
-                                    "code": "return_request",
-                                    "list": [
-                                        {
-                                            "code": "id",
-                                            "value": "678bd25c8455f06951c954a8"
-                                        },
-                                        {
-                                            "code": "item_id",
-                                            "value": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9"
-                                        },
-                                        {
-                                            "code": "parent_item_id",
-                                            "value": ""
-                                        },
-                                        {
-                                            "code": "item_quantity",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "reason_id",
-                                            "value": "001"
-                                        },
-                                        {
-                                            "code": "reason_desc",
-                                            "value": "detailed description for return"
-                                        },
-                                        {
-                                            "code": "images",
-                                            "value": "https://reference-buyer-app-assets.s3-ap-south-1.amazonaws.com/public-assets/2025-01-18-743091/824c6fb6-842f-477b-9a79-6ebaa14519ad.png"
-                                        },
-                                        {
-                                            "code": "ttl_approval",
-                                            "value": "PT24H"
-                                        },
-                                        {
-                                            "code": "ttl_reverseqc",
-                                            "value": "P3D"
-                                        },
-                                        {
-                                            "code": "initiated_by",
-                                            "value": "buyer-app-preprod-v2.ondc.org"
+                                            "value": "-8.81"
                                         }
                                     ]
                                 }
@@ -6408,9 +7023,81 @@
                     "quote": {
                         "price": {
                             "currency": "INR",
-                            "value": "1007.05"
+                            "value": "1364.71"
                         },
                         "breakup": [
+                            {
+                                "@ondc/org/item_id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
+                                "@ondc/org/item_quantity": {
+                                    "count": 1
+                                },
+                                "@ondc/org/title_type": "item",
+                                "item": {
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "120.0"
+                                    }
+                                },
+                                "title": "Cashews",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "120.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
+                                "@ondc/org/title_type": "packing",
+                                "title": "Packing Charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "5.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
+                                "@ondc/org/title_type": "delivery",
+                                "title": "Delivery Charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "100.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+                                "@ondc/org/item_quantity": {
+                                    "count": 3
+                                },
+                                "@ondc/org/title_type": "item",
+                                "item": {
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "120.0"
+                                    }
+                                },
+                                "title": "Walnuts",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "360.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
+                                "@ondc/org/title_type": "packing",
+                                "title": "Packing Charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "5.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
+                                "@ondc/org/title_type": "delivery",
+                                "title": "Delivery Charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "100.0"
+                                }
+                            },
                             {
                                 "@ondc/org/item_id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
                                 "@ondc/org/item_quantity": {
@@ -6430,7 +7117,7 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+                                "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
                                 "@ondc/org/title_type": "packing",
                                 "title": "Packing Charges",
                                 "price": {
@@ -6439,7 +7126,7 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+                                "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
                                 "@ondc/org/title_type": "delivery",
                                 "title": "Delivery Charges",
                                 "price": {
@@ -6457,48 +7144,12 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
-                                "@ondc/org/item_quantity": {
-                                    "count": 2
-                                },
-                                "@ondc/org/title_type": "item",
-                                "item": {
-                                    "price": {
-                                        "currency": "INR",
-                                        "value": "120.0"
-                                    }
-                                },
-                                "title": "Cashews",
-                                "price": {
-                                    "currency": "INR",
-                                    "value": "240.0"
-                                }
-                            },
-                            {
-                                "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
-                                "@ondc/org/title_type": "packing",
-                                "title": "Packing Charges",
-                                "price": {
-                                    "currency": "INR",
-                                    "value": "5.0"
-                                }
-                            },
-                            {
-                                "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
-                                "@ondc/org/title_type": "delivery",
-                                "title": "Delivery Charges",
-                                "price": {
-                                    "currency": "INR",
-                                    "value": "100.0"
-                                }
-                            },
-                            {
-                                "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+                                "@ondc/org/item_id": "ec3a2ef5-9f47-4934-b4d5-a8d4dca6f9c8",
                                 "@ondc/org/title_type": "misc",
                                 "title": "Convenience Fee",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "35.65"
+                                    "value": "48.31"
                                 }
                             }
                         ],
@@ -6508,8 +7159,8 @@
                         "uri": "https://razorpay.com/",
                         "tl_method": "http/get",
                         "params": {
-                            "transaction_id": "order_PkmGkn5hmLCG83",
-                            "amount": "1401.72",
+                            "transaction_id": "order_PmsrRxRfEkwUOs",
+                            "amount": "1883.79",
                             "currency": "INR"
                         },
                         "type": "ON-ORDER",
@@ -6524,16 +7175,16 @@
                             {
                                 "settlement_counterparty": "buyer",
                                 "settlement_phase": "refund",
-                                "settlement_amount": "124.4",
+                                "settlement_amount": "248.81",
                                 "settlement_type": "wallet",
-                                "settlement_timestamp": "2025-01-18T16:09:23.017Z"
+                                "settlement_timestamp": "2025-01-24T05:35:56.402Z"
                             },
                             {
                                 "settlement_counterparty": "buyer",
                                 "settlement_phase": "refund",
                                 "settlement_amount": "270.27",
                                 "settlement_type": "wallet",
-                                "settlement_timestamp": "2025-01-18T04:40:58.885Z"
+                                "settlement_timestamp": "2025-01-23T12:25:39.036Z"
                             },
                             {
                                 "settlement_counterparty": "seller-app",
@@ -6548,8 +7199,8 @@
                             }
                         ]
                     },
-                    "created_at": "2025-01-18T04:39:47.970Z",
-                    "updated_at": "2025-01-18T16:10:05.171Z"
+                    "created_at": "2025-01-23T12:24:39.050Z",
+                    "updated_at": "2025-01-24T05:37:11.189Z"
                 }
             }
         },
@@ -6564,14 +7215,14 @@
                 "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
                 "bpp_id": "ondc.pirimidtech.com/v2/seller",
                 "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-                "transaction_id": "82b9cba3-1fb4-4b53-825e-904368636e74",
-                "message_id": "fa69c70b-e841-494b-ac16-a24d51025bd2",
-                "timestamp": "2025-01-18T16:10:40.608Z",
+                "transaction_id": "e35a5fd4-3758-429e-84d0-4d831a501733",
+                "message_id": "8a362e48-6e62-4039-96e9-f83d46ec3f7a",
+                "timestamp": "2025-01-24T05:38:03.974Z",
                 "ttl": "PT30S"
             },
             "message": {
                 "order": {
-                    "id": "2025-01-18-743091",
+                    "id": "2025-01-23-103725",
                     "state": "Completed",
                     "provider": {
                         "id": "e2008459-7e90-493e-b02e-cae52ca53214",
@@ -6583,30 +7234,37 @@
                     },
                     "items": [
                         {
-                            "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
+                            "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
                             "quantity": {
                                 "count": 1
                             },
-                            "fulfillment_id": "d856122c-15d5-4211-8484-4a8cb4541948"
+                            "fulfillment_id": "6dc21188-26a8-456c-9d28-1561bd0779c9"
                         },
                         {
-                            "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
+                            "id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+                            "quantity": {
+                                "count": 1
+                            },
+                            "fulfillment_id": "6dc21188-26a8-456c-9d28-1561bd0779c9"
+                        },
+                        {
+                            "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
                             "quantity": {
                                 "count": 2
                             },
-                            "fulfillment_id": "59021f2c-bed5-4797-82e1-b06febf27eda"
+                            "fulfillment_id": "6dc21188-26a8-456c-9d28-1561bd0779c9"
                         },
                         {
                             "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
                             "quantity": {
                                 "count": 1
                             },
-                            "fulfillment_id": "59021f2c-bed5-4797-82e1-b06febf27eda"
+                            "fulfillment_id": "ec3a2ef5-9f47-4934-b4d5-a8d4dca6f9c8"
                         }
                     ],
                     "documents": [
                         {
-                            "url": "https://ondc.pirimidtech.com/v2/seller/api/order/invoice/d16658c3-f55b-4ffb-8d07-b43b16ac2ef0",
+                            "url": "https://ondc.pirimidtech.com/v2/seller/api/order/invoice/a840e0cc-8f95-4439-958f-bf5e6c2d271c",
                             "label": "Invoice"
                         }
                     ],
@@ -6623,12 +7281,12 @@
                         },
                         "email": "fhemanshu@gmail.com",
                         "phone": "7202959020",
-                        "created_at": "2025-01-18T04:39:55.715Z",
-                        "updated_at": "2025-01-18T04:39:55.715Z"
+                        "created_at": "2025-01-23T12:24:49.484Z",
+                        "updated_at": "2025-01-23T12:24:49.484Z"
                     },
                     "fulfillments": [
                         {
-                            "id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+                            "id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
                             "type": "Delivery",
                             "@ondc/org/TAT": "PT99H",
                             "provider_id": "ondc.loadshare.com/ondc/18275",
@@ -6659,14 +7317,14 @@
                                         "locality": "Ashok Vatika",
                                         "city": "Ahmedabad",
                                         "state": "Gujarat",
-                                        "area_code": "380058"
+                                        "area_code": "380054"
                                     }
                                 },
                                 "time": {
-                                    "timestamp": "2025-01-18T04:41:32.495Z",
+                                    "timestamp": "2025-01-23T12:26:52.535Z",
                                     "range": {
-                                        "start": "2025-01-18T04:41:21.404Z",
-                                        "end": "2025-01-18T07:41:21.404Z"
+                                        "start": "2025-01-23T12:26:33.368Z",
+                                        "end": "2025-01-23T15:26:33.368Z"
                                     }
                                 },
                                 "instructions": {
@@ -6694,10 +7352,10 @@
                                     }
                                 },
                                 "time": {
-                                    "timestamp": "2025-01-18T16:03:23.651Z",
+                                    "timestamp": "2025-01-24T05:34:21.324Z",
                                     "range": {
-                                        "start": "2025-01-18T07:41:21.404Z",
-                                        "end": "2025-01-22T07:41:21.404Z"
+                                        "start": "2025-01-23T15:26:33.368Z",
+                                        "end": "2025-01-27T15:26:33.368Z"
                                     }
                                 },
                                 "contact": {
@@ -6721,7 +7379,7 @@
                             ]
                         },
                         {
-                            "id": "d856122c-15d5-4211-8484-4a8cb4541948",
+                            "id": "ec3a2ef5-9f47-4934-b4d5-a8d4dca6f9c8",
                             "type": "Cancel",
                             "state": {
                                 "descriptor": {
@@ -6804,7 +7462,106 @@
                             ]
                         },
                         {
-                            "id": "678bd10a8455f06951c9542a",
+                            "id": "67932706a3b38b99e1ec6555",
+                            "type": "Return",
+                            "@ondc/org/provider_name": "LoadShare",
+                            "state": {
+                                "descriptor": {
+                                    "code": "Liquidated"
+                                }
+                            },
+                            "tags": [
+                                {
+                                    "code": "return_request",
+                                    "list": [
+                                        {
+                                            "code": "id",
+                                            "value": "67932706a3b38b99e1ec6555"
+                                        },
+                                        {
+                                            "code": "item_id",
+                                            "value": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7"
+                                        },
+                                        {
+                                            "code": "parent_item_id",
+                                            "value": ""
+                                        },
+                                        {
+                                            "code": "item_quantity",
+                                            "value": "2"
+                                        },
+                                        {
+                                            "code": "reason_id",
+                                            "value": "001"
+                                        },
+                                        {
+                                            "code": "reason_desc",
+                                            "value": "detailed description for return"
+                                        },
+                                        {
+                                            "code": "images",
+                                            "value": "https://reference-buyer-app-assets.s3-ap-south-1.amazonaws.com/public-assets/2025-01-23-103725/0ddb2db8-2cca-4e38-8040-c5a06d98fdd5.png"
+                                        },
+                                        {
+                                            "code": "ttl_approval",
+                                            "value": "PT24H"
+                                        },
+                                        {
+                                            "code": "ttl_reverseqc",
+                                            "value": "P3D"
+                                        },
+                                        {
+                                            "code": "initiated_by",
+                                            "value": "buyer-app-preprod-v2.ondc.org"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "quote_trail",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "item"
+                                        },
+                                        {
+                                            "code": "id",
+                                            "value": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7"
+                                        },
+                                        {
+                                            "code": "currency",
+                                            "value": "INR"
+                                        },
+                                        {
+                                            "code": "value",
+                                            "value": "-240"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "code": "quote_trail",
+                                    "list": [
+                                        {
+                                            "code": "type",
+                                            "value": "misc"
+                                        },
+                                        {
+                                            "code": "id",
+                                            "value": "78d8f20a-87e4-4036-b7f3-e0c1afa6f7ac"
+                                        },
+                                        {
+                                            "code": "currency",
+                                            "value": "INR"
+                                        },
+                                        {
+                                            "code": "value",
+                                            "value": "-8.81"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "id": "6793268da3b38b99e1ec64d6",
                             "type": "Return",
                             "@ondc/org/provider_name": "LoadShare",
                             "state": {
@@ -6826,7 +7583,7 @@
                                     }
                                 },
                                 "time": {
-                                    "timestamp": "2025-01-18T16:09:21.621Z"
+                                    "timestamp": "2025-01-24T05:35:55.380Z"
                                 }
                             },
                             "end": {
@@ -6836,11 +7593,11 @@
                                         "locality": "Ashok Vatika",
                                         "city": "Ahmedabad",
                                         "state": "Gujarat",
-                                        "area_code": "380058"
+                                        "area_code": "380054"
                                     }
                                 },
                                 "time": {
-                                    "timestamp": "2025-01-18T16:09:40.749Z"
+                                    "timestamp": "2025-01-24T05:36:49.982Z"
                                 }
                             },
                             "tags": [
@@ -6849,7 +7606,7 @@
                                     "list": [
                                         {
                                             "code": "id",
-                                            "value": "678bd10a8455f06951c9542a"
+                                            "value": "6793268da3b38b99e1ec64d6"
                                         },
                                         {
                                             "code": "item_id",
@@ -6861,11 +7618,11 @@
                                         },
                                         {
                                             "code": "item_quantity",
-                                            "value": "1"
+                                            "value": "2"
                                         },
                                         {
                                             "code": "reason_id",
-                                            "value": "001"
+                                            "value": "002"
                                         },
                                         {
                                             "code": "reason_desc",
@@ -6873,7 +7630,7 @@
                                         },
                                         {
                                             "code": "images",
-                                            "value": "https://reference-buyer-app-assets.s3-ap-south-1.amazonaws.com/public-assets/2025-01-18-743091/c8f3fe60-e84a-4d49-ae61-ecbc2232da26.png"
+                                            "value": "https://reference-buyer-app-assets.s3-ap-south-1.amazonaws.com/public-assets/2025-01-23-103725/7d383819-6630-4428-b4d8-b7aae2065ff1.png"
                                         },
                                         {
                                             "code": "ttl_approval",
@@ -6906,7 +7663,7 @@
                                         },
                                         {
                                             "code": "value",
-                                            "value": "-120"
+                                            "value": "-240"
                                         }
                                     ]
                                 },
@@ -6919,7 +7676,7 @@
                                         },
                                         {
                                             "code": "id",
-                                            "value": "70dd195d-c7ff-46ac-ba42-53ade2f77aef"
+                                            "value": "9333ed9f-c3e6-4e5b-a863-9ccfff56e1a7"
                                         },
                                         {
                                             "code": "currency",
@@ -6927,127 +7684,7 @@
                                         },
                                         {
                                             "code": "value",
-                                            "value": "-4.4"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        {
-                            "id": "678bd25c8455f06951c954a8",
-                            "type": "Return",
-                            "@ondc/org/provider_name": "LoadShare",
-                            "state": {
-                                "descriptor": {
-                                    "code": "Liquidated"
-                                }
-                            },
-                            "tags": [
-                                {
-                                    "code": "return_request",
-                                    "list": [
-                                        {
-                                            "code": "id",
-                                            "value": "678bd25c8455f06951c954a8"
-                                        },
-                                        {
-                                            "code": "item_id",
-                                            "value": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9"
-                                        },
-                                        {
-                                            "code": "parent_item_id",
-                                            "value": ""
-                                        },
-                                        {
-                                            "code": "item_quantity",
-                                            "value": "1"
-                                        },
-                                        {
-                                            "code": "reason_id",
-                                            "value": "001"
-                                        },
-                                        {
-                                            "code": "reason_desc",
-                                            "value": "detailed description for return"
-                                        },
-                                        {
-                                            "code": "images",
-                                            "value": "https://reference-buyer-app-assets.s3-ap-south-1.amazonaws.com/public-assets/2025-01-18-743091/824c6fb6-842f-477b-9a79-6ebaa14519ad.png"
-                                        },
-                                        {
-                                            "code": "ttl_approval",
-                                            "value": "PT24H"
-                                        },
-                                        {
-                                            "code": "ttl_reverseqc",
-                                            "value": "P3D"
-                                        },
-                                        {
-                                            "code": "initiated_by",
-                                            "value": "buyer-app-preprod-v2.ondc.org"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "quote_trail",
-                                    "list": [
-                                        {
-                                            "code": "type",
-                                            "value": "item"
-                                        },
-                                        {
-                                            "code": "id",
-                                            "value": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9"
-                                        },
-                                        {
-                                            "code": "currency",
-                                            "value": "INR"
-                                        },
-                                        {
-                                            "code": "value",
-                                            "value": "-220"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "quote_trail",
-                                    "list": [
-                                        {
-                                            "code": "type",
-                                            "value": "tax"
-                                        },
-                                        {
-                                            "code": "id",
-                                            "value": "02b04e0a-c422-48d5-8223-e97bfbc689ed"
-                                        },
-                                        {
-                                            "code": "currency",
-                                            "value": "INR"
-                                        },
-                                        {
-                                            "code": "value",
-                                            "value": "-40.7"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "code": "quote_trail",
-                                    "list": [
-                                        {
-                                            "code": "type",
-                                            "value": "misc"
-                                        },
-                                        {
-                                            "code": "id",
-                                            "value": "74ef83f4-a6f2-4db7-a3a4-b76bd9d1c1d6"
-                                        },
-                                        {
-                                            "code": "currency",
-                                            "value": "INR"
-                                        },
-                                        {
-                                            "code": "value",
-                                            "value": "-9.57"
+                                            "value": "-8.81"
                                         }
                                     ]
                                 }
@@ -7057,13 +7694,13 @@
                     "quote": {
                         "price": {
                             "currency": "INR",
-                            "value": "736.78"
+                            "value": "1115.9"
                         },
                         "breakup": [
                             {
                                 "@ondc/org/item_id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
                                 "@ondc/org/item_quantity": {
-                                    "count": 2
+                                    "count": 1
                                 },
                                 "@ondc/org/title_type": "item",
                                 "item": {
@@ -7075,11 +7712,11 @@
                                 "title": "Cashews",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "240.0"
+                                    "value": "120.0"
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+                                "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
                                 "@ondc/org/title_type": "packing",
                                 "title": "Packing Charges",
                                 "price": {
@@ -7088,7 +7725,43 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+                                "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
+                                "@ondc/org/title_type": "delivery",
+                                "title": "Delivery Charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "100.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+                                "@ondc/org/item_quantity": {
+                                    "count": 1
+                                },
+                                "@ondc/org/title_type": "item",
+                                "item": {
+                                    "price": {
+                                        "currency": "INR",
+                                        "value": "120.0"
+                                    }
+                                },
+                                "title": "Walnuts",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "120.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
+                                "@ondc/org/title_type": "packing",
+                                "title": "Packing Charges",
+                                "price": {
+                                    "currency": "INR",
+                                    "value": "5.0"
+                                }
+                            },
+                            {
+                                "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
                                 "@ondc/org/title_type": "delivery",
                                 "title": "Delivery Charges",
                                 "price": {
@@ -7099,7 +7772,7 @@
                             {
                                 "@ondc/org/item_id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
                                 "@ondc/org/item_quantity": {
-                                    "count": 1
+                                    "count": 2
                                 },
                                 "@ondc/org/title_type": "item",
                                 "item": {
@@ -7111,11 +7784,11 @@
                                 "title": "Nutraj-California-Almonds-1Kg",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "220.0"
+                                    "value": "440.0"
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+                                "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
                                 "@ondc/org/title_type": "packing",
                                 "title": "Packing Charges",
                                 "price": {
@@ -7124,7 +7797,7 @@
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+                                "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
                                 "@ondc/org/title_type": "delivery",
                                 "title": "Delivery Charges",
                                 "price": {
@@ -7138,16 +7811,16 @@
                                 "title": "Tax",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "40.7"
+                                    "value": "81.4"
                                 }
                             },
                             {
-                                "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+                                "@ondc/org/item_id": "ec3a2ef5-9f47-4934-b4d5-a8d4dca6f9c8",
                                 "@ondc/org/title_type": "misc",
                                 "title": "Convenience Fee",
                                 "price": {
                                     "currency": "INR",
-                                    "value": "26.08"
+                                    "value": "39.5"
                                 }
                             }
                         ],
@@ -7157,8 +7830,8 @@
                         "uri": "https://razorpay.com/",
                         "tl_method": "http/get",
                         "params": {
-                            "transaction_id": "order_PkmGkn5hmLCG83",
-                            "amount": "1401.72",
+                            "transaction_id": "order_PmsrRxRfEkwUOs",
+                            "amount": "1883.79",
                             "currency": "INR"
                         },
                         "type": "ON-ORDER",
@@ -7173,16 +7846,16 @@
                             {
                                 "settlement_counterparty": "buyer",
                                 "settlement_phase": "refund",
-                                "settlement_amount": "124.4",
+                                "settlement_amount": "248.81",
                                 "settlement_type": "wallet",
-                                "settlement_timestamp": "2025-01-18T16:09:23.017Z"
+                                "settlement_timestamp": "2025-01-24T05:35:56.402Z"
                             },
                             {
                                 "settlement_counterparty": "buyer",
                                 "settlement_phase": "refund",
                                 "settlement_amount": "270.27",
                                 "settlement_type": "wallet",
-                                "settlement_timestamp": "2025-01-18T04:40:58.885Z"
+                                "settlement_timestamp": "2025-01-23T12:25:39.036Z"
                             },
                             {
                                 "settlement_counterparty": "seller-app",
@@ -7197,8 +7870,8 @@
                             }
                         ]
                     },
-                    "created_at": "2025-01-18T04:39:47.970Z",
-                    "updated_at": "2025-01-18T16:10:40.608Z"
+                    "created_at": "2025-01-23T12:24:39.050Z",
+                    "updated_at": "2025-01-24T05:38:03.974Z"
                 }
             }
         },
@@ -7211,19 +7884,19 @@
                 "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
                 "bpp_id": "ondc.pirimidtech.com/v2/seller",
                 "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-                "transaction_id": "82b9cba3-1fb4-4b53-825e-904368636e74",
-                "message_id": "6b8b769b-bc46-4409-8527-3746c6b78989",
+                "transaction_id": "e35a5fd4-3758-429e-84d0-4d831a501733",
+                "message_id": "9fce732f-d90d-44e2-8e90-eba935bd1ec9",
                 "city": "std:079",
                 "country": "IND",
-                "timestamp": "2025-01-18T16:10:42.056Z"
+                "timestamp": "2025-01-24T05:38:05.404Z"
             },
             "message": {
                 "update_target": "payment",
                 "order": {
-                    "id": "2025-01-18-743091",
+                    "id": "2025-01-23-103725",
                     "fulfillments": [
                         {
-                            "id": "678bd25c8455f06951c954a8",
+                            "id": "67932706a3b38b99e1ec6555",
                             "type": "Return"
                         }
                     ],
@@ -7233,8 +7906,8 @@
                                 "settlement_counterparty": "buyer",
                                 "settlement_phase": "refund",
                                 "settlement_type": "wallet",
-                                "settlement_amount": "270.27",
-                                "settlement_timestamp": "2025-01-18T16:10:42.056Z"
+                                "settlement_amount": "248.81",
+                                "settlement_timestamp": "2025-01-24T05:38:05.404Z"
                             }
                         ]
                     }

--- a/Pirimid/SellerApp/Retail/RET-10/FLOW_6/log_validation_utitlity_response.json
+++ b/Pirimid/SellerApp/Retail/RET-10/FLOW_6/log_validation_utitlity_response.json
@@ -1,13 +1,17 @@
 {
-    "success": true,
+    "success": false,
     "response": {
-        "message": "Logs were verified successfully",
-        "report": {},
+        "message": "Logs were not verified successfully",
+        "report": {
+            "on_search_full_catalog_refresh": {
+                "prvdr0categories": "Support for variants is mandatory, categories must be present in bpp/providers[0]"
+            }
+        },
         "bpp_id": "ondc.pirimidtech.com/v2/seller",
         "bap_id": "buyer-app-preprod-v2.ondc.org",
         "domain": "ONDC:RET10",
-        "reportTimestamp": "2025-01-19T04:34:02.257Z"
+        "reportTimestamp": "2025-01-24T05:55:21.198Z"
     },
-    "signature": "RjDgJ5P0o6d/bz14GEjyh84WDh11D6ODAiGAvuzTeUAGmQ43k4VwAl5vNrH1Hyjy7K0WNJV9afnpWBtpd3ikCA==",
-    "signTimestamp": "2025-01-19T04:34:02.257Z"
+    "signature": "LWO9TgwfxLvryerrYVOpMZnBaOZpgfH93hwpy70of6ObKJ7vX/bp1mGvPXp2++j5WFese4hof+lftl43KZJbBw==",
+    "signTimestamp": "2025-01-24T05:55:21.198Z"
 }

--- a/Pirimid/SellerApp/Retail/RET-10/FLOW_6/on_confirm.json
+++ b/Pirimid/SellerApp/Retail/RET-10/FLOW_6/on_confirm.json
@@ -9,13 +9,13 @@
     "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
     "bpp_id": "ondc.pirimidtech.com/v2/seller",
     "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-    "transaction_id": "82b9cba3-1fb4-4b53-825e-904368636e74",
-    "message_id": "f84c010d-615c-446d-8b6e-e66f58470b78",
-    "timestamp": "2025-01-18T04:40:23.892Z"
+    "transaction_id": "e35a5fd4-3758-429e-84d0-4d831a501733",
+    "message_id": "910f4f8b-dd2f-4ab6-b202-1a154f31873c",
+    "timestamp": "2025-01-23T12:25:11.058Z"
   },
   "message": {
     "order": {
-      "id": "2025-01-18-743091",
+      "id": "2025-01-23-103725",
       "state": "Created",
       "provider": {
         "id": "e2008459-7e90-493e-b02e-cae52ca53214",
@@ -31,14 +31,21 @@
           "quantity": {
             "count": 3
           },
-          "fulfillment_id": "59021f2c-bed5-4797-82e1-b06febf27eda"
+          "fulfillment_id": "6dc21188-26a8-456c-9d28-1561bd0779c9"
         },
         {
           "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
           "quantity": {
             "count": 3
           },
-          "fulfillment_id": "59021f2c-bed5-4797-82e1-b06febf27eda"
+          "fulfillment_id": "6dc21188-26a8-456c-9d28-1561bd0779c9"
+        },
+        {
+          "id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+          "quantity": {
+            "count": 3
+          },
+          "fulfillment_id": "6dc21188-26a8-456c-9d28-1561bd0779c9"
         }
       ],
       "billing": {
@@ -54,12 +61,12 @@
         },
         "email": "fhemanshu@gmail.com",
         "phone": "7202959020",
-        "created_at": "2025-01-18T04:39:55.715Z",
-        "updated_at": "2025-01-18T04:39:55.715Z"
+        "created_at": "2025-01-23T12:24:49.484Z",
+        "updated_at": "2025-01-23T12:24:49.484Z"
       },
       "fulfillments": [
         {
-          "id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+          "id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
           "type": "Delivery",
           "@ondc/org/TAT": "PT99H",
           "@ondc/org/provider_name": "LoadShare",
@@ -80,7 +87,7 @@
                 "locality": "Ashok Vatika",
                 "city": "Ahmedabad",
                 "state": "Gujarat",
-                "area_code": "380058"
+                "area_code": "380054"
               }
             },
             "contact": {
@@ -114,7 +121,7 @@
       "quote": {
         "price": {
           "currency": "INR",
-          "value": "1401.72"
+          "value": "1883.79"
         },
         "breakup": [
           {
@@ -136,7 +143,7 @@
             }
           },
           {
-            "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+            "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
             "@ondc/org/title_type": "packing",
             "title": "Packing Charges",
             "price": {
@@ -145,7 +152,7 @@
             }
           },
           {
-            "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+            "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
             "@ondc/org/title_type": "delivery",
             "title": "Delivery Charges",
             "price": {
@@ -181,7 +188,7 @@
             }
           },
           {
-            "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+            "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
             "@ondc/org/title_type": "packing",
             "title": "Packing Charges",
             "price": {
@@ -190,7 +197,7 @@
             }
           },
           {
-            "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+            "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
             "@ondc/org/title_type": "delivery",
             "title": "Delivery Charges",
             "price": {
@@ -199,12 +206,48 @@
             }
           },
           {
-            "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+            "@ondc/org/item_id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+            "@ondc/org/item_quantity": {
+              "count": 3
+            },
+            "@ondc/org/title_type": "item",
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "120.0"
+              }
+            },
+            "title": "Walnuts",
+            "price": {
+              "currency": "INR",
+              "value": "360.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
+            "@ondc/org/title_type": "packing",
+            "title": "Packing Charges",
+            "price": {
+              "currency": "INR",
+              "value": "5.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
+            "@ondc/org/title_type": "delivery",
+            "title": "Delivery Charges",
+            "price": {
+              "currency": "INR",
+              "value": "100.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
             "@ondc/org/title_type": "misc",
             "title": "Convenience Fee",
             "price": {
               "currency": "INR",
-              "value": "49.62"
+              "value": "66.69"
             }
           }
         ],
@@ -214,8 +257,8 @@
         "uri": "https://razorpay.com/",
         "tl_method": "http/get",
         "params": {
-          "transaction_id": "order_PkmGkn5hmLCG83",
-          "amount": "1401.72",
+          "transaction_id": "order_PmsrRxRfEkwUOs",
+          "amount": "1883.79",
           "currency": "INR"
         },
         "type": "ON-ORDER",
@@ -240,8 +283,8 @@
           }
         ]
       },
-      "created_at": "2025-01-18T04:40:23.079Z",
-      "updated_at": "2025-01-18T04:40:23.892Z",
+      "created_at": "2025-01-23T12:25:10.086Z",
+      "updated_at": "2025-01-23T12:25:11.058Z",
       "tags": [
         {
           "code": "bpp_terms",

--- a/Pirimid/SellerApp/Retail/RET-10/FLOW_6/on_init.json
+++ b/Pirimid/SellerApp/Retail/RET-10/FLOW_6/on_init.json
@@ -9,9 +9,9 @@
     "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
     "bpp_id": "ondc.pirimidtech.com/v2/seller",
     "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-    "transaction_id": "82b9cba3-1fb4-4b53-825e-904368636e74",
-    "message_id": "e5ebd64d-5a78-444f-a7db-d74cb2eebcef",
-    "timestamp": "2025-01-18T04:39:56.488Z",
+    "transaction_id": "e35a5fd4-3758-429e-84d0-4d831a501733",
+    "message_id": "f687722c-a82c-4f49-adbd-6ec190026c2e",
+    "timestamp": "2025-01-23T12:24:50.309Z",
     "ttl": "PT30S"
   },
   "message": {
@@ -33,7 +33,7 @@
             },
             "count": 3
           },
-          "fulfillment_id": "59021f2c-bed5-4797-82e1-b06febf27eda"
+          "fulfillment_id": "6dc21188-26a8-456c-9d28-1561bd0779c9"
         },
         {
           "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
@@ -43,7 +43,17 @@
             },
             "count": 3
           },
-          "fulfillment_id": "59021f2c-bed5-4797-82e1-b06febf27eda"
+          "fulfillment_id": "6dc21188-26a8-456c-9d28-1561bd0779c9"
+        },
+        {
+          "id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+          "quantity": {
+            "unitized": {
+              "count": "3"
+            },
+            "count": 3
+          },
+          "fulfillment_id": "6dc21188-26a8-456c-9d28-1561bd0779c9"
         }
       ],
       "billing": {
@@ -59,19 +69,13 @@
         },
         "email": "fhemanshu@gmail.com",
         "phone": "7202959020",
-        "created_at": "2025-01-18T04:39:55.715Z",
-        "updated_at": "2025-01-18T04:39:55.715Z"
+        "created_at": "2025-01-23T12:24:49.484Z",
+        "updated_at": "2025-01-23T12:24:49.484Z"
       },
       "fulfillments": [
         {
-          "id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+          "id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
           "type": "Delivery",
-          "provider_id": "ondc.loadshare.com/ondc/18275",
-          "state": {
-            "descriptor": {
-              "code": "INITIALIZING"
-            }
-          },
           "tracking": false,
           "end": {
             "location": {
@@ -85,9 +89,6 @@
                 "country": "IND",
                 "area_code": "380015"
               }
-            },
-            "time": {
-              "range": {}
             },
             "instructions": {
               "name": "Status for pickup",
@@ -108,7 +109,7 @@
       "quote": {
         "price": {
           "currency": "INR",
-          "value": "1401.72"
+          "value": "1883.79"
         },
         "breakup": [
           {
@@ -130,7 +131,7 @@
             }
           },
           {
-            "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+            "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
             "@ondc/org/title_type": "packing",
             "title": "Packing Charges",
             "price": {
@@ -139,7 +140,7 @@
             }
           },
           {
-            "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+            "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
             "@ondc/org/title_type": "delivery",
             "title": "Delivery Charges",
             "price": {
@@ -175,7 +176,7 @@
             }
           },
           {
-            "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+            "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
             "@ondc/org/title_type": "packing",
             "title": "Packing Charges",
             "price": {
@@ -184,7 +185,7 @@
             }
           },
           {
-            "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+            "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
             "@ondc/org/title_type": "delivery",
             "title": "Delivery Charges",
             "price": {
@@ -193,22 +194,58 @@
             }
           },
           {
-            "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+            "@ondc/org/item_id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+            "@ondc/org/item_quantity": {
+              "count": 3
+            },
+            "@ondc/org/title_type": "item",
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "120.0"
+              }
+            },
+            "title": "Walnuts",
+            "price": {
+              "currency": "INR",
+              "value": "360.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
+            "@ondc/org/title_type": "packing",
+            "title": "Packing Charges",
+            "price": {
+              "currency": "INR",
+              "value": "5.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
+            "@ondc/org/title_type": "delivery",
+            "title": "Delivery Charges",
+            "price": {
+              "currency": "INR",
+              "value": "100.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
             "@ondc/org/title_type": "misc",
             "title": "Convenience Fee",
             "price": {
               "currency": "INR",
-              "value": "49.62"
+              "value": "66.69"
             }
           }
         ],
         "ttl": "P1D"
       },
       "payment": {
-        "uri": "https://ondc-pirimid-payment.netlify.app/payment/82b9cba3-1fb4-4b53-825e-904368636e74",
+        "uri": "https://ondc-pirimid-payment.netlify.app/payment/e35a5fd4-3758-429e-84d0-4d831a501733",
         "type": "ON-ORDER",
         "status": "NOT-PAID",
-        "collected_by": "BPP",
+        "collected_by": "BAP",
         "@ondc/org/buyer_app_finder_fee_type": "percent",
         "@ondc/org/buyer_app_finder_fee_amount": "3.0",
         "@ondc/org/withholding_amount": "0.0",
@@ -228,8 +265,8 @@
           }
         ]
       },
-      "created_at": "2025-01-18T04:39:47.970Z",
-      "updated_at": "2025-01-18T04:39:56.492Z",
+      "created_at": "2025-01-23T12:24:39.050Z",
+      "updated_at": "2025-01-23T12:24:50.315Z",
       "tags": [
         {
           "code": "bpp_terms",

--- a/Pirimid/SellerApp/Retail/RET-10/FLOW_6/on_search_full_catalog_refresh.json
+++ b/Pirimid/SellerApp/Retail/RET-10/FLOW_6/on_search_full_catalog_refresh.json
@@ -9,9 +9,9 @@
     "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
     "bpp_id": "ondc.pirimidtech.com/v2/seller",
     "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-    "transaction_id": "e53a74c5-7ce6-4498-800c-e7d90db0f2fa",
-    "message_id": "45726578-5033-41e0-b35f-2fcbcebe8f82",
-    "timestamp": "2025-01-17T12:00:21.411Z",
+    "transaction_id": "2a274964-3eec-4793-888c-1d30ef845cd1",
+    "message_id": "c5c58f68-8483-4490-b318-a1436c6ee88b",
+    "timestamp": "2025-01-23T12:00:21.519Z",
     "ttl": "PT30S"
   },
   "message": {
@@ -58,70 +58,8 @@
           "@ondc/org/fssai_license_no": "12345678912345",
           "time": {
             "label": "enable",
-            "timestamp": "2025-01-17T12:00:21.411Z"
+            "timestamp": "2025-01-23T12:00:21.519Z"
           },
-          "categories": [
-            {
-              "id": "variant10000",
-              "descriptor": {
-                "name": "Variant for Nutraj-California-Almonds-1Kg"
-              },
-              "tags": [
-                {
-                  "code": "type",
-                  "list": [
-                    {
-                      "code": "type",
-                      "value": "variant_group"
-                    }
-                  ]
-                },
-                {
-                  "code": "attr",
-                  "list": [
-                    {
-                      "code": "name",
-                      "value": "item.quantity.unitized.measure"
-                    },
-                    {
-                      "code": "seq",
-                      "value": "1"
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "id": "variant10001",
-              "descriptor": {
-                "name": "Variant for Cashews"
-              },
-              "tags": [
-                {
-                  "code": "type",
-                  "list": [
-                    {
-                      "code": "type",
-                      "value": "variant_group"
-                    }
-                  ]
-                },
-                {
-                  "code": "attr",
-                  "list": [
-                    {
-                      "code": "name",
-                      "value": "item.quantity.unitized.measure"
-                    },
-                    {
-                      "code": "seq",
-                      "value": "1"
-                    }
-                  ]
-                }
-              ]
-            }
-          ],
           "fulfillments": [
             {
               "id": "1",
@@ -141,11 +79,11 @@
                 "locality": "Ashok Vatika",
                 "city": "Ahmedabad",
                 "state": "Gujarat",
-                "area_code": "380058"
+                "area_code": "380054"
               },
               "time": {
                 "label": "enable",
-                "timestamp": "2024-12-04T13:50:34.608Z",
+                "timestamp": "2025-01-22T07:34:34.534Z",
                 "range": {
                   "start": "0930",
                   "end": "1930"
@@ -162,12 +100,85 @@
           ],
           "items": [
             {
+              "id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+              "descriptor": {
+                "name": "Walnuts",
+                "code": "1:12345678",
+                "symbol": "https://c8.alamy.com/comp/2HCTDG2/modern-design-walnut-leaf-nature-green-logo-design-2HCTDG2.jpg",
+                "short_desc": "WONDERLAND California Whole Walnut Walnuts (Akhrot)  (500 g)",
+                "long_desc": "WONDERLAND California Whole Walnut Walnuts (Akhrot)  (500 g)",
+                "images": [
+                  "https://rukminim2.flixcart.com/image/416/416/xif0q/nut-dry-fruit/h/x/t/500-california-whole-walnut-1-pouch-wonderland-original-imagy632bnvk8fde.jpeg?q=70",
+                  "https://rukminim2.flixcart.com/image/416/416/xif0q/nut-dry-fruit/q/r/t/500-california-whole-walnut-1-pouch-wonderland-original-imagy6326hdk68cd.jpeg?q=70"
+                ]
+              },
+              "price": {
+                "currency": "INR",
+                "value": "120.0",
+                "maximum_value": "200.0"
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                },
+                "unitized": {
+                  "measure": {
+                    "value": "500",
+                    "unit": "gram"
+                  }
+                }
+              },
+              "category_id": "Snacks, Dry Fruits, Nuts",
+              "fulfillment_id": "1",
+              "location_id": "39550822-c3bb-4918-bd25-2d19ef6a9aca",
+              "time": {
+                "label": "enable",
+                "timestamp": "2025-01-23T12:00:21.519Z"
+              },
+              "@ondc/org/returnable": true,
+              "@ondc/org/seller_pickup_return": false,
+              "@ondc/org/return_window": "P7D",
+              "@ondc/org/cancellable": true,
+              "@ondc/org/time_to_ship": "PT3H",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "PirimidFintech,user@gmail.com,7744774477",
+              "@ondc/org/statutory_reqs_prepackaged_food": {
+                "nutritional_info": "nutritional_info",
+                "additives_info": "additives_info",
+                "brand_owner_FSSAI_license_no": "12345678912345",
+                "other_FSSAI_license_no": "12345678912345",
+                "importer_FSSAI_license_no": "12345678912345"
+              },
+              "tags": [
+                {
+                  "code": "origin",
+                  "list": [
+                    {
+                      "code": "Country",
+                      "value": "IND"
+                    }
+                  ]
+                },
+                {
+                  "code": "veg_nonveg",
+                  "list": [
+                    {
+                      "code": "veg",
+                      "value": "yes"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
               "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
-              "parent_item_id": "variant10000",
               "descriptor": {
                 "name": "Nutraj-California-Almonds-1Kg",
                 "code": "1:12345678",
-                "symbol": "symbols.in/symbol.jpg",
+                "symbol": "https://img.freepik.com/premium-vector/almonds-nuts-nature-farm-vintage-logo-icon-symbol-vector-illustration-minimalist-design_889650-491.jpg?semt=ais_hybrid",
                 "short_desc": "Nutraj California Almond kernels 1kg Pouch|Badam Giri|Dry Fruits and Nuts|Grocery",
                 "long_desc": "Nutraj California Almond kernels 1kg Pouch|Badam Giri|Dry Fruits and Nuts|Grocery",
                 "images": [
@@ -198,7 +209,7 @@
               "location_id": "39550822-c3bb-4918-bd25-2d19ef6a9aca",
               "time": {
                 "label": "enable",
-                "timestamp": "2025-01-17T12:00:21.411Z"
+                "timestamp": "2025-01-23T12:00:21.519Z"
               },
               "@ondc/org/returnable": true,
               "@ondc/org/seller_pickup_return": false,
@@ -237,11 +248,10 @@
             },
             {
               "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
-              "parent_item_id": "variant10001",
               "descriptor": {
                 "name": "Cashews",
                 "code": "1:12345678",
-                "symbol": "symbols.in/symbol.jpg",
+                "symbol": "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTVlckKW1pwOvmkj9_s_rPbAvcsr_EdmIStMA&s",
                 "short_desc": "Emart Brand - Vedaka Whole Cashews | 500 Gram | Kaju Nuts Grade W320 | Plant Based Protein | Gluten-Free | Nutty Flavor | Healthy Snack | Rich Delicious Taste",
                 "long_desc": "Emart Brand - Vedaka Whole Cashews | 500 Gram | Kaju Nuts Grade W320 | Plant Based Protein | Gluten-Free | Nutty Flavor | Healthy Snack | Rich Delicious Taste",
                 "images": [
@@ -251,7 +261,7 @@
               "price": {
                 "currency": "INR",
                 "value": "120.0",
-                "maximum_value": "258.0"
+                "maximum_value": "212.0"
               },
               "quantity": {
                 "available": {
@@ -262,8 +272,8 @@
                 },
                 "unitized": {
                   "measure": {
-                    "value": "1",
-                    "unit": "kilogram"
+                    "value": "500",
+                    "unit": "gram"
                   }
                 }
               },
@@ -272,7 +282,7 @@
               "location_id": "39550822-c3bb-4918-bd25-2d19ef6a9aca",
               "time": {
                 "label": "enable",
-                "timestamp": "2025-01-17T12:00:21.411Z"
+                "timestamp": "2025-01-23T12:00:21.519Z"
               },
               "@ondc/org/returnable": true,
               "@ondc/org/seller_pickup_return": false,
@@ -342,36 +352,7 @@
               "list": [
                 {
                   "code": "type",
-                  "value": "Order"
-                },
-                {
-                  "code": "location",
-                  "value": "39550822-c3bb-4918-bd25-2d19ef6a9aca"
-                },
-                {
-                  "code": "day_from",
-                  "value": "1"
-                },
-                {
-                  "code": "day_to",
-                  "value": "7"
-                },
-                {
-                  "code": "time_from",
-                  "value": "0930"
-                },
-                {
-                  "code": "time_to",
-                  "value": "1930"
-                }
-              ]
-            },
-            {
-              "code": "timing",
-              "list": [
-                {
-                  "code": "type",
-                  "value": "Delivery"
+                  "value": "All"
                 },
                 {
                   "code": "location",

--- a/Pirimid/SellerApp/Retail/RET-10/FLOW_6/on_select.json
+++ b/Pirimid/SellerApp/Retail/RET-10/FLOW_6/on_select.json
@@ -9,9 +9,9 @@
     "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
     "bpp_id": "ondc.pirimidtech.com/v2/seller",
     "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-    "transaction_id": "82b9cba3-1fb4-4b53-825e-904368636e74",
-    "message_id": "3b8fc2b8-8b27-49d2-9952-dc997bd8f282",
-    "timestamp": "2025-01-18T04:39:47.958Z"
+    "transaction_id": "e35a5fd4-3758-429e-84d0-4d831a501733",
+    "message_id": "424472ba-775e-447f-8961-eaaa3327e8c9",
+    "timestamp": "2025-01-23T12:24:39.043Z"
   },
   "message": {
     "order": {
@@ -26,16 +26,20 @@
       "items": [
         {
           "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
-          "fulfillment_id": "59021f2c-bed5-4797-82e1-b06febf27eda"
+          "fulfillment_id": "6dc21188-26a8-456c-9d28-1561bd0779c9"
         },
         {
           "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
-          "fulfillment_id": "59021f2c-bed5-4797-82e1-b06febf27eda"
+          "fulfillment_id": "6dc21188-26a8-456c-9d28-1561bd0779c9"
+        },
+        {
+          "id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+          "fulfillment_id": "6dc21188-26a8-456c-9d28-1561bd0779c9"
         }
       ],
       "fulfillments": [
         {
-          "id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+          "id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
           "type": "Delivery",
           "@ondc/org/category": "Standard Delivery",
           "@ondc/org/TAT": "PT99H",
@@ -51,7 +55,7 @@
       "quote": {
         "price": {
           "currency": "INR",
-          "value": "1401.72"
+          "value": "1883.79"
         },
         "breakup": [
           {
@@ -81,7 +85,7 @@
             }
           },
           {
-            "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+            "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
             "@ondc/org/title_type": "packing",
             "title": "Packing Charges",
             "price": {
@@ -90,7 +94,7 @@
             }
           },
           {
-            "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+            "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
             "@ondc/org/title_type": "delivery",
             "title": "Delivery Charges",
             "price": {
@@ -134,7 +138,7 @@
             }
           },
           {
-            "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+            "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
             "@ondc/org/title_type": "packing",
             "title": "Packing Charges",
             "price": {
@@ -143,7 +147,7 @@
             }
           },
           {
-            "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+            "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
             "@ondc/org/title_type": "delivery",
             "title": "Delivery Charges",
             "price": {
@@ -152,12 +156,56 @@
             }
           },
           {
-            "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+            "@ondc/org/item_id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+            "@ondc/org/item_quantity": {
+              "count": 3
+            },
+            "@ondc/org/title_type": "item",
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "120.0"
+              },
+              "quantity": {
+                "available": {
+                  "count": "99"
+                },
+                "maximum": {
+                  "count": "99"
+                }
+              }
+            },
+            "title": "Walnuts",
+            "price": {
+              "currency": "INR",
+              "value": "360.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
+            "@ondc/org/title_type": "packing",
+            "title": "Packing Charges",
+            "price": {
+              "currency": "INR",
+              "value": "5.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
+            "@ondc/org/title_type": "delivery",
+            "title": "Delivery Charges",
+            "price": {
+              "currency": "INR",
+              "value": "100.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
             "@ondc/org/title_type": "misc",
             "title": "Convenience Fee",
             "price": {
               "currency": "INR",
-              "value": "49.62"
+              "value": "66.69"
             }
           }
         ],

--- a/Pirimid/SellerApp/Retail/RET-10/FLOW_6/on_status_delivered.json
+++ b/Pirimid/SellerApp/Retail/RET-10/FLOW_6/on_status_delivered.json
@@ -9,14 +9,14 @@
     "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
     "bpp_id": "ondc.pirimidtech.com/v2/seller",
     "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-    "transaction_id": "82b9cba3-1fb4-4b53-825e-904368636e74",
-    "message_id": "f7ace1d7-c971-4251-ba41-d042cb644fe6",
-    "timestamp": "2025-01-18T16:03:23.653Z",
+    "transaction_id": "e35a5fd4-3758-429e-84d0-4d831a501733",
+    "message_id": "ecbc30d5-4c3f-4dd7-a8b5-f46266545ddc",
+    "timestamp": "2025-01-24T05:34:21.328Z",
     "ttl": "PT30S"
   },
   "message": {
     "order": {
-      "id": "2025-01-18-743091",
+      "id": "2025-01-23-103725",
       "state": "Completed",
       "provider": {
         "id": "e2008459-7e90-493e-b02e-cae52ca53214",
@@ -32,26 +32,33 @@
           "quantity": {
             "count": 3
           },
-          "fulfillment_id": "59021f2c-bed5-4797-82e1-b06febf27eda"
+          "fulfillment_id": "6dc21188-26a8-456c-9d28-1561bd0779c9"
+        },
+        {
+          "id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+          "quantity": {
+            "count": 3
+          },
+          "fulfillment_id": "6dc21188-26a8-456c-9d28-1561bd0779c9"
         },
         {
           "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
           "quantity": {
             "count": 2
           },
-          "fulfillment_id": "59021f2c-bed5-4797-82e1-b06febf27eda"
+          "fulfillment_id": "6dc21188-26a8-456c-9d28-1561bd0779c9"
         },
         {
           "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
           "quantity": {
             "count": 1
           },
-          "fulfillment_id": "d856122c-15d5-4211-8484-4a8cb4541948"
+          "fulfillment_id": "ec3a2ef5-9f47-4934-b4d5-a8d4dca6f9c8"
         }
       ],
       "documents": [
         {
-          "url": "https://ondc.pirimidtech.com/v2/seller/api/order/invoice/d16658c3-f55b-4ffb-8d07-b43b16ac2ef0",
+          "url": "https://ondc.pirimidtech.com/v2/seller/api/order/invoice/a840e0cc-8f95-4439-958f-bf5e6c2d271c",
           "label": "Invoice"
         }
       ],
@@ -68,12 +75,12 @@
         },
         "email": "fhemanshu@gmail.com",
         "phone": "7202959020",
-        "created_at": "2025-01-18T04:39:55.715Z",
-        "updated_at": "2025-01-18T04:39:55.715Z"
+        "created_at": "2025-01-23T12:24:49.484Z",
+        "updated_at": "2025-01-23T12:24:49.484Z"
       },
       "fulfillments": [
         {
-          "id": "d856122c-15d5-4211-8484-4a8cb4541948",
+          "id": "ec3a2ef5-9f47-4934-b4d5-a8d4dca6f9c8",
           "type": "Cancel",
           "state": {
             "descriptor": {
@@ -156,7 +163,7 @@
           ]
         },
         {
-          "id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+          "id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
           "type": "Delivery",
           "@ondc/org/TAT": "PT99H",
           "provider_id": "ondc.loadshare.com/ondc/18275",
@@ -187,14 +194,14 @@
                 "locality": "Ashok Vatika",
                 "city": "Ahmedabad",
                 "state": "Gujarat",
-                "area_code": "380058"
+                "area_code": "380054"
               }
             },
             "time": {
-              "timestamp": "2025-01-18T04:41:32.495Z",
+              "timestamp": "2025-01-23T12:26:52.535Z",
               "range": {
-                "start": "2025-01-18T04:41:21.404Z",
-                "end": "2025-01-18T07:41:21.404Z"
+                "start": "2025-01-23T12:26:33.368Z",
+                "end": "2025-01-23T15:26:33.368Z"
               }
             },
             "instructions": {
@@ -222,10 +229,10 @@
               }
             },
             "time": {
-              "timestamp": "2025-01-18T16:03:23.651Z",
+              "timestamp": "2025-01-24T05:34:21.324Z",
               "range": {
-                "start": "2025-01-18T07:41:21.404Z",
-                "end": "2025-01-22T07:41:21.404Z"
+                "start": "2025-01-23T15:26:33.368Z",
+                "end": "2025-01-27T15:26:33.368Z"
               }
             },
             "contact": {
@@ -252,7 +259,7 @@
       "quote": {
         "price": {
           "currency": "INR",
-          "value": "1131.45"
+          "value": "1613.52"
         },
         "breakup": [
           {
@@ -274,7 +281,7 @@
             }
           },
           {
-            "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+            "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
             "@ondc/org/title_type": "packing",
             "title": "Packing Charges",
             "price": {
@@ -283,7 +290,43 @@
             }
           },
           {
-            "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+            "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
+            "@ondc/org/title_type": "delivery",
+            "title": "Delivery Charges",
+            "price": {
+              "currency": "INR",
+              "value": "100.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+            "@ondc/org/item_quantity": {
+              "count": 3
+            },
+            "@ondc/org/title_type": "item",
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "120.0"
+              }
+            },
+            "title": "Walnuts",
+            "price": {
+              "currency": "INR",
+              "value": "360.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
+            "@ondc/org/title_type": "packing",
+            "title": "Packing Charges",
+            "price": {
+              "currency": "INR",
+              "value": "5.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
             "@ondc/org/title_type": "delivery",
             "title": "Delivery Charges",
             "price": {
@@ -310,7 +353,7 @@
             }
           },
           {
-            "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+            "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
             "@ondc/org/title_type": "packing",
             "title": "Packing Charges",
             "price": {
@@ -319,7 +362,7 @@
             }
           },
           {
-            "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+            "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
             "@ondc/org/title_type": "delivery",
             "title": "Delivery Charges",
             "price": {
@@ -337,12 +380,12 @@
             }
           },
           {
-            "@ondc/org/item_id": "d856122c-15d5-4211-8484-4a8cb4541948",
+            "@ondc/org/item_id": "ec3a2ef5-9f47-4934-b4d5-a8d4dca6f9c8",
             "@ondc/org/title_type": "misc",
             "title": "Convenience Fee",
             "price": {
               "currency": "INR",
-              "value": "40.05"
+              "value": "57.12"
             }
           }
         ],
@@ -352,8 +395,8 @@
         "uri": "https://razorpay.com/",
         "tl_method": "http/get",
         "params": {
-          "transaction_id": "order_PkmGkn5hmLCG83",
-          "amount": "1401.72",
+          "transaction_id": "order_PmsrRxRfEkwUOs",
+          "amount": "1883.79",
           "currency": "INR"
         },
         "type": "ON-ORDER",
@@ -370,7 +413,7 @@
             "settlement_phase": "refund",
             "settlement_amount": "270.27",
             "settlement_type": "wallet",
-            "settlement_timestamp": "2025-01-18T04:40:58.885Z"
+            "settlement_timestamp": "2025-01-23T12:25:39.036Z"
           },
           {
             "settlement_counterparty": "seller-app",
@@ -385,8 +428,8 @@
           }
         ]
       },
-      "created_at": "2025-01-18T04:40:23.079Z",
-      "updated_at": "2025-01-18T16:03:23.653Z"
+      "created_at": "2025-01-23T12:25:10.086Z",
+      "updated_at": "2025-01-24T05:34:21.328Z"
     }
   }
 }

--- a/Pirimid/SellerApp/Retail/RET-10/FLOW_6/on_status_out_for_delivery.json
+++ b/Pirimid/SellerApp/Retail/RET-10/FLOW_6/on_status_out_for_delivery.json
@@ -9,14 +9,14 @@
     "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
     "bpp_id": "ondc.pirimidtech.com/v2/seller",
     "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-    "transaction_id": "82b9cba3-1fb4-4b53-825e-904368636e74",
-    "message_id": "a259083e-7ae3-4f0e-9442-3a8d545b0045",
-    "timestamp": "2025-01-18T16:03:18.947Z",
+    "transaction_id": "e35a5fd4-3758-429e-84d0-4d831a501733",
+    "message_id": "5e0aa811-5a04-4faa-8ae0-5a7a9fa1515a",
+    "timestamp": "2025-01-24T05:34:12.554Z",
     "ttl": "PT30S"
   },
   "message": {
     "order": {
-      "id": "2025-01-18-743091",
+      "id": "2025-01-23-103725",
       "state": "In-progress",
       "provider": {
         "id": "e2008459-7e90-493e-b02e-cae52ca53214",
@@ -32,26 +32,33 @@
           "quantity": {
             "count": 3
           },
-          "fulfillment_id": "59021f2c-bed5-4797-82e1-b06febf27eda"
+          "fulfillment_id": "6dc21188-26a8-456c-9d28-1561bd0779c9"
+        },
+        {
+          "id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+          "quantity": {
+            "count": 3
+          },
+          "fulfillment_id": "6dc21188-26a8-456c-9d28-1561bd0779c9"
         },
         {
           "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
           "quantity": {
             "count": 2
           },
-          "fulfillment_id": "59021f2c-bed5-4797-82e1-b06febf27eda"
+          "fulfillment_id": "6dc21188-26a8-456c-9d28-1561bd0779c9"
         },
         {
           "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
           "quantity": {
             "count": 1
           },
-          "fulfillment_id": "d856122c-15d5-4211-8484-4a8cb4541948"
+          "fulfillment_id": "ec3a2ef5-9f47-4934-b4d5-a8d4dca6f9c8"
         }
       ],
       "documents": [
         {
-          "url": "https://ondc.pirimidtech.com/v2/seller/api/order/invoice/d16658c3-f55b-4ffb-8d07-b43b16ac2ef0",
+          "url": "https://ondc.pirimidtech.com/v2/seller/api/order/invoice/a840e0cc-8f95-4439-958f-bf5e6c2d271c",
           "label": "Invoice"
         }
       ],
@@ -68,12 +75,12 @@
         },
         "email": "fhemanshu@gmail.com",
         "phone": "7202959020",
-        "created_at": "2025-01-18T04:39:55.715Z",
-        "updated_at": "2025-01-18T04:39:55.715Z"
+        "created_at": "2025-01-23T12:24:49.484Z",
+        "updated_at": "2025-01-23T12:24:49.484Z"
       },
       "fulfillments": [
         {
-          "id": "d856122c-15d5-4211-8484-4a8cb4541948",
+          "id": "ec3a2ef5-9f47-4934-b4d5-a8d4dca6f9c8",
           "type": "Cancel",
           "state": {
             "descriptor": {
@@ -156,7 +163,7 @@
           ]
         },
         {
-          "id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+          "id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
           "type": "Delivery",
           "@ondc/org/TAT": "PT99H",
           "provider_id": "ondc.loadshare.com/ondc/18275",
@@ -187,14 +194,14 @@
                 "locality": "Ashok Vatika",
                 "city": "Ahmedabad",
                 "state": "Gujarat",
-                "area_code": "380058"
+                "area_code": "380054"
               }
             },
             "time": {
-              "timestamp": "2025-01-18T04:41:32.495Z",
+              "timestamp": "2025-01-23T12:26:52.535Z",
               "range": {
-                "start": "2025-01-18T04:41:21.404Z",
-                "end": "2025-01-18T07:41:21.404Z"
+                "start": "2025-01-23T12:26:33.368Z",
+                "end": "2025-01-23T15:26:33.368Z"
               }
             },
             "instructions": {
@@ -223,8 +230,8 @@
             },
             "time": {
               "range": {
-                "start": "2025-01-18T07:41:21.404Z",
-                "end": "2025-01-22T07:41:21.404Z"
+                "start": "2025-01-23T15:26:33.368Z",
+                "end": "2025-01-27T15:26:33.368Z"
               }
             },
             "contact": {
@@ -251,7 +258,7 @@
       "quote": {
         "price": {
           "currency": "INR",
-          "value": "1131.45"
+          "value": "1613.52"
         },
         "breakup": [
           {
@@ -273,7 +280,7 @@
             }
           },
           {
-            "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+            "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
             "@ondc/org/title_type": "packing",
             "title": "Packing Charges",
             "price": {
@@ -282,7 +289,43 @@
             }
           },
           {
-            "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+            "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
+            "@ondc/org/title_type": "delivery",
+            "title": "Delivery Charges",
+            "price": {
+              "currency": "INR",
+              "value": "100.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+            "@ondc/org/item_quantity": {
+              "count": 3
+            },
+            "@ondc/org/title_type": "item",
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "120.0"
+              }
+            },
+            "title": "Walnuts",
+            "price": {
+              "currency": "INR",
+              "value": "360.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
+            "@ondc/org/title_type": "packing",
+            "title": "Packing Charges",
+            "price": {
+              "currency": "INR",
+              "value": "5.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
             "@ondc/org/title_type": "delivery",
             "title": "Delivery Charges",
             "price": {
@@ -309,7 +352,7 @@
             }
           },
           {
-            "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+            "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
             "@ondc/org/title_type": "packing",
             "title": "Packing Charges",
             "price": {
@@ -318,7 +361,7 @@
             }
           },
           {
-            "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+            "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
             "@ondc/org/title_type": "delivery",
             "title": "Delivery Charges",
             "price": {
@@ -336,12 +379,12 @@
             }
           },
           {
-            "@ondc/org/item_id": "d856122c-15d5-4211-8484-4a8cb4541948",
+            "@ondc/org/item_id": "ec3a2ef5-9f47-4934-b4d5-a8d4dca6f9c8",
             "@ondc/org/title_type": "misc",
             "title": "Convenience Fee",
             "price": {
               "currency": "INR",
-              "value": "40.05"
+              "value": "57.12"
             }
           }
         ],
@@ -351,8 +394,8 @@
         "uri": "https://razorpay.com/",
         "tl_method": "http/get",
         "params": {
-          "transaction_id": "order_PkmGkn5hmLCG83",
-          "amount": "1401.72",
+          "transaction_id": "order_PmsrRxRfEkwUOs",
+          "amount": "1883.79",
           "currency": "INR"
         },
         "type": "ON-ORDER",
@@ -369,7 +412,7 @@
             "settlement_phase": "refund",
             "settlement_amount": "270.27",
             "settlement_type": "wallet",
-            "settlement_timestamp": "2025-01-18T04:40:58.885Z"
+            "settlement_timestamp": "2025-01-23T12:25:39.036Z"
           },
           {
             "settlement_counterparty": "seller-app",
@@ -384,8 +427,8 @@
           }
         ]
       },
-      "created_at": "2025-01-18T04:40:23.079Z",
-      "updated_at": "2025-01-18T16:03:18.947Z"
+      "created_at": "2025-01-23T12:25:10.086Z",
+      "updated_at": "2025-01-24T05:34:12.554Z"
     }
   }
 }

--- a/Pirimid/SellerApp/Retail/RET-10/FLOW_6/on_status_packed.json
+++ b/Pirimid/SellerApp/Retail/RET-10/FLOW_6/on_status_packed.json
@@ -9,14 +9,14 @@
     "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
     "bpp_id": "ondc.pirimidtech.com/v2/seller",
     "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-    "transaction_id": "82b9cba3-1fb4-4b53-825e-904368636e74",
-    "message_id": "fd501eee-532b-49a9-a7dd-4fdf9c993dc0",
-    "timestamp": "2025-01-18T04:41:27.341Z",
+    "transaction_id": "e35a5fd4-3758-429e-84d0-4d831a501733",
+    "message_id": "72de7b9b-9eb6-4cc1-adfd-cf211237547e",
+    "timestamp": "2025-01-23T12:26:38.545Z",
     "ttl": "PT30S"
   },
   "message": {
     "order": {
-      "id": "2025-01-18-743091",
+      "id": "2025-01-23-103725",
       "state": "In-progress",
       "provider": {
         "id": "e2008459-7e90-493e-b02e-cae52ca53214",
@@ -32,21 +32,28 @@
           "quantity": {
             "count": 3
           },
-          "fulfillment_id": "59021f2c-bed5-4797-82e1-b06febf27eda"
+          "fulfillment_id": "6dc21188-26a8-456c-9d28-1561bd0779c9"
+        },
+        {
+          "id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+          "quantity": {
+            "count": 3
+          },
+          "fulfillment_id": "6dc21188-26a8-456c-9d28-1561bd0779c9"
         },
         {
           "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
           "quantity": {
             "count": 2
           },
-          "fulfillment_id": "59021f2c-bed5-4797-82e1-b06febf27eda"
+          "fulfillment_id": "6dc21188-26a8-456c-9d28-1561bd0779c9"
         },
         {
           "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
           "quantity": {
             "count": 1
           },
-          "fulfillment_id": "d856122c-15d5-4211-8484-4a8cb4541948"
+          "fulfillment_id": "ec3a2ef5-9f47-4934-b4d5-a8d4dca6f9c8"
         }
       ],
       "billing": {
@@ -62,12 +69,12 @@
         },
         "email": "fhemanshu@gmail.com",
         "phone": "7202959020",
-        "created_at": "2025-01-18T04:39:55.715Z",
-        "updated_at": "2025-01-18T04:39:55.715Z"
+        "created_at": "2025-01-23T12:24:49.484Z",
+        "updated_at": "2025-01-23T12:24:49.484Z"
       },
       "fulfillments": [
         {
-          "id": "d856122c-15d5-4211-8484-4a8cb4541948",
+          "id": "ec3a2ef5-9f47-4934-b4d5-a8d4dca6f9c8",
           "type": "Cancel",
           "state": {
             "descriptor": {
@@ -150,7 +157,7 @@
           ]
         },
         {
-          "id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+          "id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
           "type": "Delivery",
           "@ondc/org/TAT": "PT99H",
           "provider_id": "ondc.loadshare.com/ondc/18275",
@@ -181,13 +188,13 @@
                 "locality": "Ashok Vatika",
                 "city": "Ahmedabad",
                 "state": "Gujarat",
-                "area_code": "380058"
+                "area_code": "380054"
               }
             },
             "time": {
               "range": {
-                "start": "2025-01-18T04:41:21.404Z",
-                "end": "2025-01-18T07:41:21.404Z"
+                "start": "2025-01-23T12:26:33.368Z",
+                "end": "2025-01-23T15:26:33.368Z"
               }
             },
             "instructions": {
@@ -216,8 +223,8 @@
             },
             "time": {
               "range": {
-                "start": "2025-01-18T07:41:21.404Z",
-                "end": "2025-01-22T07:41:21.404Z"
+                "start": "2025-01-23T15:26:33.368Z",
+                "end": "2025-01-27T15:26:33.368Z"
               }
             },
             "contact": {
@@ -227,13 +234,24 @@
             "person": {
               "name": "Hemanshu Faldu"
             }
-          }
+          },
+          "tags": [
+            {
+              "code": "routing",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "P2P"
+                }
+              ]
+            }
+          ]
         }
       ],
       "quote": {
         "price": {
           "currency": "INR",
-          "value": "1131.45"
+          "value": "1613.52"
         },
         "breakup": [
           {
@@ -255,7 +273,7 @@
             }
           },
           {
-            "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+            "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
             "@ondc/org/title_type": "packing",
             "title": "Packing Charges",
             "price": {
@@ -264,7 +282,43 @@
             }
           },
           {
-            "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+            "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
+            "@ondc/org/title_type": "delivery",
+            "title": "Delivery Charges",
+            "price": {
+              "currency": "INR",
+              "value": "100.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+            "@ondc/org/item_quantity": {
+              "count": 3
+            },
+            "@ondc/org/title_type": "item",
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "120.0"
+              }
+            },
+            "title": "Walnuts",
+            "price": {
+              "currency": "INR",
+              "value": "360.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
+            "@ondc/org/title_type": "packing",
+            "title": "Packing Charges",
+            "price": {
+              "currency": "INR",
+              "value": "5.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
             "@ondc/org/title_type": "delivery",
             "title": "Delivery Charges",
             "price": {
@@ -291,7 +345,7 @@
             }
           },
           {
-            "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+            "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
             "@ondc/org/title_type": "packing",
             "title": "Packing Charges",
             "price": {
@@ -300,7 +354,7 @@
             }
           },
           {
-            "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+            "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
             "@ondc/org/title_type": "delivery",
             "title": "Delivery Charges",
             "price": {
@@ -318,12 +372,12 @@
             }
           },
           {
-            "@ondc/org/item_id": "d856122c-15d5-4211-8484-4a8cb4541948",
+            "@ondc/org/item_id": "ec3a2ef5-9f47-4934-b4d5-a8d4dca6f9c8",
             "@ondc/org/title_type": "misc",
             "title": "Convenience Fee",
             "price": {
               "currency": "INR",
-              "value": "40.05"
+              "value": "57.12"
             }
           }
         ],
@@ -333,8 +387,8 @@
         "uri": "https://razorpay.com/",
         "tl_method": "http/get",
         "params": {
-          "transaction_id": "order_PkmGkn5hmLCG83",
-          "amount": "1401.72",
+          "transaction_id": "order_PmsrRxRfEkwUOs",
+          "amount": "1883.79",
           "currency": "INR"
         },
         "type": "ON-ORDER",
@@ -351,7 +405,7 @@
             "settlement_phase": "refund",
             "settlement_amount": "270.27",
             "settlement_type": "wallet",
-            "settlement_timestamp": "2025-01-18T04:40:58.885Z"
+            "settlement_timestamp": "2025-01-23T12:25:39.036Z"
           },
           {
             "settlement_counterparty": "seller-app",
@@ -366,8 +420,8 @@
           }
         ]
       },
-      "created_at": "2025-01-18T04:40:23.079Z",
-      "updated_at": "2025-01-18T04:41:27.341Z"
+      "created_at": "2025-01-23T12:25:10.086Z",
+      "updated_at": "2025-01-23T12:26:38.545Z"
     }
   }
 }

--- a/Pirimid/SellerApp/Retail/RET-10/FLOW_6/on_status_pending.json
+++ b/Pirimid/SellerApp/Retail/RET-10/FLOW_6/on_status_pending.json
@@ -9,14 +9,14 @@
     "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
     "bpp_id": "ondc.pirimidtech.com/v2/seller",
     "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-    "transaction_id": "82b9cba3-1fb4-4b53-825e-904368636e74",
-    "message_id": "49e9dc17-cbee-4c26-9584-c1032eef9f28",
-    "timestamp": "2025-01-18T04:41:21.410Z",
+    "transaction_id": "e35a5fd4-3758-429e-84d0-4d831a501733",
+    "message_id": "8deb6341-9101-4288-bc86-5aba18284a32",
+    "timestamp": "2025-01-23T12:26:33.440Z",
     "ttl": "PT30S"
   },
   "message": {
     "order": {
-      "id": "2025-01-18-743091",
+      "id": "2025-01-23-103725",
       "state": "Accepted",
       "provider": {
         "id": "e2008459-7e90-493e-b02e-cae52ca53214",
@@ -32,21 +32,28 @@
           "quantity": {
             "count": 3
           },
-          "fulfillment_id": "59021f2c-bed5-4797-82e1-b06febf27eda"
+          "fulfillment_id": "6dc21188-26a8-456c-9d28-1561bd0779c9"
+        },
+        {
+          "id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+          "quantity": {
+            "count": 3
+          },
+          "fulfillment_id": "6dc21188-26a8-456c-9d28-1561bd0779c9"
         },
         {
           "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
           "quantity": {
             "count": 2
           },
-          "fulfillment_id": "59021f2c-bed5-4797-82e1-b06febf27eda"
+          "fulfillment_id": "6dc21188-26a8-456c-9d28-1561bd0779c9"
         },
         {
           "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
           "quantity": {
             "count": 1
           },
-          "fulfillment_id": "d856122c-15d5-4211-8484-4a8cb4541948"
+          "fulfillment_id": "ec3a2ef5-9f47-4934-b4d5-a8d4dca6f9c8"
         }
       ],
       "billing": {
@@ -62,12 +69,12 @@
         },
         "email": "fhemanshu@gmail.com",
         "phone": "7202959020",
-        "created_at": "2025-01-18T04:39:55.715Z",
-        "updated_at": "2025-01-18T04:39:55.715Z"
+        "created_at": "2025-01-23T12:24:49.484Z",
+        "updated_at": "2025-01-23T12:24:49.484Z"
       },
       "fulfillments": [
         {
-          "id": "d856122c-15d5-4211-8484-4a8cb4541948",
+          "id": "ec3a2ef5-9f47-4934-b4d5-a8d4dca6f9c8",
           "type": "Cancel",
           "state": {
             "descriptor": {
@@ -150,7 +157,7 @@
           ]
         },
         {
-          "id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+          "id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
           "type": "Delivery",
           "@ondc/org/TAT": "PT99H",
           "provider_id": "ondc.loadshare.com/ondc/18275",
@@ -172,13 +179,13 @@
                 "locality": "Ashok Vatika",
                 "city": "Ahmedabad",
                 "state": "Gujarat",
-                "area_code": "380058"
+                "area_code": "380054"
               }
             },
             "time": {
               "range": {
-                "start": "2025-01-18T04:41:21.404Z",
-                "end": "2025-01-18T07:41:21.404Z"
+                "start": "2025-01-23T12:26:33.368Z",
+                "end": "2025-01-23T15:26:33.368Z"
               }
             },
             "instructions": {
@@ -207,8 +214,8 @@
             },
             "time": {
               "range": {
-                "start": "2025-01-18T07:41:21.404Z",
-                "end": "2025-01-22T07:41:21.404Z"
+                "start": "2025-01-23T15:26:33.368Z",
+                "end": "2025-01-27T15:26:33.368Z"
               }
             },
             "contact": {
@@ -224,7 +231,7 @@
       "quote": {
         "price": {
           "currency": "INR",
-          "value": "1131.45"
+          "value": "1613.52"
         },
         "breakup": [
           {
@@ -246,7 +253,7 @@
             }
           },
           {
-            "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+            "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
             "@ondc/org/title_type": "packing",
             "title": "Packing Charges",
             "price": {
@@ -255,7 +262,43 @@
             }
           },
           {
-            "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+            "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
+            "@ondc/org/title_type": "delivery",
+            "title": "Delivery Charges",
+            "price": {
+              "currency": "INR",
+              "value": "100.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+            "@ondc/org/item_quantity": {
+              "count": 3
+            },
+            "@ondc/org/title_type": "item",
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "120.0"
+              }
+            },
+            "title": "Walnuts",
+            "price": {
+              "currency": "INR",
+              "value": "360.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
+            "@ondc/org/title_type": "packing",
+            "title": "Packing Charges",
+            "price": {
+              "currency": "INR",
+              "value": "5.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
             "@ondc/org/title_type": "delivery",
             "title": "Delivery Charges",
             "price": {
@@ -282,7 +325,7 @@
             }
           },
           {
-            "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+            "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
             "@ondc/org/title_type": "packing",
             "title": "Packing Charges",
             "price": {
@@ -291,7 +334,7 @@
             }
           },
           {
-            "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+            "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
             "@ondc/org/title_type": "delivery",
             "title": "Delivery Charges",
             "price": {
@@ -309,12 +352,12 @@
             }
           },
           {
-            "@ondc/org/item_id": "d856122c-15d5-4211-8484-4a8cb4541948",
+            "@ondc/org/item_id": "ec3a2ef5-9f47-4934-b4d5-a8d4dca6f9c8",
             "@ondc/org/title_type": "misc",
             "title": "Convenience Fee",
             "price": {
               "currency": "INR",
-              "value": "40.05"
+              "value": "57.12"
             }
           }
         ],
@@ -324,8 +367,8 @@
         "uri": "https://razorpay.com/",
         "tl_method": "http/get",
         "params": {
-          "transaction_id": "order_PkmGkn5hmLCG83",
-          "amount": "1401.72",
+          "transaction_id": "order_PmsrRxRfEkwUOs",
+          "amount": "1883.79",
           "currency": "INR"
         },
         "type": "ON-ORDER",
@@ -342,7 +385,7 @@
             "settlement_phase": "refund",
             "settlement_amount": "270.27",
             "settlement_type": "wallet",
-            "settlement_timestamp": "2025-01-18T04:40:58.885Z"
+            "settlement_timestamp": "2025-01-23T12:25:39.036Z"
           },
           {
             "settlement_counterparty": "seller-app",
@@ -357,8 +400,8 @@
           }
         ]
       },
-      "created_at": "2025-01-18T04:40:23.079Z",
-      "updated_at": "2025-01-18T04:41:21.410Z"
+      "created_at": "2025-01-23T12:25:10.086Z",
+      "updated_at": "2025-01-23T12:26:33.440Z"
     }
   }
 }

--- a/Pirimid/SellerApp/Retail/RET-10/FLOW_6/on_status_picked.json
+++ b/Pirimid/SellerApp/Retail/RET-10/FLOW_6/on_status_picked.json
@@ -9,14 +9,14 @@
     "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
     "bpp_id": "ondc.pirimidtech.com/v2/seller",
     "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-    "transaction_id": "82b9cba3-1fb4-4b53-825e-904368636e74",
-    "message_id": "b48a746b-f206-4de1-bcf5-b95f73cb8107",
-    "timestamp": "2025-01-18T04:41:32.497Z",
+    "transaction_id": "e35a5fd4-3758-429e-84d0-4d831a501733",
+    "message_id": "3e272b41-2e21-4be8-9069-094852c8208e",
+    "timestamp": "2025-01-23T12:26:52.548Z",
     "ttl": "PT30S"
   },
   "message": {
     "order": {
-      "id": "2025-01-18-743091",
+      "id": "2025-01-23-103725",
       "state": "In-progress",
       "provider": {
         "id": "e2008459-7e90-493e-b02e-cae52ca53214",
@@ -32,26 +32,33 @@
           "quantity": {
             "count": 3
           },
-          "fulfillment_id": "59021f2c-bed5-4797-82e1-b06febf27eda"
+          "fulfillment_id": "6dc21188-26a8-456c-9d28-1561bd0779c9"
+        },
+        {
+          "id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+          "quantity": {
+            "count": 3
+          },
+          "fulfillment_id": "6dc21188-26a8-456c-9d28-1561bd0779c9"
         },
         {
           "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
           "quantity": {
             "count": 2
           },
-          "fulfillment_id": "59021f2c-bed5-4797-82e1-b06febf27eda"
+          "fulfillment_id": "6dc21188-26a8-456c-9d28-1561bd0779c9"
         },
         {
           "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
           "quantity": {
             "count": 1
           },
-          "fulfillment_id": "d856122c-15d5-4211-8484-4a8cb4541948"
+          "fulfillment_id": "ec3a2ef5-9f47-4934-b4d5-a8d4dca6f9c8"
         }
       ],
       "documents": [
         {
-          "url": "https://ondc.pirimidtech.com/v2/seller/api/order/invoice/d16658c3-f55b-4ffb-8d07-b43b16ac2ef0",
+          "url": "https://ondc.pirimidtech.com/v2/seller/api/order/invoice/a840e0cc-8f95-4439-958f-bf5e6c2d271c",
           "label": "Invoice"
         }
       ],
@@ -68,12 +75,12 @@
         },
         "email": "fhemanshu@gmail.com",
         "phone": "7202959020",
-        "created_at": "2025-01-18T04:39:55.715Z",
-        "updated_at": "2025-01-18T04:39:55.715Z"
+        "created_at": "2025-01-23T12:24:49.484Z",
+        "updated_at": "2025-01-23T12:24:49.484Z"
       },
       "fulfillments": [
         {
-          "id": "d856122c-15d5-4211-8484-4a8cb4541948",
+          "id": "ec3a2ef5-9f47-4934-b4d5-a8d4dca6f9c8",
           "type": "Cancel",
           "state": {
             "descriptor": {
@@ -156,7 +163,7 @@
           ]
         },
         {
-          "id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+          "id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
           "type": "Delivery",
           "@ondc/org/TAT": "PT99H",
           "provider_id": "ondc.loadshare.com/ondc/18275",
@@ -187,14 +194,14 @@
                 "locality": "Ashok Vatika",
                 "city": "Ahmedabad",
                 "state": "Gujarat",
-                "area_code": "380058"
+                "area_code": "380054"
               }
             },
             "time": {
-              "timestamp": "2025-01-18T04:41:32.495Z",
+              "timestamp": "2025-01-23T12:26:52.535Z",
               "range": {
-                "start": "2025-01-18T04:41:21.404Z",
-                "end": "2025-01-18T07:41:21.404Z"
+                "start": "2025-01-23T12:26:33.368Z",
+                "end": "2025-01-23T15:26:33.368Z"
               }
             },
             "instructions": {
@@ -223,8 +230,8 @@
             },
             "time": {
               "range": {
-                "start": "2025-01-18T07:41:21.404Z",
-                "end": "2025-01-22T07:41:21.404Z"
+                "start": "2025-01-23T15:26:33.368Z",
+                "end": "2025-01-27T15:26:33.368Z"
               }
             },
             "contact": {
@@ -251,7 +258,7 @@
       "quote": {
         "price": {
           "currency": "INR",
-          "value": "1131.45"
+          "value": "1613.52"
         },
         "breakup": [
           {
@@ -273,7 +280,7 @@
             }
           },
           {
-            "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+            "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
             "@ondc/org/title_type": "packing",
             "title": "Packing Charges",
             "price": {
@@ -282,7 +289,43 @@
             }
           },
           {
-            "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+            "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
+            "@ondc/org/title_type": "delivery",
+            "title": "Delivery Charges",
+            "price": {
+              "currency": "INR",
+              "value": "100.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+            "@ondc/org/item_quantity": {
+              "count": 3
+            },
+            "@ondc/org/title_type": "item",
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "120.0"
+              }
+            },
+            "title": "Walnuts",
+            "price": {
+              "currency": "INR",
+              "value": "360.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
+            "@ondc/org/title_type": "packing",
+            "title": "Packing Charges",
+            "price": {
+              "currency": "INR",
+              "value": "5.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
             "@ondc/org/title_type": "delivery",
             "title": "Delivery Charges",
             "price": {
@@ -309,7 +352,7 @@
             }
           },
           {
-            "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+            "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
             "@ondc/org/title_type": "packing",
             "title": "Packing Charges",
             "price": {
@@ -318,7 +361,7 @@
             }
           },
           {
-            "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+            "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
             "@ondc/org/title_type": "delivery",
             "title": "Delivery Charges",
             "price": {
@@ -336,12 +379,12 @@
             }
           },
           {
-            "@ondc/org/item_id": "d856122c-15d5-4211-8484-4a8cb4541948",
+            "@ondc/org/item_id": "ec3a2ef5-9f47-4934-b4d5-a8d4dca6f9c8",
             "@ondc/org/title_type": "misc",
             "title": "Convenience Fee",
             "price": {
               "currency": "INR",
-              "value": "40.05"
+              "value": "57.12"
             }
           }
         ],
@@ -351,8 +394,8 @@
         "uri": "https://razorpay.com/",
         "tl_method": "http/get",
         "params": {
-          "transaction_id": "order_PkmGkn5hmLCG83",
-          "amount": "1401.72",
+          "transaction_id": "order_PmsrRxRfEkwUOs",
+          "amount": "1883.79",
           "currency": "INR"
         },
         "type": "ON-ORDER",
@@ -369,7 +412,7 @@
             "settlement_phase": "refund",
             "settlement_amount": "270.27",
             "settlement_type": "wallet",
-            "settlement_timestamp": "2025-01-18T04:40:58.885Z"
+            "settlement_timestamp": "2025-01-23T12:25:39.036Z"
           },
           {
             "settlement_counterparty": "seller-app",
@@ -384,8 +427,8 @@
           }
         ]
       },
-      "created_at": "2025-01-18T04:40:23.079Z",
-      "updated_at": "2025-01-18T04:41:32.497Z"
+      "created_at": "2025-01-23T12:25:10.086Z",
+      "updated_at": "2025-01-23T12:26:52.548Z"
     }
   }
 }

--- a/Pirimid/SellerApp/Retail/RET-10/FLOW_6/on_update_approval.json
+++ b/Pirimid/SellerApp/Retail/RET-10/FLOW_6/on_update_approval.json
@@ -9,14 +9,14 @@
     "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
     "bpp_id": "ondc.pirimidtech.com/v2/seller",
     "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-    "transaction_id": "82b9cba3-1fb4-4b53-825e-904368636e74",
-    "message_id": "f19e6e02-bbce-4e76-abbb-cda88385b5ae",
-    "timestamp": "2025-01-18T16:07:05.975Z",
+    "transaction_id": "e35a5fd4-3758-429e-84d0-4d831a501733",
+    "message_id": "5c2ad3ed-847e-4460-9f01-f1d66eafecb0",
+    "timestamp": "2025-01-24T05:35:48.847Z",
     "ttl": "PT30S"
   },
   "message": {
     "order": {
-      "id": "2025-01-18-743091",
+      "id": "2025-01-23-103725",
       "state": "Completed",
       "provider": {
         "id": "e2008459-7e90-493e-b02e-cae52ca53214",
@@ -32,26 +32,33 @@
           "quantity": {
             "count": 3
           },
-          "fulfillment_id": "59021f2c-bed5-4797-82e1-b06febf27eda"
+          "fulfillment_id": "6dc21188-26a8-456c-9d28-1561bd0779c9"
+        },
+        {
+          "id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+          "quantity": {
+            "count": 3
+          },
+          "fulfillment_id": "6dc21188-26a8-456c-9d28-1561bd0779c9"
         },
         {
           "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
           "quantity": {
             "count": 2
           },
-          "fulfillment_id": "59021f2c-bed5-4797-82e1-b06febf27eda"
+          "fulfillment_id": "6dc21188-26a8-456c-9d28-1561bd0779c9"
         },
         {
           "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
           "quantity": {
             "count": 1
           },
-          "fulfillment_id": "d856122c-15d5-4211-8484-4a8cb4541948"
+          "fulfillment_id": "ec3a2ef5-9f47-4934-b4d5-a8d4dca6f9c8"
         }
       ],
       "documents": [
         {
-          "url": "https://ondc.pirimidtech.com/v2/seller/api/order/invoice/d16658c3-f55b-4ffb-8d07-b43b16ac2ef0",
+          "url": "https://ondc.pirimidtech.com/v2/seller/api/order/invoice/a840e0cc-8f95-4439-958f-bf5e6c2d271c",
           "label": "Invoice"
         }
       ],
@@ -68,12 +75,12 @@
         },
         "email": "fhemanshu@gmail.com",
         "phone": "7202959020",
-        "created_at": "2025-01-18T04:39:55.715Z",
-        "updated_at": "2025-01-18T04:39:55.715Z"
+        "created_at": "2025-01-23T12:24:49.484Z",
+        "updated_at": "2025-01-23T12:24:49.484Z"
       },
       "fulfillments": [
         {
-          "id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+          "id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
           "type": "Delivery",
           "@ondc/org/TAT": "PT99H",
           "provider_id": "ondc.loadshare.com/ondc/18275",
@@ -104,14 +111,14 @@
                 "locality": "Ashok Vatika",
                 "city": "Ahmedabad",
                 "state": "Gujarat",
-                "area_code": "380058"
+                "area_code": "380054"
               }
             },
             "time": {
-              "timestamp": "2025-01-18T04:41:32.495Z",
+              "timestamp": "2025-01-23T12:26:52.535Z",
               "range": {
-                "start": "2025-01-18T04:41:21.404Z",
-                "end": "2025-01-18T07:41:21.404Z"
+                "start": "2025-01-23T12:26:33.368Z",
+                "end": "2025-01-23T15:26:33.368Z"
               }
             },
             "instructions": {
@@ -139,10 +146,10 @@
               }
             },
             "time": {
-              "timestamp": "2025-01-18T16:03:23.651Z",
+              "timestamp": "2025-01-24T05:34:21.324Z",
               "range": {
-                "start": "2025-01-18T07:41:21.404Z",
-                "end": "2025-01-22T07:41:21.404Z"
+                "start": "2025-01-23T15:26:33.368Z",
+                "end": "2025-01-27T15:26:33.368Z"
               }
             },
             "contact": {
@@ -166,7 +173,7 @@
           ]
         },
         {
-          "id": "d856122c-15d5-4211-8484-4a8cb4541948",
+          "id": "ec3a2ef5-9f47-4934-b4d5-a8d4dca6f9c8",
           "type": "Cancel",
           "state": {
             "descriptor": {
@@ -249,7 +256,7 @@
           ]
         },
         {
-          "id": "678bd10a8455f06951c9542a",
+          "id": "6793268da3b38b99e1ec64d6",
           "type": "Return",
           "@ondc/org/provider_name": "LoadShare",
           "state": {
@@ -272,8 +279,8 @@
             },
             "time": {
               "range": {
-                "start": "2025-01-18T16:08:05.878Z",
-                "end": "2025-01-25T16:03:23.651Z"
+                "start": "2025-01-24T05:35:50.825Z",
+                "end": "2025-01-31T05:34:21.324Z"
               }
             }
           },
@@ -284,7 +291,7 @@
                 "locality": "Ashok Vatika",
                 "city": "Ahmedabad",
                 "state": "Gujarat",
-                "area_code": "380058"
+                "area_code": "380054"
               }
             }
           },
@@ -294,7 +301,7 @@
               "list": [
                 {
                   "code": "id",
-                  "value": "678bd10a8455f06951c9542a"
+                  "value": "6793268da3b38b99e1ec64d6"
                 },
                 {
                   "code": "item_id",
@@ -306,11 +313,11 @@
                 },
                 {
                   "code": "item_quantity",
-                  "value": "1"
+                  "value": "2"
                 },
                 {
                   "code": "reason_id",
-                  "value": "001"
+                  "value": "002"
                 },
                 {
                   "code": "reason_desc",
@@ -318,7 +325,7 @@
                 },
                 {
                   "code": "images",
-                  "value": "https://reference-buyer-app-assets.s3-ap-south-1.amazonaws.com/public-assets/2025-01-18-743091/c8f3fe60-e84a-4d49-ae61-ecbc2232da26.png"
+                  "value": "https://reference-buyer-app-assets.s3-ap-south-1.amazonaws.com/public-assets/2025-01-23-103725/7d383819-6630-4428-b4d8-b7aae2065ff1.png"
                 },
                 {
                   "code": "ttl_approval",
@@ -340,7 +347,7 @@
       "quote": {
         "price": {
           "currency": "INR",
-          "value": "1131.45"
+          "value": "1613.52"
         },
         "breakup": [
           {
@@ -362,7 +369,7 @@
             }
           },
           {
-            "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+            "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
             "@ondc/org/title_type": "packing",
             "title": "Packing Charges",
             "price": {
@@ -371,7 +378,43 @@
             }
           },
           {
-            "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+            "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
+            "@ondc/org/title_type": "delivery",
+            "title": "Delivery Charges",
+            "price": {
+              "currency": "INR",
+              "value": "100.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+            "@ondc/org/item_quantity": {
+              "count": 3
+            },
+            "@ondc/org/title_type": "item",
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "120.0"
+              }
+            },
+            "title": "Walnuts",
+            "price": {
+              "currency": "INR",
+              "value": "360.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
+            "@ondc/org/title_type": "packing",
+            "title": "Packing Charges",
+            "price": {
+              "currency": "INR",
+              "value": "5.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
             "@ondc/org/title_type": "delivery",
             "title": "Delivery Charges",
             "price": {
@@ -398,7 +441,7 @@
             }
           },
           {
-            "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+            "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
             "@ondc/org/title_type": "packing",
             "title": "Packing Charges",
             "price": {
@@ -407,7 +450,7 @@
             }
           },
           {
-            "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+            "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
             "@ondc/org/title_type": "delivery",
             "title": "Delivery Charges",
             "price": {
@@ -425,12 +468,12 @@
             }
           },
           {
-            "@ondc/org/item_id": "d856122c-15d5-4211-8484-4a8cb4541948",
+            "@ondc/org/item_id": "ec3a2ef5-9f47-4934-b4d5-a8d4dca6f9c8",
             "@ondc/org/title_type": "misc",
             "title": "Convenience Fee",
             "price": {
               "currency": "INR",
-              "value": "40.05"
+              "value": "57.12"
             }
           }
         ],
@@ -440,8 +483,8 @@
         "uri": "https://razorpay.com/",
         "tl_method": "http/get",
         "params": {
-          "transaction_id": "order_PkmGkn5hmLCG83",
-          "amount": "1401.72",
+          "transaction_id": "order_PmsrRxRfEkwUOs",
+          "amount": "1883.79",
           "currency": "INR"
         },
         "type": "ON-ORDER",
@@ -458,7 +501,7 @@
             "settlement_phase": "refund",
             "settlement_amount": "270.27",
             "settlement_type": "wallet",
-            "settlement_timestamp": "2025-01-18T04:40:58.885Z"
+            "settlement_timestamp": "2025-01-23T12:25:39.036Z"
           },
           {
             "settlement_counterparty": "seller-app",
@@ -473,8 +516,8 @@
           }
         ]
       },
-      "created_at": "2025-01-18T04:39:47.970Z",
-      "updated_at": "2025-01-18T16:07:05.975Z"
+      "created_at": "2025-01-23T12:24:39.050Z",
+      "updated_at": "2025-01-24T05:35:48.847Z"
     }
   }
 }

--- a/Pirimid/SellerApp/Retail/RET-10/FLOW_6/on_update_delivered.json
+++ b/Pirimid/SellerApp/Retail/RET-10/FLOW_6/on_update_delivered.json
@@ -9,14 +9,14 @@
     "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
     "bpp_id": "ondc.pirimidtech.com/v2/seller",
     "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-    "transaction_id": "82b9cba3-1fb4-4b53-825e-904368636e74",
-    "message_id": "b0492fd9-f3c8-4db5-a014-26ff03008880",
-    "timestamp": "2025-01-18T16:09:40.790Z",
+    "transaction_id": "e35a5fd4-3758-429e-84d0-4d831a501733",
+    "message_id": "046acb19-a18e-4adb-afc5-97f8e113b0ac",
+    "timestamp": "2025-01-24T05:36:50.031Z",
     "ttl": "PT30S"
   },
   "message": {
     "order": {
-      "id": "2025-01-18-743091",
+      "id": "2025-01-23-103725",
       "state": "Completed",
       "provider": {
         "id": "e2008459-7e90-493e-b02e-cae52ca53214",
@@ -28,30 +28,37 @@
       },
       "items": [
         {
+          "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
+          "quantity": {
+            "count": 1
+          },
+          "fulfillment_id": "6dc21188-26a8-456c-9d28-1561bd0779c9"
+        },
+        {
+          "id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+          "quantity": {
+            "count": 3
+          },
+          "fulfillment_id": "6dc21188-26a8-456c-9d28-1561bd0779c9"
+        },
+        {
           "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
           "quantity": {
             "count": 2
           },
-          "fulfillment_id": "59021f2c-bed5-4797-82e1-b06febf27eda"
+          "fulfillment_id": "6dc21188-26a8-456c-9d28-1561bd0779c9"
         },
         {
           "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
           "quantity": {
             "count": 1
           },
-          "fulfillment_id": "d856122c-15d5-4211-8484-4a8cb4541948"
-        },
-        {
-          "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
-          "quantity": {
-            "count": 2
-          },
-          "fulfillment_id": "59021f2c-bed5-4797-82e1-b06febf27eda"
+          "fulfillment_id": "ec3a2ef5-9f47-4934-b4d5-a8d4dca6f9c8"
         }
       ],
       "documents": [
         {
-          "url": "https://ondc.pirimidtech.com/v2/seller/api/order/invoice/d16658c3-f55b-4ffb-8d07-b43b16ac2ef0",
+          "url": "https://ondc.pirimidtech.com/v2/seller/api/order/invoice/a840e0cc-8f95-4439-958f-bf5e6c2d271c",
           "label": "Invoice"
         }
       ],
@@ -68,12 +75,12 @@
         },
         "email": "fhemanshu@gmail.com",
         "phone": "7202959020",
-        "created_at": "2025-01-18T04:39:55.715Z",
-        "updated_at": "2025-01-18T04:39:55.715Z"
+        "created_at": "2025-01-23T12:24:49.484Z",
+        "updated_at": "2025-01-23T12:24:49.484Z"
       },
       "fulfillments": [
         {
-          "id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+          "id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
           "type": "Delivery",
           "@ondc/org/TAT": "PT99H",
           "provider_id": "ondc.loadshare.com/ondc/18275",
@@ -104,14 +111,14 @@
                 "locality": "Ashok Vatika",
                 "city": "Ahmedabad",
                 "state": "Gujarat",
-                "area_code": "380058"
+                "area_code": "380054"
               }
             },
             "time": {
-              "timestamp": "2025-01-18T04:41:32.495Z",
+              "timestamp": "2025-01-23T12:26:52.535Z",
               "range": {
-                "start": "2025-01-18T04:41:21.404Z",
-                "end": "2025-01-18T07:41:21.404Z"
+                "start": "2025-01-23T12:26:33.368Z",
+                "end": "2025-01-23T15:26:33.368Z"
               }
             },
             "instructions": {
@@ -139,10 +146,10 @@
               }
             },
             "time": {
-              "timestamp": "2025-01-18T16:03:23.651Z",
+              "timestamp": "2025-01-24T05:34:21.324Z",
               "range": {
-                "start": "2025-01-18T07:41:21.404Z",
-                "end": "2025-01-22T07:41:21.404Z"
+                "start": "2025-01-23T15:26:33.368Z",
+                "end": "2025-01-27T15:26:33.368Z"
               }
             },
             "contact": {
@@ -166,7 +173,7 @@
           ]
         },
         {
-          "id": "d856122c-15d5-4211-8484-4a8cb4541948",
+          "id": "ec3a2ef5-9f47-4934-b4d5-a8d4dca6f9c8",
           "type": "Cancel",
           "state": {
             "descriptor": {
@@ -249,7 +256,7 @@
           ]
         },
         {
-          "id": "678bd10a8455f06951c9542a",
+          "id": "6793268da3b38b99e1ec64d6",
           "type": "Return",
           "@ondc/org/provider_name": "LoadShare",
           "state": {
@@ -271,7 +278,7 @@
               }
             },
             "time": {
-              "timestamp": "2025-01-18T16:09:21.621Z"
+              "timestamp": "2025-01-24T05:35:55.380Z"
             }
           },
           "end": {
@@ -281,11 +288,11 @@
                 "locality": "Ashok Vatika",
                 "city": "Ahmedabad",
                 "state": "Gujarat",
-                "area_code": "380058"
+                "area_code": "380054"
               }
             },
             "time": {
-              "timestamp": "2025-01-18T16:09:40.749Z"
+              "timestamp": "2025-01-24T05:36:49.982Z"
             }
           },
           "tags": [
@@ -294,7 +301,7 @@
               "list": [
                 {
                   "code": "id",
-                  "value": "678bd10a8455f06951c9542a"
+                  "value": "6793268da3b38b99e1ec64d6"
                 },
                 {
                   "code": "item_id",
@@ -306,11 +313,11 @@
                 },
                 {
                   "code": "item_quantity",
-                  "value": "1"
+                  "value": "2"
                 },
                 {
                   "code": "reason_id",
-                  "value": "001"
+                  "value": "002"
                 },
                 {
                   "code": "reason_desc",
@@ -318,7 +325,7 @@
                 },
                 {
                   "code": "images",
-                  "value": "https://reference-buyer-app-assets.s3-ap-south-1.amazonaws.com/public-assets/2025-01-18-743091/c8f3fe60-e84a-4d49-ae61-ecbc2232da26.png"
+                  "value": "https://reference-buyer-app-assets.s3-ap-south-1.amazonaws.com/public-assets/2025-01-23-103725/7d383819-6630-4428-b4d8-b7aae2065ff1.png"
                 },
                 {
                   "code": "ttl_approval",
@@ -351,7 +358,7 @@
                 },
                 {
                   "code": "value",
-                  "value": "-120"
+                  "value": "-240"
                 }
               ]
             },
@@ -364,7 +371,7 @@
                 },
                 {
                   "code": "id",
-                  "value": "70dd195d-c7ff-46ac-ba42-53ade2f77aef"
+                  "value": "9333ed9f-c3e6-4e5b-a863-9ccfff56e1a7"
                 },
                 {
                   "code": "currency",
@@ -372,7 +379,7 @@
                 },
                 {
                   "code": "value",
-                  "value": "-4.4"
+                  "value": "-8.81"
                 }
               ]
             }
@@ -382,9 +389,81 @@
       "quote": {
         "price": {
           "currency": "INR",
-          "value": "1007.05"
+          "value": "1364.71"
         },
         "breakup": [
+          {
+            "@ondc/org/item_id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "@ondc/org/title_type": "item",
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "120.0"
+              }
+            },
+            "title": "Cashews",
+            "price": {
+              "currency": "INR",
+              "value": "120.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
+            "@ondc/org/title_type": "packing",
+            "title": "Packing Charges",
+            "price": {
+              "currency": "INR",
+              "value": "5.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
+            "@ondc/org/title_type": "delivery",
+            "title": "Delivery Charges",
+            "price": {
+              "currency": "INR",
+              "value": "100.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+            "@ondc/org/item_quantity": {
+              "count": 3
+            },
+            "@ondc/org/title_type": "item",
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "120.0"
+              }
+            },
+            "title": "Walnuts",
+            "price": {
+              "currency": "INR",
+              "value": "360.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
+            "@ondc/org/title_type": "packing",
+            "title": "Packing Charges",
+            "price": {
+              "currency": "INR",
+              "value": "5.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
+            "@ondc/org/title_type": "delivery",
+            "title": "Delivery Charges",
+            "price": {
+              "currency": "INR",
+              "value": "100.0"
+            }
+          },
           {
             "@ondc/org/item_id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
             "@ondc/org/item_quantity": {
@@ -404,7 +483,7 @@
             }
           },
           {
-            "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+            "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
             "@ondc/org/title_type": "packing",
             "title": "Packing Charges",
             "price": {
@@ -413,7 +492,7 @@
             }
           },
           {
-            "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+            "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
             "@ondc/org/title_type": "delivery",
             "title": "Delivery Charges",
             "price": {
@@ -431,48 +510,12 @@
             }
           },
           {
-            "@ondc/org/item_id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
-            "@ondc/org/item_quantity": {
-              "count": 2
-            },
-            "@ondc/org/title_type": "item",
-            "item": {
-              "price": {
-                "currency": "INR",
-                "value": "120.0"
-              }
-            },
-            "title": "Cashews",
-            "price": {
-              "currency": "INR",
-              "value": "240.0"
-            }
-          },
-          {
-            "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
-            "@ondc/org/title_type": "packing",
-            "title": "Packing Charges",
-            "price": {
-              "currency": "INR",
-              "value": "5.0"
-            }
-          },
-          {
-            "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
-            "@ondc/org/title_type": "delivery",
-            "title": "Delivery Charges",
-            "price": {
-              "currency": "INR",
-              "value": "100.0"
-            }
-          },
-          {
-            "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+            "@ondc/org/item_id": "ec3a2ef5-9f47-4934-b4d5-a8d4dca6f9c8",
             "@ondc/org/title_type": "misc",
             "title": "Convenience Fee",
             "price": {
               "currency": "INR",
-              "value": "35.65"
+              "value": "48.31"
             }
           }
         ],
@@ -482,8 +525,8 @@
         "uri": "https://razorpay.com/",
         "tl_method": "http/get",
         "params": {
-          "transaction_id": "order_PkmGkn5hmLCG83",
-          "amount": "1401.72",
+          "transaction_id": "order_PmsrRxRfEkwUOs",
+          "amount": "1883.79",
           "currency": "INR"
         },
         "type": "ON-ORDER",
@@ -498,16 +541,16 @@
           {
             "settlement_counterparty": "buyer",
             "settlement_phase": "refund",
-            "settlement_amount": "124.4",
+            "settlement_amount": "248.81",
             "settlement_type": "wallet",
-            "settlement_timestamp": "2025-01-18T16:09:23.017Z"
+            "settlement_timestamp": "2025-01-24T05:35:56.402Z"
           },
           {
             "settlement_counterparty": "buyer",
             "settlement_phase": "refund",
             "settlement_amount": "270.27",
             "settlement_type": "wallet",
-            "settlement_timestamp": "2025-01-18T04:40:58.885Z"
+            "settlement_timestamp": "2025-01-23T12:25:39.036Z"
           },
           {
             "settlement_counterparty": "seller-app",
@@ -522,8 +565,8 @@
           }
         ]
       },
-      "created_at": "2025-01-18T04:39:47.970Z",
-      "updated_at": "2025-01-18T16:09:40.790Z"
+      "created_at": "2025-01-23T12:24:39.050Z",
+      "updated_at": "2025-01-24T05:36:50.031Z"
     }
   }
 }

--- a/Pirimid/SellerApp/Retail/RET-10/FLOW_6/on_update_interim_liquidated.json
+++ b/Pirimid/SellerApp/Retail/RET-10/FLOW_6/on_update_interim_liquidated.json
@@ -9,14 +9,14 @@
     "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
     "bpp_id": "ondc.pirimidtech.com/v2/seller",
     "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-    "transaction_id": "82b9cba3-1fb4-4b53-825e-904368636e74",
-    "message_id": "945a1b17-6d01-4eed-89e7-6209d3c48fa6",
-    "timestamp": "2025-01-18T16:10:05.171Z",
+    "transaction_id": "e35a5fd4-3758-429e-84d0-4d831a501733",
+    "message_id": "104d0ea4-ba58-4984-b9b4-371fd6a95aed",
+    "timestamp": "2025-01-24T05:37:11.189Z",
     "ttl": "PT30S"
   },
   "message": {
     "order": {
-      "id": "2025-01-18-743091",
+      "id": "2025-01-23-103725",
       "state": "Completed",
       "provider": {
         "id": "e2008459-7e90-493e-b02e-cae52ca53214",
@@ -28,30 +28,37 @@
       },
       "items": [
         {
+          "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
+          "quantity": {
+            "count": 1
+          },
+          "fulfillment_id": "6dc21188-26a8-456c-9d28-1561bd0779c9"
+        },
+        {
+          "id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+          "quantity": {
+            "count": 3
+          },
+          "fulfillment_id": "6dc21188-26a8-456c-9d28-1561bd0779c9"
+        },
+        {
           "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
           "quantity": {
             "count": 2
           },
-          "fulfillment_id": "59021f2c-bed5-4797-82e1-b06febf27eda"
+          "fulfillment_id": "6dc21188-26a8-456c-9d28-1561bd0779c9"
         },
         {
           "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
           "quantity": {
             "count": 1
           },
-          "fulfillment_id": "d856122c-15d5-4211-8484-4a8cb4541948"
-        },
-        {
-          "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
-          "quantity": {
-            "count": 2
-          },
-          "fulfillment_id": "59021f2c-bed5-4797-82e1-b06febf27eda"
+          "fulfillment_id": "ec3a2ef5-9f47-4934-b4d5-a8d4dca6f9c8"
         }
       ],
       "documents": [
         {
-          "url": "https://ondc.pirimidtech.com/v2/seller/api/order/invoice/d16658c3-f55b-4ffb-8d07-b43b16ac2ef0",
+          "url": "https://ondc.pirimidtech.com/v2/seller/api/order/invoice/a840e0cc-8f95-4439-958f-bf5e6c2d271c",
           "label": "Invoice"
         }
       ],
@@ -68,12 +75,12 @@
         },
         "email": "fhemanshu@gmail.com",
         "phone": "7202959020",
-        "created_at": "2025-01-18T04:39:55.715Z",
-        "updated_at": "2025-01-18T04:39:55.715Z"
+        "created_at": "2025-01-23T12:24:49.484Z",
+        "updated_at": "2025-01-23T12:24:49.484Z"
       },
       "fulfillments": [
         {
-          "id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+          "id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
           "type": "Delivery",
           "@ondc/org/TAT": "PT99H",
           "provider_id": "ondc.loadshare.com/ondc/18275",
@@ -104,14 +111,14 @@
                 "locality": "Ashok Vatika",
                 "city": "Ahmedabad",
                 "state": "Gujarat",
-                "area_code": "380058"
+                "area_code": "380054"
               }
             },
             "time": {
-              "timestamp": "2025-01-18T04:41:32.495Z",
+              "timestamp": "2025-01-23T12:26:52.535Z",
               "range": {
-                "start": "2025-01-18T04:41:21.404Z",
-                "end": "2025-01-18T07:41:21.404Z"
+                "start": "2025-01-23T12:26:33.368Z",
+                "end": "2025-01-23T15:26:33.368Z"
               }
             },
             "instructions": {
@@ -139,10 +146,10 @@
               }
             },
             "time": {
-              "timestamp": "2025-01-18T16:03:23.651Z",
+              "timestamp": "2025-01-24T05:34:21.324Z",
               "range": {
-                "start": "2025-01-18T07:41:21.404Z",
-                "end": "2025-01-22T07:41:21.404Z"
+                "start": "2025-01-23T15:26:33.368Z",
+                "end": "2025-01-27T15:26:33.368Z"
               }
             },
             "contact": {
@@ -166,7 +173,7 @@
           ]
         },
         {
-          "id": "d856122c-15d5-4211-8484-4a8cb4541948",
+          "id": "ec3a2ef5-9f47-4934-b4d5-a8d4dca6f9c8",
           "type": "Cancel",
           "state": {
             "descriptor": {
@@ -249,7 +256,63 @@
           ]
         },
         {
-          "id": "678bd10a8455f06951c9542a",
+          "id": "67932706a3b38b99e1ec6555",
+          "type": "Return",
+          "state": {
+            "descriptor": {
+              "code": "Return_Initiated"
+            }
+          },
+          "tags": [
+            {
+              "code": "return_request",
+              "list": [
+                {
+                  "code": "id",
+                  "value": "67932706a3b38b99e1ec6555"
+                },
+                {
+                  "code": "item_id",
+                  "value": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7"
+                },
+                {
+                  "code": "parent_item_id",
+                  "value": ""
+                },
+                {
+                  "code": "item_quantity",
+                  "value": "2"
+                },
+                {
+                  "code": "reason_id",
+                  "value": "001"
+                },
+                {
+                  "code": "reason_desc",
+                  "value": "detailed description for return"
+                },
+                {
+                  "code": "images",
+                  "value": "https://reference-buyer-app-assets.s3-ap-south-1.amazonaws.com/public-assets/2025-01-23-103725/0ddb2db8-2cca-4e38-8040-c5a06d98fdd5.png"
+                },
+                {
+                  "code": "ttl_approval",
+                  "value": "PT24H"
+                },
+                {
+                  "code": "ttl_reverseqc",
+                  "value": "P3D"
+                },
+                {
+                  "code": "initiated_by",
+                  "value": "buyer-app-preprod-v2.ondc.org"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "id": "6793268da3b38b99e1ec64d6",
           "type": "Return",
           "@ondc/org/provider_name": "LoadShare",
           "state": {
@@ -271,7 +334,7 @@
               }
             },
             "time": {
-              "timestamp": "2025-01-18T16:09:21.621Z"
+              "timestamp": "2025-01-24T05:35:55.380Z"
             }
           },
           "end": {
@@ -281,11 +344,11 @@
                 "locality": "Ashok Vatika",
                 "city": "Ahmedabad",
                 "state": "Gujarat",
-                "area_code": "380058"
+                "area_code": "380054"
               }
             },
             "time": {
-              "timestamp": "2025-01-18T16:09:40.749Z"
+              "timestamp": "2025-01-24T05:36:49.982Z"
             }
           },
           "tags": [
@@ -294,7 +357,7 @@
               "list": [
                 {
                   "code": "id",
-                  "value": "678bd10a8455f06951c9542a"
+                  "value": "6793268da3b38b99e1ec64d6"
                 },
                 {
                   "code": "item_id",
@@ -306,11 +369,11 @@
                 },
                 {
                   "code": "item_quantity",
-                  "value": "1"
+                  "value": "2"
                 },
                 {
                   "code": "reason_id",
-                  "value": "001"
+                  "value": "002"
                 },
                 {
                   "code": "reason_desc",
@@ -318,7 +381,7 @@
                 },
                 {
                   "code": "images",
-                  "value": "https://reference-buyer-app-assets.s3-ap-south-1.amazonaws.com/public-assets/2025-01-18-743091/c8f3fe60-e84a-4d49-ae61-ecbc2232da26.png"
+                  "value": "https://reference-buyer-app-assets.s3-ap-south-1.amazonaws.com/public-assets/2025-01-23-103725/7d383819-6630-4428-b4d8-b7aae2065ff1.png"
                 },
                 {
                   "code": "ttl_approval",
@@ -351,7 +414,7 @@
                 },
                 {
                   "code": "value",
-                  "value": "-120"
+                  "value": "-240"
                 }
               ]
             },
@@ -364,7 +427,7 @@
                 },
                 {
                   "code": "id",
-                  "value": "70dd195d-c7ff-46ac-ba42-53ade2f77aef"
+                  "value": "9333ed9f-c3e6-4e5b-a863-9ccfff56e1a7"
                 },
                 {
                   "code": "currency",
@@ -372,63 +435,7 @@
                 },
                 {
                   "code": "value",
-                  "value": "-4.4"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "id": "678bd25c8455f06951c954a8",
-          "type": "Return",
-          "state": {
-            "descriptor": {
-              "code": "Return_Initiated"
-            }
-          },
-          "tags": [
-            {
-              "code": "return_request",
-              "list": [
-                {
-                  "code": "id",
-                  "value": "678bd25c8455f06951c954a8"
-                },
-                {
-                  "code": "item_id",
-                  "value": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9"
-                },
-                {
-                  "code": "parent_item_id",
-                  "value": ""
-                },
-                {
-                  "code": "item_quantity",
-                  "value": "1"
-                },
-                {
-                  "code": "reason_id",
-                  "value": "001"
-                },
-                {
-                  "code": "reason_desc",
-                  "value": "detailed description for return"
-                },
-                {
-                  "code": "images",
-                  "value": "https://reference-buyer-app-assets.s3-ap-south-1.amazonaws.com/public-assets/2025-01-18-743091/824c6fb6-842f-477b-9a79-6ebaa14519ad.png"
-                },
-                {
-                  "code": "ttl_approval",
-                  "value": "PT24H"
-                },
-                {
-                  "code": "ttl_reverseqc",
-                  "value": "P3D"
-                },
-                {
-                  "code": "initiated_by",
-                  "value": "buyer-app-preprod-v2.ondc.org"
+                  "value": "-8.81"
                 }
               ]
             }
@@ -438,9 +445,81 @@
       "quote": {
         "price": {
           "currency": "INR",
-          "value": "1007.05"
+          "value": "1364.71"
         },
         "breakup": [
+          {
+            "@ondc/org/item_id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "@ondc/org/title_type": "item",
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "120.0"
+              }
+            },
+            "title": "Cashews",
+            "price": {
+              "currency": "INR",
+              "value": "120.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
+            "@ondc/org/title_type": "packing",
+            "title": "Packing Charges",
+            "price": {
+              "currency": "INR",
+              "value": "5.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
+            "@ondc/org/title_type": "delivery",
+            "title": "Delivery Charges",
+            "price": {
+              "currency": "INR",
+              "value": "100.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+            "@ondc/org/item_quantity": {
+              "count": 3
+            },
+            "@ondc/org/title_type": "item",
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "120.0"
+              }
+            },
+            "title": "Walnuts",
+            "price": {
+              "currency": "INR",
+              "value": "360.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
+            "@ondc/org/title_type": "packing",
+            "title": "Packing Charges",
+            "price": {
+              "currency": "INR",
+              "value": "5.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
+            "@ondc/org/title_type": "delivery",
+            "title": "Delivery Charges",
+            "price": {
+              "currency": "INR",
+              "value": "100.0"
+            }
+          },
           {
             "@ondc/org/item_id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
             "@ondc/org/item_quantity": {
@@ -460,7 +539,7 @@
             }
           },
           {
-            "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+            "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
             "@ondc/org/title_type": "packing",
             "title": "Packing Charges",
             "price": {
@@ -469,7 +548,7 @@
             }
           },
           {
-            "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+            "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
             "@ondc/org/title_type": "delivery",
             "title": "Delivery Charges",
             "price": {
@@ -487,48 +566,12 @@
             }
           },
           {
-            "@ondc/org/item_id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
-            "@ondc/org/item_quantity": {
-              "count": 2
-            },
-            "@ondc/org/title_type": "item",
-            "item": {
-              "price": {
-                "currency": "INR",
-                "value": "120.0"
-              }
-            },
-            "title": "Cashews",
-            "price": {
-              "currency": "INR",
-              "value": "240.0"
-            }
-          },
-          {
-            "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
-            "@ondc/org/title_type": "packing",
-            "title": "Packing Charges",
-            "price": {
-              "currency": "INR",
-              "value": "5.0"
-            }
-          },
-          {
-            "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
-            "@ondc/org/title_type": "delivery",
-            "title": "Delivery Charges",
-            "price": {
-              "currency": "INR",
-              "value": "100.0"
-            }
-          },
-          {
-            "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+            "@ondc/org/item_id": "ec3a2ef5-9f47-4934-b4d5-a8d4dca6f9c8",
             "@ondc/org/title_type": "misc",
             "title": "Convenience Fee",
             "price": {
               "currency": "INR",
-              "value": "35.65"
+              "value": "48.31"
             }
           }
         ],
@@ -538,8 +581,8 @@
         "uri": "https://razorpay.com/",
         "tl_method": "http/get",
         "params": {
-          "transaction_id": "order_PkmGkn5hmLCG83",
-          "amount": "1401.72",
+          "transaction_id": "order_PmsrRxRfEkwUOs",
+          "amount": "1883.79",
           "currency": "INR"
         },
         "type": "ON-ORDER",
@@ -554,16 +597,16 @@
           {
             "settlement_counterparty": "buyer",
             "settlement_phase": "refund",
-            "settlement_amount": "124.4",
+            "settlement_amount": "248.81",
             "settlement_type": "wallet",
-            "settlement_timestamp": "2025-01-18T16:09:23.017Z"
+            "settlement_timestamp": "2025-01-24T05:35:56.402Z"
           },
           {
             "settlement_counterparty": "buyer",
             "settlement_phase": "refund",
             "settlement_amount": "270.27",
             "settlement_type": "wallet",
-            "settlement_timestamp": "2025-01-18T04:40:58.885Z"
+            "settlement_timestamp": "2025-01-23T12:25:39.036Z"
           },
           {
             "settlement_counterparty": "seller-app",
@@ -578,8 +621,8 @@
           }
         ]
       },
-      "created_at": "2025-01-18T04:39:47.970Z",
-      "updated_at": "2025-01-18T16:10:05.171Z"
+      "created_at": "2025-01-23T12:24:39.050Z",
+      "updated_at": "2025-01-24T05:37:11.189Z"
     }
   }
 }

--- a/Pirimid/SellerApp/Retail/RET-10/FLOW_6/on_update_interim_reverse_qc.json
+++ b/Pirimid/SellerApp/Retail/RET-10/FLOW_6/on_update_interim_reverse_qc.json
@@ -9,14 +9,14 @@
     "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
     "bpp_id": "ondc.pirimidtech.com/v2/seller",
     "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-    "transaction_id": "82b9cba3-1fb4-4b53-825e-904368636e74",
-    "message_id": "514316be-4639-430e-ba43-548d34c28aa0",
-    "timestamp": "2025-01-18T16:04:27.304Z",
+    "transaction_id": "e35a5fd4-3758-429e-84d0-4d831a501733",
+    "message_id": "9f397d17-2e0e-494a-aa8d-449c447b0d8d",
+    "timestamp": "2025-01-24T05:35:10.361Z",
     "ttl": "PT30S"
   },
   "message": {
     "order": {
-      "id": "2025-01-18-743091",
+      "id": "2025-01-23-103725",
       "state": "Completed",
       "provider": {
         "id": "e2008459-7e90-493e-b02e-cae52ca53214",
@@ -32,26 +32,33 @@
           "quantity": {
             "count": 3
           },
-          "fulfillment_id": "59021f2c-bed5-4797-82e1-b06febf27eda"
+          "fulfillment_id": "6dc21188-26a8-456c-9d28-1561bd0779c9"
+        },
+        {
+          "id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+          "quantity": {
+            "count": 3
+          },
+          "fulfillment_id": "6dc21188-26a8-456c-9d28-1561bd0779c9"
         },
         {
           "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
           "quantity": {
             "count": 2
           },
-          "fulfillment_id": "59021f2c-bed5-4797-82e1-b06febf27eda"
+          "fulfillment_id": "6dc21188-26a8-456c-9d28-1561bd0779c9"
         },
         {
           "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
           "quantity": {
             "count": 1
           },
-          "fulfillment_id": "d856122c-15d5-4211-8484-4a8cb4541948"
+          "fulfillment_id": "ec3a2ef5-9f47-4934-b4d5-a8d4dca6f9c8"
         }
       ],
       "documents": [
         {
-          "url": "https://ondc.pirimidtech.com/v2/seller/api/order/invoice/d16658c3-f55b-4ffb-8d07-b43b16ac2ef0",
+          "url": "https://ondc.pirimidtech.com/v2/seller/api/order/invoice/a840e0cc-8f95-4439-958f-bf5e6c2d271c",
           "label": "Invoice"
         }
       ],
@@ -68,12 +75,12 @@
         },
         "email": "fhemanshu@gmail.com",
         "phone": "7202959020",
-        "created_at": "2025-01-18T04:39:55.715Z",
-        "updated_at": "2025-01-18T04:39:55.715Z"
+        "created_at": "2025-01-23T12:24:49.484Z",
+        "updated_at": "2025-01-23T12:24:49.484Z"
       },
       "fulfillments": [
         {
-          "id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+          "id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
           "type": "Delivery",
           "@ondc/org/TAT": "PT99H",
           "provider_id": "ondc.loadshare.com/ondc/18275",
@@ -104,14 +111,14 @@
                 "locality": "Ashok Vatika",
                 "city": "Ahmedabad",
                 "state": "Gujarat",
-                "area_code": "380058"
+                "area_code": "380054"
               }
             },
             "time": {
-              "timestamp": "2025-01-18T04:41:32.495Z",
+              "timestamp": "2025-01-23T12:26:52.535Z",
               "range": {
-                "start": "2025-01-18T04:41:21.404Z",
-                "end": "2025-01-18T07:41:21.404Z"
+                "start": "2025-01-23T12:26:33.368Z",
+                "end": "2025-01-23T15:26:33.368Z"
               }
             },
             "instructions": {
@@ -139,10 +146,10 @@
               }
             },
             "time": {
-              "timestamp": "2025-01-18T16:03:23.651Z",
+              "timestamp": "2025-01-24T05:34:21.324Z",
               "range": {
-                "start": "2025-01-18T07:41:21.404Z",
-                "end": "2025-01-22T07:41:21.404Z"
+                "start": "2025-01-23T15:26:33.368Z",
+                "end": "2025-01-27T15:26:33.368Z"
               }
             },
             "contact": {
@@ -166,7 +173,7 @@
           ]
         },
         {
-          "id": "d856122c-15d5-4211-8484-4a8cb4541948",
+          "id": "ec3a2ef5-9f47-4934-b4d5-a8d4dca6f9c8",
           "type": "Cancel",
           "state": {
             "descriptor": {
@@ -249,7 +256,7 @@
           ]
         },
         {
-          "id": "678bd10a8455f06951c9542a",
+          "id": "6793268da3b38b99e1ec64d6",
           "type": "Return",
           "state": {
             "descriptor": {
@@ -262,7 +269,7 @@
               "list": [
                 {
                   "code": "id",
-                  "value": "678bd10a8455f06951c9542a"
+                  "value": "6793268da3b38b99e1ec64d6"
                 },
                 {
                   "code": "item_id",
@@ -274,11 +281,11 @@
                 },
                 {
                   "code": "item_quantity",
-                  "value": "1"
+                  "value": "2"
                 },
                 {
                   "code": "reason_id",
-                  "value": "001"
+                  "value": "002"
                 },
                 {
                   "code": "reason_desc",
@@ -286,7 +293,7 @@
                 },
                 {
                   "code": "images",
-                  "value": "https://reference-buyer-app-assets.s3-ap-south-1.amazonaws.com/public-assets/2025-01-18-743091/c8f3fe60-e84a-4d49-ae61-ecbc2232da26.png"
+                  "value": "https://reference-buyer-app-assets.s3-ap-south-1.amazonaws.com/public-assets/2025-01-23-103725/7d383819-6630-4428-b4d8-b7aae2065ff1.png"
                 },
                 {
                   "code": "ttl_approval",
@@ -308,7 +315,7 @@
       "quote": {
         "price": {
           "currency": "INR",
-          "value": "1131.45"
+          "value": "1613.52"
         },
         "breakup": [
           {
@@ -330,7 +337,7 @@
             }
           },
           {
-            "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+            "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
             "@ondc/org/title_type": "packing",
             "title": "Packing Charges",
             "price": {
@@ -339,7 +346,43 @@
             }
           },
           {
-            "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+            "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
+            "@ondc/org/title_type": "delivery",
+            "title": "Delivery Charges",
+            "price": {
+              "currency": "INR",
+              "value": "100.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+            "@ondc/org/item_quantity": {
+              "count": 3
+            },
+            "@ondc/org/title_type": "item",
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "120.0"
+              }
+            },
+            "title": "Walnuts",
+            "price": {
+              "currency": "INR",
+              "value": "360.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
+            "@ondc/org/title_type": "packing",
+            "title": "Packing Charges",
+            "price": {
+              "currency": "INR",
+              "value": "5.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
             "@ondc/org/title_type": "delivery",
             "title": "Delivery Charges",
             "price": {
@@ -366,7 +409,7 @@
             }
           },
           {
-            "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+            "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
             "@ondc/org/title_type": "packing",
             "title": "Packing Charges",
             "price": {
@@ -375,7 +418,7 @@
             }
           },
           {
-            "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+            "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
             "@ondc/org/title_type": "delivery",
             "title": "Delivery Charges",
             "price": {
@@ -393,12 +436,12 @@
             }
           },
           {
-            "@ondc/org/item_id": "d856122c-15d5-4211-8484-4a8cb4541948",
+            "@ondc/org/item_id": "ec3a2ef5-9f47-4934-b4d5-a8d4dca6f9c8",
             "@ondc/org/title_type": "misc",
             "title": "Convenience Fee",
             "price": {
               "currency": "INR",
-              "value": "40.05"
+              "value": "57.12"
             }
           }
         ],
@@ -408,8 +451,8 @@
         "uri": "https://razorpay.com/",
         "tl_method": "http/get",
         "params": {
-          "transaction_id": "order_PkmGkn5hmLCG83",
-          "amount": "1401.72",
+          "transaction_id": "order_PmsrRxRfEkwUOs",
+          "amount": "1883.79",
           "currency": "INR"
         },
         "type": "ON-ORDER",
@@ -426,7 +469,7 @@
             "settlement_phase": "refund",
             "settlement_amount": "270.27",
             "settlement_type": "wallet",
-            "settlement_timestamp": "2025-01-18T04:40:58.885Z"
+            "settlement_timestamp": "2025-01-23T12:25:39.036Z"
           },
           {
             "settlement_counterparty": "seller-app",
@@ -441,8 +484,8 @@
           }
         ]
       },
-      "created_at": "2025-01-18T04:39:47.970Z",
-      "updated_at": "2025-01-18T16:04:27.304Z"
+      "created_at": "2025-01-23T12:24:39.050Z",
+      "updated_at": "2025-01-24T05:35:10.361Z"
     }
   }
 }

--- a/Pirimid/SellerApp/Retail/RET-10/FLOW_6/on_update_liquidated.json
+++ b/Pirimid/SellerApp/Retail/RET-10/FLOW_6/on_update_liquidated.json
@@ -9,14 +9,14 @@
     "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
     "bpp_id": "ondc.pirimidtech.com/v2/seller",
     "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-    "transaction_id": "82b9cba3-1fb4-4b53-825e-904368636e74",
-    "message_id": "fa69c70b-e841-494b-ac16-a24d51025bd2",
-    "timestamp": "2025-01-18T16:10:40.608Z",
+    "transaction_id": "e35a5fd4-3758-429e-84d0-4d831a501733",
+    "message_id": "8a362e48-6e62-4039-96e9-f83d46ec3f7a",
+    "timestamp": "2025-01-24T05:38:03.974Z",
     "ttl": "PT30S"
   },
   "message": {
     "order": {
-      "id": "2025-01-18-743091",
+      "id": "2025-01-23-103725",
       "state": "Completed",
       "provider": {
         "id": "e2008459-7e90-493e-b02e-cae52ca53214",
@@ -28,30 +28,37 @@
       },
       "items": [
         {
-          "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
+          "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
           "quantity": {
             "count": 1
           },
-          "fulfillment_id": "d856122c-15d5-4211-8484-4a8cb4541948"
+          "fulfillment_id": "6dc21188-26a8-456c-9d28-1561bd0779c9"
         },
         {
-          "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
+          "id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+          "quantity": {
+            "count": 1
+          },
+          "fulfillment_id": "6dc21188-26a8-456c-9d28-1561bd0779c9"
+        },
+        {
+          "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
           "quantity": {
             "count": 2
           },
-          "fulfillment_id": "59021f2c-bed5-4797-82e1-b06febf27eda"
+          "fulfillment_id": "6dc21188-26a8-456c-9d28-1561bd0779c9"
         },
         {
           "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
           "quantity": {
             "count": 1
           },
-          "fulfillment_id": "59021f2c-bed5-4797-82e1-b06febf27eda"
+          "fulfillment_id": "ec3a2ef5-9f47-4934-b4d5-a8d4dca6f9c8"
         }
       ],
       "documents": [
         {
-          "url": "https://ondc.pirimidtech.com/v2/seller/api/order/invoice/d16658c3-f55b-4ffb-8d07-b43b16ac2ef0",
+          "url": "https://ondc.pirimidtech.com/v2/seller/api/order/invoice/a840e0cc-8f95-4439-958f-bf5e6c2d271c",
           "label": "Invoice"
         }
       ],
@@ -68,12 +75,12 @@
         },
         "email": "fhemanshu@gmail.com",
         "phone": "7202959020",
-        "created_at": "2025-01-18T04:39:55.715Z",
-        "updated_at": "2025-01-18T04:39:55.715Z"
+        "created_at": "2025-01-23T12:24:49.484Z",
+        "updated_at": "2025-01-23T12:24:49.484Z"
       },
       "fulfillments": [
         {
-          "id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+          "id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
           "type": "Delivery",
           "@ondc/org/TAT": "PT99H",
           "provider_id": "ondc.loadshare.com/ondc/18275",
@@ -104,14 +111,14 @@
                 "locality": "Ashok Vatika",
                 "city": "Ahmedabad",
                 "state": "Gujarat",
-                "area_code": "380058"
+                "area_code": "380054"
               }
             },
             "time": {
-              "timestamp": "2025-01-18T04:41:32.495Z",
+              "timestamp": "2025-01-23T12:26:52.535Z",
               "range": {
-                "start": "2025-01-18T04:41:21.404Z",
-                "end": "2025-01-18T07:41:21.404Z"
+                "start": "2025-01-23T12:26:33.368Z",
+                "end": "2025-01-23T15:26:33.368Z"
               }
             },
             "instructions": {
@@ -139,10 +146,10 @@
               }
             },
             "time": {
-              "timestamp": "2025-01-18T16:03:23.651Z",
+              "timestamp": "2025-01-24T05:34:21.324Z",
               "range": {
-                "start": "2025-01-18T07:41:21.404Z",
-                "end": "2025-01-22T07:41:21.404Z"
+                "start": "2025-01-23T15:26:33.368Z",
+                "end": "2025-01-27T15:26:33.368Z"
               }
             },
             "contact": {
@@ -166,7 +173,7 @@
           ]
         },
         {
-          "id": "d856122c-15d5-4211-8484-4a8cb4541948",
+          "id": "ec3a2ef5-9f47-4934-b4d5-a8d4dca6f9c8",
           "type": "Cancel",
           "state": {
             "descriptor": {
@@ -249,7 +256,106 @@
           ]
         },
         {
-          "id": "678bd10a8455f06951c9542a",
+          "id": "67932706a3b38b99e1ec6555",
+          "type": "Return",
+          "@ondc/org/provider_name": "LoadShare",
+          "state": {
+            "descriptor": {
+              "code": "Liquidated"
+            }
+          },
+          "tags": [
+            {
+              "code": "return_request",
+              "list": [
+                {
+                  "code": "id",
+                  "value": "67932706a3b38b99e1ec6555"
+                },
+                {
+                  "code": "item_id",
+                  "value": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7"
+                },
+                {
+                  "code": "parent_item_id",
+                  "value": ""
+                },
+                {
+                  "code": "item_quantity",
+                  "value": "2"
+                },
+                {
+                  "code": "reason_id",
+                  "value": "001"
+                },
+                {
+                  "code": "reason_desc",
+                  "value": "detailed description for return"
+                },
+                {
+                  "code": "images",
+                  "value": "https://reference-buyer-app-assets.s3-ap-south-1.amazonaws.com/public-assets/2025-01-23-103725/0ddb2db8-2cca-4e38-8040-c5a06d98fdd5.png"
+                },
+                {
+                  "code": "ttl_approval",
+                  "value": "PT24H"
+                },
+                {
+                  "code": "ttl_reverseqc",
+                  "value": "P3D"
+                },
+                {
+                  "code": "initiated_by",
+                  "value": "buyer-app-preprod-v2.ondc.org"
+                }
+              ]
+            },
+            {
+              "code": "quote_trail",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "item"
+                },
+                {
+                  "code": "id",
+                  "value": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7"
+                },
+                {
+                  "code": "currency",
+                  "value": "INR"
+                },
+                {
+                  "code": "value",
+                  "value": "-240"
+                }
+              ]
+            },
+            {
+              "code": "quote_trail",
+              "list": [
+                {
+                  "code": "type",
+                  "value": "misc"
+                },
+                {
+                  "code": "id",
+                  "value": "78d8f20a-87e4-4036-b7f3-e0c1afa6f7ac"
+                },
+                {
+                  "code": "currency",
+                  "value": "INR"
+                },
+                {
+                  "code": "value",
+                  "value": "-8.81"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "id": "6793268da3b38b99e1ec64d6",
           "type": "Return",
           "@ondc/org/provider_name": "LoadShare",
           "state": {
@@ -271,7 +377,7 @@
               }
             },
             "time": {
-              "timestamp": "2025-01-18T16:09:21.621Z"
+              "timestamp": "2025-01-24T05:35:55.380Z"
             }
           },
           "end": {
@@ -281,11 +387,11 @@
                 "locality": "Ashok Vatika",
                 "city": "Ahmedabad",
                 "state": "Gujarat",
-                "area_code": "380058"
+                "area_code": "380054"
               }
             },
             "time": {
-              "timestamp": "2025-01-18T16:09:40.749Z"
+              "timestamp": "2025-01-24T05:36:49.982Z"
             }
           },
           "tags": [
@@ -294,7 +400,7 @@
               "list": [
                 {
                   "code": "id",
-                  "value": "678bd10a8455f06951c9542a"
+                  "value": "6793268da3b38b99e1ec64d6"
                 },
                 {
                   "code": "item_id",
@@ -306,11 +412,11 @@
                 },
                 {
                   "code": "item_quantity",
-                  "value": "1"
+                  "value": "2"
                 },
                 {
                   "code": "reason_id",
-                  "value": "001"
+                  "value": "002"
                 },
                 {
                   "code": "reason_desc",
@@ -318,7 +424,7 @@
                 },
                 {
                   "code": "images",
-                  "value": "https://reference-buyer-app-assets.s3-ap-south-1.amazonaws.com/public-assets/2025-01-18-743091/c8f3fe60-e84a-4d49-ae61-ecbc2232da26.png"
+                  "value": "https://reference-buyer-app-assets.s3-ap-south-1.amazonaws.com/public-assets/2025-01-23-103725/7d383819-6630-4428-b4d8-b7aae2065ff1.png"
                 },
                 {
                   "code": "ttl_approval",
@@ -351,7 +457,7 @@
                 },
                 {
                   "code": "value",
-                  "value": "-120"
+                  "value": "-240"
                 }
               ]
             },
@@ -364,7 +470,7 @@
                 },
                 {
                   "code": "id",
-                  "value": "70dd195d-c7ff-46ac-ba42-53ade2f77aef"
+                  "value": "9333ed9f-c3e6-4e5b-a863-9ccfff56e1a7"
                 },
                 {
                   "code": "currency",
@@ -372,127 +478,7 @@
                 },
                 {
                   "code": "value",
-                  "value": "-4.4"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "id": "678bd25c8455f06951c954a8",
-          "type": "Return",
-          "@ondc/org/provider_name": "LoadShare",
-          "state": {
-            "descriptor": {
-              "code": "Liquidated"
-            }
-          },
-          "tags": [
-            {
-              "code": "return_request",
-              "list": [
-                {
-                  "code": "id",
-                  "value": "678bd25c8455f06951c954a8"
-                },
-                {
-                  "code": "item_id",
-                  "value": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9"
-                },
-                {
-                  "code": "parent_item_id",
-                  "value": ""
-                },
-                {
-                  "code": "item_quantity",
-                  "value": "1"
-                },
-                {
-                  "code": "reason_id",
-                  "value": "001"
-                },
-                {
-                  "code": "reason_desc",
-                  "value": "detailed description for return"
-                },
-                {
-                  "code": "images",
-                  "value": "https://reference-buyer-app-assets.s3-ap-south-1.amazonaws.com/public-assets/2025-01-18-743091/824c6fb6-842f-477b-9a79-6ebaa14519ad.png"
-                },
-                {
-                  "code": "ttl_approval",
-                  "value": "PT24H"
-                },
-                {
-                  "code": "ttl_reverseqc",
-                  "value": "P3D"
-                },
-                {
-                  "code": "initiated_by",
-                  "value": "buyer-app-preprod-v2.ondc.org"
-                }
-              ]
-            },
-            {
-              "code": "quote_trail",
-              "list": [
-                {
-                  "code": "type",
-                  "value": "item"
-                },
-                {
-                  "code": "id",
-                  "value": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9"
-                },
-                {
-                  "code": "currency",
-                  "value": "INR"
-                },
-                {
-                  "code": "value",
-                  "value": "-220"
-                }
-              ]
-            },
-            {
-              "code": "quote_trail",
-              "list": [
-                {
-                  "code": "type",
-                  "value": "tax"
-                },
-                {
-                  "code": "id",
-                  "value": "02b04e0a-c422-48d5-8223-e97bfbc689ed"
-                },
-                {
-                  "code": "currency",
-                  "value": "INR"
-                },
-                {
-                  "code": "value",
-                  "value": "-40.7"
-                }
-              ]
-            },
-            {
-              "code": "quote_trail",
-              "list": [
-                {
-                  "code": "type",
-                  "value": "misc"
-                },
-                {
-                  "code": "id",
-                  "value": "74ef83f4-a6f2-4db7-a3a4-b76bd9d1c1d6"
-                },
-                {
-                  "code": "currency",
-                  "value": "INR"
-                },
-                {
-                  "code": "value",
-                  "value": "-9.57"
+                  "value": "-8.81"
                 }
               ]
             }
@@ -502,13 +488,13 @@
       "quote": {
         "price": {
           "currency": "INR",
-          "value": "736.78"
+          "value": "1115.9"
         },
         "breakup": [
           {
             "@ondc/org/item_id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
             "@ondc/org/item_quantity": {
-              "count": 2
+              "count": 1
             },
             "@ondc/org/title_type": "item",
             "item": {
@@ -520,11 +506,11 @@
             "title": "Cashews",
             "price": {
               "currency": "INR",
-              "value": "240.0"
+              "value": "120.0"
             }
           },
           {
-            "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+            "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
             "@ondc/org/title_type": "packing",
             "title": "Packing Charges",
             "price": {
@@ -533,7 +519,43 @@
             }
           },
           {
-            "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+            "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
+            "@ondc/org/title_type": "delivery",
+            "title": "Delivery Charges",
+            "price": {
+              "currency": "INR",
+              "value": "100.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "@ondc/org/title_type": "item",
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "120.0"
+              }
+            },
+            "title": "Walnuts",
+            "price": {
+              "currency": "INR",
+              "value": "120.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
+            "@ondc/org/title_type": "packing",
+            "title": "Packing Charges",
+            "price": {
+              "currency": "INR",
+              "value": "5.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
             "@ondc/org/title_type": "delivery",
             "title": "Delivery Charges",
             "price": {
@@ -544,7 +566,7 @@
           {
             "@ondc/org/item_id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
             "@ondc/org/item_quantity": {
-              "count": 1
+              "count": 2
             },
             "@ondc/org/title_type": "item",
             "item": {
@@ -556,11 +578,11 @@
             "title": "Nutraj-California-Almonds-1Kg",
             "price": {
               "currency": "INR",
-              "value": "220.0"
+              "value": "440.0"
             }
           },
           {
-            "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+            "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
             "@ondc/org/title_type": "packing",
             "title": "Packing Charges",
             "price": {
@@ -569,7 +591,7 @@
             }
           },
           {
-            "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+            "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
             "@ondc/org/title_type": "delivery",
             "title": "Delivery Charges",
             "price": {
@@ -583,16 +605,16 @@
             "title": "Tax",
             "price": {
               "currency": "INR",
-              "value": "40.7"
+              "value": "81.4"
             }
           },
           {
-            "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+            "@ondc/org/item_id": "ec3a2ef5-9f47-4934-b4d5-a8d4dca6f9c8",
             "@ondc/org/title_type": "misc",
             "title": "Convenience Fee",
             "price": {
               "currency": "INR",
-              "value": "26.08"
+              "value": "39.5"
             }
           }
         ],
@@ -602,8 +624,8 @@
         "uri": "https://razorpay.com/",
         "tl_method": "http/get",
         "params": {
-          "transaction_id": "order_PkmGkn5hmLCG83",
-          "amount": "1401.72",
+          "transaction_id": "order_PmsrRxRfEkwUOs",
+          "amount": "1883.79",
           "currency": "INR"
         },
         "type": "ON-ORDER",
@@ -618,16 +640,16 @@
           {
             "settlement_counterparty": "buyer",
             "settlement_phase": "refund",
-            "settlement_amount": "124.4",
+            "settlement_amount": "248.81",
             "settlement_type": "wallet",
-            "settlement_timestamp": "2025-01-18T16:09:23.017Z"
+            "settlement_timestamp": "2025-01-24T05:35:56.402Z"
           },
           {
             "settlement_counterparty": "buyer",
             "settlement_phase": "refund",
             "settlement_amount": "270.27",
             "settlement_type": "wallet",
-            "settlement_timestamp": "2025-01-18T04:40:58.885Z"
+            "settlement_timestamp": "2025-01-23T12:25:39.036Z"
           },
           {
             "settlement_counterparty": "seller-app",
@@ -642,8 +664,8 @@
           }
         ]
       },
-      "created_at": "2025-01-18T04:39:47.970Z",
-      "updated_at": "2025-01-18T16:10:40.608Z"
+      "created_at": "2025-01-23T12:24:39.050Z",
+      "updated_at": "2025-01-24T05:38:03.974Z"
     }
   }
 }

--- a/Pirimid/SellerApp/Retail/RET-10/FLOW_6/on_update_part_cancel.json
+++ b/Pirimid/SellerApp/Retail/RET-10/FLOW_6/on_update_part_cancel.json
@@ -9,14 +9,14 @@
     "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
     "bpp_id": "ondc.pirimidtech.com/v2/seller",
     "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-    "transaction_id": "82b9cba3-1fb4-4b53-825e-904368636e74",
-    "message_id": "cb273720-15b8-47d1-8781-a2d842ea26f5",
-    "timestamp": "2025-01-18T04:40:57.704Z",
+    "transaction_id": "e35a5fd4-3758-429e-84d0-4d831a501733",
+    "message_id": "6513d9e8-e1fc-4dbf-8e10-dbb4796dbbc8",
+    "timestamp": "2025-01-23T12:25:37.698Z",
     "ttl": "PT30S"
   },
   "message": {
     "order": {
-      "id": "2025-01-18-743091",
+      "id": "2025-01-23-103725",
       "state": "Created",
       "provider": {
         "id": "e2008459-7e90-493e-b02e-cae52ca53214",
@@ -32,26 +32,33 @@
           "quantity": {
             "count": 3
           },
-          "fulfillment_id": "59021f2c-bed5-4797-82e1-b06febf27eda"
+          "fulfillment_id": "6dc21188-26a8-456c-9d28-1561bd0779c9"
+        },
+        {
+          "id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+          "quantity": {
+            "count": 3
+          },
+          "fulfillment_id": "6dc21188-26a8-456c-9d28-1561bd0779c9"
         },
         {
           "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
           "quantity": {
             "count": 2
           },
-          "fulfillment_id": "59021f2c-bed5-4797-82e1-b06febf27eda"
+          "fulfillment_id": "6dc21188-26a8-456c-9d28-1561bd0779c9"
         },
         {
           "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
           "quantity": {
             "count": 1
           },
-          "fulfillment_id": "d856122c-15d5-4211-8484-4a8cb4541948"
+          "fulfillment_id": "ec3a2ef5-9f47-4934-b4d5-a8d4dca6f9c8"
         }
       ],
       "documents": [
         {
-          "url": "https://ondc.pirimidtech.com/v2/seller/api/order/invoice/d16658c3-f55b-4ffb-8d07-b43b16ac2ef0",
+          "url": "https://ondc.pirimidtech.com/v2/seller/api/order/invoice/a840e0cc-8f95-4439-958f-bf5e6c2d271c",
           "label": "Invoice"
         }
       ],
@@ -68,12 +75,12 @@
         },
         "email": "fhemanshu@gmail.com",
         "phone": "7202959020",
-        "created_at": "2025-01-18T04:39:55.715Z",
-        "updated_at": "2025-01-18T04:39:55.715Z"
+        "created_at": "2025-01-23T12:24:49.484Z",
+        "updated_at": "2025-01-23T12:24:49.484Z"
       },
       "fulfillments": [
         {
-          "id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+          "id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
           "type": "Delivery",
           "@ondc/org/TAT": "PT99H",
           "@ondc/org/provider_name": "LoadShare",
@@ -94,7 +101,7 @@
                 "locality": "Ashok Vatika",
                 "city": "Ahmedabad",
                 "state": "Gujarat",
-                "area_code": "380058"
+                "area_code": "380054"
               }
             },
             "contact": {
@@ -125,7 +132,7 @@
           }
         },
         {
-          "id": "d856122c-15d5-4211-8484-4a8cb4541948",
+          "id": "ec3a2ef5-9f47-4934-b4d5-a8d4dca6f9c8",
           "type": "Cancel",
           "state": {
             "descriptor": {
@@ -211,7 +218,7 @@
       "quote": {
         "price": {
           "currency": "INR",
-          "value": "1131.45"
+          "value": "1613.52"
         },
         "breakup": [
           {
@@ -233,7 +240,7 @@
             }
           },
           {
-            "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+            "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
             "@ondc/org/title_type": "packing",
             "title": "Packing Charges",
             "price": {
@@ -242,7 +249,43 @@
             }
           },
           {
-            "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+            "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
+            "@ondc/org/title_type": "delivery",
+            "title": "Delivery Charges",
+            "price": {
+              "currency": "INR",
+              "value": "100.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+            "@ondc/org/item_quantity": {
+              "count": 3
+            },
+            "@ondc/org/title_type": "item",
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "120.0"
+              }
+            },
+            "title": "Walnuts",
+            "price": {
+              "currency": "INR",
+              "value": "360.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
+            "@ondc/org/title_type": "packing",
+            "title": "Packing Charges",
+            "price": {
+              "currency": "INR",
+              "value": "5.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
             "@ondc/org/title_type": "delivery",
             "title": "Delivery Charges",
             "price": {
@@ -269,7 +312,7 @@
             }
           },
           {
-            "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+            "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
             "@ondc/org/title_type": "packing",
             "title": "Packing Charges",
             "price": {
@@ -278,7 +321,7 @@
             }
           },
           {
-            "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+            "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
             "@ondc/org/title_type": "delivery",
             "title": "Delivery Charges",
             "price": {
@@ -296,12 +339,12 @@
             }
           },
           {
-            "@ondc/org/item_id": "d856122c-15d5-4211-8484-4a8cb4541948",
+            "@ondc/org/item_id": "ec3a2ef5-9f47-4934-b4d5-a8d4dca6f9c8",
             "@ondc/org/title_type": "misc",
             "title": "Convenience Fee",
             "price": {
               "currency": "INR",
-              "value": "40.05"
+              "value": "57.12"
             }
           }
         ],
@@ -311,8 +354,8 @@
         "uri": "https://razorpay.com/",
         "tl_method": "http/get",
         "params": {
-          "transaction_id": "order_PkmGkn5hmLCG83",
-          "amount": "1401.72",
+          "transaction_id": "order_PmsrRxRfEkwUOs",
+          "amount": "1883.79",
           "currency": "INR"
         },
         "type": "ON-ORDER",
@@ -337,8 +380,8 @@
           }
         ]
       },
-      "created_at": "2025-01-18T04:39:47.970Z",
-      "updated_at": "2025-01-18T04:40:57.704Z"
+      "created_at": "2025-01-23T12:24:39.050Z",
+      "updated_at": "2025-01-23T12:25:37.698Z"
     }
   }
 }

--- a/Pirimid/SellerApp/Retail/RET-10/FLOW_6/on_update_picked.json
+++ b/Pirimid/SellerApp/Retail/RET-10/FLOW_6/on_update_picked.json
@@ -9,14 +9,14 @@
     "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
     "bpp_id": "ondc.pirimidtech.com/v2/seller",
     "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-    "transaction_id": "82b9cba3-1fb4-4b53-825e-904368636e74",
-    "message_id": "e4b561cb-f8b6-44cc-bf27-4f5f514964ab",
-    "timestamp": "2025-01-18T16:09:21.698Z",
+    "transaction_id": "e35a5fd4-3758-429e-84d0-4d831a501733",
+    "message_id": "edc0667a-d6e9-4860-ba89-c5faaec08570",
+    "timestamp": "2025-01-24T05:35:55.439Z",
     "ttl": "PT30S"
   },
   "message": {
     "order": {
-      "id": "2025-01-18-743091",
+      "id": "2025-01-23-103725",
       "state": "Completed",
       "provider": {
         "id": "e2008459-7e90-493e-b02e-cae52ca53214",
@@ -28,30 +28,37 @@
       },
       "items": [
         {
+          "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
+          "quantity": {
+            "count": 1
+          },
+          "fulfillment_id": "6dc21188-26a8-456c-9d28-1561bd0779c9"
+        },
+        {
+          "id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+          "quantity": {
+            "count": 3
+          },
+          "fulfillment_id": "6dc21188-26a8-456c-9d28-1561bd0779c9"
+        },
+        {
           "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
           "quantity": {
             "count": 2
           },
-          "fulfillment_id": "59021f2c-bed5-4797-82e1-b06febf27eda"
+          "fulfillment_id": "6dc21188-26a8-456c-9d28-1561bd0779c9"
         },
         {
           "id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
           "quantity": {
             "count": 1
           },
-          "fulfillment_id": "d856122c-15d5-4211-8484-4a8cb4541948"
-        },
-        {
-          "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
-          "quantity": {
-            "count": 2
-          },
-          "fulfillment_id": "59021f2c-bed5-4797-82e1-b06febf27eda"
+          "fulfillment_id": "ec3a2ef5-9f47-4934-b4d5-a8d4dca6f9c8"
         }
       ],
       "documents": [
         {
-          "url": "https://ondc.pirimidtech.com/v2/seller/api/order/invoice/d16658c3-f55b-4ffb-8d07-b43b16ac2ef0",
+          "url": "https://ondc.pirimidtech.com/v2/seller/api/order/invoice/a840e0cc-8f95-4439-958f-bf5e6c2d271c",
           "label": "Invoice"
         }
       ],
@@ -68,12 +75,12 @@
         },
         "email": "fhemanshu@gmail.com",
         "phone": "7202959020",
-        "created_at": "2025-01-18T04:39:55.715Z",
-        "updated_at": "2025-01-18T04:39:55.715Z"
+        "created_at": "2025-01-23T12:24:49.484Z",
+        "updated_at": "2025-01-23T12:24:49.484Z"
       },
       "fulfillments": [
         {
-          "id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+          "id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
           "type": "Delivery",
           "@ondc/org/TAT": "PT99H",
           "provider_id": "ondc.loadshare.com/ondc/18275",
@@ -104,14 +111,14 @@
                 "locality": "Ashok Vatika",
                 "city": "Ahmedabad",
                 "state": "Gujarat",
-                "area_code": "380058"
+                "area_code": "380054"
               }
             },
             "time": {
-              "timestamp": "2025-01-18T04:41:32.495Z",
+              "timestamp": "2025-01-23T12:26:52.535Z",
               "range": {
-                "start": "2025-01-18T04:41:21.404Z",
-                "end": "2025-01-18T07:41:21.404Z"
+                "start": "2025-01-23T12:26:33.368Z",
+                "end": "2025-01-23T15:26:33.368Z"
               }
             },
             "instructions": {
@@ -139,10 +146,10 @@
               }
             },
             "time": {
-              "timestamp": "2025-01-18T16:03:23.651Z",
+              "timestamp": "2025-01-24T05:34:21.324Z",
               "range": {
-                "start": "2025-01-18T07:41:21.404Z",
-                "end": "2025-01-22T07:41:21.404Z"
+                "start": "2025-01-23T15:26:33.368Z",
+                "end": "2025-01-27T15:26:33.368Z"
               }
             },
             "contact": {
@@ -166,7 +173,7 @@
           ]
         },
         {
-          "id": "d856122c-15d5-4211-8484-4a8cb4541948",
+          "id": "ec3a2ef5-9f47-4934-b4d5-a8d4dca6f9c8",
           "type": "Cancel",
           "state": {
             "descriptor": {
@@ -249,7 +256,7 @@
           ]
         },
         {
-          "id": "678bd10a8455f06951c9542a",
+          "id": "6793268da3b38b99e1ec64d6",
           "type": "Return",
           "@ondc/org/provider_name": "LoadShare",
           "state": {
@@ -271,7 +278,7 @@
               }
             },
             "time": {
-              "timestamp": "2025-01-18T16:09:21.621Z"
+              "timestamp": "2025-01-24T05:35:55.380Z"
             }
           },
           "end": {
@@ -281,7 +288,7 @@
                 "locality": "Ashok Vatika",
                 "city": "Ahmedabad",
                 "state": "Gujarat",
-                "area_code": "380058"
+                "area_code": "380054"
               }
             }
           },
@@ -291,7 +298,7 @@
               "list": [
                 {
                   "code": "id",
-                  "value": "678bd10a8455f06951c9542a"
+                  "value": "6793268da3b38b99e1ec64d6"
                 },
                 {
                   "code": "item_id",
@@ -303,11 +310,11 @@
                 },
                 {
                   "code": "item_quantity",
-                  "value": "1"
+                  "value": "2"
                 },
                 {
                   "code": "reason_id",
-                  "value": "001"
+                  "value": "002"
                 },
                 {
                   "code": "reason_desc",
@@ -315,7 +322,7 @@
                 },
                 {
                   "code": "images",
-                  "value": "https://reference-buyer-app-assets.s3-ap-south-1.amazonaws.com/public-assets/2025-01-18-743091/c8f3fe60-e84a-4d49-ae61-ecbc2232da26.png"
+                  "value": "https://reference-buyer-app-assets.s3-ap-south-1.amazonaws.com/public-assets/2025-01-23-103725/7d383819-6630-4428-b4d8-b7aae2065ff1.png"
                 },
                 {
                   "code": "ttl_approval",
@@ -348,7 +355,7 @@
                 },
                 {
                   "code": "value",
-                  "value": "-120"
+                  "value": "-240"
                 }
               ]
             },
@@ -361,7 +368,7 @@
                 },
                 {
                   "code": "id",
-                  "value": "70dd195d-c7ff-46ac-ba42-53ade2f77aef"
+                  "value": "9333ed9f-c3e6-4e5b-a863-9ccfff56e1a7"
                 },
                 {
                   "code": "currency",
@@ -369,7 +376,7 @@
                 },
                 {
                   "code": "value",
-                  "value": "-4.4"
+                  "value": "-8.81"
                 }
               ]
             }
@@ -379,9 +386,81 @@
       "quote": {
         "price": {
           "currency": "INR",
-          "value": "1007.05"
+          "value": "1364.71"
         },
         "breakup": [
+          {
+            "@ondc/org/item_id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
+            "@ondc/org/item_quantity": {
+              "count": 1
+            },
+            "@ondc/org/title_type": "item",
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "120.0"
+              }
+            },
+            "title": "Cashews",
+            "price": {
+              "currency": "INR",
+              "value": "120.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
+            "@ondc/org/title_type": "packing",
+            "title": "Packing Charges",
+            "price": {
+              "currency": "INR",
+              "value": "5.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
+            "@ondc/org/title_type": "delivery",
+            "title": "Delivery Charges",
+            "price": {
+              "currency": "INR",
+              "value": "100.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
+            "@ondc/org/item_quantity": {
+              "count": 3
+            },
+            "@ondc/org/title_type": "item",
+            "item": {
+              "price": {
+                "currency": "INR",
+                "value": "120.0"
+              }
+            },
+            "title": "Walnuts",
+            "price": {
+              "currency": "INR",
+              "value": "360.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
+            "@ondc/org/title_type": "packing",
+            "title": "Packing Charges",
+            "price": {
+              "currency": "INR",
+              "value": "5.0"
+            }
+          },
+          {
+            "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
+            "@ondc/org/title_type": "delivery",
+            "title": "Delivery Charges",
+            "price": {
+              "currency": "INR",
+              "value": "100.0"
+            }
+          },
           {
             "@ondc/org/item_id": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9",
             "@ondc/org/item_quantity": {
@@ -401,7 +480,7 @@
             }
           },
           {
-            "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+            "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
             "@ondc/org/title_type": "packing",
             "title": "Packing Charges",
             "price": {
@@ -410,7 +489,7 @@
             }
           },
           {
-            "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+            "@ondc/org/item_id": "6dc21188-26a8-456c-9d28-1561bd0779c9",
             "@ondc/org/title_type": "delivery",
             "title": "Delivery Charges",
             "price": {
@@ -428,48 +507,12 @@
             }
           },
           {
-            "@ondc/org/item_id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
-            "@ondc/org/item_quantity": {
-              "count": 2
-            },
-            "@ondc/org/title_type": "item",
-            "item": {
-              "price": {
-                "currency": "INR",
-                "value": "120.0"
-              }
-            },
-            "title": "Cashews",
-            "price": {
-              "currency": "INR",
-              "value": "240.0"
-            }
-          },
-          {
-            "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
-            "@ondc/org/title_type": "packing",
-            "title": "Packing Charges",
-            "price": {
-              "currency": "INR",
-              "value": "5.0"
-            }
-          },
-          {
-            "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
-            "@ondc/org/title_type": "delivery",
-            "title": "Delivery Charges",
-            "price": {
-              "currency": "INR",
-              "value": "100.0"
-            }
-          },
-          {
-            "@ondc/org/item_id": "59021f2c-bed5-4797-82e1-b06febf27eda",
+            "@ondc/org/item_id": "ec3a2ef5-9f47-4934-b4d5-a8d4dca6f9c8",
             "@ondc/org/title_type": "misc",
             "title": "Convenience Fee",
             "price": {
               "currency": "INR",
-              "value": "35.65"
+              "value": "48.31"
             }
           }
         ],
@@ -479,8 +522,8 @@
         "uri": "https://razorpay.com/",
         "tl_method": "http/get",
         "params": {
-          "transaction_id": "order_PkmGkn5hmLCG83",
-          "amount": "1401.72",
+          "transaction_id": "order_PmsrRxRfEkwUOs",
+          "amount": "1883.79",
           "currency": "INR"
         },
         "type": "ON-ORDER",
@@ -497,7 +540,7 @@
             "settlement_phase": "refund",
             "settlement_amount": "270.27",
             "settlement_type": "wallet",
-            "settlement_timestamp": "2025-01-18T04:40:58.885Z"
+            "settlement_timestamp": "2025-01-23T12:25:39.036Z"
           },
           {
             "settlement_counterparty": "seller-app",
@@ -512,8 +555,8 @@
           }
         ]
       },
-      "created_at": "2025-01-18T04:39:47.970Z",
-      "updated_at": "2025-01-18T16:09:21.698Z"
+      "created_at": "2025-01-23T12:24:39.050Z",
+      "updated_at": "2025-01-24T05:35:55.439Z"
     }
   }
 }

--- a/Pirimid/SellerApp/Retail/RET-10/FLOW_6/search_full_catalog_refresh.json
+++ b/Pirimid/SellerApp/Retail/RET-10/FLOW_6/search_full_catalog_refresh.json
@@ -7,9 +7,9 @@
     "core_version": "1.2.0",
     "bap_id": "buyer-app-preprod-v2.ondc.org",
     "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
-    "transaction_id": "e53a74c5-7ce6-4498-800c-e7d90db0f2fa",
-    "message_id": "45726578-5033-41e0-b35f-2fcbcebe8f82",
-    "timestamp": "2025-01-17T12:00:01.818Z",
+    "transaction_id": "2a274964-3eec-4793-888c-1d30ef845cd1",
+    "message_id": "c5c58f68-8483-4490-b318-a1436c6ee88b",
+    "timestamp": "2025-01-23T12:00:01.908Z",
     "ttl": "PT30S"
   },
   "message": {

--- a/Pirimid/SellerApp/Retail/RET-10/FLOW_6/select.json
+++ b/Pirimid/SellerApp/Retail/RET-10/FLOW_6/select.json
@@ -8,9 +8,9 @@
     "bap_id": "buyer-app-preprod-v2.ondc.org",
     "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
     "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-    "transaction_id": "82b9cba3-1fb4-4b53-825e-904368636e74",
-    "message_id": "3b8fc2b8-8b27-49d2-9952-dc997bd8f282",
-    "timestamp": "2025-01-18T04:39:46.507Z",
+    "transaction_id": "e35a5fd4-3758-429e-84d0-4d831a501733",
+    "message_id": "424472ba-775e-447f-8961-eaaa3327e8c9",
+    "timestamp": "2025-01-23T12:24:37.225Z",
     "bpp_id": "ondc.pirimidtech.com/v2/seller",
     "ttl": "PT30S"
   },
@@ -26,6 +26,13 @@
         },
         {
           "id": "0984d1dd-b5ea-417f-9104-68a2ec40dbd4",
+          "quantity": {
+            "count": 3
+          },
+          "location_id": "39550822-c3bb-4918-bd25-2d19ef6a9aca"
+        },
+        {
+          "id": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7",
           "quantity": {
             "count": 3
           },

--- a/Pirimid/SellerApp/Retail/RET-10/FLOW_6/update_liquidated.json
+++ b/Pirimid/SellerApp/Retail/RET-10/FLOW_6/update_liquidated.json
@@ -8,16 +8,16 @@
     "bap_id": "buyer-app-preprod-v2.ondc.org",
     "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
     "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-    "transaction_id": "82b9cba3-1fb4-4b53-825e-904368636e74",
-    "message_id": "945a1b17-6d01-4eed-89e7-6209d3c48fa6",
-    "timestamp": "2025-01-18T16:10:04.344Z",
+    "transaction_id": "e35a5fd4-3758-429e-84d0-4d831a501733",
+    "message_id": "104d0ea4-ba58-4984-b9b4-371fd6a95aed",
+    "timestamp": "2025-01-24T05:37:10.285Z",
     "bpp_id": "ondc.pirimidtech.com/v2/seller",
     "ttl": "PT30S"
   },
   "message": {
     "update_target": "item",
     "order": {
-      "id": "2025-01-18-743091",
+      "id": "2025-01-23-103725",
       "fulfillments": [
         {
           "type": "Return",
@@ -27,11 +27,11 @@
               "list": [
                 {
                   "code": "id",
-                  "value": "678bd25c8455f06951c954a8"
+                  "value": "67932706a3b38b99e1ec6555"
                 },
                 {
                   "code": "item_id",
-                  "value": "b1f9397b-0986-49bb-a759-ea3c36e4b2a9"
+                  "value": "1b7ecabd-b5cc-4296-ad98-5c139c0ed7d7"
                 },
                 {
                   "code": "parent_item_id",
@@ -39,7 +39,7 @@
                 },
                 {
                   "code": "item_quantity",
-                  "value": "1"
+                  "value": "2"
                 },
                 {
                   "code": "reason_id",
@@ -51,7 +51,7 @@
                 },
                 {
                   "code": "images",
-                  "value": "https://reference-buyer-app-assets.s3-ap-south-1.amazonaws.com/public-assets/2025-01-18-743091/824c6fb6-842f-477b-9a79-6ebaa14519ad.png"
+                  "value": "https://reference-buyer-app-assets.s3-ap-south-1.amazonaws.com/public-assets/2025-01-23-103725/0ddb2db8-2cca-4e38-8040-c5a06d98fdd5.png"
                 },
                 {
                   "code": "ttl_approval",

--- a/Pirimid/SellerApp/Retail/RET-10/FLOW_6/update_reverse_qc.json
+++ b/Pirimid/SellerApp/Retail/RET-10/FLOW_6/update_reverse_qc.json
@@ -8,16 +8,16 @@
     "bap_id": "buyer-app-preprod-v2.ondc.org",
     "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
     "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-    "transaction_id": "82b9cba3-1fb4-4b53-825e-904368636e74",
-    "message_id": "514316be-4639-430e-ba43-548d34c28aa0",
-    "timestamp": "2025-01-18T16:04:26.188Z",
+    "transaction_id": "e35a5fd4-3758-429e-84d0-4d831a501733",
+    "message_id": "9f397d17-2e0e-494a-aa8d-449c447b0d8d",
+    "timestamp": "2025-01-24T05:35:09.213Z",
     "bpp_id": "ondc.pirimidtech.com/v2/seller",
     "ttl": "PT30S"
   },
   "message": {
     "update_target": "item",
     "order": {
-      "id": "2025-01-18-743091",
+      "id": "2025-01-23-103725",
       "fulfillments": [
         {
           "type": "Return",
@@ -27,7 +27,7 @@
               "list": [
                 {
                   "code": "id",
-                  "value": "678bd10a8455f06951c9542a"
+                  "value": "6793268da3b38b99e1ec64d6"
                 },
                 {
                   "code": "item_id",
@@ -39,11 +39,11 @@
                 },
                 {
                   "code": "item_quantity",
-                  "value": "1"
+                  "value": "2"
                 },
                 {
                   "code": "reason_id",
-                  "value": "001"
+                  "value": "002"
                 },
                 {
                   "code": "reason_desc",
@@ -51,7 +51,7 @@
                 },
                 {
                   "code": "images",
-                  "value": "https://reference-buyer-app-assets.s3-ap-south-1.amazonaws.com/public-assets/2025-01-18-743091/c8f3fe60-e84a-4d49-ae61-ecbc2232da26.png"
+                  "value": "https://reference-buyer-app-assets.s3-ap-south-1.amazonaws.com/public-assets/2025-01-23-103725/7d383819-6630-4428-b4d8-b7aae2065ff1.png"
                 },
                 {
                   "code": "ttl_approval",

--- a/Pirimid/SellerApp/Retail/RET-10/FLOW_6/update_settlement_liquidated.json
+++ b/Pirimid/SellerApp/Retail/RET-10/FLOW_6/update_settlement_liquidated.json
@@ -7,19 +7,19 @@
     "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
     "bpp_id": "ondc.pirimidtech.com/v2/seller",
     "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-    "transaction_id": "82b9cba3-1fb4-4b53-825e-904368636e74",
-    "message_id": "6b8b769b-bc46-4409-8527-3746c6b78989",
+    "transaction_id": "e35a5fd4-3758-429e-84d0-4d831a501733",
+    "message_id": "9fce732f-d90d-44e2-8e90-eba935bd1ec9",
     "city": "std:079",
     "country": "IND",
-    "timestamp": "2025-01-18T16:10:42.056Z"
+    "timestamp": "2025-01-24T05:38:05.404Z"
   },
   "message": {
     "update_target": "payment",
     "order": {
-      "id": "2025-01-18-743091",
+      "id": "2025-01-23-103725",
       "fulfillments": [
         {
-          "id": "678bd25c8455f06951c954a8",
+          "id": "67932706a3b38b99e1ec6555",
           "type": "Return"
         }
       ],
@@ -29,8 +29,8 @@
             "settlement_counterparty": "buyer",
             "settlement_phase": "refund",
             "settlement_type": "wallet",
-            "settlement_amount": "270.27",
-            "settlement_timestamp": "2025-01-18T16:10:42.056Z"
+            "settlement_amount": "248.81",
+            "settlement_timestamp": "2025-01-24T05:38:05.404Z"
           }
         ]
       }

--- a/Pirimid/SellerApp/Retail/RET-10/FLOW_6/update_settlement_part_cancel.json
+++ b/Pirimid/SellerApp/Retail/RET-10/FLOW_6/update_settlement_part_cancel.json
@@ -7,19 +7,19 @@
     "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
     "bpp_id": "ondc.pirimidtech.com/v2/seller",
     "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-    "transaction_id": "82b9cba3-1fb4-4b53-825e-904368636e74",
-    "message_id": "36dc0f08-e65a-47df-808f-4ef9edf01e9d",
+    "transaction_id": "e35a5fd4-3758-429e-84d0-4d831a501733",
+    "message_id": "a845e674-dd44-4eeb-b5a7-c28e64969fed",
     "city": "std:079",
     "country": "IND",
-    "timestamp": "2025-01-18T04:40:58.885Z"
+    "timestamp": "2025-01-23T12:25:39.036Z"
   },
   "message": {
     "update_target": "payment",
     "order": {
-      "id": "2025-01-18-743091",
+      "id": "2025-01-23-103725",
       "fulfillments": [
         {
-          "id": "d856122c-15d5-4211-8484-4a8cb4541948",
+          "id": "ec3a2ef5-9f47-4934-b4d5-a8d4dca6f9c8",
           "type": "Cancel"
         }
       ],
@@ -30,7 +30,7 @@
             "settlement_phase": "refund",
             "settlement_type": "wallet",
             "settlement_amount": "270.27",
-            "settlement_timestamp": "2025-01-18T04:40:58.885Z"
+            "settlement_timestamp": "2025-01-23T12:25:39.036Z"
           }
         ]
       }

--- a/Pirimid/SellerApp/Retail/RET-10/FLOW_6/update_settlement_reverse_qc.json
+++ b/Pirimid/SellerApp/Retail/RET-10/FLOW_6/update_settlement_reverse_qc.json
@@ -7,19 +7,19 @@
     "bap_uri": "https://buyer-app-preprod-v2.ondc.org/protocol/v1",
     "bpp_id": "ondc.pirimidtech.com/v2/seller",
     "bpp_uri": "https://ondc.pirimidtech.com/v2/seller",
-    "transaction_id": "82b9cba3-1fb4-4b53-825e-904368636e74",
-    "message_id": "2812d8a3-0a2a-4bff-96f7-14b800e0cb6f",
+    "transaction_id": "e35a5fd4-3758-429e-84d0-4d831a501733",
+    "message_id": "135d8307-00c1-4470-a701-79832c4c26d0",
     "city": "std:079",
     "country": "IND",
-    "timestamp": "2025-01-18T16:09:23.017Z"
+    "timestamp": "2025-01-24T05:35:56.402Z"
   },
   "message": {
     "update_target": "payment",
     "order": {
-      "id": "2025-01-18-743091",
+      "id": "2025-01-23-103725",
       "fulfillments": [
         {
-          "id": "678bd10a8455f06951c9542a",
+          "id": "6793268da3b38b99e1ec64d6",
           "type": "Return"
         }
       ],
@@ -29,8 +29,8 @@
             "settlement_counterparty": "buyer",
             "settlement_phase": "refund",
             "settlement_type": "wallet",
-            "settlement_amount": "124.4",
-            "settlement_timestamp": "2025-01-18T16:09:23.017Z"
+            "settlement_amount": "248.81",
+            "settlement_timestamp": "2025-01-24T05:35:56.402Z"
           }
         ]
       }


### PR DESCRIPTION
Here On search One error, that variant is mandatory, but I discussed it with **FarheenNazz**, in case our catalog item has no variant then it is optional no need to add.

"on_search_full_catalog_refresh": {
                "prvdr0categories": "Support for variants is mandatory, categories must be present in bpp/providers[0]"
  }