### PR TITLE
Log validation report for RSF 2.0

### DIFF
--- a/eComviser/RSF 2.0/flow-1/flow-1_validate_report.json
+++ b/eComviser/RSF 2.0/flow-1/flow-1_validate_report.json
@@ -1,0 +1,13 @@
+{
+    "success": true,
+    "response": {
+        "message": "Logs were verified successfully",
+        "report": {},
+        "bpp_id": "rsf-mock-service.ondc.org",
+        "bap_id": "preprod.ecomviser.com",
+        "domain": "ONDC:NTS10",
+        "reportTimestamp": "2025-04-10T11:09:40.387Z"
+    },
+    "signature": "jjQpcRrz295sQpNHBhNCwxg9O1V6Y4io/XgXuBUl+quKMUdFb50/Opm2EvhlFh4fJFHrNXCpBN1+VMHStAjHBg==",
+    "signTimestamp": "2025-04-10T11:09:40.387Z"
+}

--- a/eComviser/RSF 2.0/flow-1/flow-1_validate_request.json
+++ b/eComviser/RSF 2.0/flow-1/flow-1_validate_request.json
@@ -1,0 +1,214 @@
+{
+    "domain": "ONDC:NTS10",
+    "version": "2.0.0",
+    "bap_id": "preprod.ecomviser.com",
+    "bap_uri": "https://preprod.ecomviser.com/api",
+    "bpp_id": "rsf-mock-service.ondc.org",
+    "bpp_uri": "https://rsf-mock-service.ondc.org/seller_protocol_server_preprod/ondc",
+    "payload": {
+        "settle": {
+            "context": {
+                "domain": "ONDC:NTS10",
+                "location": {
+                    "country": {
+                        "code": "IND"
+                    },
+                    "city": {
+                        "code": "*"
+                    }
+                },
+                "version": "2.0.0",
+                "action": "settle",
+                "bap_id": "preprod.ecomviser.com",
+                "bap_uri": "https://preprod.ecomviser.com/api",
+                "bpp_id": "rsf-mock-service.ondc.org",
+                "bpp_uri": "https://rsf-mock-service.ondc.org/seller_protocol_server_preprod/ondc",
+                "transaction_id": "2244ddde-d111-4559-89f4-0f583a871230",
+                "message_id": "6b949a64-aaf0-408c-9e38-02b74ae51861",
+                "timestamp": "2025-04-10T11:05:13.343Z",
+                "ttl": "P1D"
+            },
+            "message": {
+                "collector_app_id": "buyer-app-preprod-v2.ondc.org",
+                "receiver_app_id": "preprod.ecomviser.com",
+                "settlement": {
+                    "type": "NP-NP",
+                    "id": "1744283113-000009",
+                    "orders": [
+                        {
+                            "id": "2025-04-10-267227",
+                            "inter_participant": {
+                                "amount": {
+                                    "currency": "INR",
+                                    "value": "115.00"
+                                }
+                            },
+                            "collector": {
+                                "amount": {
+                                    "currency": "INR",
+                                    "value": "4.07"
+                                }
+                            },
+                            "self": {
+                                "amount": {
+                                    "currency": "INR",
+                                    "value": "115.00"
+                                }
+                            }
+                        }
+                    ]
+                }
+            }
+        },
+        "on_settle": {
+            "context": {
+                "bap_id": "preprod.ecomviser.com",
+                "bap_uri": "https://preprod.ecomviser.com/api",
+                "bpp_id": "rsf-mock-service.ondc.org",
+                "bpp_uri": "https://rsf-mock-service.ondc.org/seller_protocol_server_preprod/ondc",
+                "location": {
+                    "country": {
+                        "code": "IND"
+                    },
+                    "city": {
+                        "code": "*"
+                    }
+                },
+                "transaction_id": "2244ddde-d111-4559-89f4-0f583a871230",
+                "message_id": "6b949a64-aaf0-408c-9e38-02b74ae51861",
+                "timestamp": "2025-04-10T11:05:40.404Z",
+                "domain": "ONDC:NTS10",
+                "version": "2.0.0",
+                "ttl": "PT10M",
+                "action": "on_settle"
+            },
+            "message": {
+                "collector_app_id": "buyer-app-preprod-v2.ondc.org",
+                "receiver_app_id": "preprod.ecomviser.com",
+                "settlement": {
+                    "type": "NP-NP",
+                    "id": "1744283113-000009",
+                    "orders": [
+                        {
+                            "id": "2025-04-10-267227",
+                            "inter_participant": {
+                                "amount": {
+                                    "value": "115.00",
+                                    "currency": "INR"
+                                },
+                                "settled_amount": {
+                                    "value": "115.00",
+                                    "currency": "INR"
+                                },
+                                "status": "SETTLED",
+                                "reference_no": "1238683618634"
+                            },
+                            "collector": {
+                                "amount": {
+                                    "value": "4.07",
+                                    "currency": "INR"
+                                }
+                            },
+                            "self": {
+                                "amount": {
+                                    "value": "115.00",
+                                    "currency": "INR"
+                                },
+                                "status": "SETTLED",
+                                "reference_no": "1238683618634"
+                            }
+                        }
+                    ]
+                }
+            }
+        },
+        "report": {
+            "context": {
+                "domain": "ONDC:NTS10",
+                "location": {
+                    "country": {
+                        "code": "IND"
+                    },
+                    "city": {
+                        "code": "*"
+                    }
+                },
+                "version": "2.0.0",
+                "action": "report",
+                "bap_id": "preprod.ecomviser.com",
+                "bap_uri": "https://preprod.ecomviser.com/api",
+                "bpp_id": "rsf-mock-service.ondc.org",
+                "bpp_uri": "https://rsf-mock-service.ondc.org/seller_protocol_server_preprod/ondc",
+                "transaction_id": "2244ddde-d111-4559-89f4-0f583a871230",
+                "message_id": "ccffeecb-cb91-459a-8ed5-672c3097f23c",
+                "timestamp": "2025-04-10T11:06:14.828Z",
+                "ttl": "P1D"
+            },
+            "message": {
+                "ref_transaction_id": "2244ddde-d111-4559-89f4-0f583a871230",
+                "ref_message_id": "6b949a64-aaf0-408c-9e38-02b74ae51861"
+            }
+        },
+        "on_report": {
+            "context": {
+                "bap_id": "preprod.ecomviser.com",
+                "bap_uri": "https://preprod.ecomviser.com/api",
+                "bpp_id": "rsf-mock-service.ondc.org",
+                "bpp_uri": "https://rsf-mock-service.ondc.org/seller_protocol_server_preprod/ondc",
+                "location": {
+                    "country": {
+                        "code": "IND"
+                    },
+                    "city": {
+                        "code": "*"
+                    }
+                },
+                "transaction_id": "2244ddde-d111-4559-89f4-0f583a871230",
+                "message_id": "ccffeecb-cb91-459a-8ed5-672c3097f23c",
+                "timestamp": "2025-04-10T11:06:34.464Z",
+                "domain": "ONDC:NTS10",
+                "version": "2.0.0",
+                "ttl": "PT10M",
+                "action": "on_report"
+            },
+            "message": {
+                "collector_app_id": "buyer-app-preprod-v2.ondc.org",
+                "receiver_app_id": "preprod.ecomviser.com",
+                "settlement": {
+                    "type": "NP-NP",
+                    "id": "1744283113-000009",
+                    "orders": [
+                        {
+                            "id": "2025-04-10-267227",
+                            "inter_participant": {
+                                "amount": {
+                                    "value": "115.00",
+                                    "currency": "INR"
+                                },
+                                "settled_amount": {
+                                    "value": "115.00",
+                                    "currency": "INR"
+                                },
+                                "status": "SETTLED",
+                                "reference_no": "1238683618634"
+                            },
+                            "collector": {
+                                "amount": {
+                                    "value": "4.07",
+                                    "currency": "INR"
+                                }
+                            },
+                            "self": {
+                                "amount": {
+                                    "value": "115.00",
+                                    "currency": "INR"
+                                },
+                                "status": "SETTLED"
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+    }
+}

--- a/eComviser/RSF 2.0/flow-1/on_report.json
+++ b/eComviser/RSF 2.0/flow-1/on_report.json
@@ -1,0 +1,61 @@
+{
+    "context": {
+        "bap_id": "preprod.ecomviser.com",
+        "bap_uri": "https://preprod.ecomviser.com/api",
+        "bpp_id": "rsf-mock-service.ondc.org",
+        "bpp_uri": "https://rsf-mock-service.ondc.org/seller_protocol_server_preprod/ondc",
+        "location": {
+            "country": {
+                "code": "IND"
+            },
+            "city": {
+                "code": "*"
+            }
+        },
+        "transaction_id": "2244ddde-d111-4559-89f4-0f583a871230",
+        "message_id": "ccffeecb-cb91-459a-8ed5-672c3097f23c",
+        "timestamp": "2025-04-10T11:06:34.464Z",
+        "domain": "ONDC:NTS10",
+        "version": "2.0.0",
+        "ttl": "PT10M",
+        "action": "on_report"
+    },
+    "message": {
+        "collector_app_id": "buyer-app-preprod-v2.ondc.org",
+        "receiver_app_id": "preprod.ecomviser.com",
+        "settlement": {
+            "type": "NP-NP",
+            "id": "1744283113-000009",
+            "orders": [
+                {
+                    "id": "2025-04-10-267227",
+                    "inter_participant": {
+                        "amount": {
+                            "value": "115.00",
+                            "currency": "INR"
+                        },
+                        "settled_amount": {
+                            "value": "115.00",
+                            "currency": "INR"
+                        },
+                        "status": "SETTLED",
+                        "reference_no": "1238683618634"
+                    },
+                    "collector": {
+                        "amount": {
+                            "value": "4.07",
+                            "currency": "INR"
+                        }
+                    },
+                    "self": {
+                        "amount": {
+                            "value": "115.00",
+                            "currency": "INR"
+                        },
+                        "status": "SETTLED"
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/eComviser/RSF 2.0/flow-1/on_settle.json
+++ b/eComviser/RSF 2.0/flow-1/on_settle.json
@@ -1,0 +1,62 @@
+{
+    "context": {
+        "bap_id": "preprod.ecomviser.com",
+        "bap_uri": "https://preprod.ecomviser.com/api",
+        "bpp_id": "rsf-mock-service.ondc.org",
+        "bpp_uri": "https://rsf-mock-service.ondc.org/seller_protocol_server_preprod/ondc",
+        "location": {
+            "country": {
+                "code": "IND"
+            },
+            "city": {
+                "code": "*"
+            }
+        },
+        "transaction_id": "2244ddde-d111-4559-89f4-0f583a871230",
+        "message_id": "6b949a64-aaf0-408c-9e38-02b74ae51861",
+        "timestamp": "2025-04-10T11:05:40.404Z",
+        "domain": "ONDC:NTS10",
+        "version": "2.0.0",
+        "ttl": "PT10M",
+        "action": "on_settle"
+    },
+    "message": {
+        "collector_app_id": "buyer-app-preprod-v2.ondc.org",
+        "receiver_app_id": "preprod.ecomviser.com",
+        "settlement": {
+            "type": "NP-NP",
+            "id": "1744283113-000009",
+            "orders": [
+                {
+                    "id": "2025-04-10-267227",
+                    "inter_participant": {
+                        "amount": {
+                            "value": "115.00",
+                            "currency": "INR"
+                        },
+                        "settled_amount": {
+                            "value": "115.00",
+                            "currency": "INR"
+                        },
+                        "status": "SETTLED",
+                        "reference_no": "1238683618634"
+                    },
+                    "collector": {
+                        "amount": {
+                            "value": "4.07",
+                            "currency": "INR"
+                        }
+                    },
+                    "self": {
+                        "amount": {
+                            "value": "115.00",
+                            "currency": "INR"
+                        },
+                        "status": "SETTLED",
+                        "reference_no": "1238683618634"
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/eComviser/RSF 2.0/flow-1/report.json
+++ b/eComviser/RSF 2.0/flow-1/report.json
@@ -1,0 +1,27 @@
+{
+    "context": {
+        "domain": "ONDC:NTS10",
+        "location": {
+            "country": {
+                "code": "IND"
+            },
+            "city": {
+                "code": "*"
+            }
+        },
+        "version": "2.0.0",
+        "action": "report",
+        "bap_id": "preprod.ecomviser.com",
+        "bap_uri": "https://preprod.ecomviser.com/api",
+        "bpp_id": "rsf-mock-service.ondc.org",
+        "bpp_uri": "https://rsf-mock-service.ondc.org/seller_protocol_server_preprod/ondc",
+        "transaction_id": "2244ddde-d111-4559-89f4-0f583a871230",
+        "message_id": "ccffeecb-cb91-459a-8ed5-672c3097f23c",
+        "timestamp": "2025-04-10T11:06:14.828Z",
+        "ttl": "P1D"
+    },
+    "message": {
+        "ref_transaction_id": "2244ddde-d111-4559-89f4-0f583a871230",
+        "ref_message_id": "6b949a64-aaf0-408c-9e38-02b74ae51861"
+    }
+}

--- a/eComviser/RSF 2.0/flow-1/settle.json
+++ b/eComviser/RSF 2.0/flow-1/settle.json
@@ -1,0 +1,54 @@
+{
+    "context": {
+        "domain": "ONDC:NTS10",
+        "location": {
+            "country": {
+                "code": "IND"
+            },
+            "city": {
+                "code": "*"
+            }
+        },
+        "version": "2.0.0",
+        "action": "settle",
+        "bap_id": "preprod.ecomviser.com",
+        "bap_uri": "https://preprod.ecomviser.com/api",
+        "bpp_id": "rsf-mock-service.ondc.org",
+        "bpp_uri": "https://rsf-mock-service.ondc.org/seller_protocol_server_preprod/ondc",
+        "transaction_id": "2244ddde-d111-4559-89f4-0f583a871230",
+        "message_id": "6b949a64-aaf0-408c-9e38-02b74ae51861",
+        "timestamp": "2025-04-10T11:05:13.343Z",
+        "ttl": "P1D"
+    },
+    "message": {
+        "collector_app_id": "buyer-app-preprod-v2.ondc.org",
+        "receiver_app_id": "preprod.ecomviser.com",
+        "settlement": {
+            "type": "NP-NP",
+            "id": "1744283113-000009",
+            "orders": [
+                {
+                    "id": "2025-04-10-267227",
+                    "inter_participant": {
+                        "amount": {
+                            "currency": "INR",
+                            "value": "115.00"
+                        }
+                    },
+                    "collector": {
+                        "amount": {
+                            "currency": "INR",
+                            "value": "4.07"
+                        }
+                    },
+                    "self": {
+                        "amount": {
+                            "currency": "INR",
+                            "value": "115.00"
+                        }
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/eComviser/RSF 2.0/flow-2/flow-2_validate_report.json
+++ b/eComviser/RSF 2.0/flow-2/flow-2_validate_report.json
@@ -1,0 +1,13 @@
+{
+    "success": true,
+    "response": {
+        "message": "Logs were verified successfully",
+        "report": {},
+        "bpp_id": "rsf-mock-service.ondc.org",
+        "bap_id": "preprod.ecomviser.com",
+        "domain": "ONDC:NTS10",
+        "reportTimestamp": "2025-04-10T11:33:33.352Z"
+    },
+    "signature": "ZT51nYy4YfcQnARetubKEqH4G8QMXZfbkDq1wPkmK3is57wMGIIjSzxBgOD6dFM8Ut+jVFNLyy52PIRUDW38BQ==",
+    "signTimestamp": "2025-04-10T11:33:33.352Z"
+}

--- a/eComviser/RSF 2.0/flow-2/flow-2_validate_request.json
+++ b/eComviser/RSF 2.0/flow-2/flow-2_validate_request.json
@@ -1,0 +1,475 @@
+{
+    "domain": "ONDC:NTS10",
+    "version": "2.0.0",
+    "bap_id": "preprod.ecomviser.com",
+    "bap_uri": "https://preprod.ecomviser.com/api",
+    "bpp_id": "rsf-mock-service.ondc.org",
+    "bpp_uri": "https://rsf-mock-service.ondc.org/seller_protocol_server_preprod/ondc",
+    "payload": {
+        "settle": {
+            "context": {
+                "domain": "ONDC:NTS10",
+                "location": {
+                    "country": {
+                        "code": "IND"
+                    },
+                    "city": {
+                        "code": "*"
+                    }
+                },
+                "version": "2.0.0",
+                "action": "settle",
+                "bap_id": "preprod.ecomviser.com",
+                "bap_uri": "https://preprod.ecomviser.com/api",
+                "bpp_id": "rsf-mock-service.ondc.org",
+                "bpp_uri": "https://rsf-mock-service.ondc.org/seller_protocol_server_preprod/ondc",
+                "transaction_id": "1e337823-bfec-4f80-826a-194e1c715c64",
+                "message_id": "2b14ea07-04de-4de0-be91-22fd2a438feb",
+                "timestamp": "2025-04-10T11:17:58.018Z",
+                "ttl": "P1D"
+            },
+            "message": {
+                "collector_app_id": "buyer-app-preprod-v2.ondc.org",
+                "receiver_app_id": "preprod.ecomviser.com",
+                "settlement": {
+                    "type": "NP-NP",
+                    "id": "1744283878-000010",
+                    "orders": [
+                        {
+                            "id": "2025-04-10-445354",
+                            "inter_participant": {
+                                "amount": {
+                                    "currency": "INR",
+                                    "value": "125.00"
+                                }
+                            },
+                            "collector": {
+                                "amount": {
+                                    "currency": "INR",
+                                    "value": "4.43"
+                                }
+                            },
+                            "self": {
+                                "amount": {
+                                    "currency": "INR",
+                                    "value": "125.00"
+                                }
+                            }
+                        }
+                    ]
+                }
+            }
+        },
+        "on_settle": {
+            "context": {
+                "bap_id": "preprod.ecomviser.com",
+                "bap_uri": "https://preprod.ecomviser.com/api",
+                "bpp_id": "rsf-mock-service.ondc.org",
+                "bpp_uri": "https://rsf-mock-service.ondc.org/seller_protocol_server_preprod/ondc",
+                "location": {
+                    "country": {
+                        "code": "IND"
+                    },
+                    "city": {
+                        "code": "*"
+                    }
+                },
+                "transaction_id": "1e337823-bfec-4f80-826a-194e1c715c64",
+                "message_id": "2b14ea07-04de-4de0-be91-22fd2a438feb",
+                "timestamp": "2025-04-10T11:18:40.971Z",
+                "domain": "ONDC:NTS10",
+                "version": "2.0.0",
+                "ttl": "PT10M",
+                "action": "on_settle"
+            },
+            "message": {
+                "collector_app_id": "buyer-app-preprod-v2.ondc.org",
+                "receiver_app_id": "preprod.ecomviser.com",
+                "settlement": {
+                    "type": "NP-NP",
+                    "id": "1744283878-000010",
+                    "orders": [
+                        {
+                            "id": "2025-04-10-445354",
+                            "inter_participant": {
+                                "amount": {
+                                    "value": "125.00",
+                                    "currency": "INR"
+                                },
+                                "settled_amount": {
+                                    "value": "125.00",
+                                    "currency": "INR"
+                                },
+                                "status": "SETTLED",
+                                "reference_no": "1238683618634",
+                                "error": {
+                                    "code": "70023",
+                                    "message": "Collector value mismatch"
+                                }
+                            },
+                            "collector": {
+                                "amount": {
+                                    "value": "4.43",
+                                    "currency": "INR"
+                                }
+                            },
+                            "self": {
+                                "amount": {
+                                    "value": "125.00",
+                                    "currency": "INR"
+                                },
+                                "status": "SETTLED",
+                                "reference_no": "1238683618634",
+                                "error": {
+                                    "code": "70023",
+                                    "message": "Collector value mismatch"
+                                }
+                            }
+                        }
+                    ]
+                }
+            }
+        },
+        "report": {
+            "context": {
+                "domain": "ONDC:NTS10",
+                "location": {
+                    "country": {
+                        "code": "IND"
+                    },
+                    "city": {
+                        "code": "*"
+                    }
+                },
+                "version": "2.0.0",
+                "action": "report",
+                "bap_id": "preprod.ecomviser.com",
+                "bap_uri": "https://preprod.ecomviser.com/api",
+                "bpp_id": "rsf-mock-service.ondc.org",
+                "bpp_uri": "https://rsf-mock-service.ondc.org/seller_protocol_server_preprod/ondc",
+                "transaction_id": "1e337823-bfec-4f80-826a-194e1c715c64",
+                "message_id": "0fcadf48-b9e1-40ca-b6c6-f855cd1ab9b0",
+                "timestamp": "2025-04-10T11:19:00.415Z",
+                "ttl": "P1D"
+            },
+            "message": {
+                "ref_transaction_id": "1e337823-bfec-4f80-826a-194e1c715c64",
+                "ref_message_id": "2b14ea07-04de-4de0-be91-22fd2a438feb"
+            }
+        },
+        "on_report": {
+            "context": {
+                "bap_id": "preprod.ecomviser.com",
+                "bap_uri": "https://preprod.ecomviser.com/api",
+                "bpp_id": "rsf-mock-service.ondc.org",
+                "bpp_uri": "https://rsf-mock-service.ondc.org/seller_protocol_server_preprod/ondc",
+                "location": {
+                    "country": {
+                        "code": "IND"
+                    },
+                    "city": {
+                        "code": "*"
+                    }
+                },
+                "transaction_id": "1e337823-bfec-4f80-826a-194e1c715c64",
+                "message_id": "0fcadf48-b9e1-40ca-b6c6-f855cd1ab9b0",
+                "timestamp": "2025-04-10T11:19:53.317Z",
+                "domain": "ONDC:NTS10",
+                "version": "2.0.0",
+                "ttl": "PT10M",
+                "action": "on_report"
+            },
+            "message": {
+                "collector_app_id": "buyer-app-preprod-v2.ondc.org",
+                "receiver_app_id": "preprod.ecomviser.com",
+                "settlement": {
+                    "type": "NP-NP",
+                    "id": "1744283878-000010",
+                    "orders": [
+                        {
+                            "id": "2025-04-10-445354",
+                            "inter_participant": {
+                                "amount": {
+                                    "value": "125.00",
+                                    "currency": "INR"
+                                },
+                                "settled_amount": {
+                                    "value": "125.00",
+                                    "currency": "INR"
+                                },
+                                "status": "SETTLED",
+                                "reference_no": "1238683618634"
+                            },
+                            "collector": {
+                                "amount": {
+                                    "value": "4.43",
+                                    "currency": "INR"
+                                }
+                            },
+                            "self": {
+                                "amount": {
+                                    "value": "125.00",
+                                    "currency": "INR"
+                                },
+                                "status": "SETTLED"
+                            },
+                            "error": {
+                                "code": "70023",
+                                "message": "Collector value mismatch"
+                            }
+                        }
+                    ]
+                }
+            }
+        },
+        "recon": {
+            "context": {
+                "domain": "ONDC:NTS10",
+                "location": {
+                    "country": {
+                        "code": "IND"
+                    },
+                    "city": {
+                        "code": "*"
+                    }
+                },
+                "version": "2.0.0",
+                "action": "recon",
+                "bap_id": "preprod.ecomviser.com",
+                "bap_uri": "https://preprod.ecomviser.com/api",
+                "bpp_id": "rsf-mock-service.ondc.org",
+                "bpp_uri": "https://rsf-mock-service.ondc.org/seller_protocol_server_preprod/ondc",
+                "transaction_id": "1e337823-bfec-4f80-826a-194e1c715c64",
+                "message_id": "c1b965d4-34d6-407f-b610-06558261e6d9",
+                "timestamp": "2025-04-10T11:20:22.176Z",
+                "ttl": "P1D"
+            },
+            "message": {
+                "orders": [
+                    {
+                        "id": "2025-04-10-445354",
+                        "amount": {
+                            "currency": "INR",
+                            "value": "125.00"
+                        },
+                        "settlements": [
+                            {
+                                "id": "1744283878-000010",
+                                "payment_id": "order_QHKqCq1CHfAEWo",
+                                "status": "SETTLED",
+                                "amount": {
+                                    "currency": "INR",
+                                    "value": "125.00"
+                                },
+                                "commission": {
+                                    "currency": "INR",
+                                    "value": "4.43"
+                                },
+                                "withholding_amount": {
+                                    "currency": "INR",
+                                    "value": "0.00"
+                                },
+                                "tds": {
+                                    "currency": "INR",
+                                    "value": "0.00"
+                                },
+                                "tcs": {
+                                    "currency": "INR",
+                                    "value": "0.00"
+                                },
+                                "settlement_ref_no": "1238683618634",
+                                "updated_at": "2025-04-10T11:18:40.971Z"
+                            }
+                        ]
+                    }
+                ]
+            }
+        },
+        "on_recon": {
+            "context": {
+                "bap_id": "preprod.ecomviser.com",
+                "bap_uri": "https://preprod.ecomviser.com/api",
+                "bpp_id": "rsf-mock-service.ondc.org",
+                "bpp_uri": "https://rsf-mock-service.ondc.org/seller_protocol_server_preprod/ondc",
+                "location": {
+                    "country": {
+                        "code": "IND"
+                    },
+                    "city": {
+                        "code": "*"
+                    }
+                },
+                "transaction_id": "1e337823-bfec-4f80-826a-194e1c715c64",
+                "message_id": "c1b965d4-34d6-407f-b610-06558261e6d9",
+                "timestamp": "2025-04-10T11:21:34.385Z",
+                "domain": "ONDC:NTS10",
+                "version": "2.0.0",
+                "ttl": "PT10M",
+                "action": "on_recon"
+            },
+            "message": {
+                "orders": [
+                    {
+                        "id": "2025-04-10-445354",
+                        "amount": {
+                            "value": "125.00",
+                            "currency": "INR"
+                        },
+                        "recon_accord": false,
+                        "settlements": [
+                            {
+                                "id": "1744283878-000010",
+                                "payment_id": "order_QHKqCq1CHfAEWo",
+                                "status": "SETTLED",
+                                "amount": {
+                                    "value": "125.00",
+                                    "currency": "INR",
+                                    "diff_value": "0.00"
+                                },
+                                "commission": {
+                                    "value": "4.43",
+                                    "currency": "INR",
+                                    "diff_value": "0.00"
+                                },
+                                "withholding_amount": {
+                                    "value": "0.00",
+                                    "currency": "INR",
+                                    "diff_value": "0.00"
+                                },
+                                "tcs": {
+                                    "value": "0.00",
+                                    "currency": "INR",
+                                    "diff_value": "0.00"
+                                },
+                                "tds": {
+                                    "value": "0.00",
+                                    "currency": "INR",
+                                    "diff_value": "0.00"
+                                },
+                                "settlement_ref_no": "1238683618634",
+                                "updated_at": "2025-04-10T11:18:40.971Z",
+                                "due_date": "2025-04-12"
+                            }
+                        ]
+                    }
+                ]
+            }
+        },
+        "settle_1": {
+            "context": {
+                "domain": "ONDC:NTS10",
+                "location": {
+                    "country": {
+                        "code": "IND"
+                    },
+                    "city": {
+                        "code": "*"
+                    }
+                },
+                "version": "2.0.0",
+                "action": "settle",
+                "bap_id": "preprod.ecomviser.com",
+                "bap_uri": "https://preprod.ecomviser.com/api",
+                "bpp_id": "rsf-mock-service.ondc.org",
+                "bpp_uri": "https://rsf-mock-service.ondc.org/seller_protocol_server_preprod/ondc",
+                "transaction_id": "2a4d723b-001d-457b-9bba-c68902376751",
+                "message_id": "62c158b1-daa6-4100-a62e-86c91e57329c",
+                "timestamp": "2025-04-10T11:22:58.018Z",
+                "ttl": "P1D"
+            },
+            "message": {
+                "collector_app_id": "buyer-app-preprod-v2.ondc.org",
+                "receiver_app_id": "preprod.ecomviser.com",
+                "settlement": {
+                    "type": "NP-NP",
+                    "id": "1744283878-000010",
+                    "orders": [
+                        {
+                            "id": "2025-04-10-445354",
+                            "inter_participant": {
+                                "amount": {
+                                    "currency": "INR",
+                                    "value": "125.00"
+                                }
+                            },
+                            "collector": {
+                                "amount": {
+                                    "currency": "INR",
+                                    "value": "4.43"
+                                }
+                            },
+                            "self": {
+                                "amount": {
+                                    "currency": "INR",
+                                    "value": "125.00"
+                                }
+                            }
+                        }
+                    ]
+                }
+            }
+        },
+        "on_settle_1": {
+            "context": {
+                "bap_id": "preprod.ecomviser.com",
+                "bap_uri": "https://preprod.ecomviser.com/api",
+                "bpp_id": "rsf-mock-service.ondc.org",
+                "bpp_uri": "https://rsf-mock-service.ondc.org/seller_protocol_server_preprod/ondc",
+                "location": {
+                    "country": {
+                        "code": "IND"
+                    },
+                    "city": {
+                        "code": "*"
+                    }
+                },
+                "transaction_id": "2a4d723b-001d-457b-9bba-c68902376751",
+                "message_id": "62c158b1-daa6-4100-a62e-86c91e57329c",
+                "timestamp": "2025-04-10T11:32:29.572Z",
+                "domain": "ONDC:NTS10",
+                "version": "2.0.0",
+                "ttl": "PT10M",
+                "action": "on_settle"
+            },
+            "message": {
+                "collector_app_id": "buyer-app-preprod-v2.ondc.org",
+                "receiver_app_id": "preprod.ecomviser.com",
+                "settlement": {
+                    "type": "NP-NP",
+                    "id": "1744283878-000010",
+                    "orders": [
+                        {
+                            "id": "2025-04-10-445354",
+                            "inter_participant": {
+                                "amount": {
+                                    "value": "125.00",
+                                    "currency": "INR"
+                                },
+                                "settled_amount": {
+                                    "value": "125.00",
+                                    "currency": "INR"
+                                },
+                                "status": "SETTLED",
+                                "reference_no": "1238683618635"
+                            },
+                            "collector": {
+                                "amount": {
+                                    "value": "4.43",
+                                    "currency": "INR"
+                                }
+                            },
+                            "self": {
+                                "amount": {
+                                    "value": "125.00",
+                                    "currency": "INR"
+                                },
+                                "status": "SETTLED",
+                                "reference_no": "1238683618635"
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+    }
+}

--- a/eComviser/RSF 2.0/flow-2/on_recon.json
+++ b/eComviser/RSF 2.0/flow-2/on_recon.json
@@ -1,0 +1,70 @@
+{
+    "context": {
+        "bap_id": "preprod.ecomviser.com",
+        "bap_uri": "https://preprod.ecomviser.com/api",
+        "bpp_id": "rsf-mock-service.ondc.org",
+        "bpp_uri": "https://rsf-mock-service.ondc.org/seller_protocol_server_preprod/ondc",
+        "location": {
+            "country": {
+                "code": "IND"
+            },
+            "city": {
+                "code": "*"
+            }
+        },
+        "transaction_id": "1e337823-bfec-4f80-826a-194e1c715c64",
+        "message_id": "c1b965d4-34d6-407f-b610-06558261e6d9",
+        "timestamp": "2025-04-10T11:21:34.385Z",
+        "domain": "ONDC:NTS10",
+        "version": "2.0.0",
+        "ttl": "PT10M",
+        "action": "on_recon"
+    },
+    "message": {
+        "orders": [
+            {
+                "id": "2025-04-10-445354",
+                "amount": {
+                    "value": "125.00",
+                    "currency": "INR"
+                },
+                "recon_accord": false,
+                "settlements": [
+                    {
+                        "id": "1744283878-000010",
+                        "payment_id": "order_QHKqCq1CHfAEWo",
+                        "status": "SETTLED",
+                        "amount": {
+                            "value": "125.00",
+                            "currency": "INR",
+                            "diff_value": "0.00"
+                        },
+                        "commission": {
+                            "value": "4.43",
+                            "currency": "INR",
+                            "diff_value": "0.00"
+                        },
+                        "withholding_amount": {
+                            "value": "0.00",
+                            "currency": "INR",
+                            "diff_value": "0.00"
+                        },
+                        "tcs": {
+                            "value": "0.00",
+                            "currency": "INR",
+                            "diff_value": "0.00"
+                        },
+                        "tds": {
+                            "value": "0.00",
+                            "currency": "INR",
+                            "diff_value": "0.00"
+                        },
+                        "settlement_ref_no": "1238683618634",
+                        "updated_at": "2025-04-10T11:18:40.971Z",
+                        "due_date": "2025-04-12"
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/eComviser/RSF 2.0/flow-2/on_report.json
+++ b/eComviser/RSF 2.0/flow-2/on_report.json
@@ -1,0 +1,65 @@
+{
+    "context": {
+        "bap_id": "preprod.ecomviser.com",
+        "bap_uri": "https://preprod.ecomviser.com/api",
+        "bpp_id": "rsf-mock-service.ondc.org",
+        "bpp_uri": "https://rsf-mock-service.ondc.org/seller_protocol_server_preprod/ondc",
+        "location": {
+            "country": {
+                "code": "IND"
+            },
+            "city": {
+                "code": "*"
+            }
+        },
+        "transaction_id": "1e337823-bfec-4f80-826a-194e1c715c64",
+        "message_id": "0fcadf48-b9e1-40ca-b6c6-f855cd1ab9b0",
+        "timestamp": "2025-04-10T11:19:53.317Z",
+        "domain": "ONDC:NTS10",
+        "version": "2.0.0",
+        "ttl": "PT10M",
+        "action": "on_report"
+    },
+    "message": {
+        "collector_app_id": "buyer-app-preprod-v2.ondc.org",
+        "receiver_app_id": "preprod.ecomviser.com",
+        "settlement": {
+            "type": "NP-NP",
+            "id": "1744283878-000010",
+            "orders": [
+                {
+                    "id": "2025-04-10-445354",
+                    "inter_participant": {
+                        "amount": {
+                            "value": "125.00",
+                            "currency": "INR"
+                        },
+                        "settled_amount": {
+                            "value": "125.00",
+                            "currency": "INR"
+                        },
+                        "status": "SETTLED",
+                        "reference_no": "1238683618634"
+                    },
+                    "collector": {
+                        "amount": {
+                            "value": "4.43",
+                            "currency": "INR"
+                        }
+                    },
+                    "self": {
+                        "amount": {
+                            "value": "125.00",
+                            "currency": "INR"
+                        },
+                        "status": "SETTLED"
+                    },
+                    "error": {
+                        "code": "70023",
+                        "message": "Collector value mismatch"
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/eComviser/RSF 2.0/flow-2/on_settle.json
+++ b/eComviser/RSF 2.0/flow-2/on_settle.json
@@ -1,0 +1,70 @@
+{
+    "context": {
+        "bap_id": "preprod.ecomviser.com",
+        "bap_uri": "https://preprod.ecomviser.com/api",
+        "bpp_id": "rsf-mock-service.ondc.org",
+        "bpp_uri": "https://rsf-mock-service.ondc.org/seller_protocol_server_preprod/ondc",
+        "location": {
+            "country": {
+                "code": "IND"
+            },
+            "city": {
+                "code": "*"
+            }
+        },
+        "transaction_id": "1e337823-bfec-4f80-826a-194e1c715c64",
+        "message_id": "2b14ea07-04de-4de0-be91-22fd2a438feb",
+        "timestamp": "2025-04-10T11:18:40.971Z",
+        "domain": "ONDC:NTS10",
+        "version": "2.0.0",
+        "ttl": "PT10M",
+        "action": "on_settle"
+    },
+    "message": {
+        "collector_app_id": "buyer-app-preprod-v2.ondc.org",
+        "receiver_app_id": "preprod.ecomviser.com",
+        "settlement": {
+            "type": "NP-NP",
+            "id": "1744283878-000010",
+            "orders": [
+                {
+                    "id": "2025-04-10-445354",
+                    "inter_participant": {
+                        "amount": {
+                            "value": "125.00",
+                            "currency": "INR"
+                        },
+                        "settled_amount": {
+                            "value": "125.00",
+                            "currency": "INR"
+                        },
+                        "status": "SETTLED",
+                        "reference_no": "1238683618634",
+                        "error": {
+                            "code": "70023",
+                            "message": "Collector value mismatch"
+                        }
+                    },
+                    "collector": {
+                        "amount": {
+                            "value": "4.43",
+                            "currency": "INR"
+                        }
+                    },
+                    "self": {
+                        "amount": {
+                            "value": "125.00",
+                            "currency": "INR"
+                        },
+                        "status": "SETTLED",
+                        "reference_no": "1238683618634",
+                        "error": {
+                            "code": "70023",
+                            "message": "Collector value mismatch"
+                        }
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/eComviser/RSF 2.0/flow-2/on_settle_1.json
+++ b/eComviser/RSF 2.0/flow-2/on_settle_1.json
@@ -1,0 +1,62 @@
+{
+    "context": {
+        "bap_id": "preprod.ecomviser.com",
+        "bap_uri": "https://preprod.ecomviser.com/api",
+        "bpp_id": "rsf-mock-service.ondc.org",
+        "bpp_uri": "https://rsf-mock-service.ondc.org/seller_protocol_server_preprod/ondc",
+        "location": {
+            "country": {
+                "code": "IND"
+            },
+            "city": {
+                "code": "*"
+            }
+        },
+        "transaction_id": "2a4d723b-001d-457b-9bba-c68902376751",
+        "message_id": "62c158b1-daa6-4100-a62e-86c91e57329c",
+        "timestamp": "2025-04-10T11:32:29.572Z",
+        "domain": "ONDC:NTS10",
+        "version": "2.0.0",
+        "ttl": "PT10M",
+        "action": "on_settle"
+    },
+    "message": {
+        "collector_app_id": "buyer-app-preprod-v2.ondc.org",
+        "receiver_app_id": "preprod.ecomviser.com",
+        "settlement": {
+            "type": "NP-NP",
+            "id": "1744283878-000010",
+            "orders": [
+                {
+                    "id": "2025-04-10-445354",
+                    "inter_participant": {
+                        "amount": {
+                            "value": "125.00",
+                            "currency": "INR"
+                        },
+                        "settled_amount": {
+                            "value": "125.00",
+                            "currency": "INR"
+                        },
+                        "status": "SETTLED",
+                        "reference_no": "1238683618635"
+                    },
+                    "collector": {
+                        "amount": {
+                            "value": "4.43",
+                            "currency": "INR"
+                        }
+                    },
+                    "self": {
+                        "amount": {
+                            "value": "125.00",
+                            "currency": "INR"
+                        },
+                        "status": "SETTLED",
+                        "reference_no": "1238683618635"
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/eComviser/RSF 2.0/flow-2/recon.json
+++ b/eComviser/RSF 2.0/flow-2/recon.json
@@ -1,0 +1,63 @@
+{
+    "context": {
+        "domain": "ONDC:NTS10",
+        "location": {
+            "country": {
+                "code": "IND"
+            },
+            "city": {
+                "code": "*"
+            }
+        },
+        "version": "2.0.0",
+        "action": "recon",
+        "bap_id": "preprod.ecomviser.com",
+        "bap_uri": "https://preprod.ecomviser.com/api",
+        "bpp_id": "rsf-mock-service.ondc.org",
+        "bpp_uri": "https://rsf-mock-service.ondc.org/seller_protocol_server_preprod/ondc",
+        "transaction_id": "1e337823-bfec-4f80-826a-194e1c715c64",
+        "message_id": "c1b965d4-34d6-407f-b610-06558261e6d9",
+        "timestamp": "2025-04-10T11:20:22.176Z",
+        "ttl": "P1D"
+    },
+    "message": {
+        "orders": [
+            {
+                "id": "2025-04-10-445354",
+                "amount": {
+                    "currency": "INR",
+                    "value": "125.00"
+                },
+                "settlements": [
+                    {
+                        "id": "1744283878-000010",
+                        "payment_id": "order_QHKqCq1CHfAEWo",
+                        "status": "SETTLED",
+                        "amount": {
+                            "currency": "INR",
+                            "value": "125.00"
+                        },
+                        "commission": {
+                            "currency": "INR",
+                            "value": "4.43"
+                        },
+                        "withholding_amount": {
+                            "currency": "INR",
+                            "value": "0.00"
+                        },
+                        "tds": {
+                            "currency": "INR",
+                            "value": "0.00"
+                        },
+                        "tcs": {
+                            "currency": "INR",
+                            "value": "0.00"
+                        },
+                        "settlement_ref_no": "1238683618634",
+                        "updated_at": "2025-04-10T11:18:40.971Z"
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/eComviser/RSF 2.0/flow-2/report.json
+++ b/eComviser/RSF 2.0/flow-2/report.json
@@ -1,0 +1,27 @@
+{
+    "context": {
+        "domain": "ONDC:NTS10",
+        "location": {
+            "country": {
+                "code": "IND"
+            },
+            "city": {
+                "code": "*"
+            }
+        },
+        "version": "2.0.0",
+        "action": "report",
+        "bap_id": "preprod.ecomviser.com",
+        "bap_uri": "https://preprod.ecomviser.com/api",
+        "bpp_id": "rsf-mock-service.ondc.org",
+        "bpp_uri": "https://rsf-mock-service.ondc.org/seller_protocol_server_preprod/ondc",
+        "transaction_id": "1e337823-bfec-4f80-826a-194e1c715c64",
+        "message_id": "0fcadf48-b9e1-40ca-b6c6-f855cd1ab9b0",
+        "timestamp": "2025-04-10T11:19:00.415Z",
+        "ttl": "P1D"
+    },
+    "message": {
+        "ref_transaction_id": "1e337823-bfec-4f80-826a-194e1c715c64",
+        "ref_message_id": "2b14ea07-04de-4de0-be91-22fd2a438feb"
+    }
+}

--- a/eComviser/RSF 2.0/flow-2/settle.json
+++ b/eComviser/RSF 2.0/flow-2/settle.json
@@ -1,0 +1,54 @@
+{
+    "context": {
+        "domain": "ONDC:NTS10",
+        "location": {
+            "country": {
+                "code": "IND"
+            },
+            "city": {
+                "code": "*"
+            }
+        },
+        "version": "2.0.0",
+        "action": "settle",
+        "bap_id": "preprod.ecomviser.com",
+        "bap_uri": "https://preprod.ecomviser.com/api",
+        "bpp_id": "rsf-mock-service.ondc.org",
+        "bpp_uri": "https://rsf-mock-service.ondc.org/seller_protocol_server_preprod/ondc",
+        "transaction_id": "1e337823-bfec-4f80-826a-194e1c715c64",
+        "message_id": "2b14ea07-04de-4de0-be91-22fd2a438feb",
+        "timestamp": "2025-04-10T11:17:58.018Z",
+        "ttl": "P1D"
+    },
+    "message": {
+        "collector_app_id": "buyer-app-preprod-v2.ondc.org",
+        "receiver_app_id": "preprod.ecomviser.com",
+        "settlement": {
+            "type": "NP-NP",
+            "id": "1744283878-000010",
+            "orders": [
+                {
+                    "id": "2025-04-10-445354",
+                    "inter_participant": {
+                        "amount": {
+                            "currency": "INR",
+                            "value": "125.00"
+                        }
+                    },
+                    "collector": {
+                        "amount": {
+                            "currency": "INR",
+                            "value": "4.43"
+                        }
+                    },
+                    "self": {
+                        "amount": {
+                            "currency": "INR",
+                            "value": "125.00"
+                        }
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/eComviser/RSF 2.0/flow-2/settle_1.json
+++ b/eComviser/RSF 2.0/flow-2/settle_1.json
@@ -1,0 +1,54 @@
+{
+    "context": {
+        "domain": "ONDC:NTS10",
+        "location": {
+            "country": {
+                "code": "IND"
+            },
+            "city": {
+                "code": "*"
+            }
+        },
+        "version": "2.0.0",
+        "action": "settle",
+        "bap_id": "preprod.ecomviser.com",
+        "bap_uri": "https://preprod.ecomviser.com/api",
+        "bpp_id": "rsf-mock-service.ondc.org",
+        "bpp_uri": "https://rsf-mock-service.ondc.org/seller_protocol_server_preprod/ondc",
+        "transaction_id": "2a4d723b-001d-457b-9bba-c68902376751",
+        "message_id": "62c158b1-daa6-4100-a62e-86c91e57329c",
+        "timestamp": "2025-04-10T11:22:58.018Z",
+        "ttl": "P1D"
+    },
+    "message": {
+        "collector_app_id": "buyer-app-preprod-v2.ondc.org",
+        "receiver_app_id": "preprod.ecomviser.com",
+        "settlement": {
+            "type": "NP-NP",
+            "id": "1744283878-000010",
+            "orders": [
+                {
+                    "id": "2025-04-10-445354",
+                    "inter_participant": {
+                        "amount": {
+                            "currency": "INR",
+                            "value": "125.00"
+                        }
+                    },
+                    "collector": {
+                        "amount": {
+                            "currency": "INR",
+                            "value": "4.43"
+                        }
+                    },
+                    "self": {
+                        "amount": {
+                            "currency": "INR",
+                            "value": "125.00"
+                        }
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/eComviser/RSF 2.0/flow-3/flow-3_validate_report.json
+++ b/eComviser/RSF 2.0/flow-3/flow-3_validate_report.json
@@ -1,0 +1,13 @@
+{
+    "success": true,
+    "response": {
+        "message": "Logs were verified successfully",
+        "report": {},
+        "bpp_id": "rsf-mock-service.ondc.org",
+        "bap_id": "preprod.ecomviser.com",
+        "domain": "ONDC:NTS10",
+        "reportTimestamp": "2025-04-10T11:56:59.889Z"
+    },
+    "signature": "LagHGzpNupmFthy+RG9Dr8TfZViYKyijPowHH7GBuRjnA4AvJibg6IlSuKLKks6L7b4THI90TqxjSkckuBxQCQ==",
+    "signTimestamp": "2025-04-10T11:56:59.890Z"
+}

--- a/eComviser/RSF 2.0/flow-3/flow-3_validate_request.json
+++ b/eComviser/RSF 2.0/flow-3/flow-3_validate_request.json
@@ -1,0 +1,359 @@
+{
+    "domain": "ONDC:NTS10",
+    "version": "2.0.0",
+    "bap_id": "preprod.ecomviser.com",
+    "bap_uri": "https://preprod.ecomviser.com/api",
+    "bpp_id": "rsf-mock-service.ondc.org",
+    "bpp_uri": "https://rsf-mock-service.ondc.org/seller_protocol_server_preprod/ondc",
+    "payload": {
+        "settle": {
+            "context": {
+                "domain": "ONDC:NTS10",
+                "location": {
+                    "country": {
+                        "code": "IND"
+                    },
+                    "city": {
+                        "code": "*"
+                    }
+                },
+                "version": "2.0.0",
+                "action": "settle",
+                "bap_id": "preprod.ecomviser.com",
+                "bap_uri": "https://preprod.ecomviser.com/api",
+                "bpp_id": "rsf-mock-service.ondc.org",
+                "bpp_uri": "https://rsf-mock-service.ondc.org/seller_protocol_server_preprod/ondc",
+                "transaction_id": "37586561-d43d-472a-b8ff-90b594f3bbd3",
+                "message_id": "5b9dbdc1-f2ee-44a7-a77f-b8580ca83fd8",
+                "timestamp": "2025-04-10T11:44:57.785Z",
+                "ttl": "P1D"
+            },
+            "message": {
+                "collector_app_id": "buyer-app-preprod-v2.ondc.org",
+                "receiver_app_id": "preprod.ecomviser.com",
+                "settlement": {
+                    "type": "NP-NP",
+                    "id": "1744285497-000011",
+                    "orders": [
+                        {
+                            "id": "2025-04-10-900686",
+                            "inter_participant": {
+                                "amount": {
+                                    "currency": "INR",
+                                    "value": "320.00"
+                                }
+                            },
+                            "collector": {
+                                "amount": {
+                                    "currency": "INR",
+                                    "value": "11.33"
+                                }
+                            },
+                            "self": {
+                                "amount": {
+                                    "currency": "INR",
+                                    "value": "320.00"
+                                }
+                            }
+                        }
+                    ]
+                }
+            }
+        },
+        "on_settle": {
+            "context": {
+                "bap_id": "preprod.ecomviser.com",
+                "bap_uri": "https://preprod.ecomviser.com/api",
+                "bpp_id": "rsf-mock-service.ondc.org",
+                "bpp_uri": "https://rsf-mock-service.ondc.org/seller_protocol_server_preprod/ondc",
+                "location": {
+                    "country": {
+                        "code": "IND"
+                    },
+                    "city": {
+                        "code": "*"
+                    }
+                },
+                "transaction_id": "37586561-d43d-472a-b8ff-90b594f3bbd3",
+                "message_id": "5b9dbdc1-f2ee-44a7-a77f-b8580ca83fd8",
+                "timestamp": "2025-04-10T11:46:00.554Z",
+                "domain": "ONDC:NTS10",
+                "version": "2.0.0",
+                "ttl": "PT10M",
+                "action": "on_settle"
+            },
+            "message": {
+                "collector_app_id": "buyer-app-preprod-v2.ondc.org",
+                "receiver_app_id": "preprod.ecomviser.com",
+                "settlement": {
+                    "type": "NP-NP",
+                    "id": "1744285497-000011",
+                    "orders": [
+                        {
+                            "id": "2025-04-10-900686",
+                            "inter_participant": {
+                                "amount": {
+                                    "value": "320.00",
+                                    "currency": "INR"
+                                },
+                                "settled_amount": {
+                                    "value": "320.00",
+                                    "currency": "INR"
+                                },
+                                "status": "NOT_SETTLED",
+                                "reference_no": "1238683618521",
+                                "error": {
+                                    "code": "70023",
+                                    "message": "Collector value mismatch"
+                                }
+                            },
+                            "collector": {
+                                "amount": {
+                                    "value": "11.33",
+                                    "currency": "INR"
+                                }
+                            },
+                            "self": {
+                                "amount": {
+                                    "value": "320.00",
+                                    "currency": "INR"
+                                },
+                                "status": "NOT_SETTLED",
+                                "reference_no": "1238683618521",
+                                "error": {
+                                    "code": "70023",
+                                    "message": "Collector value mismatch"
+                                }
+                            }
+                        }
+                    ]
+                }
+            }
+        },
+        "report": {
+            "context": {
+                "domain": "ONDC:NTS10",
+                "location": {
+                    "country": {
+                        "code": "IND"
+                    },
+                    "city": {
+                        "code": "*"
+                    }
+                },
+                "version": "2.0.0",
+                "action": "report",
+                "bap_id": "preprod.ecomviser.com",
+                "bap_uri": "https://preprod.ecomviser.com/api",
+                "bpp_id": "rsf-mock-service.ondc.org",
+                "bpp_uri": "https://rsf-mock-service.ondc.org/seller_protocol_server_preprod/ondc",
+                "transaction_id": "37586561-d43d-472a-b8ff-90b594f3bbd3",
+                "message_id": "f553a0ca-d5c6-4d98-be63-0f33926d088b",
+                "timestamp": "2025-04-10T11:46:17.305Z",
+                "ttl": "P1D"
+            },
+            "message": {
+                "ref_transaction_id": "37586561-d43d-472a-b8ff-90b594f3bbd3",
+                "ref_message_id": "5b9dbdc1-f2ee-44a7-a77f-b8580ca83fd8"
+            }
+        },
+        "on_report": {
+            "context": {
+                "bap_id": "preprod.ecomviser.com",
+                "bap_uri": "https://preprod.ecomviser.com/api",
+                "bpp_id": "rsf-mock-service.ondc.org",
+                "bpp_uri": "https://rsf-mock-service.ondc.org/seller_protocol_server_preprod/ondc",
+                "location": {
+                    "country": {
+                        "code": "IND"
+                    },
+                    "city": {
+                        "code": "*"
+                    }
+                },
+                "transaction_id": "37586561-d43d-472a-b8ff-90b594f3bbd3",
+                "message_id": "f553a0ca-d5c6-4d98-be63-0f33926d088b",
+                "timestamp": "2025-04-10T11:46:46.606Z",
+                "domain": "ONDC:NTS10",
+                "version": "2.0.0",
+                "ttl": "PT10M",
+                "action": "on_report"
+            },
+            "message": {
+                "collector_app_id": "buyer-app-preprod-v2.ondc.org",
+                "receiver_app_id": "preprod.ecomviser.com",
+                "settlement": {
+                    "type": "NP-NP",
+                    "id": "1744285497-000011",
+                    "orders": [
+                        {
+                            "id": "2025-04-10-900686",
+                            "inter_participant": {
+                                "amount": {
+                                    "value": "320.00",
+                                    "currency": "INR"
+                                },
+                                "settled_amount": {
+                                    "value": "320.00",
+                                    "currency": "INR"
+                                },
+                                "status": "NOT_SETTLED",
+                                "reference_no": "1238683618521"
+                            },
+                            "collector": {
+                                "amount": {
+                                    "value": "11.33",
+                                    "currency": "INR"
+                                }
+                            },
+                            "self": {
+                                "amount": {
+                                    "value": "320.00",
+                                    "currency": "INR"
+                                },
+                                "status": "NOT_SETTLED"
+                            },
+                            "error": {
+                                "code": "70023",
+                                "message": "Collector value mismatch"
+                            }
+                        }
+                    ]
+                }
+            }
+        },
+        "recon": {
+            "context": {
+                "domain": "ONDC:NTS10",
+                "location": {
+                    "country": {
+                        "code": "IND"
+                    },
+                    "city": {
+                        "code": "*"
+                    }
+                },
+                "version": "2.0.0",
+                "action": "recon",
+                "bap_id": "preprod.ecomviser.com",
+                "bap_uri": "https://preprod.ecomviser.com/api",
+                "bpp_id": "rsf-mock-service.ondc.org",
+                "bpp_uri": "https://rsf-mock-service.ondc.org/seller_protocol_server_preprod/ondc",
+                "transaction_id": "37586561-d43d-472a-b8ff-90b594f3bbd3",
+                "message_id": "453862f6-d9c4-403d-a8a5-f87e822cbb74",
+                "timestamp": "2025-04-10T11:47:02.959Z",
+                "ttl": "P1D"
+            },
+            "message": {
+                "orders": [
+                    {
+                        "id": "2025-04-10-900686",
+                        "amount": {
+                            "currency": "INR",
+                            "value": "320.00"
+                        },
+                        "settlements": [
+                            {
+                                "id": "1744285497-000011",
+                                "payment_id": "order_QHLIGno47zkCTl",
+                                "status": "PENDING",
+                                "amount": {
+                                    "currency": "INR",
+                                    "value": "320.00"
+                                },
+                                "commission": {
+                                    "currency": "INR",
+                                    "value": "11.33"
+                                },
+                                "withholding_amount": {
+                                    "currency": "INR",
+                                    "value": "0.00"
+                                },
+                                "tds": {
+                                    "currency": "INR",
+                                    "value": "0.00"
+                                },
+                                "tcs": {
+                                    "currency": "INR",
+                                    "value": "0.00"
+                                },
+                                "settlement_ref_no": "1238683618521",
+                                "updated_at": "2025-04-10T11:46:00.554Z"
+                            }
+                        ]
+                    }
+                ]
+            }
+        },
+        "on_recon": {
+            "context": {
+                "bap_id": "preprod.ecomviser.com",
+                "bap_uri": "https://preprod.ecomviser.com/api",
+                "bpp_id": "rsf-mock-service.ondc.org",
+                "bpp_uri": "https://rsf-mock-service.ondc.org/seller_protocol_server_preprod/ondc",
+                "location": {
+                    "country": {
+                        "code": "IND"
+                    },
+                    "city": {
+                        "code": "*"
+                    }
+                },
+                "transaction_id": "37586561-d43d-472a-b8ff-90b594f3bbd3",
+                "message_id": "453862f6-d9c4-403d-a8a5-f87e822cbb74",
+                "timestamp": "2025-04-10T11:47:43.737Z",
+                "domain": "ONDC:NTS10",
+                "version": "2.0.0",
+                "ttl": "PT10M",
+                "action": "on_recon"
+            },
+            "message": {
+                "orders": [
+                    {
+                        "id": "2025-04-10-900686",
+                        "amount": {
+                            "value": "320.00",
+                            "currency": "INR"
+                        },
+                        "recon_accord": false,
+                        "settlements": [
+                            {
+                                "id": "1744285497-000011",
+                                "payment_id": "order_QHLIGno47zkCTl",
+                                "status": "PENDING",
+                                "amount": {
+                                    "value": "320.00",
+                                    "currency": "INR",
+                                    "diff_value": "0.00"
+                                },
+                                "commission": {
+                                    "value": "11.33",
+                                    "currency": "INR",
+                                    "diff_value": "5.00"
+                                },
+                                "withholding_amount": {
+                                    "value": "0.00",
+                                    "currency": "INR",
+                                    "diff_value": "0.00"
+                                },
+                                "tcs": {
+                                    "value": "0.00",
+                                    "currency": "INR",
+                                    "diff_value": "0.00"
+                                },
+                                "tds": {
+                                    "value": "0.00",
+                                    "currency": "INR",
+                                    "diff_value": "0.00"
+                                },
+                                "settlement_ref_no": "1238683618521",
+                                "updated_at": "2025-04-10T11:46:00.554Z",
+                                "due_date": "2025-04-12"
+                            }
+                        ]
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/eComviser/RSF 2.0/flow-3/on_recon.json
+++ b/eComviser/RSF 2.0/flow-3/on_recon.json
@@ -1,0 +1,70 @@
+{
+    "context": {
+        "bap_id": "preprod.ecomviser.com",
+        "bap_uri": "https://preprod.ecomviser.com/api",
+        "bpp_id": "rsf-mock-service.ondc.org",
+        "bpp_uri": "https://rsf-mock-service.ondc.org/seller_protocol_server_preprod/ondc",
+        "location": {
+            "country": {
+                "code": "IND"
+            },
+            "city": {
+                "code": "*"
+            }
+        },
+        "transaction_id": "37586561-d43d-472a-b8ff-90b594f3bbd3",
+        "message_id": "453862f6-d9c4-403d-a8a5-f87e822cbb74",
+        "timestamp": "2025-04-10T11:47:43.737Z",
+        "domain": "ONDC:NTS10",
+        "version": "2.0.0",
+        "ttl": "PT10M",
+        "action": "on_recon"
+    },
+    "message": {
+        "orders": [
+            {
+                "id": "2025-04-10-900686",
+                "amount": {
+                    "value": "320.00",
+                    "currency": "INR"
+                },
+                "recon_accord": false,
+                "settlements": [
+                    {
+                        "id": "1744285497-000011",
+                        "payment_id": "order_QHLIGno47zkCTl",
+                        "status": "PENDING",
+                        "amount": {
+                            "value": "320.00",
+                            "currency": "INR",
+                            "diff_value": "0.00"
+                        },
+                        "commission": {
+                            "value": "11.33",
+                            "currency": "INR",
+                            "diff_value": "5.00"
+                        },
+                        "withholding_amount": {
+                            "value": "0.00",
+                            "currency": "INR",
+                            "diff_value": "0.00"
+                        },
+                        "tcs": {
+                            "value": "0.00",
+                            "currency": "INR",
+                            "diff_value": "0.00"
+                        },
+                        "tds": {
+                            "value": "0.00",
+                            "currency": "INR",
+                            "diff_value": "0.00"
+                        },
+                        "settlement_ref_no": "1238683618521",
+                        "updated_at": "2025-04-10T11:46:00.554Z",
+                        "due_date": "2025-04-12"
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/eComviser/RSF 2.0/flow-3/on_report.json
+++ b/eComviser/RSF 2.0/flow-3/on_report.json
@@ -1,0 +1,65 @@
+{
+    "context": {
+        "bap_id": "preprod.ecomviser.com",
+        "bap_uri": "https://preprod.ecomviser.com/api",
+        "bpp_id": "rsf-mock-service.ondc.org",
+        "bpp_uri": "https://rsf-mock-service.ondc.org/seller_protocol_server_preprod/ondc",
+        "location": {
+            "country": {
+                "code": "IND"
+            },
+            "city": {
+                "code": "*"
+            }
+        },
+        "transaction_id": "37586561-d43d-472a-b8ff-90b594f3bbd3",
+        "message_id": "f553a0ca-d5c6-4d98-be63-0f33926d088b",
+        "timestamp": "2025-04-10T11:46:46.606Z",
+        "domain": "ONDC:NTS10",
+        "version": "2.0.0",
+        "ttl": "PT10M",
+        "action": "on_report"
+    },
+    "message": {
+        "collector_app_id": "buyer-app-preprod-v2.ondc.org",
+        "receiver_app_id": "preprod.ecomviser.com",
+        "settlement": {
+            "type": "NP-NP",
+            "id": "1744285497-000011",
+            "orders": [
+                {
+                    "id": "2025-04-10-900686",
+                    "inter_participant": {
+                        "amount": {
+                            "value": "320.00",
+                            "currency": "INR"
+                        },
+                        "settled_amount": {
+                            "value": "320.00",
+                            "currency": "INR"
+                        },
+                        "status": "NOT_SETTLED",
+                        "reference_no": "1238683618521"
+                    },
+                    "collector": {
+                        "amount": {
+                            "value": "11.33",
+                            "currency": "INR"
+                        }
+                    },
+                    "self": {
+                        "amount": {
+                            "value": "320.00",
+                            "currency": "INR"
+                        },
+                        "status": "NOT_SETTLED"
+                    },
+                    "error": {
+                        "code": "70023",
+                        "message": "Collector value mismatch"
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/eComviser/RSF 2.0/flow-3/on_settle.json
+++ b/eComviser/RSF 2.0/flow-3/on_settle.json
@@ -1,0 +1,70 @@
+{
+    "context": {
+        "bap_id": "preprod.ecomviser.com",
+        "bap_uri": "https://preprod.ecomviser.com/api",
+        "bpp_id": "rsf-mock-service.ondc.org",
+        "bpp_uri": "https://rsf-mock-service.ondc.org/seller_protocol_server_preprod/ondc",
+        "location": {
+            "country": {
+                "code": "IND"
+            },
+            "city": {
+                "code": "*"
+            }
+        },
+        "transaction_id": "37586561-d43d-472a-b8ff-90b594f3bbd3",
+        "message_id": "5b9dbdc1-f2ee-44a7-a77f-b8580ca83fd8",
+        "timestamp": "2025-04-10T11:46:00.554Z",
+        "domain": "ONDC:NTS10",
+        "version": "2.0.0",
+        "ttl": "PT10M",
+        "action": "on_settle"
+    },
+    "message": {
+        "collector_app_id": "buyer-app-preprod-v2.ondc.org",
+        "receiver_app_id": "preprod.ecomviser.com",
+        "settlement": {
+            "type": "NP-NP",
+            "id": "1744285497-000011",
+            "orders": [
+                {
+                    "id": "2025-04-10-900686",
+                    "inter_participant": {
+                        "amount": {
+                            "value": "320.00",
+                            "currency": "INR"
+                        },
+                        "settled_amount": {
+                            "value": "320.00",
+                            "currency": "INR"
+                        },
+                        "status": "NOT_SETTLED",
+                        "reference_no": "1238683618521",
+                        "error": {
+                            "code": "70023",
+                            "message": "Collector value mismatch"
+                        }
+                    },
+                    "collector": {
+                        "amount": {
+                            "value": "11.33",
+                            "currency": "INR"
+                        }
+                    },
+                    "self": {
+                        "amount": {
+                            "value": "320.00",
+                            "currency": "INR"
+                        },
+                        "status": "NOT_SETTLED",
+                        "reference_no": "1238683618521",
+                        "error": {
+                            "code": "70023",
+                            "message": "Collector value mismatch"
+                        }
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/eComviser/RSF 2.0/flow-3/recon.json
+++ b/eComviser/RSF 2.0/flow-3/recon.json
@@ -1,0 +1,63 @@
+{
+    "context": {
+        "domain": "ONDC:NTS10",
+        "location": {
+            "country": {
+                "code": "IND"
+            },
+            "city": {
+                "code": "*"
+            }
+        },
+        "version": "2.0.0",
+        "action": "recon",
+        "bap_id": "preprod.ecomviser.com",
+        "bap_uri": "https://preprod.ecomviser.com/api",
+        "bpp_id": "rsf-mock-service.ondc.org",
+        "bpp_uri": "https://rsf-mock-service.ondc.org/seller_protocol_server_preprod/ondc",
+        "transaction_id": "37586561-d43d-472a-b8ff-90b594f3bbd3",
+        "message_id": "453862f6-d9c4-403d-a8a5-f87e822cbb74",
+        "timestamp": "2025-04-10T11:47:02.959Z",
+        "ttl": "P1D"
+    },
+    "message": {
+        "orders": [
+            {
+                "id": "2025-04-10-900686",
+                "amount": {
+                    "currency": "INR",
+                    "value": "320.00"
+                },
+                "settlements": [
+                    {
+                        "id": "1744285497-000011",
+                        "payment_id": "order_QHLIGno47zkCTl",
+                        "status": "PENDING",
+                        "amount": {
+                            "currency": "INR",
+                            "value": "320.00"
+                        },
+                        "commission": {
+                            "currency": "INR",
+                            "value": "11.33"
+                        },
+                        "withholding_amount": {
+                            "currency": "INR",
+                            "value": "0.00"
+                        },
+                        "tds": {
+                            "currency": "INR",
+                            "value": "0.00"
+                        },
+                        "tcs": {
+                            "currency": "INR",
+                            "value": "0.00"
+                        },
+                        "settlement_ref_no": "1238683618521",
+                        "updated_at": "2025-04-10T11:46:00.554Z"
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/eComviser/RSF 2.0/flow-3/report.json
+++ b/eComviser/RSF 2.0/flow-3/report.json
@@ -1,0 +1,27 @@
+{
+    "context": {
+        "domain": "ONDC:NTS10",
+        "location": {
+            "country": {
+                "code": "IND"
+            },
+            "city": {
+                "code": "*"
+            }
+        },
+        "version": "2.0.0",
+        "action": "report",
+        "bap_id": "preprod.ecomviser.com",
+        "bap_uri": "https://preprod.ecomviser.com/api",
+        "bpp_id": "rsf-mock-service.ondc.org",
+        "bpp_uri": "https://rsf-mock-service.ondc.org/seller_protocol_server_preprod/ondc",
+        "transaction_id": "37586561-d43d-472a-b8ff-90b594f3bbd3",
+        "message_id": "f553a0ca-d5c6-4d98-be63-0f33926d088b",
+        "timestamp": "2025-04-10T11:46:17.305Z",
+        "ttl": "P1D"
+    },
+    "message": {
+        "ref_transaction_id": "37586561-d43d-472a-b8ff-90b594f3bbd3",
+        "ref_message_id": "5b9dbdc1-f2ee-44a7-a77f-b8580ca83fd8"
+    }
+}

--- a/eComviser/RSF 2.0/flow-3/settle.json
+++ b/eComviser/RSF 2.0/flow-3/settle.json
@@ -1,0 +1,54 @@
+{
+    "context": {
+        "domain": "ONDC:NTS10",
+        "location": {
+            "country": {
+                "code": "IND"
+            },
+            "city": {
+                "code": "*"
+            }
+        },
+        "version": "2.0.0",
+        "action": "settle",
+        "bap_id": "preprod.ecomviser.com",
+        "bap_uri": "https://preprod.ecomviser.com/api",
+        "bpp_id": "rsf-mock-service.ondc.org",
+        "bpp_uri": "https://rsf-mock-service.ondc.org/seller_protocol_server_preprod/ondc",
+        "transaction_id": "37586561-d43d-472a-b8ff-90b594f3bbd3",
+        "message_id": "5b9dbdc1-f2ee-44a7-a77f-b8580ca83fd8",
+        "timestamp": "2025-04-10T11:44:57.785Z",
+        "ttl": "P1D"
+    },
+    "message": {
+        "collector_app_id": "buyer-app-preprod-v2.ondc.org",
+        "receiver_app_id": "preprod.ecomviser.com",
+        "settlement": {
+            "type": "NP-NP",
+            "id": "1744285497-000011",
+            "orders": [
+                {
+                    "id": "2025-04-10-900686",
+                    "inter_participant": {
+                        "amount": {
+                            "currency": "INR",
+                            "value": "320.00"
+                        }
+                    },
+                    "collector": {
+                        "amount": {
+                            "currency": "INR",
+                            "value": "11.33"
+                        }
+                    },
+                    "self": {
+                        "amount": {
+                            "currency": "INR",
+                            "value": "320.00"
+                        }
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/eComviser/RSF 2.0/flow-4/flow-4_validate_report.json
+++ b/eComviser/RSF 2.0/flow-4/flow-4_validate_report.json
@@ -1,0 +1,30 @@
+{
+    "success": false,
+    "response": {
+        "message": "Logs were not verified successfully",
+        "report": {
+            "on_settle": {
+                "schemaErr0": "/message/settlement/orders/0/inter_participant must have required property 'settled_amount'",
+                "schemaErr1": "/message/settlement/orders/0/inter_participant must have required property 'amount'",
+                "schemaErr2": "/message/settlement/orders/0/inter_participant must have required property 'reference_no'",
+                "inter_participant": "inter_participant is not required for MISC type"
+            },
+            "on_report": {
+                "schemaErr0": "/message must have required property 'collector_app_id'",
+                "schemaErr1": "/message must have required property 'receiver_app_id'",
+                "schemaErr2": "/message/settlement/type must be equal to one of the allowed values (NP-NP)",
+                "schemaErr3": "/message/settlement/orders/0 must have required property 'id'",
+                "schemaErr4": "/message/settlement/orders/0 must have required property 'collector'",
+                "schemaErr5": "/message/settlement/orders/0/inter_participant must have required property 'settled_amount'",
+                "schemaErr6": "/message/settlement/orders/0/inter_participant must have required property 'amount'",
+                "schemaErr7": "/message/settlement/orders/0/inter_participant must have required property 'reference_no'"
+            }
+        },
+        "bpp_id": "rsf-mock-service.ondc.org",
+        "bap_id": "preprod.ecomviser.com",
+        "domain": "ONDC:NTS10",
+        "reportTimestamp": "2025-04-10T13:09:27.124Z"
+    },
+    "signature": "L6YeNb8ALm7M485Wy/Kbi0vGRFZSiiWH8cWZOeA8hsZKkcYWs729MGnB+wOJ5kjbM62QKbA6Ugsyy2nRf3+3Ag==",
+    "signTimestamp": "2025-04-10T13:09:27.125Z"
+}

--- a/eComviser/RSF 2.0/flow-4/flow-4_validate_request.json
+++ b/eComviser/RSF 2.0/flow-4/flow-4_validate_request.json
@@ -1,0 +1,164 @@
+{
+    "domain": "ONDC:NTS10",
+    "version": "2.0.0",
+    "bap_id": "preprod.ecomviser.com",
+    "bap_uri": "https://preprod.ecomviser.com/api",
+    "bpp_id": "rsf-mock-service.ondc.org",
+    "bpp_uri": "https://rsf-mock-service.ondc.org/seller_protocol_server_preprod/ondc",
+    "payload": {
+        "settle": {
+            "context": {
+                "domain": "ONDC:NTS10",
+                "location": {
+                    "country": {
+                        "code": "IND"
+                    },
+                    "city": {
+                        "code": "*"
+                    }
+                },
+                "version": "2.0.0",
+                "action": "settle",
+                "bap_id": "preprod.ecomviser.com",
+                "bap_uri": "https://preprod.ecomviser.com/api",
+                "bpp_id": "rsf-mock-service.ondc.org",
+                "bpp_uri": "https://rsf-mock-service.ondc.org/seller_protocol_server_preprod/ondc",
+                "transaction_id": "8077417c-b7ba-45b4-8998-308c7da562a6",
+                "message_id": "efd10050-453c-4111-8922-044520a154c6",
+                "timestamp": "2025-04-10T12:12:20.959Z",
+                "ttl": "P1D"
+            },
+            "message": {
+                "settlement": {
+                    "type": "MISC",
+                    "id": "1744287191-00012",
+                    "orders": [
+                        {
+                            "self": {
+                                "amount": {
+                                    "currency": "INR",
+                                    "value": "200.00"
+                                }
+                            }
+                        }
+                    ]
+                }
+            }
+        },
+        "on_settle": {
+            "context": {
+                "bap_id": "preprod.ecomviser.com",
+                "bap_uri": "https://preprod.ecomviser.com/api",
+                "bpp_id": "rsf-mock-service.ondc.org",
+                "bpp_uri": "https://rsf-mock-service.ondc.org/seller_protocol_server_preprod/ondc",
+                "location": {
+                    "country": {
+                        "code": "IND"
+                    },
+                    "city": {
+                        "code": "*"
+                    }
+                },
+                "transaction_id": "8077417c-b7ba-45b4-8998-308c7da562a6",
+                "message_id": "efd10050-453c-4111-8922-044520a154c6",
+                "timestamp": "2025-04-10T12:15:20.959Z",
+                "domain": "ONDC:NTS10",
+                "version": "2.0.0",
+                "ttl": "PT10M",
+                "action": "on_settle"
+            },
+            "message": {
+                "settlement": {
+                    "type": "MISC",
+                    "id": "1744287191-00012",
+                    "orders": [
+                        {
+                            "inter_participant": {
+                                "status": "SETTLED"
+                            },
+                            "self": {
+                                "amount": {
+                                    "value": "200.00",
+                                    "currency": "INR"
+                                },
+                                "status": "SETTLED",
+                                "reference_no": "1238683618634"
+                            }
+                        }
+                    ]
+                }
+            }
+        },
+        "report": {
+            "context": {
+                "domain": "ONDC:NTS10",
+                "location": {
+                    "country": {
+                        "code": "IND"
+                    },
+                    "city": {
+                        "code": "*"
+                    }
+                },
+                "version": "2.0.0",
+                "action": "report",
+                "bap_id": "preprod.ecomviser.com",
+                "bap_uri": "https://preprod.ecomviser.com/api",
+                "bpp_id": "rsf-mock-service.ondc.org",
+                "bpp_uri": "https://rsf-mock-service.ondc.org/seller_protocol_server/ondc",
+                "transaction_id": "8077417c-b7ba-45b4-8998-308c7da562a6",
+                "message_id": "33511a43-0a86-42d6-a732-045411bdb398",
+                "timestamp": "2025-04-10T12:17:42.209Z",
+                "ttl": "P1D"
+            },
+            "message": {
+                "ref_transaction_id": "8077417c-b7ba-45b4-8998-308c7da562a6",
+                "ref_message_id": "efd10050-453c-4111-8922-044520a154c6"
+            }
+        },
+        "on_report": {
+            "context": {
+                "bap_id": "preprod.ecomviser.com",
+                "bap_uri": "https://preprod.ecomviser.com/api",
+                "bpp_id": "rsf-mock-service.ondc.org",
+                "bpp_uri": "https://rsf-mock-service.ondc.org/seller_protocol_server_preprod/ondc",
+                "location": {
+                    "country": {
+                        "code": "IND"
+                    },
+                    "city": {
+                        "code": "*"
+                    }
+                },
+                "transaction_id": "8077417c-b7ba-45b4-8998-308c7da562a6",
+                "message_id": "33511a43-0a86-42d6-a732-045411bdb398",
+                "timestamp": "2025-04-10T12:18:42.209Z",
+                "domain": "ONDC:NTS10",
+                "version": "2.0.0",
+                "ttl": "PT10M",
+                "action": "on_report"
+            },
+            "message": {
+                "settlement": {
+                    "type": "MISC",
+                    "id": "1744287191-00012",
+                    "orders": [
+                        {
+                            "inter_participant": {
+                                "status": "SETTLED"
+                            },
+                            "self": {
+                                "amount": {
+                                    "value": "200.00",
+                                    "currency": "INR"
+                                },
+                                "status": "SETTLED",
+                                "reference_no": "1238683618634"
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+    }
+}

--- a/eComviser/RSF 2.0/flow-4/on_report.json
+++ b/eComviser/RSF 2.0/flow-4/on_report.json
@@ -1,0 +1,44 @@
+{
+    "context": {
+        "bap_id": "preprod.ecomviser.com",
+        "bap_uri": "https://preprod.ecomviser.com/api",
+        "bpp_id": "rsf-mock-service.ondc.org",
+        "bpp_uri": "https://rsf-mock-service.ondc.org/seller_protocol_server_preprod/ondc",
+        "location": {
+            "country": {
+                "code": "IND"
+            },
+            "city": {
+                "code": "*"
+            }
+        },
+        "transaction_id": "8077417c-b7ba-45b4-8998-308c7da562a6",
+        "message_id": "33511a43-0a86-42d6-a732-045411bdb398",
+        "timestamp": "2025-04-10T12:18:42.209Z",
+        "domain": "ONDC:NTS10",
+        "version": "2.0.0",
+        "ttl": "PT10M",
+        "action": "on_report"
+    },
+    "message": {
+        "settlement": {
+            "type": "MISC",
+            "id": "1744287191-00012",
+            "orders": [
+                {
+                    "inter_participant": {
+                        "status": "SETTLED"
+                    },
+                    "self": {
+                        "amount": {
+                            "value": "200.00",
+                            "currency": "INR"
+                        },
+                        "status": "SETTLED",
+                        "reference_no": "1238683618634"
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/eComviser/RSF 2.0/flow-4/on_settle.json
+++ b/eComviser/RSF 2.0/flow-4/on_settle.json
@@ -1,0 +1,44 @@
+{
+    "context": {
+        "bap_id": "preprod.ecomviser.com",
+        "bap_uri": "https://preprod.ecomviser.com/api",
+        "bpp_id": "rsf-mock-service.ondc.org",
+        "bpp_uri": "https://rsf-mock-service.ondc.org/seller_protocol_server_preprod/ondc",
+        "location": {
+            "country": {
+                "code": "IND"
+            },
+            "city": {
+                "code": "*"
+            }
+        },
+        "transaction_id": "8077417c-b7ba-45b4-8998-308c7da562a6",
+        "message_id": "efd10050-453c-4111-8922-044520a154c6",
+        "timestamp": "2025-04-10T12:15:20.959Z",
+        "domain": "ONDC:NTS10",
+        "version": "2.0.0",
+        "ttl": "PT10M",
+        "action": "on_settle"
+    },
+    "message": {
+        "settlement": {
+            "type": "MISC",
+            "id": "1744287191-00012",
+            "orders": [
+                {
+                    "inter_participant": {
+                        "status": "SETTLED"
+                    },
+                    "self": {
+                        "amount": {
+                            "value": "200.00",
+                            "currency": "INR"
+                        },
+                        "status": "SETTLED",
+                        "reference_no": "1238683618634"
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/eComviser/RSF 2.0/flow-4/report.json
+++ b/eComviser/RSF 2.0/flow-4/report.json
@@ -17,7 +17,7 @@
         "bpp_uri": "https://rsf-mock-service.ondc.org/seller_protocol_server/ondc",
         "transaction_id": "8077417c-b7ba-45b4-8998-308c7da562a6",
         "message_id": "33511a43-0a86-42d6-a732-045411bdb398",
-        "timestamp": "2025-04-10T12:15:20.959Z",
+        "timestamp": "2025-04-10T12:17:42.209Z",
         "ttl": "P1D"
     },
     "message": {

--- a/eComviser/RSF 2.0/flow-4/report.json
+++ b/eComviser/RSF 2.0/flow-4/report.json
@@ -1,0 +1,27 @@
+{
+    "context": {
+        "domain": "ONDC:NTS10",
+        "location": {
+            "country": {
+                "code": "IND"
+            },
+            "city": {
+                "code": "*"
+            }
+        },
+        "version": "2.0.0",
+        "action": "report",
+        "bap_id": "preprod.ecomviser.com",
+        "bap_uri": "https://preprod.ecomviser.com/api",
+        "bpp_id": "rsf-mock-service.ondc.org",
+        "bpp_uri": "https://rsf-mock-service.ondc.org/seller_protocol_server/ondc",
+        "transaction_id": "8077417c-b7ba-45b4-8998-308c7da562a6",
+        "message_id": "33511a43-0a86-42d6-a732-045411bdb398",
+        "timestamp": "2025-04-10T12:15:20.959Z",
+        "ttl": "P1D"
+    },
+    "message": {
+        "ref_transaction_id": "8077417c-b7ba-45b4-8998-308c7da562a6",
+        "ref_message_id": "efd10050-453c-4111-8922-044520a154c6"
+    }
+}

--- a/eComviser/RSF 2.0/flow-4/settle.json
+++ b/eComviser/RSF 2.0/flow-4/settle.json
@@ -17,7 +17,7 @@
         "bpp_uri": "https://rsf-mock-service.ondc.org/seller_protocol_server_preprod/ondc",
         "transaction_id": "8077417c-b7ba-45b4-8998-308c7da562a6",
         "message_id": "efd10050-453c-4111-8922-044520a154c6",
-        "timestamp": "2025-04-10T13:13:43.737Z",
+        "timestamp": "2025-04-10T12:12:20.959Z",
         "ttl": "P1D"
     },
     "message": {

--- a/eComviser/RSF 2.0/flow-4/settle.json
+++ b/eComviser/RSF 2.0/flow-4/settle.json
@@ -1,0 +1,39 @@
+{
+    "context": {
+        "domain": "ONDC:NTS10",
+        "location": {
+            "country": {
+                "code": "IND"
+            },
+            "city": {
+                "code": "*"
+            }
+        },
+        "version": "2.0.0",
+        "action": "settle",
+        "bap_id": "preprod.ecomviser.com",
+        "bap_uri": "https://preprod.ecomviser.com/api",
+        "bpp_id": "rsf-mock-service.ondc.org",
+        "bpp_uri": "https://rsf-mock-service.ondc.org/seller_protocol_server_preprod/ondc",
+        "transaction_id": "8077417c-b7ba-45b4-8998-308c7da562a6",
+        "message_id": "efd10050-453c-4111-8922-044520a154c6",
+        "timestamp": "2025-04-10T13:13:43.737Z",
+        "ttl": "P1D"
+    },
+    "message": {
+        "settlement": {
+            "type": "MISC",
+            "id": "1744287191-00012",
+            "orders": [
+                {
+                    "self": {
+                        "amount": {
+                            "currency": "INR",
+                            "value": "200.00"
+                        }
+                    }
+                }
+            ]
+        }
+    }
+}


### PR DESCRIPTION
We are getting an issue in flow 4 in the `on_settle` response related to `inter_participant`:

```
{
    "schemaErr0": "/message/settlement/orders/0/inter_participant must have required property 'settled_amount'",
    "schemaErr1": "/message/settlement/orders/0/inter_participant must have required property 'amount'",
    "schemaErr2": "/message/settlement/orders/0/inter_participant must have required property 'reference_no'",
    "inter_participant": "inter_participant is not required for MISC type"
}
```